### PR TITLE
feat(connector): support multi-PegaServer for cross-node TP

### DIFF
--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -38,33 +38,62 @@ class PegaKVConnector(KVConnectorBase_V1):
         super().__init__(vllm_config, role)
 
         instance_id = resolve_instance_id(vllm_config)
-        tp_size = vllm_config.parallel_config.tensor_parallel_size
-        world_size = vllm_config.parallel_config.world_size
+        global_tp_size = vllm_config.parallel_config.tensor_parallel_size
+        global_world_size = vllm_config.parallel_config.world_size
         is_mla = detect_mla(vllm_config)
-        effective_tp_size = 1 if is_mla else tp_size
+        # Namespace uses global tp_size for consistent hashing across all ranks
+        effective_tp_size = 1 if is_mla else global_tp_size
         namespace = derive_namespace(vllm_config, effective_tp_size)
         num_layers = getattr(vllm_config.model_config.hf_text_config, "num_hidden_layers", 0)
         block_size = vllm_config.cache_config.block_size
 
+        # Resolve server endpoints (supports multi-server for cross-node TP)
+        endpoints = _resolve_endpoints(vllm_config)
+        num_servers = len(endpoints)
+
+        if num_servers > 1:
+            assert global_tp_size % num_servers == 0, (
+                f"tensor_parallel_size ({global_tp_size}) must be divisible by "
+                f"number of servers ({num_servers})"
+            )
+            assert global_world_size % num_servers == 0, (
+                f"world_size ({global_world_size}) must be divisible by "
+                f"number of servers ({num_servers})"
+            )
+
+        # Each server manages a local subset of ranks
+        local_tp_size = global_tp_size // num_servers
+        local_world_size = global_world_size // num_servers
+
         tp_rank: int | None = None
         device_id: int | None = None
+        engine_clients: tuple[EngineRpcClient, ...] = ()
+
         if role == KVConnectorRole.WORKER:
-            tp_rank = get_tensor_model_parallel_rank()
+            global_tp_rank = get_tensor_model_parallel_rank()
+            server_index = global_tp_rank // local_tp_size
+            tp_rank = global_tp_rank % local_tp_size
             if torch.cuda.is_available():
                 device_id = _resolve_device_id()
-
-        assert vllm_config.kv_transfer_config is not None
-        server_host = os.environ.get(
-            "PEGAFLOW_HOST"
-        ) or vllm_config.kv_transfer_config.get_from_extra_config(
-            "pegaflow.host", "http://127.0.0.1"
-        )
-        server_port = os.environ.get(
-            "PEGAFLOW_PORT"
-        ) or vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.port", 50055)
-        self._engine_endpoint = f"{server_host}:{server_port}"
-        engine_client = EngineRpcClient(self._engine_endpoint)
-        logger.info("[PegaKVConnector] Connected to engine server at %s", self._engine_endpoint)
+            engine_client = EngineRpcClient(endpoints[server_index])
+            logger.info(
+                "[PegaKVConnector] Worker connected to server %d/%d at %s "
+                "(global_rank=%d, local_rank=%d)",
+                server_index,
+                num_servers,
+                endpoints[server_index],
+                global_tp_rank,
+                tp_rank,
+            )
+        else:
+            # Scheduler connects to all servers for coordinated queries
+            engine_clients = tuple(EngineRpcClient(ep) for ep in endpoints)
+            engine_client = engine_clients[0]
+            logger.info(
+                "[PegaKVConnector] Scheduler connected to %d server(s): %s",
+                num_servers,
+                endpoints,
+            )
 
         self._state_manager = ServiceStateManager(engine_client)
 
@@ -73,13 +102,14 @@ class PegaKVConnector(KVConnectorBase_V1):
             namespace=namespace,
             block_size=block_size,
             num_layers=num_layers,
-            tp_size=tp_size,
-            world_size=world_size,
+            tp_size=local_tp_size,
+            world_size=local_world_size,
             tp_rank=tp_rank,
             device_id=device_id,
             engine_client=engine_client,
             state_manager=self._state_manager,
             is_mla=is_mla,
+            engine_clients=engine_clients,
         )
 
         self._scheduler: SchedulerConnector | None = None
