### PR TITLE
feat(connector): add cross-layer block support

### DIFF
--- a/examples/bench_kv_cache.py
+++ b/examples/bench_kv_cache.py
@@ -48,6 +48,7 @@ class VLLMServer:
         profile_output: Optional[Path] = None,
         torch_profile_output: Optional[Path] = None,
         max_model_len: Optional[int] = None,
+        cross_layer_blocks: bool = False,
     ):
         self.model = model
         self.port = port
@@ -56,6 +57,7 @@ class VLLMServer:
         self.use_lmcache = use_lmcache
         self.enable_prefix_caching = enable_prefix_caching
         self.max_model_len = max_model_len
+        self.cross_layer_blocks = cross_layer_blocks
         self.log_file = log_file
         self.health_endpoints = (
             list(health_endpoints)
@@ -82,6 +84,9 @@ class VLLMServer:
             env["LMCACHE_CHUNK_SIZE"] = "256"
             env["LMCACHE_LOCAL_CPU"] = "True"
             env["LMCACHE_MAX_LOCAL_CPU_SIZE"] = "32.0"
+
+        if self.cross_layer_blocks:
+            env["PEGAFLOW_CROSS_LAYER_BLOCKS"] = "1"
 
         if self.torch_profile_output:
             env["VLLM_TORCH_PROFILER_DIR"] = str(self.torch_profile_output)
@@ -461,6 +466,13 @@ def main():
         default=None,
         help="Maximum model context length. If not specified, uses the model's default.",
     )
+    parser.add_argument(
+        "--cross-layer-blocks",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable cross-layer block layout for PegaFlow (default: enabled). "
+        "Use --no-cross-layer-blocks to disable.",
+    )
 
     args = parser.parse_args()
     if args.tp_size < 1:
@@ -493,6 +505,7 @@ def main():
     if args.with_lmcache:
         print(f"LMCache Port:    {args.lmcache_port}")
     print(f"PegaFlow Port:   {args.pegaflow_port}")
+    print(f"Cross-Layer:     {'Enabled' if args.cross_layer_blocks else 'Disabled'}")
     if args.max_model_len:
         print(f"Max Model Len:   {args.max_model_len}")
     print(f"Results Dir:     {run_dir}")
@@ -630,6 +643,7 @@ def main():
         profile_output=profile_path,
         torch_profile_output=torch_profile_base,
         max_model_len=args.max_model_len,
+        cross_layer_blocks=args.cross_layer_blocks,
     ):
         # Cold cache run
         if args.torch_profile:

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -268,6 +268,15 @@ class PegaKVConnector(KVConnectorBase_V1):
     def get_handshake_metadata(self):
         return None
 
+    @property
+    def prefer_cross_layer_blocks(self) -> bool:
+        return os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "0") == "1"
+
+    def register_cross_layers_kv_cache(self, kv_cache, attn_backend):
+        if not self._worker:
+            return
+        self._worker.register_cross_layers_kv_cache(kv_cache, attn_backend)
+
     def set_host_xfer_buffer_ops(self, copy_operation):
         return
 

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
     from vllm.forward_context import ForwardContext
 
 
+_CROSS_LAYER_KEY = "ALL_LAYERS"
+
+
 @dataclass
 class SaveTask:
     layer_name: str
@@ -63,6 +66,9 @@ class WorkerConnector:
         self._registered_layers: list[str] = []
         self._layer_name_to_id: dict[str, int] = {}
         self._torch_device: torch.device | None = None
+
+        self._cross_layer_mode = False
+        self._cross_layer_pending_save: SaveTask | None = None
 
         self._finished_requests: set[str] = set()
 
@@ -157,6 +163,10 @@ class WorkerConnector:
             layout,
             self._ctx.instance_id,
         )
+
+    def register_cross_layers_kv_cache(self, kv_cache, attn_backend) -> None:
+        self._cross_layer_mode = True
+        self.register_kv_caches({_CROSS_LAYER_KEY: kv_cache})
 
     def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str] | None, set[str] | None]:
         finished_sending: set[str] | None = None
@@ -263,10 +273,13 @@ class WorkerConnector:
         if not all_block_ids:
             return
 
