### PR TITLE
Benchmark for memory utilization of offset allocator (#11)

### DIFF
--- a/pegaflow-core/benches/allocator_bench.rs
+++ b/pegaflow-core/benches/allocator_bench.rs
@@ -1,6 +1,3 @@
-/* This is a Rust benchmark for ScaledOffsetAllocator that simulates a steady-state LLM KV-cache workload, 
-closely mirroring allocator_bench.cpp and production usage. */
-
 use pegaflow_core::allocator::{Allocation, ScaledOffsetAllocator};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};


### PR DESCRIPTION
KV Cache Fragmentation Benchmark (Issue #11)

This PR adds a Rust benchmark for ScaledOffsetAllocator that simulates a steady-state LLM KV-cache workload, closely mirroring allocator_bench.cpp and production usage.

**Workload Model**

Fixed page size per model (128 KB)

Allocation size: 20–100 pages per request (random)

Long-running steady state with periodic churn

Prefill to ~85% utilization, then operate under pressure

Tracks:

Utilization over time

Internal fragmentation

External fragmentation

Allocation failures with free memory present

Allocation latency

This reproduces the production symptom:

allocator reaches ~88–90% minimum utilization despite large amounts of free memory remaining.