### PR TITLE
fix(connector): align decode save and load block indexes

### DIFF
--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -163,12 +163,10 @@ class PegaKVConnector(KVConnectorBase_V1):
         attn_metadata,
         **kwargs: Any,
     ) -> None:
-        if not self._worker:
-            return
-        metadata = self._get_connector_metadata()
-        if metadata is None:
-            return
-        self._worker.save_kv_layer(metadata, layer_name, kv_layer, attn_metadata, **kwargs)
+        # Save is submitted from wait_for_save() using scheduler metadata.
+        # Layer callbacks are intentionally ignored so CUDA graph replay
+        # cannot suppress save submission.
+        pass
 
     def wait_for_save(self) -> None:
         if not self._worker:

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -54,9 +54,11 @@ class SchedulerConnector:
 
         # Save state (per-request)
         self._block_hashes: dict[str, tuple[bytes, ...]] = {}
+        self._external_matched_blocks: dict[str, int] = {}
+        self._block_index_offsets: dict[str, int] = {}
         self._allocated_blocks: dict[str, list[int]] = {}
         self._scheduled_tokens: dict[str, int] = {}
-        self._stored_blocks: dict[str, int] = {}
+        self._next_stored_block_idx: dict[str, int] = {}
 
         # Live Request references – used to refresh block_hashes during decode
         # so that newly completed blocks can be saved, not just prefill blocks.
@@ -85,6 +87,7 @@ class SchedulerConnector:
         remaining_hashes = block_hashes[computed_blocks:]
 
         if not remaining_hashes:
+            self._external_matched_blocks[req_id] = computed_blocks
             return (0, False)
 
         # Check if request should bypass remote cache lookup
@@ -92,6 +95,7 @@ class SchedulerConnector:
         num_remaining_blocks = len(remaining_hashes)
         pending = self._prefetch_tracker.pending_prefetches
         if num_remaining_blocks < self.BYPASS_BLOCKS and pending >= self.HIGH_LOAD_THRESHOLD:
