### PR TITLE
fix(connector): fix MLA skip-save lifecycle and remove blocking wait_for_save

### DIFF
--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -364,22 +364,19 @@ class WorkerConnector:
                 self._ctx.tp_rank,
                 request_ids,
             )
+            with self._save_completion_lock:
+                for req_id in request_ids:
+                    self._req_pending_saves.add(req_id)
             self._complete_save_requests(request_ids)
             return
 
         with self._save_completion_lock:
-            wait_events: list[threading.Event] = []
             for req_id in request_ids:
                 if req_id not in self._req_pending_saves:
                     self._req_pending_saves.add(req_id)
                     self._save_completion_events[req_id] = threading.Event()
-                event = self._save_completion_events.get(req_id)
-                if event is not None:
-                    wait_events.append(event)
 
         self._save_queue.put(SaveTask(metadata=metadata, request_ids=request_ids))
-        for event in wait_events:
-            event.wait()
 
     def _save_worker(self) -> None:
         logger.info("[PegaKVConnector] Save worker thread started")


### PR DESCRIPTION
## Summary

- **MLA skip-save bug**: When `_should_skip_save_submission()` returned True (non-zero TP rank for MLA without DCP), requests were never added to `_req_pending_saves` before calling `_complete_save_requests`. Since that method gates on `req_id in _req_pending_saves`, nothing happened — requests were never moved to `_completed_saves`, and `get_finished()` never reported them as `finished_sending`. This caused requests to hang indefinitely.
- **Remove blocking wait in `wait_for_save`**: `wait_for_save` was blocking the forward thread with `event.wait()` after enqueuing save tasks. This is unnecessary — save completion is reported asynchronously via `get_finished()` → `finished_sending`, which vLLM polls. The blocking wait stalled the forward thread.

## Test plan

- [x] Verify MLA model inference (e.g. DeepSeek) with TP > 1 and DCP disabled completes requests correctly
- [x] Verify save throughput is not degraded (no forward-thread stalls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)