### PR TITLE
fix(python): prioritize cargo target binary over stale wheel copy

### DIFF
--- a/python/pegaflow/_bin_utils.py
+++ b/python/pegaflow/_bin_utils.py
@@ -13,23 +13,23 @@ def find_binary(name: str) -> str:
     """Locate a pegaflow binary by name.
 
     Search order:
-    1. Installed package directory (pip install from wheel)
-    2. Cargo target/release/ (dev mode / editable install)
-    3. Cargo target/debug/
+    1. Cargo target/release/ (dev mode — always freshest build)
+    2. Cargo target/debug/
+    3. Installed package directory (pip install from wheel)
     4. PATH fallback
     """
-    # 1. Wheel install: binary next to this module
-    path = _MODULE_DIR / name
-    if path.is_file():
-        return str(path)
-
-    # 2. Dev mode: cargo target/release/
+    # 1. Dev mode: cargo target/release/
     path = _REPO_ROOT / "target" / "release" / name
     if path.is_file():
         return str(path)
 
-    # 3. Dev mode: cargo target/debug/
+    # 2. Dev mode: cargo target/debug/
     path = _REPO_ROOT / "target" / "debug" / name
+    if path.is_file():
+        return str(path)
+
+    # 3. Wheel install: binary next to this module
+    path = _MODULE_DIR / name
     if path.is_file():
         return str(path)
 


### PR DESCRIPTION
## Summary
- Reorder `find_binary` search priority in `_bin_utils.py` to check `target/release/` and `target/debug/` before the module directory
- Fixes an issue where a stale binary left by a previous wheel build at `python/pegaflow/pegaflow-server-py` would shadow the freshly compiled binary, causing `pegaflow-server` to run an outdated version after `cargo build`

## Test plan
- [ ] Editable install (`pip install -e .`) + `cargo build -r --bin pegaflow-server-py` → `pegaflow-server --help` shows latest flags
- [ ] Wheel install (no `target/` dir) → falls back to bundled binary as before

Made with [Cursor](https://cursor.com)