### PR TITLE
chore: unify rust and python package versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,56 @@ jobs:
       - name: Check last commit message
         run: cz check --rev-range HEAD~1..HEAD
 
+  version-consistency-check:
+    name: version consistency check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Check Rust and Python package versions stay in sync
+        run: |
+          python3 - <<'PY'
+          import pathlib
+          import re
+
+          repo = pathlib.Path.cwd()
+          cargo_toml = (repo / "Cargo.toml").read_text(encoding="utf-8")
+          pyproject_toml = (repo / "python" / "pyproject.toml").read_text(encoding="utf-8")
+
+          def find_section_version(text: str, section: str) -> str:
+              match = re.search(
+                  rf"(?ms)^\[{re.escape(section)}\]\n(.*?)(?:^\[|\Z)",
+                  text,
+              )
+              if match is None:
+                  raise SystemExit(f"missing section [{section}]")
+
+              version_match = re.search(
+                  r'^version = "([^"]+)"$',
+                  match.group(1),
+                  re.MULTILINE,
+              )
+              if version_match is None:
+                  raise SystemExit(f"missing version in [{section}]")
+              return version_match.group(1)
+
+          rust_version = find_section_version(cargo_toml, "workspace.package")
+          python_version = find_section_version(pyproject_toml, "project")
+          commitizen_version = find_section_version(pyproject_toml, "tool.commitizen")
+
+          if rust_version != python_version or python_version != commitizen_version:
+              raise SystemExit(
+                  "version mismatch: "
+                  f"Cargo.toml={rust_version}, "
+                  f"python/pyproject.toml project={python_version}, "
+                  f"tool.commitizen={commitizen_version}"
+              )
+
+          print(f"version check passed: {rust_version}")
+          PY
+
   typos-check:
     name: typos check
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,7 +2174,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-core"
-version = "0.1.0"
+version = "0.0.16"
 dependencies = [
  "ahash",
  "bytesize",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.1.0"
+version = "0.0.16"
 dependencies = [
  "clap",
  "colored",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.1.0"
+version = "0.0.16"
 dependencies = [
  "prost",
  "tonic",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.0.1"
+version = "0.0.16"
 dependencies = [
  "log",
  "logforth",
@@ -2251,7 +2251,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.1.0"
+version = "0.0.16"
 dependencies = [
  "axum",
  "clap",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.1.0"
+version = "0.0.16"
 dependencies = [
  "bincode",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.0.16"
 edition = "2024"
 
 [workspace.dependencies]

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -18,6 +18,7 @@ use tonic::transport::Server;
 #[derive(Parser, Debug)]
 #[command(
     name = "pegaflow-metaserver",
+    version,
     about = "PegaFlow MetaServer - manages block hash keys across multi-node instances"
 )]
 pub struct Cli {

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -101,6 +101,10 @@ async fn shutdown_signal(notify: Arc<Notify>) {
 pub async fn run() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
     init_logging(&cli.log_level);
+    info!(
+        "Starting pegaflow-metaserver v{}",
+        env!("CARGO_PKG_VERSION")
+    );
 
     info!("Starting PegaFlow MetaServer");
     info!("Binding to address: {}", cli.addr);

--- a/pegaflow-server/src/bin/pegaflow-router.rs
+++ b/pegaflow-server/src/bin/pegaflow-router.rs
@@ -391,6 +391,7 @@ struct Args {
 #[tokio::main]
 async fn main() {
     pegaflow_core::logging::init_stderr("info");
+    info!("Starting pegaflow-router v{}", env!("CARGO_PKG_VERSION"));
 
     let args = Args::parse();
 

--- a/pegaflow-server/src/bin/pegaflow-router.rs
+++ b/pegaflow-server/src/bin/pegaflow-router.rs
@@ -368,6 +368,7 @@ async fn completions(state: State<RouterState>, headers: HeaderMap, body: Json<V
 
 #[derive(Parser)]
 #[command(name = "pegaflow-router")]
+#[command(version)]
 #[command(about = "PegaFlow P/D Disaggregation Router")]
 struct Args {
     /// Host to bind

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -345,6 +345,7 @@ fn init_metrics(
 pub fn run() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
     pegaflow_core::logging::init_stdout_colored(&cli.log_level);
+    info!("Starting pega-engine-server v{}", env!("CARGO_PKG_VERSION"));
     trace::init();
     pegaflow_core::set_trace_sample_rate(cli.trace_sample_rate);
 

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -45,6 +45,7 @@ static GLOBAL: Jemalloc = Jemalloc;
 #[derive(Parser, Debug)]
 #[command(
     name = "pega-engine-server",
+    version,
     about = "PegaEngine gRPC server with CUDA IPC registry"
 )]
 pub struct Cli {

--- a/pegaflow-transfer/src/bin/pegaflow_cpu_bench.rs
+++ b/pegaflow-transfer/src/bin/pegaflow_cpu_bench.rs
@@ -22,6 +22,7 @@ use pegaflow_transfer::{MooncakeTransferEngine, init_logging};
 #[derive(Parser)]
 #[command(
     name = "pegaflow_cpu_bench",
+    version,
     about = "RDMA CPU memory block-task latency benchmark"
 )]
 struct Cli {

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pegaflow-py"
-version = "0.0.1"
+version.workspace = true
 edition.workspace = true
 
 [lib]

--- a/python/pegaflow/__init__.py
+++ b/python/pegaflow/__init__.py
@@ -15,6 +15,7 @@ try:
         PegaFlowServiceError,
         PyLoadState,
         TransferEngine,
+        __version__ as _rust_version,
     )
 except ImportError:
     # Fallback for development when the Rust extension is not built
@@ -26,8 +27,10 @@ except ImportError:
         "pegaflow rust extension is not available, check pegaflow-xxx.so file exists"
     ) from None
 
-__version__ = "0.0.1"
+__version__ = _rust_version
+
 __all__ = [
+    "__version__",
     "EngineRpcClient",
     "PegaEngine",
     "PegaFlowBusinessError",

--- a/python/pegaflow/__init__.py
+++ b/python/pegaflow/__init__.py
@@ -15,6 +15,8 @@ try:
         PegaFlowServiceError,
         PyLoadState,
         TransferEngine,
+    )
+    from .pegaflow import (
         __version__ as _rust_version,
     )
 except ImportError:

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -6,6 +6,8 @@ for distributed LLM inference with vLLM and SGLang.
 
 from typing import Any
 
+__version__: str
+
 # Custom exceptions for error classification
 
 class PegaFlowError(Exception):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -103,5 +103,5 @@ profile = "black"
 [tool.commitizen]
 name = "cz_conventional_commits"
 version = "0.0.16"
-version_files = ["pyproject.toml:^version"]
+version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -665,6 +665,7 @@ impl PyLoadState {
 #[pymodule]
 fn pegaflow(m: &Bound<'_, PyModule>) -> PyResult<()> {
     pegaflow_core::logging::init_stderr("info,pegaflow_core=info");
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<PegaEngine>()?;
     m.add_class::<EngineRpcClient>()?;
     m.add_class::<PyLoadState>()?;


### PR DESCRIPTION
## Summary
- unify the workspace Rust version with the Python package release version
- expose the compiled package version through Rust CLIs and 
- add a CI check to keep Rust and Python version declarations in sync


- local version consistency script matching CI logic