### PR TITLE
fix(connector): align hybrid save window across kv groups

### DIFF
--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -12,6 +12,7 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.distributed.parallel_state import get_tensor_model_parallel_rank
 
@@ -31,7 +32,7 @@ from pegaflow.connector.worker import WorkerConnector
 from pegaflow.pegaflow import EngineRpcClient
 
 
-class PegaKVConnector(KVConnectorBase_V1):
+class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
     """v1 KV connector for PegaFlow with separated scheduler/worker logic."""
 
     def __init__(self, vllm_config, role: KVConnectorRole, kv_cache_config=None):
@@ -40,6 +41,11 @@ class PegaKVConnector(KVConnectorBase_V1):
         instance_id = resolve_instance_id(vllm_config)
         tp_size = vllm_config.parallel_config.tensor_parallel_size
         world_size = vllm_config.parallel_config.world_size
+        num_kv_groups = max(
+            1,
+            len(getattr(kv_cache_config, "kv_cache_groups", None) or []),
+        )
+        engine_world_size = world_size * num_kv_groups
         is_mla = detect_mla(vllm_config)
         dcp_world_size = (
             getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1) or 1
@@ -104,7 +110,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             block_size=block_size,
             num_layers=num_layers,
             tp_size=tp_size,
-            world_size=world_size,
+            world_size=engine_world_size,
             tp_rank=tp_rank,
             device_id=device_id,
             engine_client=engine_client,
@@ -118,13 +124,13 @@ class PegaKVConnector(KVConnectorBase_V1):
         self._scheduler: SchedulerConnector | None = None
         self._worker: WorkerConnector | None = None
         if role == KVConnectorRole.SCHEDULER:
-            self._scheduler = SchedulerConnector(self._ctx)
+            self._scheduler = SchedulerConnector(self._ctx, kv_cache_config)
         else:
             self._worker = WorkerConnector(self._ctx)
 
         logger.info(
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
-            "tp_rank=%s tp_size=%d world_size=%d layers=%d namespace=%s "
+            "tp_rank=%s tp_size=%d world_size=%d engine_world_size=%d num_kv_groups=%d layers=%d namespace=%s "
             "is_mla=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d",
             role.name,
             instance_id,
@@ -132,6 +138,8 @@ class PegaKVConnector(KVConnectorBase_V1):
             tp_rank if tp_rank is not None else "N/A",
             tp_size,
             world_size,
+            engine_world_size,
+            num_kv_groups,
             num_layers,
             namespace,
             is_mla,
@@ -213,6 +221,16 @@ class PegaKVConnector(KVConnectorBase_V1):
     ) -> tuple[bool, dict[str, Any] | None]:
         if self._scheduler:
             return self._scheduler.request_finished(request, block_ids)
+        return (False, None)
+
+    def request_finished_all_groups(
+        self,
+        request,
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        if self._scheduler:
+            flat = [bid for group in block_ids for bid in group]
+            return self._scheduler.request_finished(request, flat)
         return (False, None)
 
     def take_events(self) -> Iterable:

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -73,7 +73,7 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             cross_layer_blocks=cross_layer_blocks,
         )
         num_layers = getattr(vllm_config.model_config.hf_text_config, "num_hidden_layers", 0)
-        block_size = vllm_config.cache_config.block_size
+        block_size = _resolve_connector_block_size(vllm_config, kv_cache_config)
 
         tp_rank: int | None = None
         device_id: int | None = None
@@ -358,6 +358,35 @@ def _resolve_device_id() -> int:
         return int(mapped)
     except ValueError:
         return local_id
