### PR TITLE
fix(transfer): RDMA CONNECTING state, logging, and QP metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,7 @@ dependencies = [
  "clap",
  "libc",
  "log",
+ "mea",
  "parking_lot",
  "pegaflow-common",
  "serde",

--- a/pegaflow-core/src/backing/rdma.rs
+++ b/pegaflow-core/src/backing/rdma.rs
@@ -74,7 +74,7 @@ pub(crate) fn new_rdma(
     match RdmaTransport::new(nic_names, allocator) {
         Ok(t) => Some(Arc::new(t)),
         Err(e) => {
-            error!("Failed to initialise RDMA transport: {e}");
+            error!("Failed to initialise RDMA transport (nics={nic_names:?}): {e}");
             None
         }
     }

--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use log::{debug, info, warn};
+use mea::oneshot;
 use mea::singleflight::Group;
 use pegaflow_proto::proto::engine::engine_client::EngineClient;
 use pegaflow_proto::proto::engine::{
@@ -16,7 +17,6 @@ use pegaflow_proto::proto::engine::{
     ReleaseTransferLockRequest, TransferBlockInfo,
 };
 use pegaflow_transfer::{ConnectionStatus, HandshakeMetadata, TransferDesc, TransferOp};
-use tokio::sync::oneshot;
 use tonic::transport::{Channel, Endpoint};
 
 use pegaflow_common::NumaNode;
@@ -330,7 +330,7 @@ async fn fetch_blocks_via_rdma(
 
     // Build TransferDescs and submit RDMA READ inside a sync block so that
     // all_descs (which contains NonNull<u8>, !Send) is dropped before any .await.
-    let rx = {
+    let receivers = {
         let mut all_descs: Vec<TransferDesc> = Vec::new();
 
         for block_info in blocks {
@@ -394,12 +394,16 @@ async fn fetch_blocks_via_rdma(
             .map_err(|e| format!("RDMA batch_transfer_async failed: {e}"))?
     };
 
-    // Offload blocking recv() to a dedicated thread to avoid blocking the async runtime.
-    let _bytes = tokio::task::spawn_blocking(move || rx.recv_timeout(transfer_timeout))
-        .await
-        .map_err(|e| format!("RDMA transfer task panicked: {e}"))?
-        .map_err(|e| format!("RDMA transfer timed out or channel closed: {e}"))?
-        .map_err(|e| format!("RDMA transfer failed: {e}"))?;
+    tokio::time::timeout(transfer_timeout, async {
+        for rx in receivers {
+            rx.await
+                .map_err(|_| "RDMA transfer channel closed".to_string())?
+                .map_err(|e| format!("RDMA transfer failed: {e}"))?;
+        }
+        Ok::<(), String>(())
+    })
+    .await
+    .map_err(|_| "RDMA transfer timed out".to_string())??;
 
     // Build SealedBlocks from allocated memory
     let mut result: PrefetchResult = Vec::with_capacity(block_allocs.len());

--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -281,13 +281,16 @@ async fn ensure_connected(
             // Fast path: already connected
             let local_meta = match rdma.engine().get_or_prepare(remote_addr) {
                 Ok(ConnectionStatus::Existing) => return Ok(()),
+                Ok(ConnectionStatus::Connecting) => {
+                    return Err("handshake to this peer already in progress".into());
+                }
                 Ok(ConnectionStatus::Prepared(m)) => m,
                 Err(e) => return Err(format!("RDMA prepare: {e}")),
             };
 
             // Exchange handshake metadata via the dedicated RdmaHandshake RPC.
             let mut client = get_or_create_channel(grpc_channels, remote_addr)
-                .inspect_err(|_| rdma.engine().abort_handshake(&local_meta))?;
+                .inspect_err(|_| rdma.engine().abort_handshake(remote_addr, &local_meta))?;
 
             let request = RdmaHandshakeRequest {
                 requester_id: advertise_addr.to_string(),
@@ -297,12 +300,12 @@ async fn ensure_connected(
                 .rdma_handshake(request)
                 .await
                 .map_err(|e| format!("RdmaHandshake RPC failed: {e}"))
-                .inspect_err(|_| rdma.engine().abort_handshake(&local_meta))?
+                .inspect_err(|_| rdma.engine().abort_handshake(remote_addr, &local_meta))?
                 .into_inner();
 
             // Complete the RDMA connection with the server's QP info.
             finish_handshake(rdma, remote_addr, &local_meta, &response.handshake_metadata)
-                .inspect_err(|_| rdma.engine().abort_handshake(&local_meta))?;
+                .inspect_err(|_| rdma.engine().abort_handshake(remote_addr, &local_meta))?;
 
             Ok(())
         })

--- a/pegaflow-core/src/backing/ssd.rs
+++ b/pegaflow-core/src/backing/ssd.rs
@@ -2,8 +2,8 @@ use std::sync::{Arc, Weak};
 
 use bytesize::ByteSize;
 use log::{debug, error, info, warn};
+use mea::oneshot;
 use parking_lot::Mutex;
-use tokio::sync::oneshot;
 
 use crate::block::{BlockKey, SealedBlock};
 use crate::metrics::core_metrics;

--- a/pegaflow-core/src/backing/ssd_cache.rs
+++ b/pegaflow-core/src/backing/ssd_cache.rs
@@ -1,12 +1,12 @@
 use futures::stream::{FuturesOrdered, FuturesUnordered, StreamExt};
 use log::{debug, warn};
+use mea::oneshot;
 use parking_lot::Mutex;
 use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::Instant;
-use tokio::sync::oneshot;
 
 use super::ssd::SsdBackingStore;
 use super::uring::UringIoEngine;

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -676,6 +676,7 @@ impl PegaEngine {
         rdma.engine()
             .complete_handshake(client_addr, &server_meta, &client_meta)
             .map_err(|e| format!("complete_handshake failed: {e}"))?;
+        info!("RDMA handshake accepted: client={client_addr}");
         Ok(server_meta.to_bytes())
     }
 }

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -669,6 +669,9 @@ impl PegaEngine {
             pegaflow_transfer::ConnectionStatus::Existing => {
                 unreachable!("just invalidated connection for {client_addr}")
             }
+            pegaflow_transfer::ConnectionStatus::Connecting => {
+                return Err(format!("handshake to {client_addr} already in progress"));
+            }
         };
         rdma.engine()
             .complete_handshake(client_addr, &server_meta, &client_meta)

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -1,8 +1,10 @@
 use opentelemetry::{
     global,
-    metrics::{Counter, Histogram, Meter, UpDownCounter},
+    metrics::{Counter, Histogram, Meter, ObservableGauge, UpDownCounter},
 };
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
+
+use crate::backing::RdmaTransport;
 
 pub(crate) struct CoreMetrics {
     // Pinned pool (allocator-level)
@@ -107,6 +109,29 @@ fn duration_seconds_boundaries() -> Vec<f64> {
         2.0,   // 2s
         5.0,   // 5s
     ]
+}
+
+struct RdmaGaugeHandles {
+    _qps: ObservableGauge<u64>,
+}
+
+static RDMA_GAUGES: OnceLock<RdmaGaugeHandles> = OnceLock::new();
+
+/// Register RDMA observable gauges backed by the given transport.
+/// Must be called after [`RdmaTransport`] is created; safe to call multiple times (no-op after first).
+pub(crate) fn register_rdma_gauges(transport: &Arc<RdmaTransport>) {
+    let t = Arc::clone(transport);
+    RDMA_GAUGES.get_or_init(|| {
+        let meter = init_meter();
+        let qps = meter
+            .u64_observable_gauge("pegaflow_rdma_qps")
+            .with_description("Active RC queue pairs across all RDMA NICs")
+            .with_callback(move |observer| {
+                observer.observe(t.engine().num_qps() as u64, &[]);
+            })
+            .build();
+        RdmaGaugeHandles { _qps: qps }
+    });
 }
 
 pub(crate) fn core_metrics() -> &'static CoreMetrics {

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -159,6 +159,10 @@ impl StorageEngine {
             .filter(|nics| !nics.is_empty())
             .and_then(|nics| crate::backing::new_rdma(nics, &allocator));
 
+        if let Some(ref rdma) = rdma_transport {
+            crate::metrics::register_rdma_gauges(rdma);
+        }
+
         let is_numa = allocator.is_numa();
         let engine = Arc::new_cyclic(move |weak_engine: &Weak<Self>| {
             // Build shared allocate_fn for backing stores.

--- a/pegaflow-core/src/storage/prefetch.rs
+++ b/pegaflow-core/src/storage/prefetch.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use log::warn;
+use mea::oneshot;
 use parking_lot::Mutex;
-use tokio::sync::oneshot;
 
 use crate::backing::{PrefetchResult, RdmaFetchStore, SsdBackingStore};
 use crate::block::{BlockKey, PrefetchStatus};
@@ -96,14 +96,14 @@ impl PrefetchScheduler {
         let entry = state.active.get_mut(req_id)?;
 
         match entry.blocks_rx.try_recv() {
-            Err(oneshot::error::TryRecvError::Empty) => Some(PollResult::StillLoading),
+            Err(oneshot::TryRecvError::Empty) => Some(PollResult::StillLoading),
             Ok(ssd_blocks) => {
                 state.remove_entry(req_id);
                 drop(state);
                 read_cache.batch_insert(ssd_blocks);
                 Some(PollResult::Completed)
             }
-            Err(oneshot::error::TryRecvError::Closed) => {
+            Err(oneshot::TryRecvError::Disconnected) => {
                 warn!(
                     "Backing prefetch sender dropped for req_id={}, falling back to re-scan",
                     req_id

--- a/pegaflow-transfer/Cargo.toml
+++ b/pegaflow-transfer/Cargo.toml
@@ -16,6 +16,7 @@ serde.workspace = true
 bincode = { version = "2.0.1", features = ["serde"] }
 libc.workspace = true
 clap.workspace = true
+mea = "0.6.3"
 
 [[bin]]
 name = "pegaflow-cpu-bench"

--- a/pegaflow-transfer/src/bin/cpu_bench.rs
+++ b/pegaflow-transfer/src/bin/cpu_bench.rs
@@ -449,8 +449,9 @@ fn create_engine_context(
         .expect("server get_or_prepare failed")
     {
         pegaflow_transfer::ConnectionStatus::Prepared(m) => m,
-        pegaflow_transfer::ConnectionStatus::Existing => {
-            panic!("unexpected existing connection on fresh engine")
+        pegaflow_transfer::ConnectionStatus::Existing
+        | pegaflow_transfer::ConnectionStatus::Connecting => {
+            panic!("unexpected state on fresh engine")
         }
     };
     let client_meta = match client
@@ -458,8 +459,9 @@ fn create_engine_context(
         .expect("client get_or_prepare failed")
     {
         pegaflow_transfer::ConnectionStatus::Prepared(m) => m,
-        pegaflow_transfer::ConnectionStatus::Existing => {
-            panic!("unexpected existing connection on fresh engine")
+        pegaflow_transfer::ConnectionStatus::Existing
+        | pegaflow_transfer::ConnectionStatus::Connecting => {
+            panic!("unexpected state on fresh engine")
         }
     };
     server

--- a/pegaflow-transfer/src/bin/cpu_bench.rs
+++ b/pegaflow-transfer/src/bin/cpu_bench.rs
@@ -320,13 +320,15 @@ fn run_bench(
             build_block_scatter(ctx.client_buf.ptr, ctx.server_buf.ptr, nblocks, block_size);
 
         let start = Instant::now();
-        let rx = ctx
+        let receivers = ctx
             .client
             .batch_transfer_async(op, "bench-server", &descs)
             .expect("RDMA submit failed");
-        rx.recv()
-            .expect("completion channel dropped")
-            .expect("RDMA transfer failed");
+        for rx in receivers {
+            block_recv(rx)
+                .expect("completion channel dropped")
+                .expect("RDMA transfer failed");
+        }
         let elapsed = start.elapsed();
 
         if i >= warmup {
@@ -645,4 +647,29 @@ fn main() {
 
     println!();
     println!("bench complete.");
+}
+
+fn block_recv<T>(rx: mea::oneshot::Receiver<T>) -> Result<T, mea::oneshot::RecvError> {
+    use std::future::IntoFuture;
+    use std::pin::pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake};
+
+    struct ThreadWaker(thread::Thread);
+    impl Wake for ThreadWaker {
+        fn wake(self: Arc<Self>) {
+            self.0.unpark();
+        }
+    }
+
+    let waker = Arc::new(ThreadWaker(thread::current())).into();
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = pin!(rx.into_future());
+
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(result) => return result,
+            Poll::Pending => thread::park(),
+        }
+    }
 }

--- a/pegaflow-transfer/src/bin/cpu_bench.rs
+++ b/pegaflow-transfer/src/bin/cpu_bench.rs
@@ -471,6 +471,20 @@ fn create_engine_context(
         .complete_handshake("bench-server", &client_meta, &server_meta)
         .expect("client complete_handshake failed");
 
+    let nic_count = nic_names.len();
+    assert_eq!(
+        server.num_qps(),
+        nic_count,
+        "server should have {nic_count} QP(s) after handshake, got {}",
+        server.num_qps()
+    );
+    assert_eq!(
+        client.num_qps(),
+        nic_count,
+        "client should have {nic_count} QP(s) after handshake, got {}",
+        client.num_qps()
+    );
+
     EngineContext {
         label,
         server,

--- a/pegaflow-transfer/src/engine.rs
+++ b/pegaflow-transfer/src/engine.rs
@@ -181,6 +181,11 @@ impl TransferEngine {
     ) -> Result<std::sync::mpsc::Receiver<Result<usize>>> {
         self.backend.batch_transfer_async(op, remote_addr, descs)
     }
+
+    /// Number of active RC queue pairs across all NICs.
+    pub fn num_qps(&self) -> usize {
+        self.backend.num_qps()
+    }
 }
 
 #[cfg(test)]

--- a/pegaflow-transfer/src/engine.rs
+++ b/pegaflow-transfer/src/engine.rs
@@ -167,9 +167,8 @@ impl TransferEngine {
 
     /// Submit a batch of RDMA READ or WRITE operations against a connected peer.
     ///
-    /// Ops are NUMA-aware distributed across NICs. Returns a `Receiver`
-    /// that yields the total bytes transferred once all RDMA operations complete.
-    /// The caller decides when to block on `.recv()`.
+    /// Ops are NUMA-aware distributed across NICs. Returns one receiver per
+    /// active NIC; each yields the bytes transferred on that NIC.
     ///
     /// The connection must be established via `get_or_prepare` +
     /// `complete_handshake` before calling this method.
@@ -178,7 +177,7 @@ impl TransferEngine {
         op: TransferOp,
         remote_addr: &str,
         descs: &[TransferDesc],
-    ) -> Result<std::sync::mpsc::Receiver<Result<usize>>> {
+    ) -> Result<Vec<mea::oneshot::Receiver<Result<usize>>>> {
         self.backend.batch_transfer_async(op, remote_addr, descs)
     }
 

--- a/pegaflow-transfer/src/engine.rs
+++ b/pegaflow-transfer/src/engine.rs
@@ -93,6 +93,8 @@ impl HandshakeMetadata {
 pub enum ConnectionStatus {
     /// Already connected; call batch_transfer_async directly.
     Existing,
+    /// A handshake to this peer is already in progress.
+    Connecting,
     /// Not connected. Exchange this local metadata with remote peer via gRPC,
     /// then call complete_handshake. On failure, call abort_handshake.
     Prepared(HandshakeMetadata),
@@ -128,6 +130,7 @@ impl TransferEngine {
     pub fn get_or_prepare(&self, remote_addr: &str) -> Result<ConnectionStatus> {
         match self.backend.get_or_prepare(remote_addr)? {
             GetOrPrepareResult::Existing => Ok(ConnectionStatus::Existing),
+            GetOrPrepareResult::AlreadyConnecting => Ok(ConnectionStatus::Connecting),
             GetOrPrepareResult::NeedHandshake(nics) => {
                 Ok(ConnectionStatus::Prepared(HandshakeMetadata { nics }))
             }
@@ -146,8 +149,8 @@ impl TransferEngine {
     }
 
     /// Drop pending sessions created by get_or_prepare when handshake failed.
-    pub fn abort_handshake(&self, local_meta: &HandshakeMetadata) {
-        self.backend.abort_handshake(&local_meta.nics);
+    pub fn abort_handshake(&self, remote_addr: &str, local_meta: &HandshakeMetadata) {
+        self.backend.abort_handshake(remote_addr, &local_meta.nics);
     }
 
     /// Return cached local handshake metadata for an established connection.

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -356,6 +356,10 @@ impl RcBackend {
         }
     }
 
+    pub(crate) fn num_qps(&self) -> usize {
+        self.state.lock().num_qps()
+    }
+
     pub(crate) fn batch_transfer_async(
         &self,
         op: TransferOp,

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -314,10 +314,11 @@ impl RcBackend {
         state.addr_connections.insert(
             remote_addr.to_string(),
             AddrConnection {
-                remote_qpns,
+                remote_qpns: remote_qpns.clone(),
                 local_nics,
             },
         );
+        info!("RDMA connection established: remote={remote_addr}, remote_qpns={remote_qpns:?}");
         Ok(())
     }
 

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -92,6 +92,7 @@ impl NumaRoundRobin {
 
 pub(crate) enum GetOrPrepareResult {
     Existing,
+    AlreadyConnecting,
     NeedHandshake(Vec<NicHandshake>),
 }
 
@@ -231,13 +232,23 @@ impl RcBackend {
     /// Check if connected to remote_addr; if not, prepare local QPs.
     pub(crate) fn get_or_prepare(&self, remote_addr: &str) -> Result<GetOrPrepareResult> {
         {
-            let state = self.state.lock();
+            let mut state = self.state.lock();
             if state.addr_connections.contains_key(remote_addr) {
                 return Ok(GetOrPrepareResult::Existing);
             }
+            if state.connecting.contains(remote_addr) {
+                return Ok(GetOrPrepareResult::AlreadyConnecting);
+            }
+            state.connecting.insert(remote_addr.to_string());
         }
-        let nics = self.prepare_handshake()?;
-        Ok(GetOrPrepareResult::NeedHandshake(nics))
+        match self.prepare_handshake() {
+            Ok(nics) => Ok(GetOrPrepareResult::NeedHandshake(nics)),
+            Err(e) => {
+                let removed = self.state.lock().connecting.remove(remote_addr);
+                debug_assert!(removed, "connecting set should contain {remote_addr}");
+                Err(e)
+            }
+        }
     }
 
     /// Complete a connection after handshake exchange.
@@ -264,6 +275,7 @@ impl RcBackend {
                 for (nic_idx, nic) in local_nics.iter().enumerate() {
                     state.nics[nic_idx].remove_pending_by_qpn(nic.endpoint.qp_num);
                 }
+                state.connecting.remove(remote_addr);
                 return Ok(());
             }
             let mut sessions = Vec::with_capacity(nic_count);
@@ -293,6 +305,8 @@ impl RcBackend {
             state.nics[nic_idx].sessions.insert(remote_qpn, session);
             remote_qpns.push(remote_qpn);
         }
+        let removed = state.connecting.remove(remote_addr);
+        debug_assert!(removed, "connecting set should contain {remote_addr}");
         state.addr_connections.insert(
             remote_addr.to_string(),
             AddrConnection {
@@ -304,8 +318,10 @@ impl RcBackend {
     }
 
     /// Drop pending sessions created by get_or_prepare when handshake failed.
-    pub(crate) fn abort_handshake(&self, local_nics: &[NicHandshake]) {
+    pub(crate) fn abort_handshake(&self, remote_addr: &str, local_nics: &[NicHandshake]) {
         let mut state = self.state.lock();
+        let removed = state.connecting.remove(remote_addr);
+        debug_assert!(removed, "connecting set should contain {remote_addr}");
         for (nic_idx, nic) in local_nics.iter().enumerate() {
             state.nics[nic_idx].remove_pending_by_qpn(nic.endpoint.qp_num);
         }

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -311,14 +311,17 @@ impl RcBackend {
         }
         let removed = state.connecting.remove(remote_addr);
         debug_assert!(removed, "connecting set should contain {remote_addr}");
+        let local_qpns: Vec<u32> = local_nics.iter().map(|n| n.endpoint.qp_num).collect();
+        info!(
+            "RDMA connection established: remote={remote_addr}, local_qpns={local_qpns:?}, remote_qpns={remote_qpns:?}"
+        );
         state.addr_connections.insert(
             remote_addr.to_string(),
             AddrConnection {
-                remote_qpns: remote_qpns.clone(),
+                remote_qpns,
                 local_nics,
             },
         );
-        info!("RDMA connection established: remote={remote_addr}, remote_qpns={remote_qpns:?}");
         Ok(())
     }
 

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Instant;
 
-use log::debug;
+use log::{debug, info, warn};
 use parking_lot::Mutex;
 use sideway::ibverbs::AccessFlags;
 
@@ -114,7 +114,6 @@ impl RcBackend {
             if name.trim().is_empty() {
                 return Err(TransferError::InvalidArgument("nic_name is empty"));
             }
-            log::info!("rc backend initialize: nic={}", name);
             let runtime = RcRuntime::open(name)?;
             log::info!("rc backend initialized: nic={}", name);
             runtimes.push(runtime);
@@ -212,7 +211,12 @@ impl RcBackend {
         let mut sessions = Vec::with_capacity(self.nic_count());
         for runtime in &self.runtimes {
             let psn_seed = self.psn_counter.fetch_add(1, Ordering::Relaxed);
-            let session = RcSession::create(runtime, psn_seed)?;
+            let session = RcSession::create(runtime, psn_seed).map_err(|e| {
+                TransferError::Backend(format!(
+                    "QP creation failed on nic={}: {e}",
+                    runtime.nic_name
+                ))
+            })?;
             sessions.push(session);
         }
 
@@ -276,6 +280,7 @@ impl RcBackend {
                     state.nics[nic_idx].remove_pending_by_qpn(nic.endpoint.qp_num);
                 }
                 state.connecting.remove(remote_addr);
+                info!("handshake won by concurrent path: remote={remote_addr}");
                 return Ok(());
             }
             let mut sessions = Vec::with_capacity(nic_count);
@@ -325,6 +330,7 @@ impl RcBackend {
         for (nic_idx, nic) in local_nics.iter().enumerate() {
             state.nics[nic_idx].remove_pending_by_qpn(nic.endpoint.qp_num);
         }
+        warn!("handshake aborted: remote={remote_addr}");
     }
 
     /// Get local NicHandshake metadata for an established connection.
@@ -343,6 +349,7 @@ impl RcBackend {
             for (nic_idx, &remote_qpn) in conn.remote_qpns.iter().enumerate() {
                 state.nics[nic_idx].cleanup_connection(remote_qpn);
             }
+            info!("connection invalidated: remote={remote_addr}");
         }
     }
 

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -115,7 +115,6 @@ impl RcBackend {
                 return Err(TransferError::InvalidArgument("nic_name is empty"));
             }
             let runtime = RcRuntime::open(name)?;
-            log::info!("rc backend initialized: nic={}", name);
             runtimes.push(runtime);
         }
         let nic_count = runtimes.len();

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -16,6 +16,8 @@ use self::session::{RcSession, RdmaOp};
 use self::state::{AddrConnection, RcBackendState, RegisteredMemoryEntry};
 use std::ptr::NonNull;
 
+use mea::oneshot;
+
 use crate::engine::{NicHandshake, RegisteredMemoryRegion, TransferDesc, TransferOp};
 use crate::error::{Result, TransferError};
 use pegaflow_common::NumaNode;
@@ -360,16 +362,15 @@ impl RcBackend {
         self.state.lock().num_qps()
     }
 
+    /// One receiver per NIC that had work; each yields bytes transferred on that NIC.
     pub(crate) fn batch_transfer_async(
         &self,
         op: TransferOp,
         remote_addr: &str,
         descs: &[TransferDesc],
-    ) -> Result<std::sync::mpsc::Receiver<Result<usize>>> {
+    ) -> Result<Vec<oneshot::Receiver<Result<usize>>>> {
         if descs.is_empty() {
-            let (tx, rx) = std::sync::mpsc::sync_channel(1);
-            let _ = tx.send(Ok(0));
-            return Ok(rx);
+            return Ok(Vec::new());
         }
 
         let nic_count = self.nic_count();
@@ -467,43 +468,10 @@ impl RcBackend {
         );
 
         // --- Submit outside lock ---
-        if nic_work.len() == 1 {
-            // Single NIC path: return its receiver directly.
-            let (session, prepared) = nic_work.into_iter().next().unwrap();
-            return session.transfer_batch_async(prepared, op);
-        }
-
-        // Multi-NIC path: submit to all NICs and aggregate results.
         let mut receivers = Vec::with_capacity(nic_work.len());
         for (session, prepared) in nic_work {
-            let rx = session.transfer_batch_async(prepared, op)?;
-            receivers.push(rx);
+            receivers.push(session.transfer_batch_async(prepared, op)?);
         }
-
-        let (agg_tx, agg_rx) = std::sync::mpsc::sync_channel(1);
-        std::thread::Builder::new()
-            .name("pegaflow-transfer-agg".to_string())
-            .spawn(move || {
-                let mut total_bytes = 0usize;
-                for rx in receivers {
-                    match rx.recv() {
-                        Ok(Ok(bytes)) => total_bytes += bytes,
-                        Ok(Err(e)) => {
-                            let _ = agg_tx.send(Err(e));
-                            return;
-                        }
-                        Err(_) => {
-                            let _ = agg_tx.send(Err(TransferError::Backend(
-                                "session worker channel dropped during aggregation".to_string(),
-                            )));
-                            return;
-                        }
-                    }
-                }
-                let _ = agg_tx.send(Ok(total_bytes));
-            })
-            .map_err(|e| TransferError::Backend(format!("failed to spawn aggregator: {e}")))?;
-
-        Ok(agg_rx)
+        Ok(receivers)
     }
 }

--- a/pegaflow-transfer/src/rc_backend/runtime.rs
+++ b/pegaflow-transfer/src/rc_backend/runtime.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use log::warn;
+use log::error;
 use pegaflow_common::NumaNode;
 use sideway::ibverbs::address::Gid;
 use sideway::ibverbs::device::{DeviceInfo, DeviceList};
@@ -18,11 +18,11 @@ pub(crate) struct RcRuntime {
     pub(crate) mtu: Mtu,
     pub(crate) local_gid: Gid,
     pub(crate) numa_node: NumaNode,
+    pub(crate) nic_name: String,
 }
 
 impl RcRuntime {
     pub(crate) fn open(nic_name: &str) -> Result<Arc<Self>> {
-        log::info!("rc runtime open: nic={}", nic_name);
         let device_list =
             DeviceList::new().map_err(|error| TransferError::Backend(error.to_string()))?;
         let device = device_list
@@ -38,16 +38,15 @@ impl RcRuntime {
             .map_err(|error| TransferError::Backend(error.to_string()))?;
 
         let (port_num, gid_index, mtu, local_gid) = Self::choose_port_and_gid(&device_ctx)?;
+        let numa_node = nic_numa_node(nic_name);
         log::info!(
-            "rc runtime ready: nic={}, port={}, gid_index={}, mtu={:?}",
+            "rc runtime ready: nic={}, port={}, gid_index={}, mtu={:?}, numa={}",
             nic_name,
             port_num,
             gid_index,
             mtu,
+            numa_node,
         );
-
-        let numa_node = nic_numa_node(nic_name);
-        log::info!("rc runtime numa: nic={}, numa_node={}", nic_name, numa_node);
 
         Ok(Arc::new(Self {
             device_ctx,
@@ -57,6 +56,7 @@ impl RcRuntime {
             mtu,
             local_gid,
             numa_node,
+            nic_name: nic_name.to_owned(),
         }))
     }
 
@@ -106,7 +106,7 @@ impl RcRuntime {
             return Ok((port_num, gid_index, port_attr.active_mtu(), gid));
         }
 
-        warn!(
+        error!(
             "no active port found on NIC {}; cannot initialize transfer runtime",
             device_ctx.name()
         );

--- a/pegaflow-transfer/src/rc_backend/runtime.rs
+++ b/pegaflow-transfer/src/rc_backend/runtime.rs
@@ -40,7 +40,7 @@ impl RcRuntime {
         let (port_num, gid_index, mtu, local_gid) = Self::choose_port_and_gid(&device_ctx)?;
         let numa_node = nic_numa_node(nic_name);
         log::info!(
-            "rc runtime ready: nic={}, port={}, gid_index={}, mtu={:?}, numa={}",
+            "RDMA NIC ready: nic={}, port={}, gid_index={}, mtu={:?}, numa={}",
             nic_name,
             port_num,
             gid_index,

--- a/pegaflow-transfer/src/rc_backend/session.rs
+++ b/pegaflow-transfer/src/rc_backend/session.rs
@@ -294,7 +294,8 @@ impl RcSession {
                         };
                         if wc.status() != WorkCompletionStatus::Success as u32 {
                             return Err(TransferError::Backend(format!(
-                                "send completion failed: status={}, opcode={}, vendor_err={}",
+                                "send completion failed: local_qpn={}, status={}, opcode={}, vendor_err={}",
+                                session.local_endpoint.qp_num,
                                 wc.status(),
                                 wc.opcode(),
                                 wc.vendor_err()
@@ -311,7 +312,8 @@ impl RcSession {
                 }
                 Err(error) => {
                     return Err(TransferError::Backend(format!(
-                        "poll send CQ failed: {error}"
+                        "poll send CQ failed: local_qpn={}, {error}",
+                        session.local_endpoint.qp_num
                     )));
                 }
             }

--- a/pegaflow-transfer/src/rc_backend/session.rs
+++ b/pegaflow-transfer/src/rc_backend/session.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::mpsc as std_mpsc;
+
+use mea::oneshot;
 use std::thread;
 
 use log::{debug, warn};
@@ -43,7 +45,7 @@ enum SessionCommand {
     Transfer {
         ops: Vec<RdmaOp>,
         op: TransferOp,
-        done_tx: std_mpsc::SyncSender<Result<usize>>,
+        done_tx: oneshot::Sender<Result<usize>>,
     },
 }
 
@@ -165,8 +167,8 @@ impl RcSession {
         &self,
         ops: Vec<RdmaOp>,
         op: TransferOp,
-    ) -> Result<std_mpsc::Receiver<Result<usize>>> {
-        let (done_tx, done_rx) = std_mpsc::sync_channel(0);
+    ) -> Result<oneshot::Receiver<Result<usize>>> {
+        let (done_tx, done_rx) = oneshot::channel();
         self.cmd_tx
             .send(SessionCommand::Transfer { ops, op, done_tx })
             .map_err(|_| {

--- a/pegaflow-transfer/src/rc_backend/session.rs
+++ b/pegaflow-transfer/src/rc_backend/session.rs
@@ -112,7 +112,7 @@ impl RcSession {
             cmd_tx,
         });
 
-        Self::spawn_worker(Arc::clone(&session), cmd_rx, runtime.numa_node);
+        Self::spawn_worker(Arc::clone(&session), cmd_rx, runtime.numa_node)?;
         Ok(session)
     }
 
@@ -179,8 +179,8 @@ impl RcSession {
         session: Arc<Self>,
         cmd_rx: std_mpsc::Receiver<SessionCommand>,
         numa_node: NumaNode,
-    ) {
-        let _ = thread::Builder::new()
+    ) -> Result<()> {
+        thread::Builder::new()
             .name("pegaflow-rc-session".to_string())
             .spawn(move || {
                 if numa_node.is_valid()
@@ -209,7 +209,9 @@ impl RcSession {
                     "session worker stopped: local_qpn={}",
                     session.local_endpoint.qp_num
                 );
-            });
+            })
+            .map_err(|e| TransferError::Backend(format!("failed to spawn session worker: {e}")))?;
+        Ok(())
     }
 
     fn post_rdma_wr_chain(

--- a/pegaflow-transfer/src/rc_backend/state.rs
+++ b/pegaflow-transfer/src/rc_backend/state.rs
@@ -123,6 +123,10 @@ pub(super) struct RcBackendState {
 }
 
 impl RcBackendState {
+    pub(super) fn num_qps(&self) -> usize {
+        self.nics.iter().map(|n| n.sessions.len()).sum()
+    }
+
     pub(super) fn new(nic_count: usize) -> Self {
         Self {
             registered: HashMap::new(),

--- a/pegaflow-transfer/src/rc_backend/state.rs
+++ b/pegaflow-transfer/src/rc_backend/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 use sideway::ibverbs::memory_region::MemoryRegion;
@@ -117,6 +117,9 @@ pub(super) struct RcBackendState {
     pub(super) nics: Vec<PerNicState>,
     /// addr -> established connection info
     pub(super) addr_connections: HashMap<String, AddrConnection>,
+    /// Addresses with a handshake in progress. Prevents concurrent
+    /// `get_or_prepare` calls from creating duplicate QPs for the same peer.
+    pub(super) connecting: HashSet<String>,
 }
 
 impl RcBackendState {
@@ -125,6 +128,7 @@ impl RcBackendState {
             registered: HashMap::new(),
             nics: (0..nic_count).map(|_| PerNicState::default()).collect(),
             addr_connections: HashMap::new(),
+            connecting: HashSet::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

- **CONNECTING 状态**: `RcBackend` 新增 `connecting: HashSet<String>` 防止同一 peer 并发创建重复 QP（问题 1 修复）
- **日志审计**: 补全 RDMA 连接生命周期日志（handshake accept/complete/abort/invalidate），错误消息加 NIC 名和 local_qpn，清理冗余初始化日志
- **`num_qps` metric**: `TransferEngine::num_qps()` 接口 + `pegaflow_rdma_qps` ObservableGauge，用于监控 QP 泄漏

## Test plan

- [x] cpu_bench 双卡跑通，assert QP 数量正确
- [x] 日志输出验证：建连打 `RDMA connection established` 带 local/remote QPN，NIC 初始化只打一条 `RDMA NIC ready`
- [x] Prometheus `/metrics` 端点返回 `pegaflow_rdma_qps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)