### PR TITLE
feat(connector): enable cross-layer blocks by default

### DIFF
--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod block;
 mod cache;
 pub mod gpu_worker;
 pub mod instance;
+#[allow(dead_code)]
 pub mod internode;
 pub mod logging;
 mod metrics;

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -58,7 +58,11 @@ class PegaKVConnector(KVConnectorBase_V1):
                 dcp_world_size,
             )
 
-        namespace = derive_namespace(vllm_config, effective_tp_size, dcp_world_size, pcp_world_size)
+        cross_layer_blocks = os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
+        namespace = derive_namespace(
+            vllm_config, effective_tp_size, dcp_world_size, pcp_world_size,
+            cross_layer_blocks=cross_layer_blocks,
+        )
         num_layers = getattr(vllm_config.model_config.hf_text_config, "num_hidden_layers", 0)
         block_size = vllm_config.cache_config.block_size
 
@@ -270,7 +274,7 @@ class PegaKVConnector(KVConnectorBase_V1):
 
     @property
     def prefer_cross_layer_blocks(self) -> bool:
-        return os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "0") == "1"
+        return os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
 
     def register_cross_layers_kv_cache(self, kv_cache, attn_backend):
         if not self._worker:

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -170,12 +170,14 @@ def derive_namespace(
     tp_size: int,
     dcp_world_size: int = 1,
     pcp_world_size: int = 1,
+    cross_layer_blocks: bool = False,
 ) -> str:
     """
     Derive namespace for storage isolation.
 
-    Different DCP/PCP configurations produce incompatible KV data, so both
-    are included as factors to prevent cross-contamination.
+    Different DCP/PCP configurations or cross-layer vs per-layer layouts
+    produce incompatible KV data, so all are included as factors to prevent
+    cross-contamination.
     """
     model_config = vllm_config.model_config
     cache_config = vllm_config.cache_config
@@ -190,6 +192,7 @@ def derive_namespace(
         "cache_dtype": str(cache_config.cache_dtype),
         "dcp_world_size": dcp_world_size,
         "pcp_world_size": pcp_world_size,
+        "cross_layer_blocks": cross_layer_blocks,
     }
 
     factor_str = str(sorted(factors.items()))


### PR DESCRIPTION
## Summary
- Switch `PEGAFLOW_CROSS_LAYER_BLOCKS` default from `"0"` to `"1"`, so cross-layer unified tensor is used when the attention backend supports it (reduces cudaMemcpy calls from N to 1 per save/load)
- Add `cross_layer_blocks` as a namespace factor in `derive_namespace()` to isolate cross-layer and per-layer block data, preventing hash collisions when switching between modes on the same server

## Test plan
- [x] Run `bench_kv_cache.py` with default (cross-layer on) and verify single-layer registration in logs
- [x] Run with `PEGAFLOW_CROSS_LAYER_BLOCKS=0` and verify per-layer registration still works
- [x] Verify namespace hash differs between cross-layer and per-layer modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)