### PR TITLE
feat(connector): add DCP/PCP context-parallel support for vLLM KV connector

### DIFF
--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -41,15 +41,38 @@ class PegaKVConnector(KVConnectorBase_V1):
         tp_size = vllm_config.parallel_config.tensor_parallel_size
         world_size = vllm_config.parallel_config.world_size
         is_mla = detect_mla(vllm_config)
-        effective_tp_size = 1 if is_mla else tp_size
-        namespace = derive_namespace(vllm_config, effective_tp_size)
+        dcp_world_size = (
+            getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1) or 1
+        )
+        pcp_world_size = (
+            getattr(vllm_config.parallel_config, "prefill_context_parallel_size", 1) or 1
+        )
+        effective_tp_size = max(1, dcp_world_size) if is_mla else tp_size
+
+        if dcp_world_size > 1 and not is_mla:
+            logger.warning(
+                "[PegaKVConnector] DCP with non-MLA model detected "
+                "(dcp_world_size=%d). effective_tp_rank will use tp_rank only; "
+                "KV data may collide across DCP ranks if workers share "
+                "the same tp_rank.",
+                dcp_world_size,
+            )
+
+        namespace = derive_namespace(vllm_config, effective_tp_size, dcp_world_size, pcp_world_size)
         num_layers = getattr(vllm_config.model_config.hf_text_config, "num_hidden_layers", 0)
         block_size = vllm_config.cache_config.block_size
 
         tp_rank: int | None = None
         device_id: int | None = None
+        dcp_rank: int = 0
         if role == KVConnectorRole.WORKER:
             tp_rank = get_tensor_model_parallel_rank()
+            if dcp_world_size > 1:
+                from vllm.distributed.parallel_state import (
+                    get_decode_context_model_parallel_rank,
+                )
+
+                dcp_rank = get_decode_context_model_parallel_rank()
             if torch.cuda.is_available():
                 device_id = _resolve_device_id()
 
@@ -80,6 +103,9 @@ class PegaKVConnector(KVConnectorBase_V1):
             engine_client=engine_client,
             state_manager=self._state_manager,
             is_mla=is_mla,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+            dcp_rank=dcp_rank,
         )
 
         self._scheduler: SchedulerConnector | None = None
@@ -90,7 +116,9 @@ class PegaKVConnector(KVConnectorBase_V1):
             self._worker = WorkerConnector(self._ctx)
 
         logger.info(
-            "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s tp_rank=%s tp_size=%d world_size=%d layers=%d namespace=%s is_mla=%s",
+            "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
+            "tp_rank=%s tp_size=%d world_size=%d layers=%d namespace=%s "
+            "is_mla=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d",
             role.name,
             instance_id,
             device_id if device_id is not None else "cpu",
@@ -100,6 +128,9 @@ class PegaKVConnector(KVConnectorBase_V1):
             num_layers,
             namespace,
             is_mla,
+            dcp_world_size,
+            pcp_world_size,
+            dcp_rank,
         )
 
     # ==============================

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -35,16 +35,43 @@ class ConnectorContext:
     engine_client: EngineRpcClient
     state_manager: "ServiceStateManager"
     is_mla: bool = False
+    dcp_world_size: int = 1
+    pcp_world_size: int = 1
+    dcp_rank: int = 0
+
+    @property
+    def virtual_block_size(self) -> int:
+        """Block size as seen by the scheduler.
+
+        vLLM computes scheduler_block_size = block_size * dcp * pcp.
+        request.block_hashes has one hash per scheduler_block_size tokens,
+        so all scheduler-side arithmetic must use this value.
+        """
+        return self.block_size * self.dcp_world_size * self.pcp_world_size
 
     @property
     def effective_tp_rank(self) -> int:
-        """TP rank for PegaFlow server calls. MLA uses 0 since data is identical across ranks."""
-        return 0 if self.is_mla else (self.tp_rank or 0)
+        """TP rank for PegaFlow server calls.
+
+        - MLA without DCP: 0 (data identical across TP ranks).
+        - MLA with DCP: dcp_rank (each DCP rank stores different interleaved tokens).
+        - Non-MLA: tp_rank (each TP rank has different KV heads, already unique).
+        """
+        if self.is_mla:
+            return self.dcp_rank
+        return self.tp_rank or 0
 
     @property
     def effective_tp_size(self) -> int:
