### PR TITLE
fix: handle QueryPrefetch version skew and add version reporting

### DIFF
--- a/pegaflow-metaserver/build.rs
+++ b/pegaflow-metaserver/build.rs
@@ -15,20 +15,9 @@ fn command_output(program: &str, args: &[&str]) -> Option<String> {
     }
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
-    println!("cargo:rerun-if-env-changed=PYTHON_SYS_EXECUTABLE");
-    println!("cargo:rerun-if-env-changed=VIRTUAL_ENV");
+fn main() {
     println!("cargo:rerun-if-env-changed=PEGAFLOW_BUILD_GIT_SHA");
     println!("cargo:rerun-if-env-changed=PEGAFLOW_BUILD_TIMESTAMP");
-
-    let config = pyo3_build_config::get();
-    if let Some(lib_dir) = &config.lib_dir {
-        println!("cargo:rustc-link-search=native={lib_dir}");
-    }
-    if let Some(lib_name) = &config.lib_name {
-        println!("cargo:rustc-link-lib={lib_name}");
-    }
 
     let git_sha = std::env::var("PEGAFLOW_BUILD_GIT_SHA")
         .ok()
@@ -43,6 +32,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .or_else(|| command_output("date", &["-u", "+%Y-%m-%dT%H:%M:%SZ"]))
         .unwrap_or_else(|| "unknown".to_owned());
     println!("cargo:rustc-env=PEGAFLOW_BUILD_TIMESTAMP={build_timestamp}");
-
-    Ok(())
 }

--- a/pegaflow-metaserver/src/build_info.rs
+++ b/pegaflow-metaserver/src/build_info.rs
@@ -1,0 +1,12 @@
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const GIT_SHA: &str = env!("PEGAFLOW_BUILD_GIT_SHA");
+pub const BUILD_TIMESTAMP: &str = env!("PEGAFLOW_BUILD_TIMESTAMP");
+pub const LONG_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    "\n",
+    "git: ",
+    env!("PEGAFLOW_BUILD_GIT_SHA"),
+    "\n",
+    "built: ",
+    env!("PEGAFLOW_BUILD_TIMESTAMP")
+);

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod build_info;
 pub mod proto;
 pub mod service;
 pub mod store;
@@ -15,9 +16,13 @@ use tokio::signal;
 use tokio::sync::Notify;
 use tonic::transport::Server;
 
+use build_info::{BUILD_TIMESTAMP, GIT_SHA, LONG_VERSION, VERSION};
+
 #[derive(Parser, Debug)]
 #[command(
     name = "pegaflow-metaserver",
+    version = VERSION,
+    long_version = LONG_VERSION,
     about = "PegaFlow MetaServer - manages block hash keys across multi-node instances"
 )]
 pub struct Cli {
@@ -101,7 +106,10 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
     init_logging(&cli.log_level);
 
-    info!("Starting PegaFlow MetaServer");
+    info!(
+        "Starting pegaflow-metaserver version={} git_sha={} built={}",
+        VERSION, GIT_SHA, BUILD_TIMESTAMP
+    );
     info!("Binding to address: {}", cli.addr);
     info!("Max cache capacity: {} MB", cli.max_capacity_mb);
     info!("Cache entry TTL: {} minutes", cli.ttl_minutes);

--- a/pegaflow-server/src/build_info.rs
+++ b/pegaflow-server/src/build_info.rs
@@ -1,0 +1,12 @@
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const GIT_SHA: &str = env!("PEGAFLOW_BUILD_GIT_SHA");
+pub const BUILD_TIMESTAMP: &str = env!("PEGAFLOW_BUILD_TIMESTAMP");
+pub const LONG_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    "\n",
+    "git: ",
+    env!("PEGAFLOW_BUILD_GIT_SHA"),
+    "\n",
+    "built: ",
+    env!("PEGAFLOW_BUILD_TIMESTAMP")
+);

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod build_info;
 pub mod http_server;
 pub mod metric;
 pub mod proto;
@@ -35,6 +36,8 @@ use tokio::sync::Notify;
 use tonic::transport::Server;
 use utils::parse_memory_size;
 
