### PR TITLE
perf(core): replace std::sync::Mutex with parking_lot and optimize lock hold time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ dependencies = [
  "logforth",
  "offset-allocator",
  "opentelemetry",
+ "parking_lot",
  "serde",
  "shared_memory",
  "tokio",

--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -20,6 +20,7 @@ libc = "0.2"
 ahash.workspace = true
 io-uring = "0.7"
 futures = "0.3"
+parking_lot = "0.12"
 
 [dev-dependencies]
 criterion.workspace = true

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -8,7 +8,6 @@ pub(crate) struct CoreMetrics {
     // Pinned pool (allocator-level)
     pub pool_capacity_bytes: UpDownCounter<i64>,
     pub pool_used_bytes: UpDownCounter<i64>,
-    pub pool_largest_free_bytes: UpDownCounter<i64>,
     pub pool_alloc_failures: Counter<u64>,
 
     // Inflight (write path safety/health)
@@ -97,11 +96,6 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
                 .i64_up_down_counter("pegaflow_pool_used_bytes")
                 .with_unit("bytes")
                 .with_description("Current pinned pool usage in bytes")
-                .build(),
-            pool_largest_free_bytes: meter
-                .i64_up_down_counter("pegaflow_pool_largest_free_bytes")
-                .with_unit("bytes")
-                .with_description("Largest contiguous free region in pinned pool (fragmentation signal)")
                 .build(),
             pool_alloc_failures: meter
                 .u64_counter("pegaflow_pool_alloc_failures")


### PR DESCRIPTION
## Summary
Replace `std::sync::Mutex` with `parking_lot::Mutex` and reduce lock contention in hot allocation paths.

## Changes
- **Switch to parking_lot::Mutex** across `storage`, `pinned_pool`, and `instance` modules
  - Faster lock/unlock (no poison checking, lighter futex implementation)
  - Cleaner code (remove `.unwrap()`/`.expect("lock poisoned")` calls)
  
- **Optimize lock hold time** in `PinnedMemoryPool`:
  - Move metrics updates and pointer computation outside allocator lock
  - Shrink critical section to minimal allocator operations

- **Remove `pool_largest_free_bytes` metric** - added complexity without sufficient ROI

## Testing
- [x] All 31 unit tests pass
- [x] cargo clippy / fmt clean
- [x] No functional changes to public APIs