### PR TITLE
feat(server): support multi-device initialization with auto-detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,11 @@ cargo bench --bench uds_latency
 
 ```bash
 # Start the PegaEngine server first (required)
-cargo run -r --bin pegaflow-server -- --addr 0.0.0.0:50055 --device 0 --pool-size 30gb
+# Auto-detect all GPUs (default behavior)
+cargo run -r --bin pegaflow-server -- --addr 0.0.0.0:50055 --pool-size 30gb
+
+# Or specify specific devices (e.g., GPUs 0, 2, 4)
+cargo run -r --bin pegaflow-server -- --addr 0.0.0.0:50055 --devices 0,2,4 --pool-size 30gb
 
 # Then run examples
 uv run python examples/basic_vllm.py
@@ -55,7 +59,7 @@ uv run python examples/bench_kv_cache.py --model /path/to/model --num-prompts 10
 **Server Configuration:**
 
 - `--addr`: Bind address (default: `127.0.0.1:50055`)
-- `--device`: CUDA device ID (default: `0`)
+- `--devices`: CUDA device IDs to initialize, comma-separated (default: auto-detect all available GPUs, e.g., `--devices 0,1,2,3`)
 - `--pool-size`: Pinned memory pool size (default: `30gb`, supports: `kb`, `mb`, `gb`, `tb`)
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pegaflow-server
 **All available options:**
 
 - `--addr`: Bind address (default: `127.0.0.1:50055`)
-- `--device`: CUDA device ID (default: `0`)
+- `--devices`: CUDA device IDs to initialize, comma-separated (default: auto-detect all available GPUs, e.g., `--devices 0,1,2,3`)
 - `--pool-size`: Pinned memory pool size (default: `30gb`, supports: `kb`, `mb`, `gb`, `tb`)
 - `--hint-value-size`: Hint for typical value size to tune cache and allocator (optional, supports: `kb`, `mb`, `gb`, `tb`)
 - `--use-hugepages`: Use huge pages for pinned memory (default: `false`, requires pre-configured `/proc/sys/vm/nr_hugepages`)


### PR DESCRIPTION
## Summary

Replace single `--device` flag with `--devices` to support multiple GPU initialization and auto-detection, fixing the slow first-time registration issue for non-primary devices.

Fixes #61

## Problem

Previously, when workers on devices other than device 0 first called `register_layer`, it took 30-45 seconds due to lazy CUDA context creation:

```
[09:35:47 TP0] Registered layer_0_k  ← Fast (~15s, device 0)
[09:36:17 TP3] Registered layer_0_k  ← Slow (45s, device 3)
[09:36:17 TP5] Registered layer_0_k  ← Slow (37s, device 5)
```

## Solution

Pre-initialize CUDA contexts for all devices at server startup by:
1. Auto-detecting available CUDA devices (or using user-specified list)
2. Forcing PyTorch context creation via `torch.empty()` on each device
3. Synchronizing to ensure contexts are fully initialized

## Changes

### CLI Arguments
- **Breaking change**: Replaced `--device <id>` with `--devices <id1>,<id2>,...`
- Default behavior: Auto-detect and initialize all available GPUs
- Examples:
  ```bash
  # Auto-detect all devices (new default)
  pegaflow-server --addr 0.0.0.0:50055 --pool-size 30gb
  
  # Specify specific devices
  pegaflow-server --addr 0.0.0.0:50055 --devices 0,2,4,6 --pool-size 30gb
  ```

### Implementation Details
- Added `detect_cuda_devices()` to probe all available CUDA devices
- Updated `init_python_cuda()` to accept device list and force context creation
- Added timing logs for each device initialization

### Performance Impact
- **Startup**: Slower by ~20-30 seconds (one-time cost to init all devices)
- **Registration**: All devices now register in a few seconds (previously 30-45s for non-primary devices)
- **Net benefit**: Much faster for multi-GPU workloads

## Test Plan

- [x] Tested on 8-GPU system with auto-detection
- [x] Verified all devices initialize with proper CUDA contexts
- [x] Confirmed first-time registration is fast on all devices
- [x] Backward compatible with single device via `--devices 0`

## Breaking Changes

⚠️ The `--device` flag has been replaced with `--devices`. Update your launch scripts:

```diff
- pegaflow-server --device 0 --pool-size 30gb
+ pegaflow-server --devices 0 --pool-size 30gb  # or omit for auto-detect
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)