+            self._external_matched_blocks[req_id] = computed_blocks
             self._bypass_count += 1
             logger.info(
                 "[PegaKVConnector] req=%s bypass: remaining_blocks=%d "
@@ -112,24 +116,21 @@ class SchedulerConnector:
         if hit_blocks is None:
             return (None, False)
 
+        self._external_matched_blocks[req_id] = computed_blocks + hit_blocks
+
         # Each hit block = 1 virtual block = virtual_block_size global tokens.
         num_hit_tokens = hit_blocks * self._ctx.virtual_block_size
 
-        # --- Hash diagnostic: log first 3 query hashes ---
-        _remaining_list = list(remaining_hashes)
-        _query_hash_preview = [h.hex()[:16] for h in _remaining_list[:3]]
         logger.info(
             "[PegaKVConnector] req=%s cache_lookup: hit_blocks=%d computed_blocks=%d "
-            "hit_tokens=%d num_tokens=%d lookup_us=%.0f "
-            "total_query_hashes=%d first_hashes=%s",
+            "hit_tokens=%d num_tokens=%d lookup_us=%.0f total_query_hashes=%d",
             req_id,
             hit_blocks,
             computed_blocks,
             num_hit_tokens,
             num_tokens,
             elapsed_us,
-            len(_remaining_list),
-            _query_hash_preview,
+            len(remaining_hashes),
         )
 
         if num_hit_tokens <= 0:
@@ -153,31 +154,44 @@ class SchedulerConnector:
         # (1 hash per scheduler block = block_size * dcp_world_size tokens).
         # They are 1-to-1 with block_ids from the scheduler.
         self._block_hashes[req_id] = tuple(request.block_hashes)
-        # Save-path block IDs populated by build_connector_meta from
-        # scheduler_output (single source of truth, like offloading connector).
-        self._allocated_blocks[req_id] = []
-        self._scheduled_tokens[req_id] = 0
-        self._stored_blocks[req_id] = 0
+        if req_id not in self._allocated_blocks:
+            # The first locally allocated block may be after an external-hit
+            # prefix. Track that global block index explicitly.
+            base_block_idx = self._external_matched_blocks.get(req_id, 0)
+            self._block_index_offsets[req_id] = base_block_idx
+            self._allocated_blocks[req_id] = []
+            self._scheduled_tokens[req_id] = 0
+            self._next_stored_block_idx[req_id] = base_block_idx
 
         if num_external_tokens > 0:
             block_ids = list(blocks.get_block_ids()[0]) if blocks else []
-            # num_external_tokens is in global token space; divide by
-            # virtual_block_size to get the number of pool blocks to load.
+            num_computed_blocks = (
+                sum(block.block_hash is not None for block in blocks.blocks[0]) if blocks else 0
+            )
+            start_block_idx = num_computed_blocks
             num_load_blocks = num_external_tokens // self._ctx.virtual_block_size
-            start = len(block_ids) - num_load_blocks
+            expected_load_blocks = len(block_ids) - num_computed_blocks
+            assert num_load_blocks == expected_load_blocks, (
+                f"req {req_id} load block mismatch: external={num_load_blocks} "
+                f"expected={expected_load_blocks}"
+            )
 
             load_intent = LoadIntent(
-                block_ids=tuple(block_ids[start:]),
-                block_hashes=tuple(self._block_hashes[req_id][start : start + num_load_blocks]),
+                block_ids=tuple(block_ids[start_block_idx:]),
+                block_hashes=tuple(
+                    self._block_hashes[req_id][start_block_idx : start_block_idx + num_load_blocks]
+                ),
                 num_tokens=num_external_tokens,
             )
             self._pending_load_intents[req_id] = load_intent
             logger.info(
-                "[PegaKVConnector] req=%s alloc: total_blocks=%d load_blocks=%d "
-                "load_tokens=%d pending_loads=%d",
+                "[PegaKVConnector] req=%s alloc: total_blocks=%d computed_blocks=%d "
+                "load_blocks=%d start_block_idx=%d load_tokens=%d pending_loads=%d",
                 req_id,
                 len(block_ids),
+                num_computed_blocks,
                 len(load_intent.block_ids),
+                start_block_idx,
                 load_intent.num_tokens,
                 len(self._pending_load_intents),
             )
@@ -304,37 +318,40 @@ class SchedulerConnector:
 
         allocated = self._allocated_blocks.get(req_id, [])
         scheduled = self._scheduled_tokens.get(req_id, 0)
-        stored = self._stored_blocks.get(req_id, 0)
+        base_block_idx = self._block_index_offsets.get(req_id, 0)
+        start_block_idx = self._next_stored_block_idx.get(req_id, base_block_idx)
 
-        # Use virtual_block_size because block_hashes and allocated are both
-        # at the virtual block level (1 entry per pool block).
-        saveable = min(
-            len(block_hashes),
+        # allocated only contains local blocks, but block_hashes are indexed
+        # against the full request. Convert local progress to a global block idx.
+        local_saveable = min(
             len(allocated),
             scheduled // self._ctx.virtual_block_size,
         )
-        new_blocks = saveable - stored
+        saveable_block_idx = min(len(block_hashes), base_block_idx + local_saveable)
+        new_blocks = saveable_block_idx - start_block_idx
         if new_blocks <= 0:
             return None
 
-        start = stored
-        self._stored_blocks[req_id] = stored + new_blocks
-        save_hashes = block_hashes[start : start + new_blocks]
+        self._next_stored_block_idx[req_id] = saveable_block_idx
+        local_start = start_block_idx - base_block_idx
+        hash_start = start_block_idx
+        save_hashes = block_hashes[hash_start : hash_start + new_blocks]
+        save_block_ids = allocated[local_start : local_start + new_blocks]
 
-        # --- Hash diagnostic: log first 3 save hashes ---
-        _save_hash_preview = [h.hex()[:16] for h in save_hashes[:3]]
         logger.info(
-            "[PegaKVConnector] req=%s save_intent: start=%d new_blocks=%d "
-            "total_hashes=%d first_hashes=%s",
+            "[PegaKVConnector] req=%s save_intent: start=%d hash_start=%d "
+            "base_block_idx=%d saveable_block_idx=%d new_blocks=%d total_hashes=%d",
             req_id,
-            start,
+            local_start,
+            hash_start,
+            base_block_idx,
+            saveable_block_idx,
             new_blocks,
             len(block_hashes),
-            _save_hash_preview,
         )
 
         return SaveIntent(
-            block_ids=tuple(allocated[start : start + new_blocks]),
+            block_ids=tuple(save_block_ids),
             block_hashes=save_hashes,
         )
 
@@ -372,9 +389,11 @@ class SchedulerConnector:
         """Clean up all state for a completed request."""
         self._requests.pop(req_id, None)
         self._block_hashes.pop(req_id, None)
+        self._external_matched_blocks.pop(req_id, None)
+        self._block_index_offsets.pop(req_id, None)
         self._allocated_blocks.pop(req_id, None)
         self._scheduled_tokens.pop(req_id, None)
-        self._stored_blocks.pop(req_id, None)
+        self._next_stored_block_idx.pop(req_id, None)
         self._pending_saves.discard(req_id)
 
     def _count_available_block_prefix(

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -31,8 +31,6 @@ _CROSS_LAYER_KEY = "ALL_LAYERS"
 
 @dataclass
 class SaveTask:
-    layer_name: str
-    attn_metadata: "AttentionMetadata"
     metadata: PegaConnectorMetadata
     request_ids: list[str]
 
@@ -49,12 +47,11 @@ class WorkerConnector:
         )
         self._save_thread.start()
 
-        self._req_pending_layers: dict[str, int] = {}
+        self._req_pending_saves: set[str] = set()
         self._completed_saves: set[str] = set()
         self._save_completion_lock = threading.Lock()
         self._save_completion_events: dict[str, threading.Event] = {}
-
-        self._current_save_intents: set[str] = set()
+        self._current_metadata: PegaConnectorMetadata | None = None
 
         self._pending_loads: dict[str, PyLoadState] = {}
         self._pending_load_reqs: dict[str, set[str]] = {}
@@ -68,7 +65,6 @@ class WorkerConnector:
         self._torch_device: torch.device | None = None
 
         self._cross_layer_mode = False
-        self._cross_layer_pending_save: SaveTask | None = None
 
         self._finished_requests: set[str] = set()
 
@@ -189,7 +185,7 @@ class WorkerConnector:
 
         with self._save_completion_lock:
             # 1. Add newly finished requests (if they have pending saves) to tracking
-            self._finished_requests.update(finished_req_ids & self._req_pending_layers.keys())
+            self._finished_requests.update(finished_req_ids & self._req_pending_saves)
             # 2. Identify requests whose saves have completed
             done_saves = self._completed_saves & self._finished_requests
             done_saves.update(self._completed_saves & finished_req_ids)
@@ -268,7 +264,7 @@ class WorkerConnector:
         forward_context: "ForwardContext",
         **kwargs: Any,
     ) -> None:
-        self._current_save_intents = set(metadata.save_intents.keys())
+        self._current_metadata = metadata
 
         if not metadata.load_intents:
             return
@@ -349,92 +345,41 @@ class WorkerConnector:
         attn_metadata: "AttentionMetadata",
         **kwargs: Any,
     ) -> None:
-        if self._cross_layer_mode:
-            # Defer actual save to wait_for_save when all layers are computed.
-            # Only capture metadata on the first layer call per forward pass.
-            if self._cross_layer_pending_save is None:
-                request_ids = list(metadata.save_intents.keys())
-                if request_ids:
-                    self._cross_layer_pending_save = SaveTask(
-                        layer_name=_CROSS_LAYER_KEY,
-                        attn_metadata=attn_metadata,
-                        metadata=metadata,
-                        request_ids=request_ids,
-                    )
+        # Save is metadata-driven and submitted from wait_for_save() outside
+        # layer callbacks so CUDA graph replay cannot suppress it.
+        pass
+
+    def wait_for_save(self) -> None:
+        metadata = self._current_metadata
+        self._current_metadata = None
+        if metadata is None or not metadata.save_intents:
             return
 
         request_ids = list(metadata.save_intents.keys())
-        if not request_ids:
-            return
 
-        with self._save_completion_lock:
-            for req_id in request_ids:
-                if req_id not in self._req_pending_layers:
-                    # Initialize tracking for new request
-                    self._req_pending_layers[req_id] = len(self._registered_layers)
-                    self._save_completion_events[req_id] = threading.Event()
-
-        self._save_queue.put(
-            SaveTask(
-                layer_name=layer_name,
-                attn_metadata=attn_metadata,
-                metadata=metadata,
-                request_ids=request_ids,
-            )
-        )
-
-    def wait_for_save(self) -> None:
-        skipped_requests: set[str] = set()
-
-        if self._cross_layer_mode:
-            task = self._cross_layer_pending_save
-            self._cross_layer_pending_save = None
-            if task:
-                with self._save_completion_lock:
-                    for req_id in task.request_ids:
-                        if req_id not in self._req_pending_layers:
-                            self._req_pending_layers[req_id] = 1
-                            self._save_completion_events[req_id] = threading.Event()
-                self._save_queue.put(task)
-            else:
-                with self._save_completion_lock:
-                    pending_layers = set(self._req_pending_layers.keys())
-                    skipped_requests = self._current_save_intents - pending_layers
-                    if skipped_requests:
-                        self._completed_saves.update(skipped_requests)
-            self._current_save_intents = set()
-            if skipped_requests:
-                logger.debug(
-                    "[PegaKVConnector] Detected %d skipped cross-layer saves (CUDA graph): %s",
-                    len(skipped_requests),
-                    skipped_requests,
-                )
-                self._handle_save_completion(skipped_requests, reason="CUDA graph skip")
-            return
-
-        with self._save_completion_lock:
-            pending_layers = set(self._req_pending_layers.keys())
-            skipped_requests = self._current_save_intents - pending_layers
-
-            if skipped_requests:
-                self._completed_saves.update(skipped_requests)
-
-            self._current_save_intents = set()
-
-            pending_reqs = len(self._req_pending_layers)
-            if pending_reqs > 0:
-                logger.debug(
-                    "[PegaKVConnector] %d requests still have pending layer saves",
-                    pending_reqs,
-                )
-
-        if skipped_requests:
+        if self._should_skip_save_submission():
             logger.debug(
-                "[PegaKVConnector] Detected %d skipped saves (CUDA graph): %s",
-                len(skipped_requests),
-                skipped_requests,
+                "[PegaKVConnector] Skipping save submission on non-zero TP rank for MLA "
+                "without DCP: tp_rank=%s reqs=%s",
+                self._ctx.tp_rank,
+                request_ids,
             )