@@ -90,16 +120,19 @@ class PegaKVConnector(KVConnectorBase_V1):
             self._worker = WorkerConnector(self._ctx)
 
         logger.info(
-            "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s tp_rank=%s tp_size=%d world_size=%d layers=%d namespace=%s is_mla=%s",
+            "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
+            "tp_rank=%s tp_size=%d world_size=%d layers=%d namespace=%s "
+            "is_mla=%s num_servers=%d",
             role.name,
             instance_id,
             device_id if device_id is not None else "cpu",
             tp_rank if tp_rank is not None else "N/A",
-            tp_size,
-            world_size,
+            local_tp_size,
+            local_world_size,
             num_layers,
             namespace,
             is_mla,
+            num_servers,
         )
 
     # ==============================
@@ -248,6 +281,49 @@ class PegaKVConnector(KVConnectorBase_V1):
             self._worker.shutdown()
         if self._state_manager:
             self._state_manager.shutdown()
+
+
+def _resolve_endpoints(vllm_config) -> list[str]:
+    """Resolve PegaFlow server endpoints.
+
+    Priority:
+        1. PEGAFLOW_ENDPOINTS env var (comma-separated)
+        2. pegaflow.endpoints in kv_transfer_config.extra_config
+        3. PEGAFLOW_HOST + PEGAFLOW_PORT (single server, backward compatible)
+    """
+    assert vllm_config.kv_transfer_config is not None
+
+    # 1. PEGAFLOW_ENDPOINTS env var
+    endpoints_env = os.environ.get("PEGAFLOW_ENDPOINTS")
+    if endpoints_env:
+        endpoints = [ep.strip() for ep in endpoints_env.split(",") if ep.strip()]
+        if endpoints:
+            return endpoints
+        logger.warning(
+            "[PegaKVConnector] PEGAFLOW_ENDPOINTS is set but contains no valid "
+            "endpoints: %r, falling back to host+port",
+            endpoints_env,
+        )
+
+    # 2. pegaflow.endpoints extra_config
+    endpoints_config = vllm_config.kv_transfer_config.get_from_extra_config(
+        "pegaflow.endpoints", None
+    )
+    if endpoints_config and isinstance(endpoints_config, list):
+        endpoints = [str(ep).strip() for ep in endpoints_config if str(ep).strip()]
+        if endpoints:
+            return endpoints
+
+    # 3. Fallback: single endpoint from host + port
+    server_host = os.environ.get(
+        "PEGAFLOW_HOST"
+    ) or vllm_config.kv_transfer_config.get_from_extra_config(
+        "pegaflow.host", "http://127.0.0.1"
+    )
+    server_port = os.environ.get(
+        "PEGAFLOW_PORT"
+    ) or vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.port", 50055)
+    return [f"{server_host}:{server_port}"]
 
 
 def _resolve_device_id() -> int:

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -35,6 +35,7 @@ class ConnectorContext:
     engine_client: EngineRpcClient
     state_manager: "ServiceStateManager"
     is_mla: bool = False