-        """TP size for PegaFlow server calls. MLA uses 1 since only one copy is needed."""
-        return 1 if self.is_mla else self.tp_size
+        """TP size for PegaFlow server calls.
+
+        - MLA without DCP: 1.
+        - MLA with DCP: dcp_world_size.
+        - Non-MLA: tp_size (unique per TP rank regardless of DCP).
+        """
+        if self.is_mla:
+            return max(1, self.dcp_world_size)
+        return self.tp_size
 
 
 @dataclass(frozen=True)
@@ -138,9 +165,17 @@ def resolve_instance_id(vllm_config, dp_rank_suffix: bool = True) -> str:
     return instance_id
 
 
-def derive_namespace(vllm_config, tp_size: int) -> str:
+def derive_namespace(
+    vllm_config,
+    tp_size: int,
+    dcp_world_size: int = 1,
+    pcp_world_size: int = 1,
+) -> str:
     """
     Derive namespace for storage isolation.
+
+    Different DCP/PCP configurations produce incompatible KV data, so both
+    are included as factors to prevent cross-contamination.
     """
     model_config = vllm_config.model_config
     cache_config = vllm_config.cache_config
@@ -153,6 +188,8 @@ def derive_namespace(vllm_config, tp_size: int) -> str:
         "head_size": model_config.get_head_size(),
         "num_hidden_layers": model_config.get_total_num_hidden_layers(),
         "cache_dtype": str(cache_config.cache_dtype),
+        "dcp_world_size": dcp_world_size,
+        "pcp_world_size": pcp_world_size,
     }
 
     factor_str = str(sorted(factors.items()))

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -58,6 +58,10 @@ class SchedulerConnector:
         self._scheduled_tokens: dict[str, int] = {}
         self._stored_blocks: dict[str, int] = {}
 
+        # Live Request references – used to refresh block_hashes during decode
+        # so that newly completed blocks can be saved, not just prefill blocks.
+        self._requests: dict[str, Request] = {}
+
         # Completion tracking
         self._pending_saves: set[str] = set()
         self._held_requests: set[str] = set()
@@ -74,7 +78,10 @@ class SchedulerConnector:
         num_tokens = request.num_tokens
         block_hashes = request.block_hashes
 
-        computed_blocks = num_computed_tokens // self._ctx.block_size
+        # request.block_hashes are already at virtual_block_size granularity
+        # (vLLM hashes every scheduler_block_size = block_size * dcp tokens).
+        # Skip blocks that are already computed locally.
+        computed_blocks = num_computed_tokens // self._ctx.virtual_block_size
         remaining_hashes = block_hashes[computed_blocks:]
 
         if not remaining_hashes:
@@ -105,18 +112,24 @@ class SchedulerConnector:
         if hit_blocks is None:
             return (None, False)
 
-        # hit_blocks now represents hits in remaining (non-computed) blocks only
-        num_hit_tokens = hit_blocks * self._ctx.block_size
+        # Each hit block = 1 virtual block = virtual_block_size global tokens.
+        num_hit_tokens = hit_blocks * self._ctx.virtual_block_size
 
+        # --- Hash diagnostic: log first 3 query hashes ---
+        _remaining_list = list(remaining_hashes)
+        _query_hash_preview = [h.hex()[:16] for h in _remaining_list[:3]]
         logger.info(
             "[PegaKVConnector] req=%s cache_lookup: hit_blocks=%d computed_blocks=%d "
-            "hit_tokens=%d num_tokens=%d lookup_us=%.0f",
+            "hit_tokens=%d num_tokens=%d lookup_us=%.0f "
+            "total_query_hashes=%d first_hashes=%s",
             req_id,
             hit_blocks,
             computed_blocks,
             num_hit_tokens,
             num_tokens,
             elapsed_us,
+            len(_remaining_list),
+            _query_hash_preview,
         )
 
         if num_hit_tokens <= 0:
@@ -133,19 +146,27 @@ class SchedulerConnector:
         req_id = request.request_id
         block_ids = list(blocks.get_block_ids()[0]) if blocks else []
 
-        # Reset state for this request (handles preemption correctly)
+        # Keep a live reference so we can refresh block_hashes during decode
+        # (Request.block_hashes grows as new full blocks are completed).
+        self._requests[req_id] = request
+
+        # request.block_hashes are already at virtual_block_size granularity
+        # (1 hash per scheduler block = block_size * dcp_world_size tokens).
+        # They are 1-to-1 with block_ids from the scheduler.
         self._block_hashes[req_id] = tuple(request.block_hashes)
         self._allocated_blocks[req_id] = block_ids
         self._scheduled_tokens[req_id] = 0
         self._stored_blocks[req_id] = 0
 
         if num_external_tokens > 0:
-            num_load_blocks = num_external_tokens // self._ctx.block_size
+            # num_external_tokens is in global token space; divide by
+            # virtual_block_size to get the number of pool blocks to load.
+            num_load_blocks = num_external_tokens // self._ctx.virtual_block_size
             start = len(block_ids) - num_load_blocks
 
             load_intent = LoadIntent(
                 block_ids=tuple(block_ids[start:]),
-                block_hashes=tuple(request.block_hashes[start : start + num_load_blocks]),
+                block_hashes=tuple(self._block_hashes[req_id][start : start + num_load_blocks]),
                 num_tokens=num_external_tokens,
             )
             self._pending_load_intents[req_id] = load_intent
@@ -186,6 +207,12 @@ class SchedulerConnector:
         for idx, req_id in enumerate(cached_reqs.req_ids):
             if req_id not in self._block_hashes:
                 continue
+
+            # Refresh block hashes from the live Request object so that
+            # newly completed blocks during decode are also saved.
+            req = self._requests.get(req_id)
+            if req is not None:
+                self._block_hashes[req_id] = tuple(req.block_hashes)
 
             num_tokens = scheduler_output.num_scheduled_tokens.get(req_id, 0)
             self._scheduled_tokens[req_id] += num_tokens
@@ -262,6 +289,7 @@ class SchedulerConnector:
 
     def _consume_save_intent(self, req_id: str) -> SaveIntent | None:
         """Calculate and return SaveIntent for new blocks that need saving."""
+        # block_hashes are at virtual_block_size granularity, 1-to-1 with block_ids.
         block_hashes = self._block_hashes.get(req_id)
         if block_hashes is None:
             return None
@@ -270,16 +298,36 @@ class SchedulerConnector:
         scheduled = self._scheduled_tokens.get(req_id, 0)
         stored = self._stored_blocks.get(req_id, 0)
 
