### PR TITLE
docs: polish README, add Apache-2.0 LICENSE, and reorganize docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ resolver = "2"
 [workspace.package]
 version = "0.0.16"
 edition = "2024"
+license = "Apache-2.0"
 
 [workspace.dependencies]
 # Workspace members

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -2,25 +2,26 @@
 
 <div align="center">
   <img src="./assets/logo.png" width="200" />
-  <p><em>Named after Pegasus, the winged horse of ancient myth — a creature born to cross impossible distances with effortless grace.</em></p>
+  <p><strong><em>KV cache on the wings of Pegasus.</em></strong></p>
+
+  [![CI](https://github.com/novitalabs/pegaflow/actions/workflows/ci.yml/badge.svg)](https://github.com/novitalabs/pegaflow/actions/workflows/ci.yml)
+  [![PyPI](https://img.shields.io/pypi/v/pegaflow-llm)](https://pypi.org/project/pegaflow-llm/)
+  [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 </div>
 
-PegaFlow is a **high-performance KV cache offloading solution** for LLM inference engines, supporting single-node GPU-to-CPU offloading and cross-node sharing via RDMA.
+**PegaFlow is a high-performance KV cache storage engine for LLM inference.** Offload KV cache from GPU to host memory or SSD, and share it across nodes via RDMA.
 
-## What is PegaFlow?
-
-PegaFlow enables efficient KV cache transfer and sharing for LLM inference workloads:
-
-- **Single-node KV cache offloading** — offload KV cache to host memory and restore it back to GPU with minimal latency
-- **Full parallelism support** — works with Pipeline Parallel (PP), Tensor Parallel (TP), and Data Parallel (DP)
-- **Layer-wise transfer** — fine-grained, layer-by-layer KV cache operations for optimal memory utilization
-- **Cross-node KV cache sharing** — share cached blocks across nodes via RDMA to avoid recomputation
-- **~9x TTFT improvement** — warm-start requests achieve dramatically lower time-to-first-token compared to cold-start
+- **Decoupled from inference lifecycle** — runs as an independent sidecar; KV cache survives engine restarts, scales independently, and is shared across instances
+- **Topology-aware, PCIe-saturating transfers** — NUMA-aware pinned memory + layer-wise DMA to maximize hardware bandwidth
+- **GIL-free Rust core** — zero Python overhead on the hot path; your inference engine keeps its threads
+- **Production-ready observability** — built-in Prometheus metrics and OTLP export, not an afterthought
+- **Pluggable** — works with vLLM and SGLang as a drop-in KV connector
 
 ## Framework Integration
 
 | Framework | Status | Link |
 |-----------|--------|------|
+| vLLM | ✅ Ready | [Quick Start](#3-launch-your-inference-engine) |
 | SGLang | 🚧 Under Review | [PR #17221](https://github.com/sgl-project/sglang/pull/17221) |
 
 ## Quick Start
@@ -28,13 +29,9 @@ PegaFlow enables efficient KV cache transfer and sharing for LLM inference workl
 ### 1. Install
 
 ```bash
-uv venv --prompt pegaflow
-source .venv/bin/activate
-
-uv pip install pegaflow-llm
+uv pip install pegaflow-llm        # CUDA 12
+uv pip install pegaflow-llm-cu13   # CUDA 13
 ```
-
-> Hint for sglang users: If you running in sglang docker, you can create venv with `uv venv --prompt pegaflow --system-site-packages`.
 
 ### 2. Start PegaFlow Server
 
@@ -42,174 +39,44 @@ uv pip install pegaflow-llm
 pegaflow-server
 ```
 
-**All available server options:**
+### 3. Launch your inference engine
 
-- `--addr`: Bind address (default: `127.0.0.1:50055`)
-- `--devices`: CUDA device IDs to initialize, comma-separated (default: auto-detect all available GPUs, e.g., `--devices 0,1,2,3`)
-- `--pool-size`: Pinned memory pool size (default: `30gb`, supports: `kb`, `mb`, `gb`, `tb`)
-- `--hint-value-size`: Hint for typical value size to tune cache and allocator (optional, supports: `kb`, `mb`, `gb`, `tb`)
-- `--use-hugepages`: Use huge pages for pinned memory (default: `false`, requires pre-configured `/proc/sys/vm/nr_hugepages`)
-- `--enable-lfu-admission`: Enable TinyLFU cache admission policy (default: plain LRU)
-- `--disable-numa-affinity`: Disable NUMA-aware memory allocation (default: enabled)
-- `--http-addr`: HTTP server address for health check and Prometheus metrics (default: `0.0.0.0:9091`, always enabled)
-- `--enable-prometheus`: Enable Prometheus `/metrics` endpoint (default: `true`)
-- `--metrics-otel-endpoint`: OTLP metrics export endpoint (optional, leave unset to disable)
-- `--metrics-period-secs`: Metrics export period in seconds (default: `5`, only used with OTLP)
-- `--log-level`: Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`)
-- `--ssd-cache-path`: Enable SSD cache by providing cache file path (optional)
-- `--ssd-cache-capacity`: SSD cache capacity (default: `512gb`, supports: `kb`, `mb`, `gb`, `tb`)
-- `--ssd-write-queue-depth`: SSD write queue depth, max pending write batches (default: `8`)
-- `--ssd-prefetch-queue-depth`: SSD prefetch queue depth, max pending prefetch batches (default: `2`)
-- `--ssd-write-inflight`: SSD write inflight, max concurrent block writes (default: `2`)
-- `--ssd-prefetch-inflight`: SSD prefetch inflight, max concurrent block reads (default: `16`)
-- `--max-prefetch-blocks`: Max blocks allowed in prefetching state, backpressure for SSD prefetch (default: `800`)
-- `--metaserver-addr`: MetaServer gRPC address for cross-node block hash registry (e.g., `http://127.0.0.1:50056`). When set, saved block hashes are inserted to the metaserver for cross-node discovery.
-- `--advertise-addr`: Advertised address (ip:port) reported to the metaserver for cross-node discovery. Other nodes use this address to connect to this server. Fallback order: this flag > `PEGAFLOW_HOST_IP` env + bind port > auto-detected IP + bind port.
-- `--enable-remote-fetch`: Enable cross-node remote fetch via RDMA on cache miss (default: `false`). Requires `--metaserver-addr` and `--rdma-nic`.
-- `--rdma-nic`: RDMA NIC name for the transfer engine (e.g., `mlx5_0`). Required when `--enable-remote-fetch` is set.
-- `--rdma-port`: RDMA transfer engine RPC port for session establishment (default: `50057`)
-- `--transfer-lock-timeout-secs`: Transfer lock timeout in seconds for cross-node RDMA transfers (default: `30`)
-- `--max-remote-fetch-blocks`: Max blocks in remote fetch in-flight, backpressure limit (default: `200`)
-
-### 2b. (Optional) Start MetaServer for Multi-Node
-
-For multi-node setups, start a MetaServer to coordinate block hashes across nodes. Each pegaflow-server registers its block hashes with the MetaServer, enabling cross-node KV cache discovery.
+**vLLM (recommended):**
 
 ```bash
-pegaflow-metaserver
+vllm serve Qwen/Qwen3-0.6B \
+  --kv-transfer-config '{"kv_connector": "PegaKVConnector", "kv_role": "kv_both", "kv_connector_module_path": "pegaflow.connector"}'
 ```
 
-Then point each pegaflow-server to the MetaServer:
+**SGLang:**
 
 ```bash
-pegaflow-server --metaserver-addr http://<metaserver-host>:50056
+python3 -m sglang.launch_server \
+  --model-path Qwen/Qwen3-0.6B \
+  --enable-pegaflow
 ```
 
-**MetaServer options:**
-
-- `--addr`: Bind address (default: `127.0.0.1:50056`)
-- `--log-level`: Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`)
-- `--max-capacity-mb`: Maximum cache capacity in MB (default: `512`)
-- `--ttl-minutes`: Cache entry TTL in minutes (default: `120`)
-
-### 3. Connect to Server with client
-
-#### Sglang:
-
-example 1:
-
-```bash
-python3 -m sglang.launch_server --model-path Qwen/Qwen3-0.6B --served-model-name Qwen/Qwen3-0.6B --trust-remote-code --enable-cache-report --page-size 256 --host "0.0.0.0" --port 8000 --mem-fraction-static 0.8 --max-running-requests 32 --enable-pegaflow
-```
-
-example 2:
-
-```bash
-python3 -m sglang.launch_server --model-loader-extra-config "{\"enable_multithread_load\": true, \"num_threads\": 64}"  --model-path deepseek-ai/DeepSeek-V3.2 --served-model-name deepseek-ai/DeepSeek-V3.2 --trust-remote-code --page-size "64" --reasoning-parser deepseek-v3 --tool-call-parser deepseekv32 --enable-cache-report --host "0.0.0.0" --port 8031 --mem-fraction-static 0.83 --max-running-requests 64 --tp-size "8" --enable-pegaflow
-```
-
-#### vLLM:
-
-```bash
-vllm serve Qwen/Qwen3-0.6B --trust-remote-code --kv-transfer-config '{"kv_connector": "PegaKVConnector", "kv_role": "kv_both", "kv_connector_module_path": "pegaflow.connector", "kv_connector_extra_config": {"pegaflow.host": "http://127.0.0.1", "pegaflow.port": 50055}}'
-```
-
-## NUMA Topology Detection
-
-Basic NUMA support for optimizing GPU-CPU memory transfers. Use the CLI to inspect system topology:
-
-```bash
-cargo run -p pegaflow-transfer --bin pegaflow_topo_cli
-```
-
-### Inter-Node RDMA Transfer
-
-PegaFlow Transfer provides RDMA-based inter-node memory transfers for cross-node KV cache sharing with one-sided RDMA READ/WRITE, automatic session management, and NUMA-aware NIC selection. See [pegaflow-transfer/README.md](./pegaflow-transfer/README.md) for architecture, API, CLI tools, and benchmarks.
+> For full server options, multi-node setup, and advanced configuration, see [Server Configuration](./docs/server.md).
 
 ## Development
 
 ### Build from source
 
 ```bash
-# Set environment variables for PyO3
 export PYO3_PYTHON=$(which python)
 export LD_LIBRARY_PATH=$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))"):$LD_LIBRARY_PATH
 
-# Start the server with defaults (127.0.0.1:50055, device 0, 30gb pool)
-cargo run -r
+cargo run -r                    # start server
+cd python && maturin develop -r # build Python bindings
 ```
 
-Additional args:
-
-**Customize pool size** (if needed):
-
-```bash
-cargo run -r -- --pool-size 50gb
-```
-
-**Enable debug logging** to see internal state and detailed operation logs:
-
-```bash
-# Option 1: Use --log-level flag
-cargo run -r -- --log-level debug
-
-# Option 2: Use RUST_LOG environment variable for fine-grained control
-RUST_LOG=debug cargo run -r
-RUST_LOG=info,pegaflow_core=debug cargo run -r  # Debug core only
-```
-
-### Build Python Bindings
-
-```bash
-cd python
-maturin develop --release
-cd ..
-```
-
-To build a wheel for the Python bindings (for distribution or local use):
-
-```bash
-cd python
-maturin build --release
-```
-### Git commit message format
-
-We use [Commitizen](https://commitizen-tools.github.io/commitizen/) for conventional commit messages.
-You can use the `cz c` command to create properly formatted commits via an interactive prompt:
-
-```bash
-cz c
-```
-
-This will guide you through writing a commit message that follows the [Conventional Commits](https://www.conventionalcommits.org/) specification, making the commit history clean and consistent.
-
-
-### Bump version with cz
-
-```bash
-pip install commitizen
-
-cd python && cz bump --increment PATCH
-```
+We use [Conventional Commits](https://www.conventionalcommits.org/) — run `cz c` for an interactive commit prompt.
 
 ## Benchmarks
 
 ### KV Cache Benchmark
 
-`examples/bench_kv_cache.py` automates a full TTFT-focused benchmark. Provide your checkpoint path (we test with Llama-3.1-8B on H800):
-
-```bash
-uv run python examples/bench_kv_cache.py \
-  --model /path/to/your/Llama-3.1-8B \
-  --num-prompts 10 \
-  --input-len 4096 \
-  --output-len 1 \
-  --request-rate 1.0
-```
-
-H800 Reference Numbers
-
-PegaFlow TTFT measurements from an H800 with Llama-3.1-8B (8 prompts, 10K-token prefill, 1-token decode, 4.0 req/s):
+H800 reference numbers with Llama-3.1-8B (8 prompts, 10K-token prefill, 1-token decode, 4.0 req/s):
 
 | Configuration   | TTFT mean (ms) | TTFT p99 (ms) |
 | --------------- | -------------- | ------------- |
@@ -218,104 +85,10 @@ PegaFlow TTFT measurements from an H800 with Llama-3.1-8B (8 prompts, 10K-token 
 
 The warm-start path achieves **~9x faster TTFT** compared to cold-start, demonstrating effective KV cache sharing across requests.
 
-### vLLM Patch for Better I/O Performance
+## Documentation
 
-To maximize I/O throughput when using PegaFlow with vLLM, we recommend a small patch to vLLM's KV cache block allocation. Sorting block IDs ensures GPU memory addresses are as sequential and contiguous as possible, which improves DMA/RDMA transfer efficiency.
-
-Upstream RFC: https://github.com/vllm-project/vllm/issues/31371
-
-Locate the file `vllm/v1/core/kv_cache_utils.py` in your vLLM installation (e.g., `.venv/lib/python3.10/site-packages/vllm/v1/core/kv_cache_utils.py`), find the `append_n` method in the `FreeKVCacheBlockQueue` class, and add a sorting line:
-
-```python
-def append_n(self, blocks: list[KVCacheBlock]) -> None:
-    """Put a list of blocks back into the free list
-
-    Args:
-        blocks: The blocks to append.
-    """
-    if len(blocks) == 0:
-        return
-
-    blocks.sort(key=lambda x: x.block_id)  # <-- Add this line
-    last_block = self.fake_free_list_tail.prev_free_block
-    ...
-```
-
-This simple change can noticeably reduce transfer latency by enabling more efficient memory access patterns during KV cache operations.
-
-## P/D Router
-
-PegaFlow includes a lightweight P/D router (`pegaflow-router`) that coordinates Prefill/Decode disaggregation. P and D nodes each run an independent pegaflow-server as a local KV cache store. The router directs requests to P nodes for prefill, then to D nodes for decode — PegaFlow handles KV cache storage on each node, not the inter-node KV transfer.
-
-### Architecture
-
-```
-Client Request
-      │
-      ▼
-   Router (:8000)
-      │
-      ├──► P Node (:8100) ─── prefill, generate KV cache ───┐
-      │                                                     │
-      │                                                     ▼
-      │                                              PegaEngine Server
-      │                                            (centralized KV store)
-      │                                                     │
-      └──► D Node (:8200) ◄─── load KV cache ───────────────┘
-               │
-               ▼
-        Response to Client
-```
-
-### Benchmark Results (H800, Qwen3-8B, 5K input tokens)
-
-| Configuration  | TTFT mean (ms) | TPOT mean (ms) | TPOT p99 (ms) | ITL p99 (ms) |
-| -------------- | -------------- | -------------- | ------------- | ------------ |
-| P/D (1P+1D)    | 573.78         | 15.68          | 15.89         | 21.71        |
-| Baseline (DP2) | 438.24         | 22.67          | 24.32         | 142.70       |
-
-The P/D setup trades higher TTFT for **significantly more stable decode latency** — TPOT p99 drops from 24.32ms to 15.89ms, and ITL p99 improves dramatically from 142.70ms to 21.71ms.
-
-## Goals
-
-1. **A Data Path Purpose-Built for LLM Inference**
-
-   Focus exclusively on the typical data flows in large model inference: data movement between GPU and CPU, between compute nodes, and high-throughput transport of KV cache blocks. We only solve this specific class of problems—high-bandwidth, predictable, structured data paths.
-
-2. **RDMA-First, High-Performance Implementation**
-
-   The initial version prioritizes RDMA, leveraging static topology, long-lived connections, and pre-allocated resources to push throughput, stability, and tail latency close to hardware limits—validating the value of a "dedicated transport layer".
-
-3. **Developer-Friendly Abstractions**
-
-   Provide clear, minimal transport semantics and channel models: easy to understand, simple to integrate, and predictable in behavior. Avoid hidden policies that cause mysterious performance jitter, allowing users to make confident performance assumptions.
-
-4. **Built-In Observability and Tunability**
-
-   Export key metrics and debugging information from day one (throughput, latency distribution, resource utilization, error signals, etc.), giving cluster operators data to guide topology and parameter tuning—rather than black-box trial-and-error.
-
-5. **Embeddable in Existing Inference Systems**
-
-   Serve as an optional "transport backend" that can plug into existing inference/dispatch/scheduling components—without requiring a full rewrite of the upper layers—ensuring the PoC can be validated quickly in real production stacks.
-
-## Non-Goals
-
-1. **Not a General-Purpose RPC or Service Framework**
-
-   No request routing, load balancing, IDL, or serialization format wars—these concerns belong to upper layers or other projects.
-
-2. **Not a Universal Network Virtualization Layer**
-
-   No attempt to automatically adapt to all network environments, cloud providers, or dynamic topologies; the initial focus is deep optimization for known, controlled, performance-sensitive clusters.
-
-3. **Not a Full-Featured Communication Middleware**
-
-   Does not cover collectives, group communication semantics, or a comprehensive flow control ecosystem—only focused on high-value point-to-point (or few-node) bulk transfer scenarios.
-
-4. **Not a "Runs Everywhere" Compatibility Solution**
-
-   No compromising design sharpness for compatibility with low-spec or non-accelerated network environments; other protocols or software fallbacks are incremental extensions, not core promises.
-
-5. **Not a Security or Compliance Component**
-
-   No built-in complex authentication, encryption, or multi-tenant isolation; default assumption is deployment in controlled environments, with security handled by infrastructure.
+- [Server Configuration](./docs/server.md) — full CLI options, SSD cache, multi-node setup
+- [P/D Router](./docs/pd.md) — prefill/decode disaggregation
+- [vLLM I/O Patch](./docs/vllm-patch.md) — optional patch for better transfer throughput
+- [Metrics](./docs/metrics.md) — Prometheus and OTLP metrics reference
+- [Goals & Non-Goals](./docs/goals.md) — project scope and design philosophy

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -1,0 +1,43 @@
+# Goals
+
+1. **A Data Path Purpose-Built for LLM Inference**
+
+   Focus exclusively on the typical data flows in large model inference: data movement between GPU and CPU, between compute nodes, and high-throughput transport of KV cache blocks. We only solve this specific class of problems—high-bandwidth, predictable, structured data paths.
+
+2. **RDMA-First, High-Performance Implementation**
+
+   The initial version prioritizes RDMA, leveraging static topology, long-lived connections, and pre-allocated resources to push throughput, stability, and tail latency close to hardware limits—validating the value of a "dedicated transport layer".
+
+3. **Developer-Friendly Abstractions**
+
+   Provide clear, minimal transport semantics and channel models: easy to understand, simple to integrate, and predictable in behavior. Avoid hidden policies that cause mysterious performance jitter, allowing users to make confident performance assumptions.
+
+4. **Built-In Observability and Tunability**
+
+   Export key metrics and debugging information from day one (throughput, latency distribution, resource utilization, error signals, etc.), giving cluster operators data to guide topology and parameter tuning—rather than black-box trial-and-error.
+
+5. **Embeddable in Existing Inference Systems**
+
+   Serve as an optional "transport backend" that can plug into existing inference/dispatch/scheduling components—without requiring a full rewrite of the upper layers—ensuring the PoC can be validated quickly in real production stacks.
+
+# Non-Goals
+
+1. **Not a General-Purpose RPC or Service Framework**
+
+   No request routing, load balancing, IDL, or serialization format wars—these concerns belong to upper layers or other projects.
+
+2. **Not a Universal Network Virtualization Layer**
+
+   No attempt to automatically adapt to all network environments, cloud providers, or dynamic topologies; the initial focus is deep optimization for known, controlled, performance-sensitive clusters.
+
+3. **Not a Full-Featured Communication Middleware**
+
+   Does not cover collectives, group communication semantics, or a comprehensive flow control ecosystem—only focused on high-value point-to-point (or few-node) bulk transfer scenarios.
+
+4. **Not a "Runs Everywhere" Compatibility Solution**
+
+   No compromising design sharpness for compatibility with low-spec or non-accelerated network environments; other protocols or software fallbacks are incremental extensions, not core promises.
+
+5. **Not a Security or Compliance Component**
+
+   No built-in complex authentication, encryption, or multi-tenant isolation; default assumption is deployment in controlled environments, with security handled by infrastructure.

--- a/docs/pd.md
+++ b/docs/pd.md
@@ -114,6 +114,15 @@ class PegaPDRouter:
             self._pending_requests[req_id].set()
 ```
 
+## Benchmark Results (H800, Qwen3-8B, 5K input tokens)
+
+| Configuration  | TTFT mean (ms) | TPOT mean (ms) | TPOT p99 (ms) | ITL p99 (ms) |
+| -------------- | -------------- | -------------- | ------------- | ------------ |
+| P/D (1P+1D)    | 573.78         | 15.68          | 15.89         | 21.71        |
+| Baseline (DP2) | 438.24         | 22.67          | 24.32         | 142.70       |
+
+The P/D setup trades higher TTFT for **significantly more stable decode latency** — TPOT p99 drops from 24.32ms to 15.89ms, and ITL p99 improves dramatically from 142.70ms to 21.71ms.
+
 ## TODO
 
 - [ ] Implement `_notify_router()` in connector

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,63 @@
+# Server Configuration
+
+## PegaFlow Server
+
+```bash
+pegaflow-server
+```
+
+### Options
+
+- `--addr`: Bind address (default: `127.0.0.1:50055`)
+- `--devices`: CUDA device IDs to initialize, comma-separated (default: auto-detect all available GPUs, e.g., `--devices 0,1,2,3`)
+- `--pool-size`: Pinned memory pool size (default: `30gb`, supports: `kb`, `mb`, `gb`, `tb`)
+- `--hint-value-size`: Hint for typical value size to tune cache and allocator (optional, supports: `kb`, `mb`, `gb`, `tb`)
+- `--use-hugepages`: Use huge pages for pinned memory (default: `false`, requires pre-configured `/proc/sys/vm/nr_hugepages`)
+- `--enable-lfu-admission`: Enable TinyLFU cache admission policy (default: plain LRU)
+- `--disable-numa-affinity`: Disable NUMA-aware memory allocation (default: enabled)
+- `--blockwise-alloc`: Allocate each block separately instead of contiguous batch allocation. Reduces memory fragmentation when blocks are freed in different order (default: `false`)
+- `--log-level`: Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`)
+
+### HTTP & Metrics
+
+- `--http-addr`: HTTP server address for health check and Prometheus metrics (default: `0.0.0.0:9091`, always enabled)
+- `--enable-prometheus`: Enable Prometheus `/metrics` endpoint (default: `true`)
+- `--metrics-otel-endpoint`: OTLP metrics export endpoint (optional, leave unset to disable)
+- `--metrics-period-secs`: Metrics export period in seconds (default: `10`, only used with OTLP)
+
+### SSD Cache
+
+- `--ssd-cache-path`: Enable SSD cache by providing cache file path (optional)
+- `--ssd-cache-capacity`: SSD cache capacity (default: `512gb`, supports: `kb`, `mb`, `gb`, `tb`)
+- `--ssd-write-queue-depth`: SSD write queue depth, max pending write batches (default: `8`)
+- `--ssd-prefetch-queue-depth`: SSD prefetch queue depth, max pending prefetch batches (default: `2`)
+- `--ssd-write-inflight`: SSD write inflight, max concurrent block writes (default: `2`)
+- `--ssd-prefetch-inflight`: SSD prefetch inflight, max concurrent block reads (default: `16`)
+- `--max-prefetch-blocks`: Max blocks allowed in prefetching state, backpressure for SSD prefetch (default: `800`)
+
+### Cross-Node (Multi-Node Setup)
+
+- `--metaserver-addr`: MetaServer gRPC address for cross-node block hash registry (e.g., `http://127.0.0.1:50056`). When set, saved block hashes are inserted to the metaserver for cross-node discovery.
+- `--advertise-addr`: Advertised address (ip:port) reported to the metaserver for cross-node discovery. Other nodes use this address to connect to this server. Fallback order: this flag > `PEGAFLOW_HOST_IP` env + bind port > auto-detected IP + bind port.
+- `--metaserver-queue-depth`: MetaServer registration queue depth, max pending registration batches
+
+## MetaServer
+
+For multi-node setups, start a MetaServer to coordinate block hashes across nodes. Each pegaflow-server registers its block hashes with the MetaServer, enabling cross-node KV cache discovery.
+
+```bash
+pegaflow-metaserver
+```
+
+Then point each pegaflow-server to the MetaServer:
+
+```bash
+pegaflow-server --metaserver-addr http://<metaserver-host>:50056
+```
+
+### Options
+
+- `--addr`: Bind address (default: `127.0.0.1:50056`)
+- `--log-level`: Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`)
+- `--max-capacity-mb`: Maximum cache capacity in MB (default: `512`)
+- `--ttl-minutes`: Cache entry TTL in minutes (default: `120`)

--- a/docs/vllm-patch.md
+++ b/docs/vllm-patch.md
@@ -1,0 +1,24 @@
+# vLLM Patch for Better I/O Performance
+
+To maximize I/O throughput when using PegaFlow with vLLM, we recommend a small patch to vLLM's KV cache block allocation. Sorting block IDs ensures GPU memory addresses are as sequential and contiguous as possible, which improves DMA/RDMA transfer efficiency.
+
+Upstream RFC: https://github.com/vllm-project/vllm/issues/31371
+
+Locate the file `vllm/v1/core/kv_cache_utils.py` in your vLLM installation (e.g., `.venv/lib/python3.10/site-packages/vllm/v1/core/kv_cache_utils.py`), find the `append_n` method in the `FreeKVCacheBlockQueue` class, and add a sorting line:
+
+```python
+def append_n(self, blocks: list[KVCacheBlock]) -> None:
+    """Put a list of blocks back into the free list
+
+    Args:
+        blocks: The blocks to append.
+    """
+    if len(blocks) == 0:
+        return
+
+    blocks.sort(key=lambda x: x.block_id)  # <-- Add this line
+    last_block = self.fake_free_list_tail.prev_free_block
+    ...
+```
+
+This simple change can noticeably reduce transfer latency by enabling more efficient memory access patterns during KV cache operations.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.16"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "PegaFlow Contributors" }
 ]


### PR DESCRIPTION
## Summary

- Add Apache-2.0 LICENSE and update license fields in Cargo.toml and pyproject.toml
- Rewrite README with new slogan, badges (CI/PyPI/License), and streamlined intro highlighting key differentiators (decoupled lifecycle, topology-aware transfers, GIL-free Rust core, observability, pluggable)
- Simplify Quick Start to 3 steps with CUDA 12/13 install options, vLLM as recommended
- Move verbose content (server flags, P/D router, vLLM patch, goals/non-goals) to `docs/`
- Create `docs/server.md` with up-to-date CLI reference
- Fix broken anchor link and outdated GitHub repo description

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Verify all `docs/` links resolve
- [ ] Verify PyPI page still works with updated pyproject.toml license field

🤖 Generated with [Claude Code](https://claude.com/claude-code)