### PR TITLE
fix(python): restore gRPC client message size limits

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -277,7 +277,11 @@ impl EngineRpcClient {
         let channel = rt
             .block_on(endpoint_cfg.connect())
             .map_err(|err| transport_connect_error(&endpoint, err))?;
-        let client = EngineClient::new(channel);
+        // Match server's 64 MiB limit to avoid Status::resource_exhausted on large payloads
+        const MAX_GRPC_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+        let client = EngineClient::new(channel)
+            .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE);
         let rt_handle = rt.handle().clone();
 
         Ok(Self {


### PR DESCRIPTION
## Summary

- Reinstate `max_decoding_message_size` and `max_encoding_message_size` (64 MiB) on `EngineClient` that were accidentally removed in #106
- Without these limits, Tonic defaults to 4 MiB, causing `Status::resource_exhausted` errors on large `BatchSave`/`RegisterContext` payloads

## Changes

```rust
// Match server's 64 MiB limit to avoid Status::resource_exhausted on large payloads
const MAX_GRPC_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
let client = EngineClient::new(channel)
    .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
    .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE);
```

## Test plan

- [x] `cargo fmt --check` passes
- [x] Change matches server configuration in `pegaflow-server/src/lib.rs:532-536`

Closes #110