### PR TITLE
perf(storage): optimize lock contention in batch insert path

### DIFF
--- a/pegaflow-core/src/storage.rs
+++ b/pegaflow-core/src/storage.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, Mutex, Weak};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use crate::block::{
-    BlockHash, BlockInsertError, BlockKey, InflightBlock, LayerBlock, PrefetchStatus, SealedBlock,
+    BlockInsertError, BlockKey, InflightBlock, LayerBlock, PrefetchStatus, SealedBlock,
 };
 use crate::cache::{CacheInsertOutcome, TinyLfuCache};
 use crate::metrics::core_metrics;
@@ -470,88 +470,72 @@ impl StorageEngine {
             .collect()
     }
 
-    /// Insert a slot into a block. Handles:
-    /// - Skip if already in cache (sealed)
-    /// - Skip if slot already exists in inflight
-    /// - Create inflight block if needed
-    /// - Seal when complete (but does NOT auto-admit to cache)
-    ///
-    /// Returns:
-    /// - `Ok(None)` if slot was skipped (already exists) or block not yet complete
-    /// - `Ok(Some((key, block)))` if block just completed and was sealed
-    ///
-    /// Caller is responsible for calling `cache_admit` to insert into cache.
-    pub fn insert_slot(
+    /// Batch insert slots and admit sealed blocks in a single lock acquisition.
+    /// Returns all sealed blocks (for SSD write-through).
+    pub fn insert_slots_batch(
         &self,
-        namespace: &str,
-        block_hash: BlockHash,
+        blocks: &[(BlockKey, Arc<LayerBlock>)],
         slot_id: usize,
-        block: Arc<LayerBlock>,
         total_slots: usize,
-    ) -> Result<Option<(BlockKey, Arc<SealedBlock>)>, BlockInsertError> {
-        let key = BlockKey::new(namespace.to_string(), block_hash);
-
+    ) -> Result<Vec<(BlockKey, Arc<SealedBlock>)>, BlockInsertError> {
         let mut inner = self.inner.lock().unwrap();
+        let mut sealed_blocks: Vec<(BlockKey, Arc<SealedBlock>)> = Vec::new();
 
-        // Fast path: already sealed in cache
-        if inner.cache.contains_key(&key) {
-            return Ok(None);
-        }
+        for (key, block) in blocks {
+            let footprint_bytes = block.memory_footprint();
 
-        // Get or create inflight block
-        let inflight_block = match inner.inflight.entry(key.clone()) {
-            Entry::Vacant(v) => v.insert(InflightBlock::new(total_slots)),
-            Entry::Occupied(o) => o.into_mut(),
-        };
-
-        // Check if slot already exists
-        if inflight_block.slot_exists(slot_id) {
-            return Ok(None);
-        }
-
-        let slot_footprint = block.memory_footprint();
-        let completed = inflight_block.insert_slot(slot_id, block, total_slots)?;
-        record_inflight_bytes_added(slot_footprint);
-
-        if completed {
-            // Remove from inflight and seal
-            let inflight_block = inner.inflight.remove(&key).expect("just checked");
-            let total_footprint = inflight_block.footprint();
-            record_inflight_bytes_removed(total_footprint);
-            let sealed = Arc::new(inflight_block.seal());
-
-            // Notify external consumers (fire-and-forget)
-            drop(inner); // Release lock before sending to channel
-            if let Some(tx) = &self.seal_notify_tx {
-                let _ = tx.send((key.clone(), Arc::downgrade(&sealed)));
+            // Skip if already sealed in cache
+            if inner.cache.contains_key(key) {
+                continue;
             }
 
-            return Ok(Some((key, sealed)));
+            // Get or create inflight block
+            let inflight_block = match inner.inflight.entry(key.clone()) {
+                Entry::Vacant(v) => v.insert(InflightBlock::new(total_slots)),
+                Entry::Occupied(o) => o.into_mut(),
+            };
+
+            // Skip if slot already exists
+            if inflight_block.slot_exists(slot_id) {
+                continue;
+            }
+
+            // Insert slot
+            let completed = inflight_block.insert_slot(slot_id, Arc::clone(block), total_slots)?;
+            record_inflight_bytes_added(footprint_bytes);
+
+            if completed {
+                // Remove from inflight and seal
+                let inflight_block = inner.inflight.remove(key).expect("just checked");
+                let total_footprint = inflight_block.footprint();
+                record_inflight_bytes_removed(total_footprint);
+                let sealed = Arc::new(inflight_block.seal());
+
+                // Try to admit to cache
+                match inner.cache.insert(key.clone(), Arc::clone(&sealed)) {
+                    CacheInsertOutcome::InsertedNew => {
+                        record_cache_insert_new(total_footprint);
+                    }
+                    CacheInsertOutcome::AlreadyExists => {}
+                    CacheInsertOutcome::Rejected => {
+                        core_metrics().cache_block_admission_rejections.add(1, &[]);
+                    }
+                }
+
+                sealed_blocks.push((key.clone(), sealed));
+            }
         }
 
-        Ok(None)
-    }
+        drop(inner);
 
-    /// Attempt to admit a sealed block into cache using TinyLFU policy.
-    /// Returns true if admitted, false if rejected.
-    pub fn cache_admit(&self, key: BlockKey, block: Arc<SealedBlock>) -> bool {
-        let footprint_bytes = block.memory_footprint();
-
-        let mut inner = self.inner.lock().unwrap();
-        match inner.cache.insert(key, block) {
-            CacheInsertOutcome::InsertedNew => {
-                record_cache_insert_new(footprint_bytes);
-                true
-            }
-            CacheInsertOutcome::AlreadyExists => {
-                // No overwrite, no-op for metrics.
-                true
-            }
-            CacheInsertOutcome::Rejected => {
-                core_metrics().cache_block_admission_rejections.add(1, &[]);
-                false
+        // Notify all sealed blocks
+        if let Some(tx) = &self.seal_notify_tx {
+            for (key, block) in &sealed_blocks {
+                let _ = tx.send((key.clone(), Arc::downgrade(block)));
             }
         }
+
+        Ok(sealed_blocks)
     }
 
     /// Send a batch of sealed blocks to SSD writer for async persistence.


### PR DESCRIPTION
## Summary
- Reduce lock contention by batching insert + cache admit into single lock acquisition
- Pre-create keys and compute footprints outside critical sections
- Remove over-engineered code (stop_admitting, admitted tracking)
- Fix SSD write policy: all sealed blocks written to SSD (write-through)

## Changes

### Commit 1: move key creation and footprint calculation outside locks
Optimize hot path methods by pre-creating keys and computing memory
footprints outside of critical sections:
- filter_blocks_to_save: pre-create BlockKeys before lock
- cache_lookup_many: pre-create pin_keys before lock
- unpin_blocks: pre-create pin_keys before lock
- check_prefix_and_prefetch: pre-create keys, compute footprint during cache lookup

### Commit 2: simplify insert_slots_batch and remove dead code
- Remove stop_admitting/admitted tracking (over-engineering)
- Return all sealed blocks for SSD write-through
- Remove unused methods: insert_slot, insert_slot_and_admit, cache_admit

## Test plan
- [x] cargo check passes
- [x] cargo clippy passes (existing too_many_arguments warning unrelated)
- [x] Manual verification of SSD write behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)