### PR TITLE
docs(unsafe): add SAFETY comments to unsafe blocks

### DIFF
--- a/.claude/skills/server-ops/SKILL.md
+++ b/.claude/skills/server-ops/SKILL.md
@@ -54,7 +54,7 @@ uv run python examples/bench_kv_cache.py --model /path/to/model --num-prompts 10
 ## Key Files
 
 - `pegaflow-server/src/service.rs`: gRPC service implementation
-- `pegaflow-server/src/bin/pegaflow-router.rs`: P/D disaggregation router
+- `pegaflow-server/src/bin/pegaflow-router.rs`: P/D request router
 - `pegaflow-metaserver/src/lib.rs`: MetaServer entry point and CLI
 - `pegaflow-metaserver/src/service.rs`: MetaServer gRPC service
 - `pegaflow-metaserver/src/store.rs`: Block hash store (LRU + TTL, backed by moka)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ A comprehensive guide for LLM agents working with the PegaFlow repository. PegaF
 PegaFlow enables efficient KV cache offloading and sharing for LLM inference workloads:
 
 - **Single-node KV cache offloading** — offload KV cache to host memory and restore it back to GPU with minimal latency
-- **P/D disaggregation** — separate prefill and decode phases across GPUs for better resource utilization
+- **Cross-node KV cache sharing** — share cached blocks across nodes via RDMA to avoid recomputation
 - **Prefix Caching** — reuse computed KV cache across requests
 - **High-performance transport** — based on CUDA IPC and zero-copy techniques
 - **~9x TTFT improvement** — warm-start requests achieve dramatically lower time-to-first-token
@@ -18,7 +18,7 @@ PegaFlow enables efficient KV cache offloading and sharing for LLM inference wor
 pegaflow/
 ├── pegaflow-core/          # Core Rust engine (storage/transfer/allocator)
 ├── pegaflow-proto/         # Protobuf/gRPC definitions
-├── pegaflow-server/        # gRPC server + P/D Router
+├── pegaflow-server/        # gRPC server + request router
 ├── python/                 # PyO3 bindings + Python connector
 │   ├── src/lib.rs          # PyO3 bindings entry point
 │   ├── pegaflow/connector/ # vLLM v1 connector (scheduler/worker)
@@ -69,7 +69,7 @@ Proto files define service interfaces including instance registration, KV operat
 | `main.rs` | Server binary entry point |
 | `service.rs` | Tonic gRPC service implementation |
 | `registry.rs` | Instance/worker registry |
-| `bin/pegaflow-router.rs` | P/D disaggregation router |
+| `bin/pegaflow-router.rs` | P/D request router |
 | `utils.rs` | Utility functions (e.g., memory size parsing) |
 | `metric.rs` | Server metrics and monitoring |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,11 @@ cargo bench --bench uds_latency
 2. **pegaflow-core** (Rust): Core storage engine
    - `PegaEngine`: Main engine managing GPU workers and KV cache storage
    - `storage/`: Modular block storage engine
-     - `mod.rs`: `StorageEngine` — aggregates allocator, read cache, prefetch, write pipeline, SSD store
+     - `mod.rs`: `StorageEngine` — aggregates allocator, read cache, prefetch, write pipeline, SSD store, remote fetch
      - `read_cache.rs`: Pin/unpin/consume operations on sealed blocks
      - `prefetch.rs`: Per-request SSD prefetch state machine
+     - `remote_fetch.rs`: Per-request cross-node remote fetch state machine (oneshot + backpressure)
+     - `transfer_lock.rs`: Transfer lock manager — prevents LRU eviction during RDMA transfer
      - `write_path.rs`: Async insert worker thread for batched writes
    - `backing/`: SSD backing store
      - `ssd.rs`: `SsdBackingStore` coordinator
@@ -55,7 +57,12 @@ cargo bench --bench uds_latency
    - `transfer.rs`: GPU-CPU transfer operations via CUDA
    - `cache.rs`: LRU cache for blocks
    - `gpu_worker.rs`: Per-GPU worker handling async operations
