### PR TITLE
feat(core): support SSD alignment padding for unaligned block sizes

### DIFF
--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -277,7 +277,8 @@ fn process_load_task(task: &LoadTask, stream: &CudaStream) -> Result<(), EngineE
 
         if registration.segments == 2 && registration.kv_stride_bytes > registration.bytes_per_block
         {
-            // Layer-first layout with KV stride: batch K and V separately
+            // Layer-first layout with KV stride: batch K and V separately.
+            // Actual (unpadded) GPU segment size — matches GPU memory layout.
             let segment_size = registration.bytes_per_block;
 
             let mut k_transfers = Vec::with_capacity(layer_data.blocks.len());
@@ -327,7 +328,8 @@ fn process_load_task(task: &LoadTask, stream: &CudaStream) -> Result<(), EngineE
 
             total_bytes += layer_data.blocks.len() * segment_size * 2;
         } else {
-            // Contiguous or single-segment layout - use batch copy for better performance
+            // Contiguous or single-segment layout.
+            // Actual (unpadded) block size — matches GPU memory layout.
             let block_size = registration.block_size_bytes;
             let mut transfers = Vec::with_capacity(layer_data.blocks.len());
 
@@ -406,7 +408,9 @@ fn process_save_task(task: &SaveTask, stream: &CudaStream) -> Result<(), EngineE
         let (layer_bytes, layer_memcpy) = if registration.segments == 2
             && registration.kv_stride_bytes > registration.bytes_per_block
         {
-            // Layer-first layout: K and V segments stored separately
+            // Layer-first layout: K and V segments stored separately.
+            // Actual (unpadded) GPU segment size — pinned memory may use a
+            // larger padded stride, but CUDA copies only the real data.
             let segment_size = registration.bytes_per_block;
 
             // Build transfer lists for batch copy
@@ -446,7 +450,8 @@ fn process_save_task(task: &SaveTask, stream: &CudaStream) -> Result<(), EngineE
 
             (layer.blocks.len() * segment_size * 2, k_batches + v_batches)
         } else {
-            // Contiguous or single-segment layout - build transfer list for batch copy
+            // Contiguous or single-segment layout.
+            // Actual (unpadded) block size — matches GPU memory layout.
             let block_size = registration.block_size_bytes;
             let mut transfers = Vec::with_capacity(layer.blocks.len());
 

--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -27,16 +27,6 @@ struct LayerMetadata {
     gpu_contexts: HashMap<i32, Arc<GpuContext>>,
 }
 
-/// Compute greatest common divisor using Euclidean algorithm.
-fn gcd(mut a: usize, mut b: usize) -> usize {
-    while b != 0 {
-        let t = b;
-        b = a % b;
-        a = t;
-    }
-    a
-}
-
 /// Registration information for a KV cache layer.
 ///
 /// This struct captures the memory layout of a layer's KV cache,
@@ -52,10 +42,11 @@ pub struct KVCacheRegistration {
     /// Number of blocks in this layer's cache.
     pub num_blocks: usize,
 
-    /// Size of each block's segment in bytes (for one of K or V).
+    /// Actual GPU-side segment size in bytes (one of K or V).
+    /// Used for CUDA memcpy sizes and GPU offset calculations.
     pub bytes_per_block: usize,
 
-    /// Total block size including all segments (`bytes_per_block * segments`).
+    /// Actual GPU-side total block size (`bytes_per_block * segments`).
     pub block_size_bytes: usize,
 
     /// Stride in bytes between K and V segments for split storage layouts.
@@ -64,6 +55,15 @@ pub struct KVCacheRegistration {
 
     /// Number of segments per block (1 for contiguous, 2 for K/V split).
     pub segments: usize,
+
+    /// CPU/SSD-side segment size, rounded up to SSD alignment.
+    /// Controls pinned memory allocation stride and SSD iovec lengths.
+    /// Equals `bytes_per_block` when no SSD padding is needed.
+    pub padded_bytes_per_block: usize,
+
+    /// CPU/SSD-side total block size (`padded_bytes_per_block * segments`).
+    /// Becomes `LayerBlock.size` → `SlotMeta.size` for SSD I/O.
+    pub padded_block_size_bytes: usize,
 }
 
 impl KVCacheRegistration {
@@ -123,23 +123,20 @@ impl KVCacheRegistration {
             block_size_bytes,
             kv_stride_bytes,
             segments,
+            padded_bytes_per_block: bytes_per_block,
+            padded_block_size_bytes: block_size_bytes,
         })
     }
 
-    /// Check SSD alignment requirement.
+    /// Apply SSD alignment padding to segment sizes.
     ///
-    /// Returns `None` if aligned, or `Some(error_message)` with fix hint.
-    pub fn check_ssd_alignment(&self, alignment: usize) -> Option<String> {
-        if self.bytes_per_block.is_multiple_of(alignment) {
-            return None;
-        }
-
-        let factor = alignment / gcd(self.bytes_per_block, alignment);
-        Some(format!(
-            "SSD cache requires bytes_per_block to be aligned to {} bytes, but got {}. \
-             Hint: multiply block_size by {} to achieve alignment.",
-            alignment, self.bytes_per_block, factor
-        ))
+    /// Each segment (`bytes_per_block`) is rounded up to the next multiple of
+    /// `alignment` so that every iovec in split writev is independently aligned.
+    pub fn with_ssd_padding(mut self, alignment: usize) -> Self {
+        let padded = self.bytes_per_block.next_multiple_of(alignment);
+        self.padded_bytes_per_block = padded;
+        self.padded_block_size_bytes = padded * self.segments;
+        self
     }
 }
 
@@ -524,10 +521,27 @@ mod tests {
     }
 
     #[test]
-    fn ssd_alignment_check() {
-        let reg = KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 128, 0, 1).unwrap();
-        assert!(reg.check_ssd_alignment(512).unwrap().contains("4"));
-        assert!(reg.check_ssd_alignment(128).is_none());
+    fn padded_block_size() {
+        // Unaligned: 8848 % 512 = 144, padded to 9216
+        let reg = KVCacheRegistration::new(0x1000, 10_000_000, 100, 8848, 0, 1)
+            .unwrap()
+            .with_ssd_padding(512);
+        assert_eq!(reg.padded_bytes_per_block, 9216);
+        assert_eq!(reg.padded_block_size_bytes, 9216);
+
+        // Already aligned: no change
+        let reg = KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1)
+            .unwrap()
+            .with_ssd_padding(512);
+        assert_eq!(reg.padded_bytes_per_block, 1024);
+        assert_eq!(reg.padded_block_size_bytes, 1024);
+
+        // Split layout: padded per segment, total = padded * segments
+        let reg = KVCacheRegistration::new(0x1000, 10_000_000, 100, 8848, 900_000, 2)
+            .unwrap()
+            .with_ssd_padding(512);
+        assert_eq!(reg.padded_bytes_per_block, 9216);
+        assert_eq!(reg.padded_block_size_bytes, 9216 * 2);
     }
 
     /// Simulates the inference-side registration flow (single GPU).

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -304,7 +304,7 @@ impl PegaEngine {
         }
 
         // Construct and validate registration
-        let registration = KVCacheRegistration::new(
+        let mut registration = KVCacheRegistration::new(
             data_ptr,
             size_bytes,
             num_blocks,
@@ -314,13 +314,15 @@ impl PegaEngine {
         )
         .map_err(|e| EngineError::InvalidArgument(format!("layer {layer_name}: {e}")))?;
 
-        // SSD alignment check
-        if self.storage.is_ssd_enabled()
-            && let Some(msg) = registration.check_ssd_alignment(SSD_ALIGNMENT)
-        {
-            return Err(EngineError::InvalidArgument(format!(
-                "layer {layer_name}: {msg}"
-            )));
+        // Apply SSD alignment padding when SSD cache is enabled
+        if self.storage.is_ssd_enabled() {
+            registration = registration.with_ssd_padding(SSD_ALIGNMENT);
+            if registration.padded_bytes_per_block != registration.bytes_per_block {
+                info!(
+                    "SSD alignment padding: layer={layer_name}, bytes_per_block={} -> padded={}",
+                    registration.bytes_per_block, registration.padded_bytes_per_block
+                );
+            }
         }
 
         // Get or create instance, then register new layer on GPU

--- a/pegaflow-core/src/offload.rs
+++ b/pegaflow-core/src/offload.rs
@@ -28,13 +28,17 @@ use crate::{EngineError, PegaEngine};
 // ============================================================================
 
 /// How a layer's blocks are laid out in pinned memory after GPU copy.
+///
+/// Sizes here are *padded* (SSD-aligned). GPU copies use actual (unpadded)
+/// sizes from `KVCacheRegistration`; the padding tail is unused.
 pub(crate) enum LayerAlloc {
     Split {
         k_allocation: Arc<PinnedAllocation>,
         v_allocation: Arc<PinnedAllocation>,
         k_base: usize,
         v_base: usize,
-        segment_size: usize,
+        /// Per-segment stride in pinned memory (padded for SSD alignment).
+        padded_segment_size: usize,
     },
     Contiguous {
         allocation: Arc<PinnedAllocation>,
@@ -51,10 +55,10 @@ impl LayerAlloc {
                 v_allocation,
                 k_base,
                 v_base,
-                segment_size,
+                padded_segment_size,
             } => {
-                let k_ptr = (k_base + index * segment_size) as *mut u8;
-                let v_ptr = (v_base + index * segment_size) as *mut u8;
+                let k_ptr = (k_base + index * padded_segment_size) as *mut u8;
+                let v_ptr = (v_base + index * padded_segment_size) as *mut u8;
                 Arc::new(LayerBlock::new_split(
                     k_ptr,
                     v_ptr,
@@ -81,7 +85,8 @@ impl LayerAlloc {
 /// Per-layer data for deferred LayerBlock construction.
 pub(crate) struct RawSaveLayer {
     pub slot_id: usize,
-    pub block_size: usize,
+    /// Padded block size (SSD-aligned). Becomes `LayerBlock.size` → `SlotMeta.size`.
+    pub padded_block_size: usize,
     pub alloc: LayerAlloc,
     /// Block hashes in allocation order.
     pub block_hashes: Vec<Vec<u8>>,
@@ -108,7 +113,7 @@ pub(crate) fn build_insert_entries(batch: &RawSaveBatch) -> (InsertEntries, u64,
 
     for layer in &batch.layers {
         for (i, hash) in layer.block_hashes.iter().enumerate() {
-            let block = layer.alloc.make_layer_block(i, layer.block_size);
+            let block = layer.alloc.make_layer_block(i, layer.padded_block_size);
             hash_entries
                 .entry(hash.clone())
                 .or_default()
@@ -116,7 +121,7 @@ pub(crate) fn build_insert_entries(batch: &RawSaveBatch) -> (InsertEntries, u64,
         }
         let layer_blocks = layer.block_hashes.len();
         total_blocks += layer_blocks;
-        total_bytes += (layer.block_size as u64).saturating_mul(layer_blocks as u64);
+        total_bytes += (layer.padded_block_size as u64).saturating_mul(layer_blocks as u64);
     }
 
     let entries: InsertEntries = hash_entries
@@ -156,7 +161,8 @@ impl PegaEngine {
         struct LayerMeta {
             registration: KVCacheRegistration,
             slot_id: usize,
-            block_size: usize,
+            /// Padded total block size (SSD-aligned), used for pinned allocation.
+            padded_block_size: usize,
             valid_blocks: Vec<(usize, Vec<u8>)>,
         }
 
@@ -215,11 +221,11 @@ impl PegaEngine {
                 continue;
             }
 
-            let block_size = registration.block_size_bytes;
+            let padded_block_size = registration.padded_block_size_bytes;
             layer_metas.push(LayerMeta {
                 registration,
                 slot_id,
-                block_size,
+                padded_block_size,
                 valid_blocks,
             });
         }
@@ -319,8 +325,8 @@ impl PegaEngine {
                 && registration.kv_stride_bytes > registration.bytes_per_block;
 
             if is_split {
-                let segment_size = registration.bytes_per_block;
-                let alloc_size = (segment_size as u64)
+                let padded_segment_size = registration.padded_bytes_per_block;
+                let alloc_size = (padded_segment_size as u64)
                     .checked_mul(num_blocks as u64)
                     .and_then(NonZeroU64::new)
                     .ok_or_else(|| {
@@ -359,8 +365,8 @@ impl PegaEngine {
                     .enumerate()
                     .map(|(i, (block_idx, _))| SaveBlock {
                         block_idx: *block_idx,
-                        k_dst_ptr: (k_base + i * segment_size) as *mut u8,
-                        v_dst_ptr: Some((v_base + i * segment_size) as *mut u8),
+                        k_dst_ptr: (k_base + i * padded_segment_size) as *mut u8,
+                        v_dst_ptr: Some((v_base + i * padded_segment_size) as *mut u8),
                     })
                     .collect();
 
@@ -373,11 +379,11 @@ impl PegaEngine {
                     v_allocation,
                     k_base,
                     v_base,
-                    segment_size,
+                    padded_segment_size,
                 });
             } else {
-                let block_size = meta.block_size;
-                let alloc_size = (block_size as u64)
+                let padded_block_size = meta.padded_block_size;
+                let alloc_size = (padded_block_size as u64)
                     .checked_mul(num_blocks as u64)
                     .and_then(NonZeroU64::new)
                     .ok_or_else(|| EngineError::Storage("allocation size overflow".to_string()))?;
@@ -404,7 +410,7 @@ impl PegaEngine {
                     .enumerate()
                     .map(|(i, (block_idx, _))| SaveBlock {
                         block_idx: *block_idx,
-                        k_dst_ptr: (base_addr + i * block_size) as *mut u8,
+                        k_dst_ptr: (base_addr + i * padded_block_size) as *mut u8,
                         v_dst_ptr: None,
                     })
                     .collect();
@@ -437,7 +443,7 @@ impl PegaEngine {
         for prep in &layers_to_save {
             let meta = &layer_metas[prep.meta_idx];
             let num_blocks = prep.blocks_to_save.len();
-            let bytes = (meta.block_size as u64)
+            let bytes = (meta.padded_block_size as u64)
                 .checked_mul(num_blocks as u64)
                 .unwrap_or(0);
             total_bytes += bytes;
@@ -474,7 +480,7 @@ impl PegaEngine {
                     .collect();
                 RawSaveLayer {
                     slot_id: meta.slot_id,
-                    block_size: meta.block_size,
+                    padded_block_size: meta.padded_block_size,
                     alloc,
                     block_hashes,
                 }


### PR DESCRIPTION
## Question
[2026-02-28 07:07:17] INFO worker.py:107: [PegaKVConnector] model.layers.0.self_attn.indexer.k_cache: shape=torch.Size([10895, 64, 132]), stride=(8448, 132, 1), element_size=1, bytes_per_block=132, storage_offset=0

## Summary
- Models whose `bytes_per_block` is not a multiple of the SSD sector size (512) were previously rejected at registration time. This PR replaces the hard error with automatic padding.
- `KVCacheRegistration` gains `padded_bytes_per_block` / `padded_block_size_bytes` fields. CPU pinned memory allocation and SSD iovecs use the padded stride; GPU CUDA copies continue using actual (unpadded) sizes — no extra data is transferred.
- Example: Qwen3-4B with block_size=16 → `bytes_per_block=8848`, padded to `9216` (next multiple of 512).

## Test plan
- [x] Unit test `padded_block_size` covers unaligned, aligned, and split-layout cases
- [ ] End-to-end benchmark with a model that was previously rejected (e.g. Qwen3-4B block_size=16) with SSD cache enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)