### PR TITLE
chore(release): bump pegaflow version to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "colored",
  "libc",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "ahash",
  "bytesize",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "clap",
  "log",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "prost",
  "tonic",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "axum",
  "clap",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.17.0"
+version = "0.18.0"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -105,6 +105,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.17.0"
+version = "0.18.0"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## Summary
- bump the workspace package version from 0.17.0 to 0.18.0 in `Cargo.toml`
- bump the Python package and Commitizen versions to 0.18.0 in `python/pyproject.toml`
- refresh `Cargo.lock` package entries so Rust crate metadata stays aligned with the release version

## Testing
- python3 version consistency check from `.github/workflows/ci.yml`
- cargo check -p pegaflow-server