### PR TITLE
fix(connector): check pending_save_requests in is_empty() to fix stal…

### DIFF
--- a/python/pegaflow/connector/connector_metrics.py
+++ b/python/pegaflow/connector/connector_metrics.py
@@ -221,6 +221,7 @@ class PegaKVConnectorStats(KVConnectorStats):
     def is_empty(self) -> bool:
         return (
             self.data.get("pending_prefetches", 0) == 0
+            and self.data.get("pending_save_requests", 0) == 0
             and self.data.get("bypass_count", 0) == 0
             and len(self.data.get("prefetch_duration", [])) == 0
             and len(self.data.get("load_duration", [])) == 0


### PR DESCRIPTION
Problem                                                                                        
                                                                                               
pega_pending_save_requests Prometheus gauge stays stuck at a high value on some production     
nodes, even after all save operations have completed.                                          
                                                                                               
Root Cause                                                                                     
 
PegaKVConnectorStats.is_empty() checks every stats field except pending_save_requests:         
                                                          
def is_empty(self) -> bool:                                                                    
    return (                                                                                   
        self.data.get("pending_prefetches", 0) == 0                                            
        # ❌ missing: pending_save_requests                                                    
        and self.data.get("bypass_count", 0) == 0                                              
        ...                                                                                    
    )                                                                                          
                                                                                               
This causes the following sequence:                                                            
                                                          
1. get_stats() reports pending_save_requests=N alongside save_duration records → gauge         
correctly set to N, then clone_and_reset() clears all stats
2. Next collection cycle: save worker is still processing (no new completions yet),            
pending_save_requests=N is the only non-zero field                                             
3. is_empty() doesn't check it → returns True → get_stats() returns None → gauge not updated,
stays at stale value                                                                           
                                                          
Fix                                                                                            
                                                          
Add pending_save_requests to is_empty(). One-line change. After the fix, the gauge is always   
refreshed whenever there are pending saves.