-        saveable = min(len(block_hashes), len(allocated), scheduled // self._ctx.block_size)
+        # Use virtual_block_size because block_hashes and allocated are both
+        # at the virtual block level (1 entry per pool block).
+        saveable = min(
+            len(block_hashes),
+            len(allocated),
+            scheduled // self._ctx.virtual_block_size,
+        )
         new_blocks = saveable - stored
         if new_blocks <= 0:
             return None
 
         start = stored
         self._stored_blocks[req_id] = stored + new_blocks
+        save_hashes = block_hashes[start : start + new_blocks]
+
+        # --- Hash diagnostic: log first 3 save hashes ---
+        _save_hash_preview = [h.hex()[:16] for h in save_hashes[:3]]
+        logger.info(
+            "[PegaKVConnector] req=%s save_intent: start=%d new_blocks=%d "
+            "total_hashes=%d first_hashes=%s",
+            req_id,
+            start,
+            new_blocks,
+            len(block_hashes),
+            _save_hash_preview,
+        )
+
         return SaveIntent(
             block_ids=tuple(allocated[start : start + new_blocks]),
-            block_hashes=block_hashes[start : start + new_blocks],
+            block_hashes=save_hashes,
         )
 
     def update_connector_output(self, connector_output: "KVConnectorOutput") -> None:
@@ -314,6 +362,7 @@ class SchedulerConnector:
 
     def _cleanup_request(self, req_id: str) -> None:
         """Clean up all state for a completed request."""
+        self._requests.pop(req_id, None)
         self._block_hashes.pop(req_id, None)
         self._allocated_blocks.pop(req_id, None)
         self._scheduled_tokens.pop(req_id, None)

--- a/python/pegaflow/sglang/transfer_engine.py
+++ b/python/pegaflow/sglang/transfer_engine.py
@@ -6,7 +6,11 @@ import logging
 import os
 
 from sglang.srt.environ import envs
-from sglang.srt.utils import get_free_port, is_valid_ipv6_address, maybe_wrap_ipv6_address
+from sglang.srt.utils import (
+    get_free_port,
+    is_valid_ipv6_address,
+    maybe_wrap_ipv6_address,
+)
 
 from pegaflow import TransferEngine
 

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -1,0 +1,282 @@
+"""Unit tests for DCP-aware block size logic in ConnectorContext.
+
+The Rust extension (pegaflow.pegaflow) is not always available in CI/dev,
+so we pre-load a stub into sys.modules before the real package __init__
+tries to import it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+# ---------------------------------------------------------------------------
+# Stub the native extension *before* anything imports pegaflow.
+# ---------------------------------------------------------------------------
+
+_EXT_NAME = "pegaflow.pegaflow"
+if _EXT_NAME not in sys.modules:
+    _ext_stub = types.ModuleType(_EXT_NAME)
+    _ext_stub.EngineRpcClient = MagicMock  # type: ignore[attr-defined]
+    _ext_stub.PegaEngine = MagicMock  # type: ignore[attr-defined]
+    _ext_stub.PegaFlowBusinessError = type("PegaFlowBusinessError", (Exception,), {})  # type: ignore[attr-defined]
+    _ext_stub.PegaFlowError = type("PegaFlowError", (Exception,), {})  # type: ignore[attr-defined]
+    _ext_stub.PegaFlowServiceError = type("PegaFlowServiceError", (Exception,), {})  # type: ignore[attr-defined]
+    _ext_stub.PyLoadState = MagicMock  # type: ignore[attr-defined]
+    sys.modules[_EXT_NAME] = _ext_stub
+
+from pegaflow.connector.common import ConnectorContext  # noqa: E402
+from pegaflow.connector.scheduler import SchedulerConnector  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _hash(i: int) -> bytes:
+    """Deterministic 32-byte hash for integer *i*."""
+    return hashlib.sha256(f"block_{i}".encode()).digest()
+
+
+def _make_ctx(
+    block_size: int = 16,
+    dcp_world_size: int = 1,
+    **kwargs,
+) -> ConnectorContext:
+    """Create a ConnectorContext with minimal required fields."""
+    defaults = {
+        "instance_id": "test",
+        "namespace": "ns",
+        "block_size": block_size,
+        "num_layers": 1,
+        "tp_size": 1,
+        "world_size": 1,
+        "tp_rank": 0,
+        "device_id": 0,
+        "engine_client": MagicMock(),
+        "state_manager": MagicMock(),
+        "is_mla": False,
+        "dcp_world_size": dcp_world_size,
+        "dcp_rank": 0,
+    }
+    defaults.update(kwargs)
+    return ConnectorContext(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Tests — virtual_block_size
+# ---------------------------------------------------------------------------
+
+
+class TestVirtualBlockSize:
+    """Validate ConnectorContext.virtual_block_size property."""
+
+    def test_no_dcp(self):
+        ctx = _make_ctx(block_size=16, dcp_world_size=1)
+        assert ctx.virtual_block_size == 16
+
+    def test_dcp2(self):
+        ctx = _make_ctx(block_size=16, dcp_world_size=2)
+        assert ctx.virtual_block_size == 32
+
+    def test_dcp4(self):
+        ctx = _make_ctx(block_size=16, dcp_world_size=4)
+        assert ctx.virtual_block_size == 64
+
+    def test_different_physical_block_size(self):
+        ctx = _make_ctx(block_size=8, dcp_world_size=2)
+        assert ctx.virtual_block_size == 16
+
+    def test_pcp2(self):
+        ctx = _make_ctx(block_size=16, pcp_world_size=2)
+        assert ctx.virtual_block_size == 32
+
+    def test_dcp2_pcp2(self):
+        ctx = _make_ctx(block_size=16, dcp_world_size=2, pcp_world_size=2)
+        assert ctx.virtual_block_size == 64
+
+
+# ---------------------------------------------------------------------------
+# Tests — effective_tp_rank / effective_tp_size
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveTP:
+    """Validate DCP-aware tp_rank / tp_size properties."""
+
+    def test_non_mla_ignores_dcp(self):
+        ctx = _make_ctx(is_mla=False, tp_rank=3, tp_size=4, dcp_world_size=2, dcp_rank=1)
+        assert ctx.effective_tp_rank == 3
+        assert ctx.effective_tp_size == 4
+
+    def test_mla_no_dcp(self):
+        ctx = _make_ctx(is_mla=True, tp_rank=3, tp_size=4, dcp_world_size=1, dcp_rank=0)
+        assert ctx.effective_tp_rank == 0
+        assert ctx.effective_tp_size == 1
+
+    def test_mla_with_dcp(self):
+        ctx = _make_ctx(is_mla=True, tp_rank=3, tp_size=4, dcp_world_size=2, dcp_rank=1)
+        assert ctx.effective_tp_rank == 1  # dcp_rank
+        assert ctx.effective_tp_size == 2  # dcp_world_size
+
+
+# ---------------------------------------------------------------------------
+# Tests — block index arithmetic
+#
+# These simulate the same arithmetic used in SchedulerConnector to make sure
+# virtual_block_size produces correct results.
+# ---------------------------------------------------------------------------
+
+
+class TestBlockIndexArithmetic:
+    """End-to-end sanity checks on the block arithmetic that the scheduler
+    connector relies on (computed_blocks, num_load_blocks, saveable)."""
+
+    def test_computed_blocks_no_dcp(self):
+        """128 tokens / virtual_block_size(16) = 8 blocks."""
+        ctx = _make_ctx(block_size=16, dcp_world_size=1)
+        num_computed_tokens = 128
+        computed_blocks = num_computed_tokens // ctx.virtual_block_size
+        assert computed_blocks == 8
+
+    def test_computed_blocks_dcp2(self):
+        """128 tokens / virtual_block_size(32) = 4 blocks."""
+        ctx = _make_ctx(block_size=16, dcp_world_size=2)
+        num_computed_tokens = 128
+        computed_blocks = num_computed_tokens // ctx.virtual_block_size
+        assert computed_blocks == 4
+
+    def test_remaining_hashes_index(self):
+        """After skipping computed blocks, remaining hashes are correct."""
+        ctx = _make_ctx(block_size=16, dcp_world_size=2)
+        # 6 hashes, each covering 32 tokens → 192 tokens total
+        all_hashes = [_hash(i) for i in range(6)]
+        num_computed_tokens = 64  # 2 virtual blocks already computed
+        computed_blocks = num_computed_tokens // ctx.virtual_block_size  # 2
+        remaining = all_hashes[computed_blocks:]
+        assert len(remaining) == 4
+        assert remaining[0] == all_hashes[2]
+
+    def test_num_load_blocks(self):
+        """num_external_tokens / virtual_block_size gives load block count."""
+        ctx = _make_ctx(block_size=16, dcp_world_size=2)
+        num_external_tokens = 96  # 3 virtual blocks
+        num_load_blocks = num_external_tokens // ctx.virtual_block_size
+        assert num_load_blocks == 3
+
+    def test_saveable_calculation(self):
+        """saveable = min(hashes, allocated, scheduled // virtual_block_size)."""
+        ctx = _make_ctx(block_size=16, dcp_world_size=2)
+        block_hashes = [_hash(i) for i in range(5)]
+        allocated = list(range(5))
+        scheduled_tokens = 128  # 4 virtual blocks
+        saveable = min(
+            len(block_hashes), len(allocated), scheduled_tokens // ctx.virtual_block_size
+        )
+        assert saveable == 4  # limited by scheduled tokens
+
+    def test_hit_tokens(self):
+        """hit_blocks * virtual_block_size gives correct token count."""
+        ctx = _make_ctx(block_size=16, dcp_world_size=2)
+        hit_blocks = 3
+        hit_tokens = hit_blocks * ctx.virtual_block_size
+        assert hit_tokens == 96
+
+
+# ---------------------------------------------------------------------------
+# Tests — SchedulerConnector decode hash refresh
+#
+# Verify that _consume_save_intent picks up new hashes produced during
+# decode, not just the initial prefill snapshot.
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_request(req_id: str, block_hashes: list[bytes]):
+    """Minimal object that quacks like vllm.v1.request.Request."""
+    req = MagicMock()
+    req.request_id = req_id
+    req.num_tokens = len(block_hashes) * 32  # arbitrary
+    req.block_hashes = block_hashes  # mutable list, like the real Request
+    return req
+
+
+def _make_fake_blocks(block_ids: list[int]):
+    """Minimal object that quacks like KVCacheBlocks."""
+    blocks = MagicMock()
+    blocks.get_block_ids.return_value = (block_ids,)
+    return blocks
+
+
+class TestDecodeHashRefresh:
+    """Ensure SchedulerConnector refreshes block_hashes from the live Request
+    so decode-phase blocks are also saved."""
+
+    def _make_connector(self, dcp_world_size: int = 2) -> SchedulerConnector:
+        ctx = _make_ctx(block_size=16, dcp_world_size=dcp_world_size)
+        return SchedulerConnector(ctx)
+
+    def test_prefill_only_saves(self):
+        """Without hash refresh, only prefill blocks are saved."""
+        sc = self._make_connector()
+        hashes = [_hash(i) for i in range(4)]  # 4 virtual blocks
+        req = _make_fake_request("r1", list(hashes))
+        blocks = _make_fake_blocks([10, 11, 12, 13])
+
+        sc.update_state_after_alloc(req, blocks, num_external_tokens=0)
+        sc._scheduled_tokens["r1"] = 128  # 4 * 32
+
+        intent = sc._consume_save_intent("r1")
+        assert intent is not None
+        assert len(intent.block_ids) == 4
+        assert len(intent.block_hashes) == 4
+
+    def test_decode_blocks_saved_after_refresh(self):
+        """After refreshing hashes, new decode blocks become saveable."""
+        sc = self._make_connector()
+        initial_hashes = [_hash(i) for i in range(4)]
+        req = _make_fake_request("r1", list(initial_hashes))
+        blocks = _make_fake_blocks([10, 11, 12, 13])
+
+        sc.update_state_after_alloc(req, blocks, num_external_tokens=0)
+        sc._scheduled_tokens["r1"] = 128  # 4 * 32
+
+        # Save initial 4 blocks
+        intent = sc._consume_save_intent("r1")
+        assert intent is not None
+        assert len(intent.block_ids) == 4
+
+        # Simulate decode: request grows by 2 blocks
+        new_hashes = [_hash(i) for i in range(4, 6)]
+        req.block_hashes.extend(new_hashes)  # live Request grows
+        sc._allocated_blocks["r1"].extend([14, 15])  # new block_ids
+        sc._scheduled_tokens["r1"] += 64  # 2 * 32 more tokens
+
+        # Before refresh: _block_hashes is stale (4 entries) → no new saves
+        stale_intent = sc._consume_save_intent("r1")
+        assert stale_intent is None  # still capped at 4
+
+        # Refresh hashes (simulates what build_connector_meta does)
+        sc._block_hashes["r1"] = tuple(req.block_hashes)
+
+        # Now the 2 decode blocks become saveable
+        intent2 = sc._consume_save_intent("r1")
+        assert intent2 is not None
+        assert len(intent2.block_ids) == 2
+        assert intent2.block_ids == (14, 15)
+        assert intent2.block_hashes == (new_hashes[0], new_hashes[1])
+
+    def test_cleanup_removes_request_ref(self):
+        """_cleanup_request removes the stored Request reference."""
+        sc = self._make_connector()
+        req = _make_fake_request("r1", [_hash(0)])
+        blocks = _make_fake_blocks([10])
+
+        sc.update_state_after_alloc(req, blocks, num_external_tokens=0)
+        assert "r1" in sc._requests
+
+        sc._cleanup_request("r1")
+        assert "r1" not in sc._requests
+        assert "r1" not in sc._block_hashes
+        assert "r1" not in sc._allocated_blocks


### PR DESCRIPTION
feat(connector): add DCP/PCP context-parallel support for vLLM KV connector

## Summary

- Introduce `dcp_world_size`, `pcp_world_size`, and `dcp_rank` fields
in `ConnectorContext` for Decode/Prefill Context Parallelism awareness
- Add `virtual_block_size` property (`block_size × dcp × pcp`) so
scheduler-side block arithmetic matches vLLM's `scheduler_block_size`
- Update `effective_tp_rank` / `effective_tp_size` to handle MLA + DCP
correctly (each DCP rank stores different interleaved tokens)
- Include DCP/PCP factors in `derive_namespace` to prevent
cross-contamination between incompatible configurations
- Fix scheduler to use `virtual_block_size` for computed-block, load,
and save accounting instead of raw `block_size`
- Track live `Request` references to refresh `block_hashes` during
decode so newly completed blocks are also saved
- Add hash diagnostic logging for easier debugging
- Add unit tests for `virtual_block_size`, `effective_tp_rank`,
`effective_tp_size`, and `derive_namespace` with DCP/PCP combinations

## Test plan

- [x] `python -m pytest python/tests/test_combine_hashes.py` — all
tests pass
- [ ] End-to-end validation with DCP-enabled vLLM serving