-   - `internode/`: Cross-node communication — `PegaflowClient` for querying remote nodes, service discovery via metaserver
+   - `internode/`: Cross-node communication
+     - `client.rs`: `PegaflowClient` / `PegaflowClientPool` for querying remote nodes
+     - `metaserver_query.rs`: MetaServer query client for block location discovery
+     - `remote_fetch_worker.rs`: Async RDMA fetch worker (MetaServer → gRPC → RDMA READ → SealedBlock)
+     - `registrar.rs`: Fire-and-forget block hash registration with MetaServer
+     - `service_discovery.rs`: Kubernetes pod watcher for PegaFlow instance discovery
 
 3. **pegaflow-proto** (Rust): Protobuf definitions
    - gRPC service definitions built with prost/tonic
@@ -64,7 +71,7 @@ cargo bench --bench uds_latency
    - `service.rs`: Tonic gRPC service implementation
    - `registry.rs`: Instance/worker registration
    - `http_server.rs`: HTTP health check and Prometheus metrics endpoint
-   - `bin/pegaflow-router.rs`: P/D disaggregation router
+   - `bin/pegaflow-router.rs`: P/D request router (coordinates P/D nodes; PegaFlow itself is a KV store)
 
 5. **pegaflow-metaserver** (Rust): Cross-node block hash registry
    - `service.rs`: gRPC MetaServer service (insert/query block hashes)
@@ -90,8 +97,10 @@ cargo bench --bench uds_latency
 vLLM/SGLang Worker <--gRPC--> PegaEngine Server <--CUDA IPC--> GPU Memory
                                     |
                              Pinned CPU Memory (KV cache storage)
-                                    |
-                             SSD Cache (optional, io_uring)
+                                   / \
+                   SSD Cache (io_uring)  Remote Node (RDMA READ)
+                                              |
+                                        MetaServer (block discovery)
 ```
 
 ### Key Concepts
@@ -137,12 +146,16 @@ vLLM/SGLang Worker <--gRPC--> PegaEngine Server <--CUDA IPC--> GPU Memory
 - `pegaflow-common/src/logging.rs`: Unified log initialization
 - `pegaflow-common/src/numa.rs`: NUMA topology detection and CPU affinity
 - `pegaflow-core/src/lib.rs`: Main PegaEngine implementation
-- `pegaflow-core/src/storage/mod.rs`: StorageEngine (allocator, read cache, prefetch, write pipeline)
+- `pegaflow-core/src/storage/mod.rs`: StorageEngine (allocator, read cache, prefetch, write pipeline, remote fetch)
 - `pegaflow-core/src/storage/read_cache.rs`: Pin/unpin/consume operations
 - `pegaflow-core/src/storage/prefetch.rs`: SSD prefetch state machine
+- `pegaflow-core/src/storage/remote_fetch.rs`: Cross-node remote fetch state machine
+- `pegaflow-core/src/storage/transfer_lock.rs`: Transfer lock manager for RDMA transfers
 - `pegaflow-core/src/storage/write_path.rs`: Async insert worker thread
 - `pegaflow-core/src/backing/ssd.rs`: SSD backing store coordinator
-- `pegaflow-core/src/internode/`: Cross-node client and service discovery
+- `pegaflow-core/src/internode/client.rs`: PegaflowClient/PegaflowClientPool for remote nodes
+- `pegaflow-core/src/internode/metaserver_query.rs`: MetaServer query client
+- `pegaflow-core/src/internode/remote_fetch_worker.rs`: Async RDMA fetch worker
 - `pegaflow-server/src/service.rs`: gRPC service implementation
 - `pegaflow-metaserver/src/lib.rs`: MetaServer entry point and CLI
 - `pegaflow-metaserver/src/service.rs`: MetaServer gRPC service

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <p><em>Named after Pegasus, the winged horse of ancient myth — a creature born to cross impossible distances with effortless grace.</em></p>
 </div>
 
-PegaFlow is a **high-performance KV cache offloading solution** for LLM inference engines on single-node multi-GPU setups.
+PegaFlow is a **high-performance KV cache offloading solution** for LLM inference engines, supporting single-node GPU-to-CPU offloading and cross-node sharing via RDMA.
 
 ## What is PegaFlow?
 
@@ -14,7 +14,7 @@ PegaFlow enables efficient KV cache transfer and sharing for LLM inference workl
 - **Single-node KV cache offloading** — offload KV cache to host memory and restore it back to GPU with minimal latency
 - **Full parallelism support** — works with Pipeline Parallel (PP), Tensor Parallel (TP), and Data Parallel (DP)
 - **Layer-wise transfer** — fine-grained, layer-by-layer KV cache operations for optimal memory utilization
-- **P/D disaggregation** — separate prefill and decode phases across GPUs for better resource utilization
+- **Cross-node KV cache sharing** — share cached blocks across nodes via RDMA to avoid recomputation
 - **~9x TTFT improvement** — warm-start requests achieve dramatically lower time-to-first-token compared to cold-start
 
 ## Framework Integration
@@ -65,6 +65,11 @@ pegaflow-server
 - `--max-prefetch-blocks`: Max blocks allowed in prefetching state, backpressure for SSD prefetch (default: `800`)
 - `--metaserver-addr`: MetaServer gRPC address for cross-node block hash registry (e.g., `http://127.0.0.1:50056`). When set, saved block hashes are inserted to the metaserver for cross-node discovery.
 - `--advertise-addr`: Advertised address (ip:port) reported to the metaserver for cross-node discovery. Other nodes use this address to connect to this server. Fallback order: this flag > `PEGAFLOW_HOST_IP` env + bind port > auto-detected IP + bind port.