+
+
+def _resolve_connector_block_size(vllm_config, kv_cache_config) -> int:
+    """Resolve the block/hash granularity PegaFlow can safely use.
+
+    PegaFlow connector metadata currently assumes request.block_hashes and
+    physical block ids are 1:1 for every KV cache group. vLLM 0.20 added
+    heterogeneous group block sizes with finer hash granularity; that needs a
+    per-group hash mapping before it can be supported safely.
+    """
+    fallback = vllm_config.cache_config.block_size
+    groups = getattr(kv_cache_config, "kv_cache_groups", None) or []
+    if not groups:
+        return fallback
+
+    group_block_sizes: list[int] = []
+    for group in groups:
+        spec = getattr(group, "kv_cache_spec", None)
+        group_block_sizes.append(getattr(spec, "block_size", fallback))
+
+    if len(set(group_block_sizes)) > 1:
+        raise ValueError(
+            "PegaKVConnector does not support heterogeneous KV cache group "
+            f"block sizes yet: {group_block_sizes}. vLLM 0.20+ may use finer "
+            "request.block_hashes than physical group blocks; refusing to "
+            "avoid corrupt save/load hash mappings."
+        )
+
+    return group_block_sizes[0]
 
 
 __all__ = ["PegaKVConnector", "KVConnectorRole"]

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -76,18 +76,26 @@ class ConnectorContext:
 
 @dataclass(frozen=True)
 class LoadIntent:
-    """Intent for a KV load operation."""
+    """Intent for a KV load operation.
 
-    block_ids: tuple[int, ...]
+    group_block_ids[i] holds the pool slot indices for kv_cache_group i.
+    block_hashes is shared across all groups (content-based, same token range).
+    """
+
+    group_block_ids: tuple[tuple[int, ...], ...]
     block_hashes: tuple[bytes, ...]
     num_tokens: int
 
 
 @dataclass(frozen=True)
 class SaveIntent:
-    """Intent for a KV save operation."""
+    """Intent for a KV save operation.
 
-    block_ids: tuple[int, ...]
+    group_block_ids[i] holds the pool slot indices for kv_cache_group i.
+    block_hashes is shared across all groups (content-based, same token range).
+    """
+
+    group_block_ids: tuple[tuple[int, ...], ...]
     block_hashes: tuple[bytes, ...]
 
 
@@ -99,12 +107,18 @@ class PegaConnectorMetadata(KVConnectorMetadata):
         load_intents: dict[str, LoadIntent] | None = None,
         save_intents: dict[str, SaveIntent] | None = None,
         preempted_req_ids: set[str] | None = None,
+        layer_to_group: dict[str, int] | None = None,
+        group_layer_names: list[list[str]] | None = None,
     ):
         super().__init__()
         # Maps request_id -> intent
         self.load_intents: dict[str, LoadIntent] = load_intents or {}
         self.save_intents: dict[str, SaveIntent] = save_intents or {}
         self.preempted_req_ids: set[str] = preempted_req_ids or set()