+    engine_clients: tuple[EngineRpcClient, ...] = ()
 
     @property
     def effective_tp_rank(self) -> int:

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -333,19 +333,27 @@ class SchedulerConnector:
             - If service unavailable, returns 0 (no cache hits)
             - Any exception marks service unavailable and returns 0
         """
-        # Check service availability first
         if not self._ctx.state_manager.is_available():
             return 0
 
         block_hash_list = list(block_hashes)
+        clients = self._ctx.engine_clients or (self._ctx.engine_client,)
+
+        if len(clients) == 1:
+            return self._query_single_server(clients[0], block_hash_list, req_id)
+
+        return self._query_multi_server(clients, block_hash_list, req_id)
+
+    def _query_single_server(
+        self, client, block_hash_list: list[bytes], req_id: str
+    ) -> int | None:
+        """Single-server query path (original logic)."""
         try:
-            result = self._ctx.engine_client.query_prefetch(self._ctx.instance_id, block_hash_list)
+            result = client.query_prefetch(self._ctx.instance_id, block_hash_list)
         except PegaFlowServiceError as e:
-            # Service error (network/internal) - mark unavailable
             self._ctx.state_manager.mark_unavailable(str(e))
             return 0
         except PegaFlowBusinessError as e:
-            # Business error (invalid args, etc.) - log details and propagate
             logger.error(
                 "[PegaKVConnector] Query business error: %s, "
                 "req_id=%s, instance_id=%s, num_blocks=%d",
@@ -356,10 +364,8 @@ class SchedulerConnector:
             )
             raise
 
-        # Handle new dict response format
         if isinstance(result, dict):
             if not result.get("ok", False):
-                # Response-level errors are treated as business errors
                 error_msg = result.get("message", "unknown error")
                 logger.error(
                     "[PegaKVConnector] Query failed: %s, req_id=%s, instance_id=%s, num_blocks=%d",
@@ -374,7 +380,6 @@ class SchedulerConnector:
             hit_blocks = result.get("hit_blocks", 0)
 
             if prefetch_state == "loading":
-                # Record first time we see loading state
                 if req_id not in self._prefetch_start_times:
                     self._prefetch_start_times[req_id] = time.perf_counter()
                     self._prefetch_tracker.on_prefetch_start()
@@ -383,15 +388,13 @@ class SchedulerConnector:
                         req_id,
                         self._prefetch_tracker.pending_prefetches,
                     )
-                return None  # Signal scheduler to retry later
+                return None
 
-            # Prefetch done - log duration if we were tracking
             if req_id in self._prefetch_start_times:
                 prefetch_duration_ms = (
                     time.perf_counter() - self._prefetch_start_times.pop(req_id)
                 ) * 1000
                 self._prefetch_tracker.on_prefetch_complete(prefetch_duration_ms, hit_blocks)
-
                 logger.info(
                     "[PegaKVConnector] Prefetch completed: req=%s hit_blocks=%d "
                     "prefetch_duration_ms=%.2f pending_prefetches=%d",
@@ -403,9 +406,125 @@ class SchedulerConnector:
 
             return hit_blocks
 
-        # Legacy tuple response format (ok, message, hit_blocks)
+        # Legacy tuple response format
         _, _, hit_blocks = result
         return hit_blocks
+
+    def _unpin_done_results(
+        self,
+        done_results: list[tuple[object, int]],
+        block_hash_list: list[bytes],
+    ) -> None:
+        """Unpin blocks on servers that already returned done results."""
+        for client, hit_count in done_results:
+            if hit_count > 0:
+                try:
+                    client.unpin(self._ctx.instance_id, block_hash_list[:hit_count])
+                except Exception:
+                    pass
+
+    def _query_multi_server(
+        self, clients: tuple, block_hash_list: list[bytes], req_id: str
+    ) -> int | None:
+        """Multi-server query: query all servers, take min hits, unpin excess.
+
+        Semantics:
+            - Any server loading → unpin already-done servers, return None (retry)
+            - Any server error → unpin done servers, mark unavailable, return 0
+            - All done → take min(hit_blocks), unpin excess on servers with more hits
+
+        Note: ServiceStateManager only health-checks engine_clients[0]. In
+        multi-server topology a single server failure disables all queries
+        until that server recovers. Acceptable for v1 — both servers are
+        expected to be up for cross-node TP to function.
+        """
+        done_results: list[tuple[object, int]] = []  # (client, hit_blocks)
+        any_loading = False
+
+        for client in clients:
+            try:
+                result = client.query_prefetch(self._ctx.instance_id, block_hash_list)
+            except PegaFlowServiceError as e:
+                self._ctx.state_manager.mark_unavailable(str(e))
+                self._unpin_done_results(done_results, block_hash_list)
+                return 0
+            except PegaFlowBusinessError as e:
+                self._unpin_done_results(done_results, block_hash_list)
+                logger.error(
+                    "[PegaKVConnector] Query business error: %s, "
+                    "req_id=%s, instance_id=%s, num_blocks=%d",
+                    e,
+                    req_id,
+                    self._ctx.instance_id,
+                    len(block_hash_list),
+                )
+                raise
+
+            if not isinstance(result, dict) or not result.get("ok", False):
+                self._unpin_done_results(done_results, block_hash_list)
+                error_msg = (
+                    result.get("message", "unknown error")
+                    if isinstance(result, dict)
+                    else str(result)
+                )
+                raise RuntimeError(f"Query failed: {error_msg}")
+
+            prefetch_state = result.get("prefetch_state", "done")
+            hit_blocks = result.get("hit_blocks", 0)
+
+            if prefetch_state == "loading":
+                any_loading = True
+                # Loading state does not pin, nothing to track for this server
+            else:
+                done_results.append((client, hit_blocks))
+
+        if any_loading:
+            # Track prefetch timing
+            if req_id not in self._prefetch_start_times:
+                self._prefetch_start_times[req_id] = time.perf_counter()
+                self._prefetch_tracker.on_prefetch_start()
+                logger.info(
+                    "[PegaKVConnector] Prefetch started (multi-server): "
+                    "req=%s pending_prefetches=%d",
+                    req_id,
+                    self._prefetch_tracker.pending_prefetches,
+                )
+            # Unpin servers that returned done (they pinned their blocks)
+            self._unpin_done_results(done_results, block_hash_list)
+            return None
+
+        # All servers returned done — compute min hits
+        if not done_results:
+            return 0
+
+        hit_counts = [hit for _, hit in done_results]
+        min_hits = min(hit_counts)
+
+        # Track prefetch completion
+        if req_id in self._prefetch_start_times:
+            prefetch_duration_ms = (
+                time.perf_counter() - self._prefetch_start_times.pop(req_id)
+            ) * 1000
+            self._prefetch_tracker.on_prefetch_complete(prefetch_duration_ms, min_hits)
+            logger.info(
+                "[PegaKVConnector] Prefetch completed (multi-server): req=%s "
+                "hit_blocks=%d prefetch_duration_ms=%.2f pending_prefetches=%d",
+                req_id,
+                min_hits,
+                prefetch_duration_ms,
+                self._prefetch_tracker.pending_prefetches,
+            )
+
+        # Unpin excess blocks on servers with more hits than the minimum
+        for client, hit_count in done_results:
+            if hit_count > min_hits:
+                excess_hashes = block_hash_list[min_hits:hit_count]
+                try:
+                    client.unpin(self._ctx.instance_id, excess_hashes)
+                except Exception:
+                    pass  # Unpin failure is non-critical; GC handles pin leaks
+
+        return min_hits
 
     def get_stats(self) -> PegaKVConnectorStats | None:
         """Get current connector stats for metrics exposure."""


### PR DESCRIPTION
## Summary

- Support vLLM TP16 across 2 nodes where each node runs its own PegaServer (each managing 8 GPUs)
- Add `PEGAFLOW_ENDPOINTS` env var / `pegaflow.endpoints` extra_config for multi-server endpoint resolution
- Connector maps global ranks to local (server-scoped) `tp_rank`/`tp_size`/`world_size` — each PegaServer sees itself as TP8 transparently
- Scheduler queries all servers, takes `min(hit_blocks)`, unpins excess blocks on over-hitting servers
- Single-server (`num_servers=1`) behavior is fully backward compatible, zero overhead

## Changed files

| File | Change |
|------|--------|
| `python/pegaflow/connector/common.py` | Add `engine_clients` field to `ConnectorContext` |
| `python/pegaflow/connector/__init__.py` | Multi-endpoint resolution + local rank mapping |
| `python/pegaflow/connector/scheduler.py` | Multi-server query with min-reduce + unpin excess |

## Design

- **No Rust changes, no vLLM changes** — purely Python connector layer
- Namespace uses global `tp_size` for consistent hashing across all ranks
- Worker auto-connects to its local server: `server_index = global_rank // local_tp_size`
- Scheduler coordinates queries across all servers with proper pin cleanup in all error paths

## Test plan

- [ ] Single-server config: verify identical behavior (regression)
- [ ] TP16 / 2-server: verify correct rank mapping (rank 0-7 → server 0, rank 8-15 → server 1)
- [ ] Multi-server cache hit alignment: verify min-reduce and excess unpin
- [ ] Error paths: verify no pin leaks on service error / business error / loading state

🤖 Generated with [Claude Code](https://claude.com/claude-code)