+- `--enable-remote-fetch`: Enable cross-node remote fetch via RDMA on cache miss (default: `false`). Requires `--metaserver-addr` and `--rdma-nic`.
+- `--rdma-nic`: RDMA NIC name for the transfer engine (e.g., `mlx5_0`). Required when `--enable-remote-fetch` is set.
+- `--rdma-port`: RDMA transfer engine RPC port for session establishment (default: `50057`)
+- `--transfer-lock-timeout-secs`: Transfer lock timeout in seconds for cross-node RDMA transfers (default: `30`)
+- `--max-remote-fetch-blocks`: Max blocks in remote fetch in-flight, backpressure limit (default: `200`)
 
 ### 2b. (Optional) Start MetaServer for Multi-Node
 
@@ -119,7 +124,7 @@ cargo run -p pegaflow-transfer --bin pegaflow_topo_cli
 
 ### Inter-Node RDMA Transfer
 
-PegaFlow Transfer provides RDMA-based inter-node memory transfers for P/D disaggregation with one-sided RDMA READ/WRITE, automatic session management, and NUMA-aware NIC selection. See [pegaflow-transfer/README.md](./pegaflow-transfer/README.md) for architecture, API, CLI tools, and benchmarks.
+PegaFlow Transfer provides RDMA-based inter-node memory transfers for cross-node KV cache sharing with one-sided RDMA READ/WRITE, automatic session management, and NUMA-aware NIC selection. See [pegaflow-transfer/README.md](./pegaflow-transfer/README.md) for architecture, API, CLI tools, and benchmarks.
 
 ## Development
 
@@ -238,9 +243,9 @@ def append_n(self, blocks: list[KVCacheBlock]) -> None:
 
 This simple change can noticeably reduce transfer latency by enabling more efficient memory access patterns during KV cache operations.
 
-## P/D Disaggregation
+## P/D Router
 
-PegaFlow supports Prefill/Decode (P/D) disaggregation, where prefill and decode phases run on separate GPU nodes. A lightweight router coordinates the flow: requests first go to P nodes for prefill (KV cache generation), then to D nodes for decode (token generation).
+PegaFlow includes a lightweight P/D router (`pegaflow-router`) that coordinates Prefill/Decode disaggregation. P and D nodes each run an independent pegaflow-server as a local KV cache store. The router directs requests to P nodes for prefill, then to D nodes for decode — PegaFlow handles KV cache storage on each node, not the inter-node KV transfer.
 
 ### Architecture
 
@@ -269,13 +274,13 @@ Client Request
 | P/D (1P+1D)    | 573.78         | 15.68          | 15.89         | 21.71        |
 | Baseline (DP2) | 438.24         | 22.67          | 24.32         | 142.70       |
 
-P/D disaggregation trades higher TTFT for **significantly more stable decode latency** — TPOT p99 drops from 24.32ms to 15.89ms, and ITL p99 improves dramatically from 142.70ms to 21.71ms.
+The P/D setup trades higher TTFT for **significantly more stable decode latency** — TPOT p99 drops from 24.32ms to 15.89ms, and ITL p99 improves dramatically from 142.70ms to 21.71ms.
 
 ## Goals
 
 1. **A Data Path Purpose-Built for LLM Inference**
 
