### PR TITLE
chore(python): remove unreachable dead code in __init__.py

### DIFF
--- a/python/pegaflow/__init__.py
+++ b/python/pegaflow/__init__.py
@@ -15,14 +15,8 @@ try:
         PegaFlowServiceError,
         PyLoadState,
     )
-    from .pegaflow import (
-        __version__ as _rust_version,
-    )
+    from .pegaflow import __version__ as _rust_version
 except ImportError:
-    # Fallback for development when the Rust extension is not built
-    EngineRpcClient = None
-    PegaEngine = None
-    PyLoadState = None
     raise ImportError(
         "pegaflow rust extension is not available, check pegaflow-xxx.so file exists"
     ) from None


### PR DESCRIPTION
## Summary

- Remove 3 unreachable `None` assignments (`EngineRpcClient`, `PegaEngine`, `PyLoadState`) in the `except ImportError` block — the unconditional `raise` makes them dead code
- isort simplified the `__version__` alias import from multi-line to single-line

Closes #171

## Correctness Proof

### Why the removed code is dead

```python
# BEFORE (lines 22-28):
except ImportError:
    EngineRpcClient = None   # ← dead: raise below executes unconditionally
    PegaEngine = None        # ← dead
    PyLoadState = None       # ← dead
    raise ImportError(...)   # ← this always runs, None values never observed
```

The `raise` is **unconditional** — no `if`, no `return`, no `break` between the assignments and the `raise`. The `None` values are never read by any code path.

### Verification evidence

| Check | Result |
|-------|--------|
| `python -c "import ast; ast.parse(...)"` | ✅ Syntax valid |
| `ruff check` | ✅ No issues |
| `ruff format --check` | ✅ Already formatted |
| `isort` (pre-commit hook) | ✅ Passed |
| `codespell` | ✅ Passed |
| `commitizen check` | ✅ Passed |
| All pre-commit hooks | ✅ 13/13 passed |

### Impact analysis

- `__all__` exports: **unchanged** — only executes on happy path (import succeeds)
- `__version__`: **unchanged** — `_rust_version` still imported in the `try` block
- Downstream callers (`connector/`, `sglang/`, tests): **no impact** — they import from the module, which either succeeds or raises `ImportError`

## Test plan

- [x] All pre-commit hooks pass locally (isort, ruff, codespell, commitizen, etc.)
- [x] CI checks pass (cargo check, clippy, fmt, ruff, typos, version consistency, wheel builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)