-            self._handle_save_completion(skipped_requests, reason="CUDA graph skip")
+            self._complete_save_requests(request_ids)
+            return
+
+        with self._save_completion_lock:
+            wait_events: list[threading.Event] = []
+            for req_id in request_ids:
+                if req_id not in self._req_pending_saves:
+                    self._req_pending_saves.add(req_id)
+                    self._save_completion_events[req_id] = threading.Event()
+                event = self._save_completion_events.get(req_id)
+                if event is not None:
+                    wait_events.append(event)
+
+        self._save_queue.put(SaveTask(metadata=metadata, request_ids=request_ids))
+        for event in wait_events:
+            event.wait()
 
     def _save_worker(self) -> None:
         logger.info("[PegaKVConnector] Save worker thread started")
@@ -471,21 +416,24 @@ class WorkerConnector:
         for task in batch:
             all_request_ids.extend(task.request_ids)
 
-            if (
-                getattr(task.attn_metadata, "block_table", None) is None
-                and getattr(task.attn_metadata, "slot_mapping", None) is None
-            ):
-                continue
-
             for save_intent in task.metadata.save_intents.values():
                 if not save_intent.block_ids:
                     continue
 
-                if task.layer_name not in saves_by_layer:
-                    saves_by_layer[task.layer_name] = ([], [])
+                if self._cross_layer_mode:
+                    target_layers = (_CROSS_LAYER_KEY,)
+                else:
+                    assert self._registered_layers, (
+                        "KV caches must be registered before submitting save intents"
+                    )
+                    target_layers = tuple(self._registered_layers)
 
