### PR TITLE
fix(ci): add typos.toml config

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+# Rust std library path (std::f64::consts)
+consts = "consts"


### PR DESCRIPTION
Allow 'consts' for std::f64::consts