### PR TITLE
fix(core): fix inflight bytes overcount and move insert worker to std::thread

### DIFF
--- a/pegaflow-core/src/block.rs
+++ b/pegaflow-core/src/block.rs
@@ -204,7 +204,20 @@ impl SealedBlock {
 }
 
 // ============================================================================
-// Errors
+// SlotInsertResult
+// ============================================================================
+
+/// Result of inserting a slot into an inflight block.
+pub(crate) enum SlotInsertResult {
+    /// Slot was newly inserted.
+    Inserted {
+        completed: bool,
+        footprint_added: u64,
+    },
+    /// Slot already existed (no-op).
+    Duplicate,
+}
+
 // ============================================================================
 // Inflight Block (write path, mutable)
 // ============================================================================
@@ -254,14 +267,12 @@ impl InflightBlock {
     }
 
     /// Insert a slot idempotently. Duplicate inserts are no-ops.
-    ///
-    /// Returns `true` if all slots are now filled (ready to seal).
     pub fn insert_slot(
         &mut self,
         slot_id: usize,
         block: Arc<LayerBlock>,
         numa_node: NumaNode,
-    ) -> bool {
+    ) -> SlotInsertResult {
         debug_assert!(
             slot_id < self.total_slots,
             "slot_id {} must be < total_slots {}",
@@ -269,16 +280,23 @@ impl InflightBlock {
             self.total_slots
         );
 
-        if self.slots[slot_id].is_none() {
-            self.footprint += block.memory_footprint();
-            self.slots[slot_id] = Some(block);
-            self.slot_numas[slot_id] = numa_node;
-            self.remaining = self
-                .remaining
-                .checked_sub(1)
-                .expect("remaining should not underflow");
+        if self.slots[slot_id].is_some() {
+            return SlotInsertResult::Duplicate;
         }
-        self.remaining == 0
+
+        let footprint_added = block.memory_footprint();
+        self.footprint += footprint_added;
+        self.slots[slot_id] = Some(block);
+        self.slot_numas[slot_id] = numa_node;
+        self.remaining = self
+            .remaining
+            .checked_sub(1)
+            .expect("remaining should not underflow");
+
+        SlotInsertResult::Inserted {
+            completed: self.remaining == 0,
+            footprint_added,
+        }
     }
 
     /// Seal the block, converting to immutable SealedBlock.

--- a/pegaflow-core/src/storage.rs
+++ b/pegaflow-core/src/storage.rs
@@ -20,6 +20,7 @@ use log::{debug, error, info, warn};
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet, hash_map::Entry};
 use std::num::NonZeroU64;
+use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Weak};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
@@ -28,7 +29,7 @@ use pegaflow_proto::proto::engine::InsertBlockHashesRequest;
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient;
 use tonic::transport::Channel;
 
-use crate::block::{BlockKey, InflightBlock, PrefetchStatus, SealedBlock};
+use crate::block::{BlockKey, InflightBlock, PrefetchStatus, SealedBlock, SlotInsertResult};
 use crate::cache::{CacheInsertOutcome, TinyLfuCache};
 use crate::metrics::core_metrics;
 use crate::numa::NumaNode;
@@ -199,7 +200,7 @@ pub struct StorageEngine {
     inner: Mutex<StorageInner>,
 
     /// Channel to the insert worker thread (owns inflight HashMap)
-    insert_tx: UnboundedSender<InsertWorkerCommand>,
+    insert_tx: Sender<InsertWorkerCommand>,
 
     /// Channel to notify consumers when blocks are sealed (for SSD offload)
     seal_notify_tx: Option<UnboundedSender<SealNotification>>,
@@ -289,8 +290,8 @@ impl StorageEngine {
         // Create unbounded channel for seal notifications
         let (seal_notify_tx, seal_notify_rx) = mpsc::unbounded_channel();
 
-        // Create insert worker channel
-        let (insert_tx, insert_rx) = mpsc::unbounded_channel();
+        // Create insert worker channel (std::sync::mpsc — worker is a dedicated OS thread)
+        let (insert_tx, insert_rx) = std::sync::mpsc::channel();
 
         let engine = Arc::new(Self {
             allocator,
@@ -302,10 +303,13 @@ impl StorageEngine {
             metaserver_tx: Mutex::new(None),
         });
 
-        // Spawn insert worker task (owns inflight HashMap, receives batches)
+        // Spawn insert worker on a dedicated OS thread (CPU-bound work)
         {
             let weak_engine = Arc::downgrade(&engine);
-            tokio::spawn(insert_worker_loop(insert_rx, weak_engine));
+            std::thread::Builder::new()
+                .name("pegaflow-insert".into())
+                .spawn(move || insert_worker_loop(insert_rx, weak_engine))
+                .expect("failed to spawn insert worker thread");
         }
 
         // Spawn SSD workers after Arc is created (they need callbacks into storage)
@@ -1102,13 +1106,10 @@ impl StorageEngine {
 /// Dedicated insert worker task. Owns the inflight HashMap exclusively,
 /// eliminating lock contention on the hot insert path. Sealed blocks are
 /// admitted to cache via brief `StorageInner` lock acquisitions.
-async fn insert_worker_loop(
-    mut rx: UnboundedReceiver<InsertWorkerCommand>,
-    engine: Weak<StorageEngine>,
-) {
+fn insert_worker_loop(rx: Receiver<InsertWorkerCommand>, engine: Weak<StorageEngine>) {
     let mut inflight: HashMap<BlockKey, InflightBlock> = HashMap::new();
 
-    while let Some(cmd) = rx.recv().await {
+    while let Ok(cmd) = rx.recv() {
         // Drain additional commands for batching
         let mut cmds = vec![cmd];
         while let Ok(more) = rx.try_recv() {
@@ -1202,12 +1203,18 @@ fn process_insert_batch(
         // Insert all slots for this hash
         let mut completed = false;
         for (slot_id, block) in slots {
-            let footprint_bytes = block.memory_footprint();
-            completed = inflight_block.insert_slot(slot_id, block, numa_node);
-            inflight_bytes_added = inflight_bytes_added.saturating_add(footprint_bytes);
-
-            if completed {
-                break;
+            match inflight_block.insert_slot(slot_id, block, numa_node) {
+                SlotInsertResult::Inserted {
+                    completed: c,
+                    footprint_added,
+                } => {
+                    inflight_bytes_added = inflight_bytes_added.saturating_add(footprint_added);
+                    completed = c;
+                    if completed {
+                        break;
+                    }
+                }
+                SlotInsertResult::Duplicate => {}
             }
         }
 


### PR DESCRIPTION
## Summary

- **#111**: `insert_slot` now returns `SlotInsertResult` with exact `footprint_added`, preventing duplicate slots from inflating the `inflight_bytes` metric
- **#109**: Moved `insert_worker_loop` from `tokio::spawn` to `std::thread::Builder` (`pegaflow-insert` thread), avoiding CPU-bound work blocking the async runtime
- Replaced `tokio::sync::mpsc` with `std::sync::mpsc` for the insert channel (drain-batching pattern maps 1:1; `tokio::sync::oneshot` for GC reply unchanged)

Closes #111, closes #109

## Test plan

- [x] `cargo check` passes
- [x] `./scripts/check.sh` passes (fmt, clippy, typos)
- [ ] Verify `inflight_bytes` metric accuracy under duplicate slot inserts
- [ ] Confirm no async runtime stalls under high save throughput

🤖 Generated with [Claude Code](https://claude.com/claude-code)