### PR TITLE
fix(core): harden MetaServer registrar against data loss and CPU spin

### DIFF
--- a/pegaflow-core/src/internode/mod.rs
+++ b/pegaflow-core/src/internode/mod.rs
@@ -33,7 +33,9 @@ pub mod types;
 
 // Re-export commonly used types for convenience
 pub use client::{PegaflowClient, PegaflowClientPool};
-pub use registrar::{MetaServerRegistrar, MetaServerRegistrarConfig};
+pub use registrar::{
+    DEFAULT_METASERVER_QUEUE_DEPTH, MetaServerRegistrar, MetaServerRegistrarConfig,
+};
 pub use registry::InstanceRegistry;
 pub use service_discovery::start_service_discovery;
 pub use types::{

--- a/pegaflow-core/src/internode/registrar.rs
+++ b/pegaflow-core/src/internode/registrar.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use log::{debug, error, info, warn};
 use pegaflow_proto::proto::engine::InsertBlockHashesRequest;
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient;
@@ -6,12 +8,15 @@ use tonic::transport::Channel;
 
 use crate::metrics::core_metrics;
 
-const DEFAULT_QUEUE_DEPTH: usize = 16;
+pub const DEFAULT_METASERVER_QUEUE_DEPTH: usize = 256;
+
+const INITIAL_BACKOFF_MS: u64 = 100;
+const MAX_BACKOFF_MS: u64 = 30_000;
 
 pub struct MetaServerRegistrarConfig {
-    pub metaserver_addr: String,
-    pub advertise_addr: String,
-    pub queue_depth: usize,
+    metaserver_addr: String,
+    advertise_addr: String,
+    queue_depth: usize,
 }
 
 impl MetaServerRegistrarConfig {
@@ -19,14 +24,20 @@ impl MetaServerRegistrarConfig {
         Self {
             metaserver_addr,
             advertise_addr,
-            queue_depth: DEFAULT_QUEUE_DEPTH,
+            queue_depth: DEFAULT_METASERVER_QUEUE_DEPTH,
         }
+    }
+
+    pub fn with_queue_depth(mut self, depth: usize) -> Self {
+        self.queue_depth = depth;
+        self
     }
 }
 
+/// A batch of (namespace, block_hash) pairs to register with MetaServer.
+/// Sent as a single channel message to avoid consuming multiple queue slots.
 struct RegistrationBatch {
-    namespace: String,
-    block_hashes: Vec<Vec<u8>>,
+    entries: Vec<(String, Vec<u8>)>,
 }
 
 pub struct MetaServerRegistrar {
@@ -34,6 +45,9 @@ pub struct MetaServerRegistrar {
 }
 
 impl MetaServerRegistrar {
+    /// Create a new registrar and spawn the background registration loop.
+    ///
+    /// Must be called from within a tokio runtime context.
     pub fn new(config: MetaServerRegistrarConfig) -> Self {
         let (tx, rx) = mpsc::channel(config.queue_depth);
 
@@ -52,27 +66,39 @@ impl MetaServerRegistrar {
     }
 
     /// Fire-and-forget registration. Mirrors `SsdBackingStore::ingest_batch()`.
-    pub(crate) fn try_register(&self, namespace: String, block_hashes: Vec<Vec<u8>>) {
-        if block_hashes.is_empty() {
+    ///
+    /// Accepts a flat list of (namespace, block_hash) pairs. The background loop
+    /// groups by namespace before issuing gRPC calls.
+    pub(crate) fn try_register(&self, entries: Vec<(String, Vec<u8>)>) {
+        if entries.is_empty() {
             return;
         }
-        let count = block_hashes.len();
-        let batch = RegistrationBatch {
-            namespace,
-            block_hashes,
-        };
-        if self.tx.try_send(batch).is_ok() {
-            core_metrics()
-                .metaserver_registration_blocks
-                .add(count as u64, &[]);
-        } else {
-            warn!(
-                "MetaServer registration queue full, dropping {} hashes",
-                count
-            );
-            core_metrics()
-                .metaserver_registration_queue_full
-                .add(count as u64, &[]);
+        let count = entries.len();
+        let batch = RegistrationBatch { entries };
+        match self.tx.try_send(batch) {
+            Ok(()) => {
+                core_metrics()
+                    .metaserver_registration_blocks
+                    .add(count as u64, &[]);
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                warn!(
+                    "MetaServer registration queue full, dropping {} hashes",
+                    count
+                );
+                core_metrics()
+                    .metaserver_registration_queue_full
+                    .add(count as u64, &[]);
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                error!(
+                    "MetaServer registration loop has exited, dropping {} hashes",
+                    count
+                );
+                core_metrics()
+                    .metaserver_registration_queue_full
+                    .add(count as u64, &[]);
+            }
         }
     }
 }
@@ -83,30 +109,28 @@ async fn registration_loop(
     advertise_addr: String,
 ) {
     let mut client: Option<MetaServerClient<Channel>> = None;
+    let mut backoff_ms: u64 = INITIAL_BACKOFF_MS;
 
     while let Some(batch) = rx.recv().await {
-        // Drain all pending batches for batching
-        let mut batches = vec![batch];
+        // Drain all pending batches for coalescing
+        let mut all_entries = batch.entries;
         while let Ok(more) = rx.try_recv() {
-            batches.push(more);
+            all_entries.extend(more.entries);
         }
 
         // Group by namespace
-        let mut grouped: std::collections::HashMap<String, Vec<Vec<u8>>> =
-            std::collections::HashMap::new();
-        for b in batches {
-            grouped
-                .entry(b.namespace)
-                .or_default()
-                .extend(b.block_hashes);
+        let mut grouped: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+        for (namespace, hash) in all_entries {
+            grouped.entry(namespace).or_default().push(hash);
         }
 
-        // Lazy-connect
+        // Lazy-connect with exponential backoff
         if client.is_none() {
             match MetaServerClient::connect(metaserver_addr.clone()).await {
                 Ok(c) => {
                     info!("Connected to MetaServer at {}", metaserver_addr);
                     client = Some(c);
+                    backoff_ms = INITIAL_BACKOFF_MS;
                 }
                 Err(e) => {
                     error!("Failed to connect to MetaServer: {e}");
@@ -114,18 +138,24 @@ async fn registration_loop(
                     core_metrics()
                         .metaserver_registration_failures
                         .add(total as u64, &[]);
+                    tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
+                    backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);
                     continue;
                 }
             }
         }
 
-        let c = client.as_mut().unwrap();
+        let c = client.as_mut().expect("client is Some after lazy-connect");
 
-        for (namespace, hashes) in grouped {
+        // Collect into Vec for indexed iteration so we can count remaining on failure
+        let namespaces: Vec<(String, Vec<Vec<u8>>)> = grouped.into_iter().collect();
+        let mut failed_at = None;
+
+        for (i, (namespace, hashes)) in namespaces.iter().enumerate() {
             let count = hashes.len();
             let request = InsertBlockHashesRequest {
                 namespace: namespace.clone(),
-                block_hashes: hashes,
+                block_hashes: hashes.clone(),
                 node: advertise_addr.clone(),
             };
 
@@ -142,14 +172,19 @@ async fn registration_loop(
                         "MetaServer insert_block_hashes failed (namespace={}, count={}): {e}",
                         namespace, count
                     );
-                    core_metrics()
-                        .metaserver_registration_failures
-                        .add(count as u64, &[]);
-                    // Reset client to force reconnect on next batch
-                    client = None;
+                    failed_at = Some(i);
                     break;
                 }
             }
+        }
+
+        if let Some(idx) = failed_at {
+            // Count all hashes from the failed namespace onward as failures
+            let dropped: usize = namespaces[idx..].iter().map(|(_, h)| h.len()).sum();
+            core_metrics()
+                .metaserver_registration_failures
+                .add(dropped as u64, &[]);
+            client = None;
         }
     }
 

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -36,7 +36,9 @@ pub use block::{
     BlockHash, BlockKey, BlockStatus, LayerBlock, LayerSave, PrefetchStatus, SealedBlock,
 };
 pub use instance::{GpuContext, InstanceContext, KVCacheRegistration};
-pub use internode::{MetaServerRegistrar, MetaServerRegistrarConfig};
+pub use internode::{
+    DEFAULT_METASERVER_QUEUE_DEPTH, MetaServerRegistrar, MetaServerRegistrarConfig,
+};
 pub use pegaflow_common::NumaNode;
 use pegaflow_common::NumaTopology;
 pub use pinned_pool::PinnedAllocation;

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -259,7 +259,7 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
                 .build(),
             metaserver_registration_queue_full: meter
                 .u64_counter("pegaflow_metaserver_registration_queue_full")
-                .with_description("Registration batches dropped due to full queue")
+                .with_description("Block hashes dropped due to full registration queue")
                 .build(),
         }
     })

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Weak};
 
 use crate::backing::{AllocateFn, DEFAULT_MAX_PREFETCH_BLOCKS, SsdBackingStore, SsdCacheConfig};
 use crate::block::{BlockKey, PrefetchStatus, SealedBlock};
-use crate::internode::registrar::MetaServerRegistrar;
+use crate::internode::MetaServerRegistrar;
 use crate::metrics::core_metrics;
 use crate::pinned_pool::{PinnedAllocation, PinnedAllocator};
 use pegaflow_common::NumaNode;
@@ -104,7 +104,6 @@ impl StorageEngine {
         let write_pipeline = Arc::new(write_pipeline);
 
         let is_numa = allocator.is_numa();
-        let registrar = metaserver_registrar;
         let engine = Arc::new_cyclic(move |weak_engine: &Weak<Self>| {
             // Build shared allocate_fn for backing stores.
             let alloc_weak = weak_engine.clone();
@@ -125,7 +124,7 @@ impl StorageEngine {
                 prefetch,
                 write_pipeline: write_pipeline.clone(),
                 ssd_store,
-                metaserver_registrar: registrar,
+                metaserver_registrar,
             }
         });
 

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -7,7 +7,7 @@ use tokio::sync::oneshot;
 
 use crate::backing::SsdBackingStore;
 use crate::block::{BlockKey, InflightBlock, SealedBlock, SlotInsertResult};
-use crate::internode::registrar::MetaServerRegistrar;
+use crate::internode::MetaServerRegistrar;
 use crate::metrics::core_metrics;
 use crate::offload::InsertEntries;
 use pegaflow_common::NumaNode;
@@ -205,16 +205,11 @@ fn send_backing_batches(deps: &InsertDeps, blocks: &[(BlockKey, Arc<SealedBlock>
 }
 
 fn register_block_hashes(registrar: &MetaServerRegistrar, blocks: &[(BlockKey, Arc<SealedBlock>)]) {
-    let mut grouped: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
-    for (key, _) in blocks {
-        grouped
-            .entry(key.namespace.clone())
-            .or_default()
-            .push(key.hash.clone());
-    }
-    for (namespace, hashes) in grouped {
-        registrar.try_register(namespace, hashes);
-    }
+    let entries: Vec<(String, Vec<u8>)> = blocks
+        .iter()
+        .map(|(key, _)| (key.namespace.clone(), key.hash.clone()))
+        .collect();
+    registrar.try_register(entries);
 }
 
 fn gc_inflight(

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -141,6 +141,10 @@ pub struct Cli {
     /// Defaults to PEGAFLOW_HOST_IP env + bind port, or the bind address.
     #[arg(long)]
     pub advertise_addr: Option<String>,
+
+    /// MetaServer registration queue depth (max pending registration batches).
+    #[arg(long, default_value_t = pegaflow_core::DEFAULT_METASERVER_QUEUE_DEPTH)]
+    pub metaserver_queue_depth: usize,
 }
 
 fn parse_sample_rate(s: &str) -> Result<f64, String> {
@@ -430,12 +434,12 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         let metaserver_registrar = cli.metaserver_addr.as_ref().map(|addr| {
             let advertise = resolve_advertise_addr(cli.advertise_addr.as_deref(), &cli.addr);
             info!(
-                "MetaServer registration enabled: metaserver={}, advertise={}",
-                addr, advertise
+                "MetaServer registration enabled: metaserver={}, advertise={}, queue_depth={}",
+                addr, advertise, cli.metaserver_queue_depth
             );
-            Arc::new(pegaflow_core::MetaServerRegistrar::new(
-                pegaflow_core::MetaServerRegistrarConfig::new(addr.clone(), advertise),
-            ))
+            let config = pegaflow_core::MetaServerRegistrarConfig::new(addr.clone(), advertise)
+                .with_queue_depth(cli.metaserver_queue_depth);
+            Arc::new(pegaflow_core::MetaServerRegistrar::new(config))
         });
 
         // Create PegaEngine inside tokio runtime context (needed for SSD cache tokio::spawn)


### PR DESCRIPTION
## Summary

Follow-up to #152. Addresses code review feedback to harden the MetaServer registrar:

- **Fix silent data loss**: on RPC failure, all remaining namespace hashes in the batch are now counted as failures (previously only the failing namespace was counted, the rest were silently dropped)
- **Add exponential backoff** (100ms → 30s) on MetaServer reconnect to prevent CPU spin during downtime
- **Eliminate double namespace grouping**: send flat `(namespace, hash)` pairs as a single channel message instead of one message per namespace, reducing queue pressure from N slots to 1
- **Distinguish `TrySendError::Full` vs `Closed`**: log at error level when the background loop has exited, instead of misleadingly reporting "queue full"
- **Increase default queue depth** from 16 to 256, expose `--metaserver-queue-depth` CLI flag
- **Make `MetaServerRegistrarConfig` fields private** per CLAUDE.md visibility convention
- **Fix metric description**: "Registration batches dropped" → "Block hashes dropped due to full registration queue"
- **Use re-export import paths** instead of internal module paths

## Test plan

- [x] `cargo check -p pegaflow-core -p pegaflow-server --no-default-features` passes
- [x] `cargo clippy -p pegaflow-core -p pegaflow-server --no-default-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] All pre-commit hooks pass (typos, commitizen, cargo fmt, cargo clippy)
- [ ] Integration test: verify reconnect backoff under MetaServer downtime

🤖 Generated with [Claude Code](https://claude.ai/code)