+use build_info::{BUILD_TIMESTAMP, GIT_SHA, LONG_VERSION, VERSION};
+
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 
@@ -44,7 +47,9 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "pega-engine-server",
+    name = "pegaflow-server",
+    version = VERSION,
+    long_version = LONG_VERSION,
     about = "PegaEngine gRPC server with CUDA IPC registry"
 )]
 pub struct Cli {
@@ -346,6 +351,10 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     pegaflow_core::logging::init_stdout_colored(&cli.log_level);
     trace::init();
     pegaflow_core::set_trace_sample_rate(cli.trace_sample_rate);
+    info!(
+        "Starting pegaflow-server version={} git_sha={} built={}",
+        VERSION, GIT_SHA, BUILD_TIMESTAMP
+    );
 
     // Initialize CUDA in the main thread before starting Tokio runtime
     init_cuda_driver()?;

--- a/python/pegaflow/__init__.py
+++ b/python/pegaflow/__init__.py
@@ -5,6 +5,17 @@ This package provides:
 2. PegaKVConnector: vLLM KV connector for distributed inference
 """
 
+from importlib.metadata import PackageNotFoundError, version as package_version
+
+
+def _detect_version() -> str:
+    for dist_name in ("pegaflow-llm", "pegaflow"):
+        try:
+            return package_version(dist_name)
+        except PackageNotFoundError:
+            continue
+    return "unknown"
+
 # Import Rust-based PegaEngine from the compiled extension
 try:
     from .pegaflow import (
@@ -26,7 +37,7 @@ except ImportError:
         "pegaflow rust extension is not available, check pegaflow-xxx.so file exists"
     ) from None
 
-__version__ = "0.0.1"
+__version__ = _detect_version()
 __all__ = [
     "EngineRpcClient",
     "PegaEngine",

--- a/python/pegaflow/compat.py
+++ b/python/pegaflow/compat.py
@@ -1,0 +1,52 @@
+"""Compatibility helpers for mixed-version PegaFlow deployments."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from logging import Logger
+
+from pegaflow import __version__ as PEGAFLOW_VERSION
+from pegaflow.pegaflow import PegaFlowBusinessError
+
+_WARNED_QUERY_PREFETCH_ENDPOINTS: set[str] = set()
+
+
+def _is_query_prefetch_unimplemented(error: PegaFlowBusinessError) -> bool:
+    message = str(error).lower()
+    return (
+        "unimplemented" in message
+        or "not implemented" in message
+        or "not supported" in message
+    )
+
+
+def query_prefetch_with_fallback(
+    engine_client,
+    instance_id: str,
+    block_hashes: Sequence[bytes],
+    logger: Logger,
+):
+    """Call ``QueryPrefetch`` and fall back to legacy ``Query`` when unavailable."""
+    try:
+        return engine_client.query_prefetch(instance_id, list(block_hashes))
+    except PegaFlowBusinessError as error:
+        if not _is_query_prefetch_unimplemented(error):
+            raise
+
+        endpoint = getattr(engine_client, "endpoint", "unknown")
+        if endpoint not in _WARNED_QUERY_PREFETCH_ENDPOINTS:
+            logger.warning(
+                "[PegaFlowCompat] remote pegaflow-server at %s does not support "
+                "QueryPrefetch; falling back to legacy Query without SSD prefetch "
+                "(connector_version=%s). Upgrade the server to restore "
+                "QueryPrefetch/SSD-prefetch support. Original error: %s",
+                endpoint,
+                PEGAFLOW_VERSION,
+                error,
+            )
+            _WARNED_QUERY_PREFETCH_ENDPOINTS.add(endpoint)
+
+        return engine_client.query(instance_id, list(block_hashes))
+
+
+__all__ = ["query_prefetch_with_fallback"]

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -28,6 +28,7 @@ from pegaflow.connector.common import (
 from pegaflow.connector.scheduler import SchedulerConnector
 from pegaflow.connector.state_manager import ServiceStateManager
 from pegaflow.connector.worker import WorkerConnector
+from pegaflow import __version__ as PEGAFLOW_VERSION
 from pegaflow.pegaflow import EngineRpcClient
 
 
@@ -91,7 +92,12 @@ class PegaKVConnector(KVConnectorBase_V1):
         ) or vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.port", 50055)
         self._engine_endpoint = f"{server_host}:{server_port}"
         engine_client = EngineRpcClient(self._engine_endpoint)
-        logger.info("[PegaKVConnector] Connected to engine server at %s", self._engine_endpoint)
+        logger.info(
+            "[PegaKVConnector] Connected to engine server at %s "
+            "(connector_version=%s)",
+            self._engine_endpoint,
+            PEGAFLOW_VERSION,
+        )
 
         self._state_manager = ServiceStateManager(engine_client)
 

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -15,6 +15,7 @@ from pegaflow.connector.common import (
     logger,
     parse_env_int,
 )
+from pegaflow.compat import query_prefetch_with_fallback
 from pegaflow.connector.connector_metrics import PrefetchTracker
 from pegaflow.pegaflow import PegaFlowBusinessError, PegaFlowServiceError
 
@@ -388,7 +389,12 @@ class SchedulerConnector:
 
         block_hash_list = list(block_hashes)
         try:
-            result = self._ctx.engine_client.query_prefetch(self._ctx.instance_id, block_hash_list)
+            result = query_prefetch_with_fallback(
+                self._ctx.engine_client,
+                self._ctx.instance_id,
+                block_hash_list,
+                logger,
+            )
         except PegaFlowServiceError as e:
             # Service error (network/internal) - mark unavailable
             self._ctx.state_manager.mark_unavailable(str(e))

--- a/python/pegaflow/sglang/peagflow_radix_cache.py
+++ b/python/pegaflow/sglang/peagflow_radix_cache.py
@@ -19,6 +19,7 @@ from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 
 from pegaflow import EngineRpcClient, PegaFlowError, PyLoadState
+from pegaflow.compat import query_prefetch_with_fallback
 from pegaflow.ipc_wrapper import CudaIPCWrapper
 
 logger = logging.getLogger(__name__)
@@ -432,7 +433,12 @@ class PeagflowRadixCache(RadixCache):
 
                 # Query availability before issuing load
                 try:
-                    query_res = self.engine_client.query_prefetch(self.instance_id, block_hashes)
+                    query_res = query_prefetch_with_fallback(
+                        self.engine_client,
+                        self.instance_id,
+                        block_hashes,
+                        logger,
+                    )
                     logger.debug(f"[PeagflowRadixCache] query hash: {block_hashes[0]}")
                     hit_blocks = (
                         query_res.get("hit_blocks", 0) if isinstance(query_res, dict) else 0

--- a/python/tests/test_query_prefetch_fallback.py
+++ b/python/tests/test_query_prefetch_fallback.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _install_test_stubs() -> None:
+    repo_python = Path(__file__).resolve().parents[1]
+    package_dir = repo_python / "pegaflow"
+
+    pegaflow_pkg = types.ModuleType("pegaflow")
+    pegaflow_pkg.__path__ = [str(package_dir)]
+    pegaflow_pkg.__version__ = "0.0.16-test"
+    sys.modules["pegaflow"] = pegaflow_pkg
+
+    connector_pkg = types.ModuleType("pegaflow.connector")
+    connector_pkg.__path__ = [str(package_dir / "connector")]
+    sys.modules["pegaflow.connector"] = connector_pkg
+
+    vllm_pkg = types.ModuleType("vllm")
+    vllm_pkg.__path__ = []
+    sys.modules["vllm"] = vllm_pkg
+
+    distributed_pkg = types.ModuleType("vllm.distributed")
+    distributed_pkg.__path__ = []
+    sys.modules["vllm.distributed"] = distributed_pkg
+
+    kv_transfer_pkg = types.ModuleType("vllm.distributed.kv_transfer")
+    kv_transfer_pkg.__path__ = []
+    sys.modules["vllm.distributed.kv_transfer"] = kv_transfer_pkg
+
+    kv_connector_pkg = types.ModuleType("vllm.distributed.kv_transfer.kv_connector")
+    kv_connector_pkg.__path__ = []
+    sys.modules["vllm.distributed.kv_transfer.kv_connector"] = kv_connector_pkg
+
+    v1_pkg = types.ModuleType("vllm.distributed.kv_transfer.kv_connector.v1")
+    v1_pkg.__path__ = []
+    sys.modules["vllm.distributed.kv_transfer.kv_connector.v1"] = v1_pkg
+
+    base_mod = types.ModuleType("vllm.distributed.kv_transfer.kv_connector.v1.base")
+
+    class KVConnectorMetadata:
+        pass
+
+    base_mod.KVConnectorMetadata = KVConnectorMetadata
+    sys.modules[base_mod.__name__] = base_mod
+
+    metrics_mod = types.ModuleType("vllm.distributed.kv_transfer.kv_connector.v1.metrics")
+
+    class KVConnectorPromMetrics:
+        pass
+
+    class KVConnectorStats:
+        def __init__(self, data=None):
+            self.data = data or {}
+
+    class PromMetric:
+        pass
+
+    metrics_mod.KVConnectorPromMetrics = KVConnectorPromMetrics
+    metrics_mod.KVConnectorStats = KVConnectorStats
+    metrics_mod.PromMetric = PromMetric
+    metrics_mod.PromMetricT = object
+    sys.modules[metrics_mod.__name__] = metrics_mod
+
+    pegaflow_ext = types.ModuleType("pegaflow.pegaflow")
+
+    class PegaFlowError(Exception):
+        pass
+
+    class PegaFlowBusinessError(PegaFlowError):
+        pass
+
+    class PegaFlowServiceError(PegaFlowError):
+        pass
+
+    pegaflow_ext.PegaFlowError = PegaFlowError
+    pegaflow_ext.PegaFlowBusinessError = PegaFlowBusinessError
+    pegaflow_ext.PegaFlowServiceError = PegaFlowServiceError
+    pegaflow_ext.EngineRpcClient = object
+    sys.modules[pegaflow_ext.__name__] = pegaflow_ext
+
+
+@pytest.fixture()
+def scheduler_module():
+    _install_test_stubs()
+    repo_python = Path(__file__).resolve().parents[1]
+
+    for module_name in [
+        "pegaflow.compat",
+        "pegaflow.connector.common",
+        "pegaflow.connector.connector_metrics",
+        "pegaflow.connector.scheduler",
+    ]:
+        sys.modules.pop(module_name, None)
+
+    compat_spec = importlib.util.spec_from_file_location(
+        "pegaflow.compat",
+        repo_python / "pegaflow" / "compat.py",
+    )
+    compat_module = importlib.util.module_from_spec(compat_spec)
+    sys.modules["pegaflow.compat"] = compat_module
+    assert compat_spec and compat_spec.loader
+    compat_spec.loader.exec_module(compat_module)
+
+    scheduler_spec = importlib.util.spec_from_file_location(
+        "pegaflow.connector.scheduler",
+        repo_python / "pegaflow" / "connector" / "scheduler.py",
+    )
+    module = importlib.util.module_from_spec(scheduler_spec)
+    sys.modules["pegaflow.connector.scheduler"] = module
+    assert scheduler_spec and scheduler_spec.loader
+    scheduler_spec.loader.exec_module(module)
+    yield module
+
+    for module_name in [
+        "pegaflow.compat",
+        "pegaflow.connector",
+        "pegaflow.connector.common",
+        "pegaflow.connector.connector_metrics",
+        "pegaflow.connector.scheduler",
+        "pegaflow.pegaflow",
+        "vllm.distributed.kv_transfer.kv_connector.v1.base",
+        "vllm.distributed.kv_transfer.kv_connector.v1.metrics",
+        "vllm.distributed.kv_transfer.kv_connector.v1",
+        "vllm.distributed.kv_transfer.kv_connector",
+        "vllm.distributed.kv_transfer",
+        "vllm.distributed",
+        "vllm",
+        "pegaflow",
+    ]:
+        sys.modules.pop(module_name, None)
+
+
+def test_scheduler_falls_back_to_legacy_query(scheduler_module):
+    class FakeStateManager:
+        def is_available(self) -> bool:
+            return True
+
+        def mark_unavailable(self, reason: str) -> None:
+            raise AssertionError(f"unexpected mark_unavailable: {reason}")
+
+    class FakeEngineClient:
+        endpoint = "http://legacy-server:50055"
+
+        def __init__(self):
+            self.query_prefetch_calls = 0
+            self.query_calls = 0
+
+        def query_prefetch(self, instance_id: str, block_hashes: list[bytes]):
+            self.query_prefetch_calls += 1
+            raise scheduler_module.PegaFlowBusinessError(
+                "rpc RPC failed: code: 'Operation is not implemented or not supported'"
+            )
+
+        def query(self, instance_id: str, block_hashes: list[bytes]):
+            self.query_calls += 1
+            return {
+                "ok": True,
+                "message": "legacy query fallback",
+                "hit_blocks": 2,
+                "prefetch_state": "done",
+                "loading_blocks": 0,
+                "missing_blocks": 1,
+            }
+
+    context = SimpleNamespace(
+        engine_client=FakeEngineClient(),
+        state_manager=FakeStateManager(),
+        instance_id="instance-1",
+    )
+    connector = scheduler_module.SchedulerConnector(context)
+
+    hit_blocks = connector._count_available_block_prefix([b"a", b"b", b"c"], "req-1")
+
+    assert hit_blocks == 2
+    assert context.engine_client.query_prefetch_calls == 1
+    assert context.engine_client.query_calls == 1
+
+
+def test_scheduler_preserves_non_compat_business_errors(scheduler_module):
+    class FakeStateManager:
+        def is_available(self) -> bool:
+            return True
+
+        def mark_unavailable(self, reason: str) -> None:
+            raise AssertionError(f"unexpected mark_unavailable: {reason}")
+
+    class FakeEngineClient:
+        endpoint = "http://new-server:50055"
+
+        def query_prefetch(self, instance_id: str, block_hashes: list[bytes]):
+            raise scheduler_module.PegaFlowBusinessError("invalid block hash payload")
+
+        def query(self, instance_id: str, block_hashes: list[bytes]):
+            raise AssertionError("legacy query should not be used")
+
+    context = SimpleNamespace(
+        engine_client=FakeEngineClient(),
+        state_manager=FakeStateManager(),
+        instance_id="instance-1",
+    )
+    connector = scheduler_module.SchedulerConnector(context)
+
+    with pytest.raises(scheduler_module.PegaFlowBusinessError):
+        connector._count_available_block_prefix([b"a"], "req-2")


### PR DESCRIPTION
## Summary

- fall back to legacy `Query` when older servers do not implement `QueryPrefetch`
- log connector version locally and add build metadata / `--version` output for `pegaflow-server` and `pegaflow-metaserver`
- add a focused regression test for the Python fallback path

## Why

Mixed-version deployments could fail with an opaque `UNIMPLEMENTED`-style error when newer connector code hit an older `pegaflow-server`. That error bubbled up as a `PegaFlowBusinessError` and could kill the vLLM engine instead of degrading gracefully.

This patch makes that path safer and much easier for operators to diagnose.

Closes #136.

## Validation

- `cargo fmt --all --check`
- self-contained Python fallback repro/validation script
- `python3 -m py_compile python/pegaflow/__init__.py python/pegaflow/compat.py python/pegaflow/connector/__init__.py python/pegaflow/connector/scheduler.py python/pegaflow/sglang/peagflow_radix_cache.py python/tests/test_query_prefetch_fallback.py`
- `PYTHONPATH=. uv run --no-project --with pytest python -m pytest --noconftest tests/test_query_prefetch_fallback.py -q`
- `uv run --with grpcio-tools env PROTOC=/tmp/protoc-wrapper cargo check -p pegaflow-metaserver -p pegaflow-server`
- `uv run --with grpcio-tools env PROTOC=/tmp/protoc-wrapper cargo run -q -p pegaflow-server -- --version`
- `uv run --with grpcio-tools env PROTOC=/tmp/protoc-wrapper cargo run -q -p pegaflow-metaserver -- --version`

## Notes

- The fallback is intentionally limited to restoring legacy `Query` behavior; it does not re-create SSD prefetch semantics on older servers.
- Fallback detection is still heuristic on the returned error text because there is no explicit runtime capability handshake yet.
