### PR TITLE
feat(server): add HTTP endpoints for instance cleanup

### DIFF
--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -353,6 +353,30 @@ impl PegaEngine {
         Ok(())
     }
 
+    /// Unregister all instances, returning the IDs that were removed.
+    pub fn unregister_all_instances(&self) -> Vec<String> {
+        let mut instances = self
+            .instances
+            .write()
+            .expect("instances write lock poisoned");
+        let ids: Vec<String> = instances.keys().cloned().collect();
+        instances.clear();
+        if !ids.is_empty() {
+            info!("Unregistered all instances: {:?}", ids);
+        }
+        ids
+    }
+
+    /// List all registered instance IDs.
+    pub fn list_instance_ids(&self) -> Vec<String> {
+        self.instances
+            .read()
+            .expect("instances read lock poisoned")
+            .keys()
+            .cloned()
+            .collect()
+    }
+
     /// Pure memory-only prefix query.
     ///
     /// Checks which prefix blocks are in the memory cache without triggering

--- a/pegaflow-server/src/http_server.rs
+++ b/pegaflow-server/src/http_server.rs
@@ -1,9 +1,25 @@
-use axum::{Router, routing::get};
-use log::info;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::{Json, Router, routing::get, routing::post};
+use log::{info, warn};
+use parking_lot::Mutex;
+use pegaflow_core::PegaEngine;
 use prometheus::{Registry, TextEncoder};
+use serde::Serialize;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
+
+use crate::registry::CudaTensorRegistry;
+
+/// Shared state for HTTP handlers that need engine access.
+#[derive(Clone)]
+struct AppState {
+    engine: Arc<PegaEngine>,
+    registry: Arc<Mutex<CudaTensorRegistry>>,
+    prometheus_registry: Option<Registry>,
+}
 
 /// Handler for health check endpoint
 async fn health_handler() -> &'static str {
@@ -11,53 +27,114 @@ async fn health_handler() -> &'static str {
 }
 
 /// Handler for Prometheus /metrics endpoint
-async fn metrics_handler(axum::extract::State(registry): axum::extract::State<Registry>) -> String {
+async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let Some(ref registry) = state.prometheus_registry else {
+        return (StatusCode::NOT_FOUND, "metrics not enabled".to_string());
+    };
     let encoder = TextEncoder::new();
     let metric_families = registry.gather();
-    encoder
-        .encode_to_string(&metric_families)
-        .unwrap_or_else(|e| format!("# Error encoding metrics: {e}"))
+    (
+        StatusCode::OK,
+        encoder
+            .encode_to_string(&metric_families)
+            .unwrap_or_else(|e| format!("# Error encoding metrics: {e}")),
+    )
 }
 
-/// Start HTTP server for health check and optional Prometheus metrics
+#[derive(Serialize)]
+struct InstancesResponse {
+    instances: Vec<String>,
+}
+
+/// Handler for listing all registered instances.
+async fn list_instances_handler(State(state): State<AppState>) -> Json<InstancesResponse> {
+    let instances = state.engine.list_instance_ids();
+    Json(InstancesResponse { instances })
+}
+
+#[derive(Serialize)]
+struct CleanupResponse {
+    removed_instances: Vec<String>,
+    removed_tensors: usize,
+}
+
+/// Handler for cleaning up all instances and their CUDA tensors.
+async fn cleanup_instances_handler(State(state): State<AppState>) -> Json<CleanupResponse> {
+    // 1. Drop all CUDA IPC tensors first (requires GIL, gc.collect, empty_cache)
+    let removed_tensors = {
+        let mut registry = state.registry.lock();
+        registry.clear_and_count()
+    };
+
+    // 2. Remove all instances from the engine
+    let removed_instances = state.engine.unregister_all_instances();
+
+    if !removed_instances.is_empty() || removed_tensors > 0 {
+        warn!(
+            "Cleanup: removed {} instance(s) {:?}, {} CUDA tensor(s)",
+            removed_instances.len(),
+            removed_instances,
+            removed_tensors
+        );
+    } else {
+        info!("Cleanup: nothing to clean");
+    }
+
+    Json(CleanupResponse {
+        removed_instances,
+        removed_tensors,
+    })
+}
+
+/// Start HTTP server for health check, optional Prometheus metrics, and instance management.
 pub async fn start_http_server(
     addr: std::net::SocketAddr,
+    engine: Arc<PegaEngine>,
+    registry: Arc<Mutex<CudaTensorRegistry>>,
     enable_prometheus: bool,
     prometheus_registry: Option<Registry>,
     shutdown: Arc<Notify>,
 ) -> Result<tokio::task::JoinHandle<()>, std::io::Error> {
     let listener = TcpListener::bind(addr).await?;
 
-    let handle = if enable_prometheus {
-        let registry = prometheus_registry
-            .expect("prometheus_registry must be Some when enable_prometheus is true");
-        let app = Router::new()
-            .route("/health", get(health_handler))
-            .route("/metrics", get(metrics_handler))
-            .with_state(registry);
-        info!("Starting HTTP server on {} (/health and /metrics)", addr);
-
-        tokio::spawn(async move {
-            axum::serve(listener, app)
-                .with_graceful_shutdown(async move {
-                    shutdown.notified().await;
-                })
-                .await
-                .ok();
-        })
-    } else {
-        let app = Router::new().route("/health", get(health_handler));
-        info!("Starting HTTP server on {} (/health only)", addr);
-
-        tokio::spawn(async move {
-            axum::serve(listener, app)
-                .with_graceful_shutdown(async move {
-                    shutdown.notified().await;
-                })
-                .await
-                .ok();
-        })
+    let state = AppState {
+        engine,
+        registry,
+        prometheus_registry: if enable_prometheus {
+            prometheus_registry
+        } else {
+            None
+        },
     };
+
+    let mut app = Router::new()
+        .route("/health", get(health_handler))
+        .route("/instances", get(list_instances_handler))
+        .route("/instances/cleanup", post(cleanup_instances_handler));
+
+    if enable_prometheus {
+        app = app.route("/metrics", get(metrics_handler));
+        info!(
+            "Starting HTTP server on {} (/health, /metrics, /instances, /instances/cleanup)",
+            addr
+        );
+    } else {
+        info!(
+            "Starting HTTP server on {} (/health, /instances, /instances/cleanup)",
+            addr
+        );
+    }
+
+    let app = app.with_state(state);
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                shutdown.notified().await;
+            })
+            .await
+            .ok();
+    });
 
     Ok(handle)
 }