-        target_layers: list[str] = []
-        for layer_name, layer in forward_context.no_compile_layers.items():
-            if hasattr(layer, "kv_cache"):
-                target_layers.append(layer_name)
+        if self._cross_layer_mode:
+            target_layers = [_CROSS_LAYER_KEY]
+        else:
+            target_layers = []
+            for layer_name, layer in forward_context.no_compile_layers.items():
+                if hasattr(layer, "kv_cache"):
+                    target_layers.append(layer_name)
 
         if not target_layers:
             return
@@ -321,6 +334,20 @@ class WorkerConnector:
         attn_metadata: "AttentionMetadata",
         **kwargs: Any,
     ) -> None:
+        if self._cross_layer_mode:
+            # Defer actual save to wait_for_save when all layers are computed.
+            # Only capture metadata on the first layer call per forward pass.
+            if self._cross_layer_pending_save is None:
+                request_ids = list(metadata.save_intents.keys())
+                if request_ids:
+                    self._cross_layer_pending_save = SaveTask(
+                        layer_name=_CROSS_LAYER_KEY,
+                        attn_metadata=attn_metadata,
+                        metadata=metadata,
+                        request_ids=request_ids,
+                    )
+            return
+
         request_ids = list(metadata.save_intents.keys())
         if not request_ids:
             return
@@ -342,6 +369,19 @@ class WorkerConnector:
         )
 
     def wait_for_save(self) -> None:
+        if self._cross_layer_mode:
+            task = self._cross_layer_pending_save
+            self._cross_layer_pending_save = None
+            if task:
+                with self._save_completion_lock:
+                    for req_id in task.request_ids:
+                        if req_id not in self._req_pending_layers:
+                            self._req_pending_layers[req_id] = 1
+                            self._save_completion_events[req_id] = threading.Event()
+                self._save_queue.put(task)
+            self._current_save_intents = set()
+            return
+
         skipped_requests: set[str] = set()
 
         with self._save_completion_lock:


### PR DESCRIPTION
## Summary

- Add `prefer_cross_layer_blocks` property and `register_cross_layers_kv_cache()` to support vLLM cross-layer KV cache allocation
- In cross-layer mode, register a single `ALL_LAYERS` pseudo-layer — Rust engine sees 1 large block instead of N per-layer blocks
- `save_kv_layer` becomes a deferred no-op; actual save enqueued in `wait_for_save` as a single `SaveTask`
- `start_load_kv` targets `ALL_LAYERS` directly, skipping `no_compile_layers` iteration
- Benchmark script: `--cross-layer-blocks` flag (default enabled), sets `PEGAFLOW_CROSS_LAYER_BLOCKS=1`

## Benchmark: GLM-4.7-FP8, TP=8, block_size=128, 10K input tokens, 50 prompts

### TTFT (warm cache, all hit)

| Mode | Mean | Median | P99 |
|------|------|--------|-----|
| GPU prefix cache | 50.46ms | 48.98ms | 63.55ms |
| PegaFlow layer-first | 87.02ms | 82.76ms | 122.44ms |
| **PegaFlow page-first (cross-layer)** | **87.19ms** | **79.05ms** | **137.92ms** |

### Transfer efficiency (per-device load)

| Mode | layers | memcpy_calls | bandwidth | latency |
|------|--------|-------------|-----------|---------|
| Layer-first | 92 | 368-552 | 44-47 GB/s | 10.5ms |
| **Page-first** | **1** | **2** | **52-54 GB/s** | **8.9ms** |

Cross-layer reduces memcpy calls by ~200x and improves transfer bandwidth by 18%. The end-to-end TTFT gap between layer-first and page-first is modest for this workload because the transfer is already fast (~10ms); the benefit grows for larger models or slower PCIe links.

## Test plan

- [x] Syntax check (py_compile) passes for all 3 files
- [x] GLM-4.7-FP8 TP=8 cold+warm with cross-layer: memcpy_calls=2, layers=1
- [x] GLM-4.7-FP8 TP=8 cold+warm without cross-layer: memcpy_calls=368-552, layers=92
- [ ] Preemption scenario: verify handle_preemptions still waits correctly (pending_layers=1 in cross-layer mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
