### PR TITLE
chore: bump version to 0.0.13

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.0.12"
+version = "0.0.13"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -100,6 +100,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.0.12"
+version = "0.0.13"
 version_files = ["pyproject.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## Summary
- Bump pegaflow-llm package version from 0.0.12 to 0.0.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)