### PR TITLE
chore: bump version to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,7 +2166,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.0.16"
+version = "0.17.0"
 dependencies = [
  "colored",
  "libc",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.0.16"
+version = "0.17.0"
 dependencies = [
  "ahash",
  "bytesize",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.0.16"
+version = "0.17.0"
 dependencies = [
  "clap",
  "log",
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.0.16"
+version = "0.17.0"
 dependencies = [
  "prost",
  "tonic",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.0.16"
+version = "0.17.0"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.0.16"
+version = "0.17.0"
 dependencies = [
  "axum",
  "clap",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.0.16"
+version = "0.17.0"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.16"
+version = "0.17.0"
 edition = "2024"
 
 [workspace.dependencies]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.0.16"
+version = "0.17.0"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -105,6 +105,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.0.16"
+version = "0.17.0"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## Summary
- bump the workspace Rust package version to `0.17.0`
- bump the Python package and Commitizen version to `0.17.0`
- refresh `Cargo.lock` so workspace crate versions stay aligned

## Validation
- verified the Rust workspace version, Python package version, and Commitizen version are all `0.17.0`
- attempted `cargo run -q -p pegaflow-metaserver -- --version`, but local validation is blocked by missing `libclang` while building `rdma-mummy-sys`