--- a/pegaflow-server/src/http_server.rs
+++ b/pegaflow-server/src/http_server.rs
@@ -1,7 +1,7 @@
-use axum::extract::State;
+use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::{Json, Router, routing::get, routing::post};
+use axum::{Json, Router, routing::delete, routing::get, routing::post};
 use log::{info, warn};
 use parking_lot::Mutex;
 use pegaflow_core::PegaEngine;
@@ -86,6 +86,58 @@ async fn cleanup_instances_handler(State(state): State<AppState>) -> Json<Cleanu
     })
 }
 
+#[derive(Serialize)]
+struct DeleteInstanceResponse {
+    instance_id: String,
+    removed_tensors: usize,
+}
+
+/// Handler for deleting a specific instance and its CUDA tensors.
+async fn delete_instance_handler(
+    State(state): State<AppState>,
+    Path(instance_id): Path<String>,
+) -> impl IntoResponse {
+    // 1. Drop CUDA IPC tensors for this instance
+    let removed_tensors = {
+        let mut registry = state.registry.lock();
+        registry.drop_instance(&instance_id)
+    };
+
+    // 2. Remove instance from the engine
+    match state.engine.unregister_instance(&instance_id) {
+        Ok(()) => {
+            warn!(
+                "Deleted instance {}, {} CUDA tensor(s) released",
+                instance_id, removed_tensors
+            );
+            (
+                StatusCode::OK,
+                Json(DeleteInstanceResponse {
+                    instance_id,
+                    removed_tensors,
+                })
+                .into_response(),
+            )
+        }
+        Err(_) if removed_tensors > 0 => {
+            // Tensors were cleaned but instance was already gone from engine
+            warn!(
+                "Instance {} not in engine but cleaned {} CUDA tensor(s)",
+                instance_id, removed_tensors
+            );
+            (
+                StatusCode::OK,
+                Json(DeleteInstanceResponse {
+                    instance_id,
+                    removed_tensors,
+                })
+                .into_response(),
+            )
+        }
+        Err(e) => (StatusCode::NOT_FOUND, format!("{e}").into_response()),
+    }
+}
+
 /// Start HTTP server for health check, optional Prometheus metrics, and instance management.
 pub async fn start_http_server(
     addr: std::net::SocketAddr,
@@ -110,17 +162,18 @@ pub async fn start_http_server(
     let mut app = Router::new()
         .route("/health", get(health_handler))
         .route("/instances", get(list_instances_handler))
-        .route("/instances/cleanup", post(cleanup_instances_handler));
+        .route("/instances/cleanup", post(cleanup_instances_handler))
+        .route("/instances/{instance_id}", delete(delete_instance_handler));
 
     if enable_prometheus {
         app = app.route("/metrics", get(metrics_handler));
         info!(
-            "Starting HTTP server on {} (/health, /metrics, /instances, /instances/cleanup)",
+            "Starting HTTP server on {} (/health, /metrics, /instances, /instances/cleanup, /instances/:id)",
             addr
         );
     } else {
         info!(
-            "Starting HTTP server on {} (/health, /instances, /instances/cleanup)",
+            "Starting HTTP server on {} (/health, /instances, /instances/cleanup, /instances/:id)",
             addr
         );
     }

--- a/pegaflow-server/src/http_server.rs
+++ b/pegaflow-server/src/http_server.rs
@@ -1,19 +1,18 @@
-use axum::extract::{Path, State};
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::{Json, Router, routing::delete, routing::get, routing::post};
+use axum::{Json, Router, routing::get, routing::post};
 use log::{info, warn};
 use parking_lot::Mutex;
 use pegaflow_core::PegaEngine;
 use prometheus::{Registry, TextEncoder};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 
 use crate::registry::CudaTensorRegistry;
 
-/// Shared state for HTTP handlers that need engine access.
 #[derive(Clone)]
 struct AppState {
     engine: Arc<PegaEngine>,
@@ -21,12 +20,10 @@ struct AppState {
     prometheus_registry: Option<Registry>,
 }
 
-/// Handler for health check endpoint
 async fn health_handler() -> &'static str {
     "ok"
 }
 
-/// Handler for Prometheus /metrics endpoint
 async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
     let Some(ref registry) = state.prometheus_registry else {
         return (StatusCode::NOT_FOUND, "metrics not enabled".to_string());
@@ -46,10 +43,14 @@ struct InstancesResponse {
     instances: Vec<String>,
 }
 
-/// Handler for listing all registered instances.
 async fn list_instances_handler(State(state): State<AppState>) -> Json<InstancesResponse> {
     let instances = state.engine.list_instance_ids();
     Json(InstancesResponse { instances })
+}
+
+#[derive(Deserialize)]
+struct CleanupQuery {
+    id: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -58,83 +59,78 @@ struct CleanupResponse {
     removed_tensors: usize,
 }
 
-/// Handler for cleaning up all instances and their CUDA tensors.
-async fn cleanup_instances_handler(State(state): State<AppState>) -> Json<CleanupResponse> {
-    // 1. Drop all CUDA IPC tensors first (requires GIL, gc.collect, empty_cache)
-    let removed_tensors = {
-        let mut registry = state.registry.lock();
-        registry.clear_and_count()
-    };
-
-    // 2. Remove all instances from the engine
-    let removed_instances = state.engine.unregister_all_instances();
-
-    if !removed_instances.is_empty() || removed_tensors > 0 {
-        warn!(
-            "Cleanup: removed {} instance(s) {:?}, {} CUDA tensor(s)",
-            removed_instances.len(),
-            removed_instances,
-            removed_tensors
-        );
-    } else {
-        info!("Cleanup: nothing to clean");
-    }
-
-    Json(CleanupResponse {
-        removed_instances,
-        removed_tensors,
-    })
-}
-
-#[derive(Serialize)]
-struct DeleteInstanceResponse {
-    instance_id: String,
-    removed_tensors: usize,
-}
-
-/// Handler for deleting a specific instance and its CUDA tensors.
-async fn delete_instance_handler(
+/// POST /instances/cleanup[?id=<instance_id>]
+///
+/// Without `id`: remove all instances and release all CUDA IPC tensors.
+/// With `id`:    remove only the specified instance.
+async fn cleanup_handler(
     State(state): State<AppState>,
-    Path(instance_id): Path<String>,
+    Query(query): Query<CleanupQuery>,
 ) -> impl IntoResponse {
-    // 1. Drop CUDA IPC tensors for this instance
-    let removed_tensors = {
-        let mut registry = state.registry.lock();
-        registry.drop_instance(&instance_id)
-    };
+    match query.id {
+        None => {
+            let removed_tensors = {
+                let mut registry = state.registry.lock();
+                registry.clear_and_count()
+            };
+            let removed_instances = state.engine.unregister_all_instances();
 
-    // 2. Remove instance from the engine
-    match state.engine.unregister_instance(&instance_id) {
-        Ok(()) => {
-            warn!(
-                "Deleted instance {}, {} CUDA tensor(s) released",
-                instance_id, removed_tensors
-            );
+            if !removed_instances.is_empty() || removed_tensors > 0 {
+                warn!(
+                    "Cleanup all: removed {:?}, {} CUDA tensor(s) released",
+                    removed_instances, removed_tensors
+                );
+            } else {
+                info!("Cleanup all: nothing to remove");
+            }
+
             (
                 StatusCode::OK,
-                Json(DeleteInstanceResponse {
-                    instance_id,
+                Json(CleanupResponse {
+                    removed_instances,
                     removed_tensors,
                 })
                 .into_response(),
             )
         }
-        Err(_) if removed_tensors > 0 => {
-            // Tensors were cleaned but instance was already gone from engine
-            warn!(
-                "Instance {} not in engine but cleaned {} CUDA tensor(s)",
-                instance_id, removed_tensors
-            );
-            (
-                StatusCode::OK,
-                Json(DeleteInstanceResponse {
-                    instance_id,
-                    removed_tensors,
-                })
-                .into_response(),
-            )
+        Some(instance_id) => {
+            let removed_tensors = {
+                let mut registry = state.registry.lock();
+                registry.drop_instance(&instance_id)
+            };
+
+            match state.engine.unregister_instance(&instance_id) {
+                Ok(()) => {
+                    warn!(
+                        "Cleanup instance {}: {} CUDA tensor(s) released",
+                        instance_id, removed_tensors
+                    );
+                    (
+                        StatusCode::OK,
+                        Json(CleanupResponse {
+                            removed_instances: vec![instance_id],
+                            removed_tensors,
+                        })
+                        .into_response(),
+                    )
+                }
+                Err(_) if removed_tensors > 0 => {
+                    warn!(
+                        "Instance {} not in engine but cleaned {} CUDA tensor(s)",
+                        instance_id, removed_tensors
+                    );
+                    (
+                        StatusCode::OK,
+                        Json(CleanupResponse {
+                            removed_instances: vec![instance_id],
+                            removed_tensors,
+                        })
+                        .into_response(),
+                    )
+                }
+                Err(e) => (StatusCode::NOT_FOUND, format!("{e}").into_response()),
+            }
         }
-        Err(e) => (StatusCode::NOT_FOUND, format!("{e}").into_response()),
     }
 }
 
@@ -162,18 +158,17 @@ pub async fn start_http_server(
     let mut app = Router::new()
         .route("/health", get(health_handler))
         .route("/instances", get(list_instances_handler))
-        .route("/instances/cleanup", post(cleanup_instances_handler))
-        .route("/instances/{instance_id}", delete(delete_instance_handler));
+        .route("/instances/cleanup", post(cleanup_handler));
 
     if enable_prometheus {
         app = app.route("/metrics", get(metrics_handler));
         info!(
-            "Starting HTTP server on {} (/health, /metrics, /instances, /instances/cleanup, /instances/:id)",
+            "Starting HTTP server on {} (/health, /metrics, /instances, /instances/cleanup)",
             addr
         );
     } else {
         info!(
-            "Starting HTTP server on {} (/health, /instances, /instances/cleanup, /instances/:id)",
+            "Starting HTTP server on {} (/health, /instances, /instances/cleanup)",
             addr
         );
     }

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -509,6 +509,8 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         // Start HTTP server for health check (always enabled)
         let http_server_handle = http_server::start_http_server(
             cli.http_addr,
+            Arc::clone(&engine),
+            Arc::clone(&registry),
             cli.enable_prometheus,
             metrics_state.prometheus_registry.clone(),
             Arc::clone(&shutdown),

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -127,6 +127,13 @@ impl CudaTensorRegistry {
     }
 
     pub fn clear(&mut self) {
+        self.clear_and_count();
+    }
+
+    /// Clear all contexts and return the total number of tensors removed.
+    pub fn clear_and_count(&mut self) -> usize {
+        let tensor_count: usize = self.contexts.values().map(|ctx| ctx.tensors.len()).sum();
+
         // Clear all contexts under GIL to ensure proper Python object cleanup
         Python::attach(|py| {
             self.contexts.clear();
@@ -139,6 +146,8 @@ impl CudaTensorRegistry {
             let cuda = torch.getattr("cuda").expect("torch.cuda");
             let _ = cuda.call_method0("empty_cache");
         });
+
+        tensor_count
     }
 
     fn materialize_tensor(device_id: i32, wrapper_bytes: &[u8]) -> PyResult<LayerTensor> {


### PR DESCRIPTION
## Summary

- Add `GET /instances` to list registered instance IDs
- Add `POST /instances/cleanup` to release all CUDA IPC tensors and unregister all instances
- Add `PegaEngine::unregister_all_instances()` and `list_instance_ids()`
- Add `CudaTensorRegistry::clear_and_count()` returning removed tensor count

When vLLM crashes (`kill -9`) without normal shutdown, its CUDA IPC tensors remain mapped in pegaflow-server (~11GB leaked GPU memory on RTX 5070 Ti with Qwen3-0.6B). This endpoint lets operators manually reclaim resources before restarting vLLM.

## Verified locally

| Step | GPU Memory |
|------|-----------|
| pegaflow-server baseline | 224 MiB |
| vLLM running with PegaFlow | ~15 GiB |
| After `kill -9` vLLM | 11826 MiB (leaked) |
| After `POST /instances/cleanup` | **224 MiB** (recovered) |
| New vLLM started + bench cold/warm | OK |

## Test plan

- [x] `cargo clippy` clean
- [x] Manual test: start server → start vLLM → kill -9 → verify leak → cleanup → verify recovery → restart vLLM → bench

🤖 Generated with [Claude Code](https://claude.com/claude-code)