+        # Maps layer_name -> kv_cache_group index (built from KVCacheConfig)
+        self.layer_to_group: dict[str, int] = layer_to_group or {}
+        # group_layer_names[i] = list of layer names in kv_cache_group i
+        self.group_layer_names: list[list[str]] = group_layer_names or []
 
     def __repr__(self) -> str:
         return (

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -39,8 +39,28 @@ class SchedulerConnector:
     # When this limit is reached, new save intents will be dropped (shorter first).
     MAX_PENDING_SAVE_REQUESTS: int = parse_env_int("PEGA_MAX_PENDING_SAVE_REQUESTS", 0)
 
-    def __init__(self, context: ConnectorContext):
+    def __init__(self, context: ConnectorContext, kv_cache_config=None):
         self._ctx = context
+
+        # Group layout from KVCacheConfig (populated on scheduler role only)
+        self._group_layer_names: list[list[str]] = []
+        self._layer_to_group: dict[str, int] = {}
+        self._num_groups: int = 1
+
+        if kv_cache_config is not None:
+            groups = getattr(kv_cache_config, "kv_cache_groups", None) or []
+            if groups:
+                self._num_groups = len(groups)
+                self._group_layer_names = [list(g.layer_names) for g in groups]
+                for g_idx, g in enumerate(groups):
+                    for ln in g.layer_names:
+                        self._layer_to_group[ln] = g_idx
+                logger.info(
+                    "[PegaKVConnector] KV cache groups: %d groups, layer_counts=%s, groups=%s",
+                    self._num_groups,
+                    [len(g.layer_names) for g in groups],
+                    [list(g.layer_names) for g in groups],
+                )
 
         # Load state
         self._pending_load_intents: dict[str, LoadIntent] = {}
@@ -53,8 +73,9 @@ class SchedulerConnector:
         self._bypass_count: int = 0
 
         # Save state (per-request)
+        # _allocated_blocks[req_id][g] = list of block IDs for kv_cache_group g
         self._block_hashes: dict[str, tuple[bytes, ...]] = {}
-        self._allocated_blocks: dict[str, list[int]] = {}
+        self._allocated_blocks: dict[str, list[list[int]]] = {}
         self._scheduled_tokens: dict[str, int] = {}
         self._stored_blocks: dict[str, int] = {}
 
@@ -160,26 +181,36 @@ class SchedulerConnector:
         self._stored_blocks[req_id] = 0
 
         if num_external_tokens > 0:
-            block_ids = list(blocks.get_block_ids()[0]) if blocks else []
-            # num_external_tokens is in global token space; divide by
-            # virtual_block_size to get the number of pool blocks to load.
+            # Use unhashed blocks: these are the ext_comp blocks (not yet
+            # computed locally), laid out before the new-compute blocks.
+            unhashed_groups = blocks.get_unhashed_block_ids_all_groups() if blocks else []
             num_load_blocks = num_external_tokens // self._ctx.virtual_block_size
-            start = len(block_ids) - num_load_blocks
+
+            group_block_ids: list[tuple[int, ...]] = [
+                tuple(g[:num_load_blocks]) for g in unhashed_groups
+            ]
+
+            # Block hashes start after locally-computed blocks.
+            computed_blocks = request.num_computed_tokens // self._ctx.virtual_block_size
+            load_hashes = tuple(
+                self._block_hashes[req_id][computed_blocks : computed_blocks + num_load_blocks]
+            )
 
             load_intent = LoadIntent(
-                block_ids=tuple(block_ids[start:]),
-                block_hashes=tuple(self._block_hashes[req_id][start : start + num_load_blocks]),
+                group_block_ids=tuple(group_block_ids),
+                block_hashes=load_hashes,
                 num_tokens=num_external_tokens,
             )
             self._pending_load_intents[req_id] = load_intent
             logger.info(
-                "[PegaKVConnector] req=%s alloc: total_blocks=%d load_blocks=%d "
-                "load_tokens=%d pending_loads=%d",
+                "[PegaKVConnector] req=%s alloc: computed_blocks=%d load_blocks=%d "
+                "load_tokens=%d pending_loads=%d num_groups=%d",
                 req_id,
-                len(block_ids),
-                len(load_intent.block_ids),
+                computed_blocks,
+                num_load_blocks,
                 load_intent.num_tokens,
                 len(self._pending_load_intents),
+                len(group_block_ids),
             )
 
     def build_connector_meta(self, scheduler_output: "SchedulerOutput") -> PegaConnectorMetadata:
@@ -201,8 +232,9 @@ class SchedulerConnector:
 
             # Populate block IDs from scheduler_output — single source of
             # truth for the save path (consistent with offloading connector).
+            # req.block_ids is tuple[list[int], ...]: one list per kv_cache_group.
             if req.block_ids:
-                self._allocated_blocks[req_id] = list(req.block_ids[0])
+                self._allocated_blocks[req_id] = [list(g) for g in req.block_ids]
 
             self._scheduled_tokens[req_id] += num_tokens
 
@@ -224,10 +256,14 @@ class SchedulerConnector:
             num_tokens = scheduler_output.num_scheduled_tokens.get(req_id, 0)
             self._scheduled_tokens[req_id] += num_tokens
 
-            # Append newly allocated blocks
+            # Append newly allocated blocks (new_block_ids: tuple[list[int], ...])
             new_block_ids = cached_reqs.new_block_ids[idx]
             if new_block_ids:
-                self._allocated_blocks[req_id].extend(new_block_ids[0])
+                for g_idx, g_ids in enumerate(new_block_ids):
+                    if g_idx < len(self._allocated_blocks[req_id]):
+                        self._allocated_blocks[req_id][g_idx].extend(g_ids)
+                    else:
+                        self._allocated_blocks[req_id].append(list(g_ids))
 
             if save_intent := self._consume_save_intent(req_id):
                 potential_saves[req_id] = save_intent
@@ -293,6 +329,8 @@ class SchedulerConnector:
             load_intents=load_intents,
             save_intents=save_intents,
             preempted_req_ids=scheduler_output.preempted_req_ids or None,
+            layer_to_group=self._layer_to_group if self._layer_to_group else None,
+            group_layer_names=self._group_layer_names if self._group_layer_names else None,
         )
 
     def _consume_save_intent(self, req_id: str) -> SaveIntent | None:
@@ -302,15 +340,24 @@ class SchedulerConnector:
         if block_hashes is None:
             return None
 
+        # allocated is list[list[int]]: one list per kv_cache_group
         allocated = self._allocated_blocks.get(req_id, [])
         scheduled = self._scheduled_tokens.get(req_id, 0)
         stored = self._stored_blocks.get(req_id, 0)
+
+        if not allocated:
+            return None
+
+        # Hybrid/SWA save semantics require a full block hash to be writable by
+        # every KV cache group. Restrict saving to the common suffix that all
+        # groups can still represent, instead of the longest group's history.
+        common_blocks_in_groups = min((len(g) for g in allocated), default=0)
 
         # Use virtual_block_size because block_hashes and allocated are both
         # at the virtual block level (1 entry per pool block).
         saveable = min(
             len(block_hashes),
-            len(allocated),
+            common_blocks_in_groups,
             scheduled // self._ctx.virtual_block_size,
         )
         new_blocks = saveable - stored
@@ -325,16 +372,20 @@ class SchedulerConnector:
         _save_hash_preview = [h.hex()[:16] for h in save_hashes[:3]]
         logger.info(
             "[PegaKVConnector] req=%s save_intent: start=%d new_blocks=%d "
-            "total_hashes=%d first_hashes=%s",
+            "total_hashes=%d first_hashes=%s num_groups=%d",
             req_id,
             start,
             new_blocks,
             len(block_hashes),
             _save_hash_preview,
+            len(allocated),
         )
 
+        group_block_ids = tuple(
+            tuple(g[start : start + new_blocks]) for g in allocated
+        )
         return SaveIntent(
-            block_ids=tuple(allocated[start : start + new_blocks]),
+            group_block_ids=group_block_ids,
             block_hashes=save_hashes,
         )
 

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -359,40 +359,61 @@ class SchedulerConnector:
         # every KV cache group. Restrict saving to the common suffix that all
         # groups can still represent, instead of the longest group's history.
         common_blocks_in_groups = min((len(g) for g in allocated), default=0)
+        if common_blocks_in_groups <= 0:
+            return None
 
-        # Use virtual_block_size because block_hashes and allocated are both
-        # at the virtual block level (1 entry per pool block).
-        saveable = min(
-            len(block_hashes),
-            common_blocks_in_groups,
-            scheduled // self._ctx.virtual_block_size,
-        )
-        saveable_block_idx = min(len(block_hashes), base_block_idx + saveable)
-        new_blocks = saveable_block_idx - start_block_idx
+        # Use virtual_block_size because block_hashes are at the scheduler hash
+        # granularity. In external-hit cases, scheduled tokens are local-only,
+        # so add the first local block index tracked during allocation.
+        local_ready_blocks = scheduled // self._ctx.virtual_block_size
+        saveable_block_idx = min(len(block_hashes), base_block_idx + local_ready_blocks)
+
+        # KV cache groups with sliding/local attention keep only a suffix of
+        # the request. Save only the global hash range represented by every
+        # group, then map that global suffix back into each group's local list.
+        common_window_start = max(base_block_idx, saveable_block_idx - common_blocks_in_groups)
+        hash_start = max(start_block_idx, common_window_start)
+        new_blocks = saveable_block_idx - hash_start
         if new_blocks <= 0:
             return None
 
-        self._next_stored_block_idx[req_id] = saveable_block_idx
-        hash_start = start_block_idx
         save_hashes = block_hashes[hash_start : hash_start + new_blocks]
 
         logger.debug(
             "[PegaKVConnector] req=%s save_intent: start=%d hash_start=%d "
-            "base_block_idx=%d saveable_block_idx=%d new_blocks=%d "
-            "total_hashes=%d num_groups=%d",
+            "base_block_idx=%d common_window_start=%d saveable_block_idx=%d "
+            "new_blocks=%d total_hashes=%d num_groups=%d",
             req_id,
-            hash_start,
+            start_block_idx,
             hash_start,
             base_block_idx,
+            common_window_start,
             saveable_block_idx,
             new_blocks,
             len(block_hashes),
             len(allocated),
         )
 