-   Focus exclusively on the typical data flows in large model inference: data movement between prefill and decode phases, between different compute roles, and high-throughput transport of weights and KV/activations. We only solve this specific class of problems—high-bandwidth, predictable, structured data paths.
+   Focus exclusively on the typical data flows in large model inference: data movement between GPU and CPU, between compute nodes, and high-throughput transport of KV cache blocks. We only solve this specific class of problems—high-bandwidth, predictable, structured data paths.
 
 2. **RDMA-First, High-Performance Implementation**
 

--- a/pegaflow-common/src/numa.rs
+++ b/pegaflow-common/src/numa.rs
@@ -191,6 +191,9 @@ pub fn pin_thread_to_numa_node(node: NumaNode) -> Result<(), String> {
         return Err(format!("CPU list is empty for NUMA node {}", node.0));
     }
 
+    // SAFETY: cpu_set_t is a plain C struct safe to zero-initialize. CPU_SET
+    // writes to valid indices. sched_setaffinity(0, ...) targets the calling
+    // thread; the cpu_set is correctly sized.
     unsafe {
         let mut cpu_set: libc::cpu_set_t = mem::zeroed();
 

--- a/pegaflow-core/benches/pinned_copy.rs
+++ b/pegaflow-core/benches/pinned_copy.rs
@@ -28,11 +28,18 @@ impl TransferFixture {
 
         let block_bytes = bytes_per_block * segments;
         let mut host_ptr: *mut c_void = ptr::null_mut();
+        // SAFETY: host_ptr is a valid stack pointer, block_bytes > 0 (asserted above).
         check_cuda(
             unsafe { sys::cuMemAllocHost_v2(&mut host_ptr, block_bytes) },
             "cuMemAllocHost_v2",
         );
+        assert!(
+            !host_ptr.is_null(),
+            "cuMemAllocHost_v2 returned null pointer"
+        );
         let host_ptr = host_ptr as *mut u8;
+        // SAFETY: host_ptr is non-null (asserted) and valid for block_bytes
+        // from cuMemAllocHost_v2.
         unsafe {
             let slice = std::slice::from_raw_parts_mut(host_ptr, block_bytes);
             for (idx, byte) in slice.iter_mut().enumerate() {
@@ -42,6 +49,7 @@ impl TransferFixture {
 
         let mut device_ptr: sys::CUdeviceptr = 0;
         let device_bytes = kv_stride * (segments - 1) + bytes_per_block;
+        // SAFETY: device_ptr is a valid stack pointer, device_bytes > 0.
         check_cuda(
             unsafe { sys::cuMemAlloc_v2(&mut device_ptr, device_bytes) },
             "cuMemAlloc_v2",
@@ -69,6 +77,7 @@ impl TransferFixture {
 
     fn copy_single(&self) {
         self.ensure_context();
+        // SAFETY: device_ptr and host_ptr are valid; block_bytes fits both allocations.
         check_cuda(
             unsafe {
                 sys::cuMemcpyHtoD_v2(
@@ -84,8 +93,10 @@ impl TransferFixture {
     fn copy_segments(&self) {
         self.ensure_context();
         for segment in 0..self.segments {
+            // SAFETY: host_ptr + segment*bytes_per_block is within the block_bytes allocation.
             let src = unsafe { self.host_ptr.add(segment * self.bytes_per_block) };
             let dst = self.device_ptr + (segment * self.kv_stride) as u64;
+            // SAFETY: src and dst are valid pointers within their respective allocations.
             check_cuda(
                 unsafe { sys::cuMemcpyHtoD_v2(dst, src as *const c_void, self.bytes_per_block) },
                 "cuMemcpyHtoD_v2(segment)",
@@ -114,6 +125,7 @@ impl TransferFixture {
             Height: self.segments,
         };
 
+        // SAFETY: request fields reference valid host/device memory with correct pitches.
         check_cuda(unsafe { sys::cuMemcpy2D_v2(&request) }, "cuMemcpy2D_v2");
     }
 }
@@ -122,10 +134,18 @@ impl Drop for TransferFixture {
     fn drop(&mut self) {
         unsafe {
             if self.device_ptr != 0 {
-                sys::cuMemFree_v2(self.device_ptr);
+                // SAFETY: self.device_ptr was allocated by cuMemAlloc_v2 and has not been freed.
+                let r = sys::cuMemFree_v2(self.device_ptr);
+                if r != sys::CUresult::CUDA_SUCCESS {
+                    eprintln!("cuMemFree_v2 failed in Drop: {r:?}");
+                }
             }
             if !self.host_ptr.is_null() {
-                sys::cuMemFreeHost(self.host_ptr as *mut c_void);
+                // SAFETY: self.host_ptr was allocated by cuMemAllocHost_v2 and has not been freed.
+                let r = sys::cuMemFreeHost(self.host_ptr as *mut c_void);
+                if r != sys::CUresult::CUDA_SUCCESS {
+                    eprintln!("cuMemFreeHost failed in Drop: {r:?}");
+                }
             }
         }
     }

--- a/pegaflow-core/src/backing/uring.rs
+++ b/pegaflow-core/src/backing/uring.rs
@@ -58,8 +58,10 @@ struct IoCtx {
     iovecs: Option<Box<[libc::iovec]>>,
 }
 
+// SAFETY: IoCtx is created on one thread and sent to the io_uring shard thread
+// via mpsc channel. The raw pointers in iovecs reference pinned memory that
+// outlives the I/O operation (guaranteed by the caller).
 unsafe impl Send for IoCtx {}
-unsafe impl Sync for IoCtx {}
 
 struct UringShard {
     rx: mpsc::Receiver<IoCtx>,
@@ -127,13 +129,19 @@ impl UringShard {
 
                 let data = Box::into_raw(Box::new(ctx)) as u64;
                 let sqe = sqe.user_data(data);
-                // Safety: we keep ctx boxed and rely on user_data to free it in completion.
-                unsafe {
-                    self.uring
-                        .submission()
-                        .push(&sqe)
-                        .expect("submission queue full")
-                };
+                // SAFETY: The Box<IoCtx> is leaked via into_raw and recovered in the
+                // completion path via Box::from_raw. The iovec pointers within IoCtx
+                // reference pinned memory guaranteed by the caller to remain valid
+                // until the oneshot completes.
+                let push_result = unsafe { self.uring.submission().push(&sqe) };
+                if push_result.is_err() {
+                    // Recover the leaked IoCtx to avoid memory leak.
+                    let ctx = unsafe { Box::from_raw(data as *mut IoCtx) };
+                    let _ = ctx
+                        .complete
+                        .send(Err(io::Error::other("submission queue full")));
+                    continue;
+                }
                 inflight += 1;
             }
 

--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -273,6 +273,8 @@ fn process_load_task(task: &LoadTask, stream: &CudaStream) -> Result<(), EngineE
                     .map_err(EngineError::Storage)?;
 
                 let k_cpu_ptr = block.layer_block.k_ptr();
+                // SAFETY: For contiguous layout (v_ptr is None), the allocation is
+                // 2 * segment_size bytes, so k_ptr + segment_size is within bounds.
                 let v_cpu_ptr = block
                     .layer_block
                     .v_ptr()
@@ -404,6 +406,8 @@ fn process_save_task(task: &SaveTask, stream: &CudaStream) -> Result<(), EngineE
                     .map_err(EngineError::Storage)?;
                 let v_offset = transfer::segment_offset(registration, block.block_idx, 1)
                     .map_err(EngineError::Storage)?;
+                // SAFETY: For contiguous layout (v_ptr is None), the allocation is
+                // 2 * segment_size bytes, so k_ptr + segment_size is within bounds.
                 let v_ptr = block
                     .v_dst_ptr
                     .unwrap_or_else(|| unsafe { block.k_dst_ptr.add(segment_size) });

--- a/pegaflow-core/src/pinned_mem.rs
+++ b/pegaflow-core/src/pinned_mem.rs
@@ -119,6 +119,8 @@ impl std::fmt::Debug for PinnedMemory {
 // - Fixed in physical memory (pinned by CUDA)
 // - Safe to access from any thread
 // The pointer is valid for the lifetime of this struct.
+// Sync is safe because PinnedMemory exposes only an immutable pointer via
+// as_ptr() and has no interior mutability.
 unsafe impl Send for PinnedMemory {}
 unsafe impl Sync for PinnedMemory {}
 
@@ -165,6 +167,7 @@ impl PinnedMemory {
         let (ptr, aligned_size) = match strategy {
             AllocStrategy::Regular => {
                 let mut ptr: *mut libc::c_void = std::ptr::null_mut();
+                // SAFETY: ptr is a valid stack pointer; size is validated non-zero above.
                 let result = unsafe { rt::cudaHostAlloc(&mut ptr, size, 0) };
                 if result != rt::cudaError::cudaSuccess {
                     return Err(PinnedMemError::CudaAllocFailed(result));
@@ -173,6 +176,7 @@ impl PinnedMemory {
             }
             AllocStrategy::WriteCombined => {
                 let mut ptr: *mut libc::c_void = std::ptr::null_mut();
+                // SAFETY: ptr is a valid stack pointer; size is validated non-zero above.
                 let result =
                     unsafe { rt::cudaHostAlloc(&mut ptr, size, rt::cudaHostAllocWriteCombined) };
                 if result != rt::cudaError::cudaSuccess {
@@ -186,7 +190,9 @@ impl PinnedMemory {
                 let aligned = (size + huge_page_size - 1) & !(huge_page_size - 1);
                 let flags = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_HUGETLB;
 
-                // SAFETY: mmap with MAP_ANONYMOUS creates a new anonymous mapping.
+                // SAFETY: All parameters are valid: null hint, aligned non-zero size,
+                // valid protection flags, MAP_ANONYMOUS with fd=-1. Return is checked
+                // against MAP_FAILED before use.
                 let ptr = unsafe {
                     libc::mmap(
                         std::ptr::null_mut(),
@@ -203,6 +209,7 @@ impl PinnedMemory {
                 }
 
                 // Register with CUDA for DMA
+                // SAFETY: ptr is a valid mmap'd region of `aligned` bytes (checked above).
                 let result =
                     unsafe { rt::cudaHostRegister(ptr, aligned, rt::cudaHostRegisterDefault) };
 

--- a/pegaflow-core/src/sync_state.rs
+++ b/pegaflow-core/src/sync_state.rs
@@ -227,6 +227,9 @@ fn init_new_mapping(shmem: &Shmem) -> Result<NonNull<LoadStateMem>, LoadStateErr
     }
 
     // Record the offset so attach() can find the aligned region.
+    // SAFETY: The mapping has at least LOAD_STATE_META_SIZE (8) bytes.
+    // write_unaligned is used because the base pointer has no usize alignment
+    // guarantee. No other references to this memory exist (freshly created).
     unsafe {
         (shmem.as_ptr() as *mut usize).write_unaligned(offset);
     }
@@ -251,6 +254,9 @@ fn attach_mapping(shmem: &Shmem) -> Result<NonNull<LoadStateMem>, LoadStateError
     }
 
     let base = shmem.as_ptr() as usize;
+    // SAFETY: The mapping has at least LOAD_STATE_META_SIZE bytes (checked above).
+    // read_unaligned is used because base pointer alignment is not guaranteed.
+    // The returned offset is validated below before use.
     let offset = unsafe { (shmem.as_ptr() as *const usize).read_unaligned() };
 
     if offset < LOAD_STATE_META_SIZE {

--- a/pegaflow-core/src/transfer.rs
+++ b/pegaflow-core/src/transfer.rs
@@ -55,6 +55,8 @@ fn copy_gpu_to_cpu_async(
 
     let src_ptr = gpu_base_ptr + offset as u64;
 
+    // SAFETY: src_ptr is gpu_base_ptr + offset, within a valid GPU allocation.
+    // dst_ptr points to pinned CPU memory of sufficient size. The stream is valid.
     unsafe {
         let result = sys::cuMemcpyDtoHAsync_v2(
             dst_ptr as *mut std::ffi::c_void,
@@ -91,6 +93,8 @@ fn copy_cpu_to_gpu_async(
     let dst_ptr = gpu_base_ptr + offset as u64;
     let src_ptr = cpu_buffer.as_ptr();
 
+    // SAFETY: dst_ptr is gpu_base_ptr + offset, within a valid GPU allocation.
+    // src_ptr is validated to have at least `size` bytes above. The stream is valid.
     unsafe {
         let result = sys::cuMemcpyHtoDAsync_v2(
             dst_ptr,
@@ -130,6 +134,8 @@ pub(crate) fn batch_copy_segments_to_gpu(
             let (next_gpu_offset, next_cpu_ptr) = transfers[i + count];
 
             let expected_gpu_offset = start_gpu_offset + count * segment_size;
+            // SAFETY: All cpu_ptr values in `transfers` point into the same contiguous
+            // allocation. This arithmetic is used only for contiguity comparison.
             let expected_cpu_ptr = unsafe { start_cpu_ptr.add(count * segment_size) };
 
             let gpu_contiguous = next_gpu_offset == expected_gpu_offset;
@@ -146,6 +152,9 @@ pub(crate) fn batch_copy_segments_to_gpu(
             .checked_mul(count)
             .ok_or_else(|| "batch_copy_segments_to_gpu: total_size overflow".to_string())?;
 
+        // SAFETY: start_cpu_ptr points to valid, initialized pinned memory of at least
+        // total_size bytes. The contiguity check above confirms the segments form a
+        // single contiguous range. total_size is checked via checked_mul.
         let buffer = unsafe { std::slice::from_raw_parts(start_cpu_ptr, total_size) };
         copy_cpu_to_gpu_async(
             registration.data_ptr,
@@ -186,6 +195,8 @@ pub(crate) fn batch_copy_segments_from_gpu(
             let (next_gpu_offset, next_cpu_ptr) = transfers[i + count];
 
             let expected_gpu_offset = start_gpu_offset + count * segment_size;
+            // SAFETY: All cpu_ptr values in `transfers` point into the same contiguous
+            // allocation. This arithmetic is used only for contiguity comparison.
             let expected_cpu_ptr = unsafe { start_cpu_ptr.add(count * segment_size) };
 
             let gpu_contiguous = next_gpu_offset == expected_gpu_offset;

--- a/pegaflow-core/tests/common/gpu_buffer.rs
+++ b/pegaflow-core/tests/common/gpu_buffer.rs
@@ -9,7 +9,9 @@ pub struct GpuBuffer {
 
 impl GpuBuffer {
     pub fn alloc(len: usize) -> Self {
+        assert!(len > 0, "GpuBuffer::alloc: len must be > 0");
         let mut ptr: sys::CUdeviceptr = 0;
+        // SAFETY: len > 0 (asserted above). ptr is a valid stack pointer.
         check_cuda(
             unsafe { sys::cuMemAlloc_v2(&raw mut ptr, len) },
             "cuMemAlloc_v2",
@@ -23,6 +25,8 @@ impl GpuBuffer {
 
     pub fn copy_from_host(&self, data: &[u8]) {
         assert_eq!(data.len(), self.len);
+        // SAFETY: self.ptr is a valid device pointer from cuMemAlloc_v2.
+        // data.len() matches the copy size.
         check_cuda(
             unsafe { sys::cuMemcpyHtoD_v2(self.ptr, data.as_ptr() as *const c_void, self.len) },
             "cuMemcpyHtoD_v2",
@@ -31,6 +35,7 @@ impl GpuBuffer {
 
     pub fn copy_to_host(&self) -> Vec<u8> {
         let mut output = vec![0u8; self.len];
+        // SAFETY: self.ptr is valid, out has sufficient capacity (len bytes).
         check_cuda(
             unsafe { sys::cuMemcpyDtoH_v2(output.as_mut_ptr() as *mut c_void, self.ptr, self.len) },
             "cuMemcpyDtoH_v2",
@@ -39,6 +44,7 @@ impl GpuBuffer {
     }
 
     pub fn zero(&self) {
+        // SAFETY: self.ptr is a valid device pointer, self.len matches the allocation.
         check_cuda(
             unsafe { sys::cuMemsetD8_v2(self.ptr, 0, self.len) },
             "cuMemsetD8_v2",
@@ -49,6 +55,7 @@ impl GpuBuffer {
 impl Drop for GpuBuffer {
     fn drop(&mut self) {
         if self.ptr != 0 {
+            // SAFETY: self.ptr was allocated by cuMemAlloc_v2 and has not been freed.
             check_cuda(unsafe { sys::cuMemFree_v2(self.ptr) }, "cuMemFree_v2");
             self.ptr = 0;
         }


### PR DESCRIPTION
Add or improve `// SAFETY:` documentation for unsafe blocks across numa pinning, GPU worker, sync state, transfer, and pinned memory modules. Update docs, skills.