### PR TITLE
[CMD]support reading from external configurations

### DIFF
--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -15,10 +15,6 @@ from pegaflow.pegaflow import EngineRpcClient
 
 logger = get_connector_logger()
 
-# Engine server endpoint (gRPC URL)
-ENGINE_ENDPOINT = os.environ.get("PEGAFLOW_ENGINE_ENDPOINT", "http://127.0.0.1:50055")
-
-
 @dataclass(frozen=True)
 class ConnectorContext:
     """Shared configuration for scheduler/worker connectors."""
@@ -304,7 +300,6 @@ def derive_namespace(vllm_config, tp_size: int) -> str:
 
 __all__ = [
     "ConnectorContext",
-    "ENGINE_ENDPOINT",
     "LoadIntent",
     "LoadState",
     "PegaConnectorMetadata",


### PR DESCRIPTION
u can now use `--kv-transfer-config '{"kv_connector": "PegaKVConnector", "kv_role": "kv_both", "kv_connector_module_path": "pegaflow.connector", "kv_connector_extra_config": {"pegaflow.host": "http://127.0.0.1", "pegaflow.port": 50055}}'`   to start vllm.