### PR TITLE
fix(connector): use actual layer count for DSA models

### DIFF
--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -98,6 +98,10 @@ class WorkerConnector:
         for layer_id, layer_name in enumerate(kv_caches.keys()):
             self._layer_name_to_id[layer_name] = layer_id
 
+        # Use actual number of registered layers, not model's num_hidden_layers
+        # This is important for models like DSA where indexer layers are separate
+        actual_num_layers = len(kv_caches)
+
         layout = "unknown"
         for layer_name, kv_cache in kv_caches.items():
             assert kv_cache.storage_offset() == 0, (
@@ -127,10 +131,6 @@ class WorkerConnector:
             assert bytes_per_block != 0, (
                 f"Invalid bytes_per_block for {layer_name}: stride={stride}"
             )
-
-            # Use actual number of registered layers, not model's num_hidden_layers
-            # This is important for models like DSA where indexer layers are separate
-            actual_num_layers = len(kv_caches)
 
             ok, message = self._ctx.engine_client.register_context(
                 self._ctx.instance_id,
@@ -491,7 +491,7 @@ class WorkerConnector:
             return
 
         suffix = "" if not reason else f" ({reason})"
-        layer_count = len(self._registered_layers) or self._ctx.num_layers
+        layer_count = len(self._registered_layers)
         for req_id in req_list:
             logger.debug(
                 "[PegaKVConnector] Request %s all %d layers saved%s",


### PR DESCRIPTION
## Summary
- Use `len(kv_caches)` instead of `num_hidden_layers` for registration
- Fixes `total_slots` calculation for DSA models (e.g., DeepSeek-V3.2)

## Problem
DSA models have separate indexer K cache layers in addition to main MLA layers:
- `num_hidden_layers` = 78 (from HF config)
- Actual registered layers = 156 (78 main + 78 indexer)

Using wrong `num_layers` caused blocks to never seal (not all slots filled).

need use with https://github.com/vllm-project/vllm/pull/35399
## Test plan
- [x] Tested with DeepSeek-V3.2 DSA model
- [x] Verified blocks are correctly sealed with all 156 layers
- [x] Confirmed cache hits on repeated requests