### PR TITLE
feat(trace): add optional fastrace tracing for query rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastant"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e825441bfb2d831c47c97d05821552db8832479f44c571b97fededbf0099c07"
+dependencies = [
+ "small_ctor",
+ "web-time",
+]
+
+[[package]]
+name = "fastrace"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df0cb35ba204d668c758a6400c2e43eab9b038843debfab606b26f194ad7f1b"
+dependencies = [
+ "fastant",
+ "fastrace-macro",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.2",
+ "rtrb",
+ "serde",
+]
+
+[[package]]
+name = "fastrace-macro"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6ca71d5dfcbab9e09b19b5248e06a4bd8ac779055491fb47e6ebbdd20e5567"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1524,7 @@ dependencies = [
  "colored",
  "criterion",
  "cudarc",
+ "fastrace",
  "futures",
  "hashlink",
  "io-uring",
@@ -1534,6 +1572,7 @@ dependencies = [
  "clap",
  "colored",
  "cudarc",
+ "fastrace",
  "log",
  "logforth",
  "opentelemetry",
@@ -1674,6 +1713,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -2136,6 +2197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtrb"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8388ea1a9e0ea807e442e8263a699e7edcb320ecbcd21b4fa8ff859acce3ba"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,6 +2472,12 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "small_ctor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88414a5ca1f85d82cc34471e975f0f74f6aa54c40f062efa42c0080e7f763f81"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ pyo3-build-config = { version = "0.27", features = ["resolve-config"] }
 log = "0.4"
 logforth = { version = "0.29", features = ["starter-log","layout-text"] }
 colored = "3.0"
+fastrace = "0.7.16"
 
 # Dev dependencies
 criterion = "0.8"

--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -3,6 +3,10 @@ name = "pegaflow-core"
 version.workspace = true
 edition.workspace = true
 
+[features]
+default = []
+tracing = ["fastrace"]
+
 [dependencies]
 cudarc.workspace = true
 log.workspace = true
@@ -21,6 +25,7 @@ ahash.workspace = true
 io-uring = "0.7"
 futures = "0.3"
 parking_lot = "0.12"
+fastrace = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -690,6 +690,7 @@ impl PegaEngine {
     /// - `Done { hit, missing: 0 }`: all blocks in memory cache
     /// - `Loading { hit, loading }`: some blocks being fetched from SSD
     /// - `Done { hit, missing }`: some blocks don't exist
+    #[cfg_attr(feature = "tracing", fastrace::trace)]
     pub fn count_prefix_hit_blocks_with_prefetch(
         &self,
         instance_id: &str,

--- a/pegaflow-server/Cargo.toml
+++ b/pegaflow-server/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 default-run = "pegaflow-server"
 
+[features]
+default = []
+tracing = ["fastrace", "pegaflow-core/tracing"]
+
 [lib]
 name = "pegaflow_server"
 path = "src/lib.rs"
@@ -38,6 +42,7 @@ opentelemetry-prometheus.workspace = true
 prometheus.workspace = true
 tikv-jemallocator.workspace = true
 colored.workspace = true
+fastrace = { workspace = true, features = ["enable"], optional = true }
 
 [build-dependencies]
 pyo3-build-config.workspace = true

--- a/pegaflow-server/src/trace.rs
+++ b/pegaflow-server/src/trace.rs
@@ -1,0 +1,40 @@
+use fastrace::collector::{Config, Reporter, SpanRecord};
+
+pub fn init() {
+    // Full collection by default; reporting interval controls batching cadence.
+    fastrace::set_reporter(LogReporter::default(), Config::default());
+}
+
+pub fn flush() {
+    fastrace::flush();
+}
+
+#[derive(Default)]
+struct LogReporter;
+
+impl Reporter for LogReporter {
+    fn report(&mut self, spans: Vec<SpanRecord>) {
+        for span in spans {
+            let duration_us = span.duration_ns / 1_000;
+            log::info!(
+                target: "pegaflow_trace",
+                "trace span name={} dur_us={} trace_id={} span_id={} parent_id={} props={} events={}",
+                span.name,
+                duration_us,
+                span.trace_id,
+                span.span_id,
+                span.parent_id,
+                span.properties.len(),
+                span.events.len(),
+            );
+
+            if !span.properties.is_empty() {
+                log::info!(target: "pegaflow_trace", "trace span props: {:?}", span.properties);
+            }
+
+            if !span.events.is_empty() {
+                log::info!(target: "pegaflow_trace", "trace span events: {:?}", span.events);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What
- add optional fastrace tracing for query RPC
- feature-gated via `tracing` (default off)
- log reporter emits compact span summaries to `pegaflow_trace`

## Why
- prepare trace instrumentation for future observability
- keep default behavior unchanged (feature off)

## How to enable
`cargo run -r -p pegaflow-server --features tracing`

## Example logs
```
2026-02-04T14:09:03.397118+08:00   INFO pegaflow_trace: trace.rs:19 trace span name=rpc.query dur_us=141 trace_id=ffa5e87538baa6256c244c3c1ea89c6b span_id=c18aaf5000000027 parent_id=0000000000000000 props=2 events=0
2026-02-04T14:09:03.397176+08:00   INFO pegaflow_trace: trace.rs:32 trace span props: [("instance_id", "60065866-b87a-4b65-9a0f-927f3d7aee96"), ("block_hashes", "32")]
2026-02-04T14:09:03.397191+08:00   INFO pegaflow_trace: trace.rs:19 trace span name=pegaflow_core::PegaEngine::count_prefix_hit_blocks_with_prefetch dur_us=136 trace_id=ffa5e87538baa6256c244c3c1ea89c6b span_id=c18aaf5000000028 parent_id=c18aaf5000000027 props=0 events=0
```