-                saves_by_layer[task.layer_name][0].extend(save_intent.block_ids)
-                saves_by_layer[task.layer_name][1].extend(save_intent.block_hashes)
+                for layer_name in target_layers:
+                    if layer_name not in saves_by_layer:
+                        saves_by_layer[layer_name] = ([], [])
+
+                    saves_by_layer[layer_name][0].extend(save_intent.block_ids)
+                    saves_by_layer[layer_name][1].extend(save_intent.block_hashes)
 
         if saves_by_layer:
             # Ensure all GPU kernels have completed before reading KV cache
@@ -530,27 +478,21 @@ class WorkerConnector:
             with self._stats_lock:
                 self._stats.record_save(save_duration, total_blocks, success)
 
-        # Always decrement layer counter to release blocks, even if save failed
-        self._decrement_layer_counter(all_request_ids)
+        # Always complete the request save lifecycle, even if save failed.
+        self._complete_save_requests(all_request_ids)
 
-    def _decrement_layer_counter(self, request_ids: list[str]) -> None:
+    def _complete_save_requests(self, request_ids: list[str]) -> None:
         completed_reqs: list[str] = []
 
         with self._save_completion_lock:
             for req_id in request_ids:
-                if req_id in self._req_pending_layers:
-                    self._req_pending_layers[req_id] -= 1
-                    assert self._req_pending_layers[req_id] >= 0, (
-                        f"Layer count mismatch for request {req_id}: counter went negative"
-                    )
-
-                    if self._req_pending_layers[req_id] == 0:
-                        self._completed_saves.add(req_id)
-                        del self._req_pending_layers[req_id]
-                        completed_reqs.append(req_id)
-                        event = self._save_completion_events.pop(req_id, None)
-                        if event:
-                            event.set()
+                if req_id in self._req_pending_saves:
+                    self._req_pending_saves.discard(req_id)
+                    self._completed_saves.add(req_id)
+                    completed_reqs.append(req_id)
+                    event = self._save_completion_events.pop(req_id, None)
+                    if event:
+                        event.set()
 
         self._handle_save_completion(completed_reqs)
 
@@ -562,14 +504,15 @@ class WorkerConnector:
             return
 
         suffix = "" if not reason else f" ({reason})"
-        layer_count = len(self._registered_layers)
         for req_id in req_list:
             logger.debug(
-                "[PegaKVConnector] Request %s all %d layers saved%s",
+                "[PegaKVConnector] Request %s save completed%s",
                 req_id,
-                layer_count,
                 suffix,
             )
+
+    def _should_skip_save_submission(self) -> bool:
+        return self._ctx.is_mla and self._ctx.dcp_world_size == 1 and (self._ctx.tp_rank or 0) != 0
 
     def handle_preemptions(self, preempted_req_ids: set[str] | None) -> None:
         """Wait for preempted requests' saves to complete before blocks are reused.
@@ -608,7 +551,7 @@ class WorkerConnector:
         with self._stats_lock:
             # Add current queue depth as gauge
             with self._save_completion_lock:
-                self._stats.data["pending_save_requests"] = len(self._req_pending_layers)
+                self._stats.data["pending_save_requests"] = len(self._req_pending_saves)
 
             if self._stats.is_empty():
                 return None


### PR DESCRIPTION
## What changed

- moved KV save submission out of `save_kv_layer()` callbacks and into metadata-driven `wait_for_save()` handling so CUDA graph replay cannot suppress save submission

- aligned scheduler save block indexing to explicit global block indices, matching the offloading connector model

- aligned load intent indexing to explicit computed-block offsets instead of relying on tail slicing assumptions

- kept MLA without DCP on TP rank 0 for actual save submission to avoid duplicate save RPCs
## Why








- callback-driven save was not graph-safe under CUDA graph replay

- scheduler save intent previously mixed global request hash indices with local allocated block indices, which broke decode-prefix reuse across rounds

- load path used a weaker indexing assumption than offloading and is now made explicit

## Validation
- `python3 -m py_compile python/pegaflow/connector/__init__.py python/pegaflow/connector/scheduler.py python/pegaflow/connector/worker.py`
- remote `mtb` multi-round run recovered steadily increasing cache hit rate after the fix (observed up to 93.37%%)
- load/save index summary logs were checked and showed aligned monotonic block indices
- pre-commit Python hooks passed; unrelated Rust test `ssd_prefetch_roundtrip_after_eviction` is flaky in this environment