-        group_block_ids = tuple(
-            tuple(g[hash_start : hash_start + new_blocks]) for g in allocated
-        )
+        group_block_id_lists: list[tuple[int, ...]] = []
+        for g in allocated:
+            group_global_start = saveable_block_idx - len(g)
+            group_slice_start = hash_start - group_global_start
+            group_slice_end = group_slice_start + new_blocks
+            if group_slice_start < 0 or group_slice_end > len(g):
+                logger.warning(
+                    "[PegaKVConnector] req=%s save_intent group slice out of range: "
+                    "hash_start=%d new_blocks=%d group_start=%d group_len=%d",
+                    req_id,
+                    hash_start,
+                    new_blocks,
+                    group_global_start,
+                    len(g),
+                )
+                return None
+            group_block_id_lists.append(tuple(g[group_slice_start:group_slice_end]))
+
+        group_block_ids = tuple(group_block_id_lists)
+        self._next_stored_block_idx[req_id] = saveable_block_idx
         return SaveIntent(
             group_block_ids=group_block_ids,
             block_hashes=save_hashes,

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -56,8 +56,11 @@ class WorkerConnector:
 
         self._current_save_intents: set[str] = set()
 
-        self._pending_loads: dict[str, PyLoadState] = {}
-        self._pending_load_reqs: dict[str, set[str]] = {}
+        # _pending_loads[req_id] = list of PyLoadState objects, one per kv_cache_group.
+        # A request is done loading only when ALL group states are ready.
+        self._pending_loads: dict[str, list[PyLoadState]] = {}
+        self._shm_to_load_state: dict[str, PyLoadState] = {}  # shm_name -> load_state
+        self._pending_load_reqs: dict[str, set[str]] = {}  # shm_name -> req_ids
         self._pending_load_meta: dict[
             str, tuple[float, int]
         ] = {}  # shm_name -> (start_time, num_blocks)
@@ -205,41 +208,52 @@ class WorkerConnector:
             completed_shms: list[str] = []
             load_stats_to_record: list[tuple[float, int, bool]] = []
 
-            for shm_name, req_ids in self._pending_load_reqs.items():
-                sample_req_id = next(iter(req_ids))
-                load_state = self._pending_loads.get(sample_req_id)
+            for shm_name, req_ids in list(self._pending_load_reqs.items()):
+                load_state = self._shm_to_load_state.get(shm_name)
                 if load_state is None:
+                    completed_shms.append(shm_name)
                     continue
 
-                if load_state.is_ready():
-                    state = load_state.get_state()
-                    success = state >= 0
-                    if not success:
-                        logger.error(
-                            "[PegaKVConnector] async_load_failed: reqs=%s state=%d",
-                            req_ids,
-                            state,
-                        )
-                    else:
-                        logger.info(
-                            "[PegaKVConnector] async_load_completed: reqs=%s",
-                            req_ids,
-                        )
+                if not load_state.is_ready():
+                    continue
 
-                    # Calculate load duration
-                    if shm_name in self._pending_load_meta:
-                        start_time, num_blocks = self._pending_load_meta[shm_name]
-                        duration = time.perf_counter() - start_time
-                        load_stats_to_record.append((duration, num_blocks, success))
+                state = load_state.get_state()
+                success = state >= 0
+                if not success:
+                    logger.error(
+                        "[PegaKVConnector] async_load_failed: reqs=%s state=%d",
+                        req_ids,
+                        state,
+                    )
+                else:
+                    logger.info(
+                        "[PegaKVConnector] async_load_group_completed: reqs=%s shm=%s",
+                        req_ids,
+                        shm_name,
+                    )
 
-                    completed_reqs.update(req_ids)
-                    completed_shms.append(shm_name)
+                # Calculate load duration
+                if shm_name in self._pending_load_meta:
+                    start_time, num_blocks = self._pending_load_meta[shm_name]
+                    duration = time.perf_counter() - start_time
+                    load_stats_to_record.append((duration, num_blocks, success))
+
+                completed_shms.append(shm_name)
+
+                # Remove this group's load_state from each req's pending list.
+                # A request is fully done when its pending list becomes empty.
+                for req_id in req_ids:
+                    states = self._pending_loads.get(req_id)
+                    if states is not None:
+                        self._pending_loads[req_id] = [ls for ls in states if ls is not load_state]
+                        if not self._pending_loads[req_id]:
+                            del self._pending_loads[req_id]
+                            completed_reqs.add(req_id)
 
             for shm_name in completed_shms:
-                req_ids = self._pending_load_reqs.pop(shm_name, set())
+                self._pending_load_reqs.pop(shm_name, None)
+                self._shm_to_load_state.pop(shm_name, None)
                 self._pending_load_meta.pop(shm_name, None)
-                for req_id in req_ids:
-                    self._pending_loads.pop(req_id, None)
 
             if completed_reqs:
                 finished_recving = completed_reqs
@@ -275,67 +289,134 @@ class WorkerConnector:
 
         total_requests = len(metadata.load_intents)
         load_start = time.perf_counter()
-
-        all_block_ids: list[int] = []
-        all_block_hashes: list[bytes] = []
-        request_ids: list[str] = []
-
-        for req_id, load_intent in metadata.load_intents.items():
-            all_block_ids.extend(load_intent.block_ids)
-            all_block_hashes.extend(load_intent.block_hashes)
-            request_ids.append(req_id)
-
-        if not all_block_ids:
-            return
+        request_ids = list(metadata.load_intents.keys())
 
         if self._cross_layer_mode:
-            target_layers = [_CROSS_LAYER_KEY]
-        else:
-            target_layers = []
-            for layer_name, layer in forward_context.no_compile_layers.items():
-                if hasattr(layer, "kv_cache"):
-                    target_layers.append(layer_name)
+            # Cross-layer: single fused KV tensor, use group 0 block_ids.
+            all_block_ids: list[int] = []
+            all_block_hashes: list[bytes] = []
+            for load_intent in metadata.load_intents.values():
+                g0 = load_intent.group_block_ids[0] if load_intent.group_block_ids else ()
+                all_block_ids.extend(g0)
+                all_block_hashes.extend(load_intent.block_hashes)
 
-        if not target_layers:
+            if not all_block_ids:
+                return
+
+            load_state = PyLoadState()
+            shm_name = load_state.shm_name()
+            ok, message = self._ctx.engine_client.load(
+                self._ctx.instance_id,
+                self._ctx.effective_tp_rank,
+                self._ctx.device_id,
+                shm_name,
+                [_CROSS_LAYER_KEY],
+                all_block_ids,
+                all_block_hashes,
+            )
+            if not ok:
+                raise RuntimeError(f"Load request failed: {message}")
+
+            with self._load_completion_lock:
+                for req_id in request_ids:
+                    self._pending_loads[req_id] = [load_state]
+                self._pending_load_reqs[shm_name] = set(request_ids)
+                self._shm_to_load_state[shm_name] = load_state
+                self._pending_load_meta[shm_name] = (time.perf_counter(), len(all_block_ids))
+
+            logger.debug(
+                "[PegaKVConnector] started async cross-layer load: %d blocks for %d reqs, shm=%s",
+                len(all_block_ids),
+                total_requests,
+                shm_name,
+            )
             return
 
-        load_state = PyLoadState()
-        shm_name = load_state.shm_name()
+        # Determine which KV layers belong to each group.
+        layer_to_group = metadata.layer_to_group
+        if layer_to_group:
+            # HMA mode: split layers by kv_cache_group index.
+            layers_by_group: dict[int, list[str]] = {}
+            for layer_name, layer in forward_context.no_compile_layers.items():
+                if hasattr(layer, "kv_cache"):
+                    g_idx = layer_to_group.get(layer_name, 0)
+                    layers_by_group.setdefault(g_idx, []).append(layer_name)
+        else:
+            # Non-HMA: all KV-bearing layers map to group 0.
+            layers_by_group = {
+                0: [
+                    ln
+                    for ln, l in forward_context.no_compile_layers.items()
+                    if hasattr(l, "kv_cache")
+                ]
+            }
 
-        ok, message = self._ctx.engine_client.load(
-            self._ctx.instance_id,
-            self._ctx.effective_tp_rank,
-            self._ctx.device_id,
-            shm_name,
-            target_layers,
-            all_block_ids,
-            all_block_hashes,
+        if not any(layers_by_group.values()):
+            return
+
+        num_groups = max(
+            (len(li.group_block_ids) for li in metadata.load_intents.values()),
+            default=1,
         )
+        if not layer_to_group:
+            num_groups = 1
 
-        if not ok:
-            raise RuntimeError(f"Load request failed: {message}")
+        groups_launched = 0
+        for g_idx in range(num_groups):
+            target_layers = layers_by_group.get(g_idx, [])
+            if not target_layers:
+                continue
 
-        num_layers = len(target_layers)
-        num_blocks = len(all_block_ids)
+            group_block_ids_all: list[int] = []
+            group_block_hashes_all: list[bytes] = []
+            for load_intent in metadata.load_intents.values():
+                if g_idx < len(load_intent.group_block_ids):
+                    g_block_ids = load_intent.group_block_ids[g_idx]
+                elif load_intent.group_block_ids:
+                    g_block_ids = load_intent.group_block_ids[0]
+                else:
+                    g_block_ids = ()
+                group_block_ids_all.extend(g_block_ids)
+                # Sliding attention groups keep only the most recent n blocks,
+                # so their physical blocks map to the LAST n virtual block hashes.
+                n = len(g_block_ids)
+                if n > 0:
+                    group_block_hashes_all.extend(load_intent.block_hashes[-n:])
 
-        schedule_end = time.perf_counter()
-        schedule_time_us = (schedule_end - load_start) * 1e6
+            if not group_block_ids_all:
+                continue
 
-        with self._load_completion_lock:
-            for req_id in request_ids:
-                self._pending_loads[req_id] = load_state
-            self._pending_load_reqs[shm_name] = set(request_ids)
-            # Record start time and block count for stats
-            self._pending_load_meta[shm_name] = (time.perf_counter(), num_blocks)
+            load_state = PyLoadState()
+            shm_name = load_state.shm_name()
+            num_blocks = len(group_block_ids_all)
 
+            ok, message = self._ctx.engine_client.load(
+                self._ctx.instance_id,
+                self._ctx.effective_tp_rank,
+                self._ctx.device_id,
+                shm_name,
+                target_layers,
+                group_block_ids_all,
+                group_block_hashes_all,
+            )
+            if not ok:
+                raise RuntimeError(f"Load request failed: {message}")
+
+            with self._load_completion_lock:
+                for req_id in request_ids:
+                    self._pending_loads.setdefault(req_id, []).append(load_state)
+                self._pending_load_reqs[shm_name] = set(request_ids)
+                self._shm_to_load_state[shm_name] = load_state
+                self._pending_load_meta[shm_name] = (time.perf_counter(), num_blocks)
+
+            groups_launched += 1
+
+        schedule_time_us = (time.perf_counter() - load_start) * 1e6
         logger.debug(
-            "[PegaKVConnector] started async load: %d blocks across %d layers for %d reqs, "
-            "schedule %.0f us, shm=%s",
-            num_blocks,
-            num_layers,
+            "[PegaKVConnector] started async load: %d groups for %d reqs, schedule %.0f us",
+            groups_launched,
             total_requests,
             schedule_time_us,
-            shm_name,
         )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
@@ -477,14 +558,39 @@ class WorkerConnector:
             ):
                 continue
 
+            # Determine which kv_cache_group this layer belongs to.
+            layer_to_group = task.metadata.layer_to_group
+            g_idx = layer_to_group.get(task.layer_name, 0) if layer_to_group else 0
+
             for save_intent in task.metadata.save_intents.values():
-                if not save_intent.block_ids:
+                if not save_intent.group_block_ids:
+                    continue
+
+                # Pick block_ids for this layer's group; fall back to group 0.
+                if g_idx < len(save_intent.group_block_ids):
+                    block_ids = save_intent.group_block_ids[g_idx]
+                else:
+                    block_ids = save_intent.group_block_ids[0]
+
+                if not block_ids:
                     continue
 
                 if task.layer_name not in saves_by_layer:
                     saves_by_layer[task.layer_name] = ([], [])
 
-                saves_by_layer[task.layer_name][0].extend(save_intent.block_ids)
+                if len(block_ids) != len(save_intent.block_hashes):
+                    logger.warning(
+                        "[PegaKVConnector] save_intent mismatch layer=%s group=%d "
+                        "block_count=%d hash_count=%d reqs=%s",
+                        task.layer_name,
+                        g_idx,
+                        len(block_ids),
+                        len(save_intent.block_hashes),
+                        task.request_ids,
+                    )
+                    continue
+
+                saves_by_layer[task.layer_name][0].extend(block_ids)
                 saves_by_layer[task.layer_name][1].extend(save_intent.block_hashes)
 
         if saves_by_layer:

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -337,8 +337,8 @@ class WorkerConnector:
         if layer_to_group:
             # HMA mode: split layers by kv_cache_group index.
             layers_by_group: dict[int, list[str]] = {}
-            for layer_name, layer in forward_context.no_compile_layers.items():
-                if hasattr(layer, "kv_cache"):
+            for layer_name in forward_context.no_compile_layers:
+                if layer_name in self._layer_name_to_id:
                     g_idx = layer_to_group.get(layer_name, 0)
                     layers_by_group.setdefault(g_idx, []).append(layer_name)
         else:
@@ -346,8 +346,8 @@ class WorkerConnector:
             layers_by_group = {
                 0: [
                     ln
-                    for ln, layer in forward_context.no_compile_layers.items()
-                    if hasattr(layer, "kv_cache")
+                    for ln in forward_context.no_compile_layers
+                    if ln in self._layer_name_to_id
                 ]
             }
 

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -346,8 +346,8 @@ class WorkerConnector:
             layers_by_group = {
                 0: [
                     ln
-                    for ln, l in forward_context.no_compile_layers.items()
-                    if hasattr(l, "kv_cache")
+                    for ln, layer in forward_context.no_compile_layers.items()
+                    if hasattr(layer, "kv_cache")
                 ]
             }
 

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -298,3 +298,43 @@ class TestDecodeHashRefresh:
         assert intent is not None
         assert intent.block_hashes == block_hashes[6:9]
         assert intent.group_block_ids == ((200, 201, 202),)
+
+    def test_hybrid_save_uses_common_suffix(self):
+        """Hybrid save maps common hash suffix into each group's local block list."""
+        sc = self._make_connector()
+        block_hashes = tuple(_hash(i) for i in range(6))
+
+        sc._block_hashes["r1"] = block_hashes
+        sc._block_index_offsets["r1"] = 0
+        sc._next_stored_block_idx["r1"] = 0
+        sc._scheduled_tokens["r1"] = 6 * 32
+        sc._allocated_blocks["r1"] = [
+            [10, 11, 12, 13, 14, 15],
+            [30, 31, 32],
+        ]
+
+        intent = sc._consume_save_intent("r1")
+
+        assert intent is not None
+        assert intent.block_hashes == block_hashes[3:6]
+        assert intent.group_block_ids == ((13, 14, 15), (30, 31, 32))
+
+    def test_external_hit_hybrid_save_uses_group_suffix_offsets(self):
+        """External-hit save maps global suffix indices into shorter SWA groups."""
+        sc = self._make_connector(dcp_world_size=1)
+        block_hashes = tuple(_hash(i) for i in range(9))
+
+        sc._block_hashes["r1"] = block_hashes
+        sc._block_index_offsets["r1"] = 6
+        sc._next_stored_block_idx["r1"] = 6
+        sc._scheduled_tokens["r1"] = 48
+        sc._allocated_blocks["r1"] = [
+            [100, 101, 102, 103, 104, 105, 200, 201, 202],
+            [300, 301, 302],
+        ]
+
+        intent = sc._consume_save_intent("r1")
+
+        assert intent is not None
+        assert intent.block_hashes == block_hashes[6:9]
+        assert intent.group_block_ids == ((200, 201, 202), (300, 301, 302))


### PR DESCRIPTION
## Summary
- make the connector register HMA-aware metadata for KV groups
- compute hybrid save windows from the common suffix shared by all KV groups
- align worker-side save hash mapping with the scheduler window so saved blocks can seal and load correctly

## Validation
- reproduced the hybrid/SWA save mismatch on 5090 with repeated-prefix requests
- verified external prefix cache hits and successful remote loads after the fix
