### PR TITLE
fix(connector): isolate cross-layer KV cache across PP ranks

### DIFF
--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -4,7 +4,13 @@
 //! multi-tenant inference instances and their associated GPU resources.
 
 use parking_lot::Mutex;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use cudarc::driver::CudaContext;
 use log::info;
@@ -216,7 +222,8 @@ pub struct InstanceContext {
     namespace: String,
 
     /// Number of transformer layers in the model.
-    num_layers: usize,
+    /// Grows via `expand_num_layers` when PP ranks register additional layers.
+    num_layers: AtomicUsize,
 
     /// Tensor parallelism degree (number of GPUs per instance).
     tp_size: usize,
@@ -250,7 +257,7 @@ impl InstanceContext {
         Ok(Self {
             _id: id,
             namespace,
-            num_layers,
+            num_layers: AtomicUsize::new(num_layers),
             tp_size,
             world_size,
             metadata: Mutex::new(LayerMetadata {
@@ -291,7 +298,7 @@ impl InstanceContext {
     ///
     /// Slots are organized as a flattened 2D array: `[layer][tp_rank]`.
     pub(crate) fn total_slots(&self) -> usize {
-        self.num_layers * self.tp_size
+        self.num_layers.load(Ordering::Relaxed) * self.tp_size
     }
 
     /// Compute the slot index for a specific layer and TP rank.
@@ -306,10 +313,11 @@ impl InstanceContext {
         layer_id: usize,
         tp_rank: usize,
     ) -> Result<usize, EngineError> {
-        if layer_id >= self.num_layers {
+        let num_layers = self.num_layers.load(Ordering::Relaxed);
+        if layer_id >= num_layers {
             return Err(EngineError::InvalidArgument(format!(
                 "layer_id {} out of range ({} layers)",
-                layer_id, self.num_layers
+                layer_id, num_layers
             )));
         }
         if tp_rank >= self.tp_size {
@@ -422,14 +430,15 @@ impl InstanceContext {
         tp_size: usize,
         world_size: usize,
     ) -> Result<(), String> {
-        if self.num_layers != num_layers || self.tp_size != tp_size || self.world_size != world_size
-        {
+        if self.tp_size != tp_size || self.world_size != world_size {
             return Err(format!(
-                "exists with layers={}, tp={}, world={}; \
-                 requested layers={}, tp={}, world={}",
-                self.num_layers, self.tp_size, self.world_size, num_layers, tp_size, world_size
+                "exists with tp={}, world={}; \
+                 requested tp={}, world={}",
+                self.tp_size, self.world_size, tp_size, world_size
             ));
         }
+        // Grow num_layers to accommodate PP ranks registering additional layers.
+        self.num_layers.fetch_max(num_layers, Ordering::Relaxed);
         Ok(())
     }
 }
@@ -519,7 +528,11 @@ mod tests {
 
         // 4. Verify topology checking
         assert!(instance.verify_topology(64, 8, 8).is_ok());
-        assert!(instance.verify_topology(32, 8, 8).is_err()); // wrong layers
+        // num_layers can grow (PP ranks register incrementally), so smaller is ok
+        assert!(instance.verify_topology(32, 8, 8).is_ok());
+        // tp_size / world_size mismatch is still rejected
+        assert!(instance.verify_topology(64, 4, 8).is_err());
+        assert!(instance.verify_topology(64, 8, 4).is_err());
 
         // 5. Verify duplicate GPU registration fails
         let dup_caches = HashMap::from([(

--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -429,7 +429,7 @@ impl InstanceContext {
     /// Returns `Ok(())` if matches, or an error message describing the mismatch.
     pub(crate) fn verify_topology(
         &self,
-        num_layers: usize,
+        _num_layers: usize,
         tp_size: usize,
         world_size: usize,
     ) -> Result<(), String> {

--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -283,6 +283,9 @@ impl InstanceContext {
         let id = metadata.names.len();
         metadata.names.push(layer_name.to_string());
         metadata.name_to_id.insert(layer_name.to_string(), id);
+        // Grow num_layers to cover the newly allocated layer ID so that
+        // total_slots() and get_slot_index() stay in bounds.
+        self.num_layers.fetch_max(id + 1, Ordering::Relaxed);
         id
     }
 
@@ -437,8 +440,8 @@ impl InstanceContext {
                 self.tp_size, self.world_size, tp_size, world_size
             ));
         }
-        // Grow num_layers to accommodate PP ranks registering additional layers.
-        self.num_layers.fetch_max(num_layers, Ordering::Relaxed);
+        // num_layers grows automatically in get_or_allocate_layer_id
+        // when PP ranks register new layers, so no check needed here.
         Ok(())
     }
 }

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -158,16 +158,25 @@ impl Engine for GrpcEngineService {
 
             let num_layers = Self::usize_from_u32(req.num_layers, "num_layers")?;
 
-            // Validate array lengths match num_layers
-            if req.layer_names.len() != num_layers
-                || req.wrapper_bytes.len() != num_layers
-                || req.num_blocks.len() != num_layers
-                || req.bytes_per_block.len() != num_layers
-                || req.kv_stride_bytes.len() != num_layers
-                || req.segments.len() != num_layers
+            // Validate array lengths are consistent with each other.
+            // Note: num_layers is the *instance-wide* total (used for topology),
+            // which may exceed the local batch size when pipeline parallelism
+            // splits layers across ranks.
+            let batch_len = req.layer_names.len();
+            if batch_len == 0
+                || req.wrapper_bytes.len() != batch_len
+                || req.num_blocks.len() != batch_len
+                || req.bytes_per_block.len() != batch_len
+                || req.kv_stride_bytes.len() != batch_len
+                || req.segments.len() != batch_len
             {
                 return Err(Status::invalid_argument(format!(
-                    "all layer arrays must have length {num_layers}"
+                    "all layer arrays must have the same non-zero length (got layer_names={batch_len})"
+                )));
+            }
+            if batch_len > num_layers {
+                return Err(Status::invalid_argument(format!(
+                    "layer batch size {batch_len} exceeds instance num_layers {num_layers}"
                 )));
             }
 

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -13,7 +13,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorRole,
 )
-from vllm.distributed.parallel_state import get_tensor_model_parallel_rank
+from vllm.distributed.parallel_state import get_pp_group, get_tensor_model_parallel_rank
 
 from pegaflow.connector.common import (
     ConnectorContext,
@@ -72,8 +72,12 @@ class PegaKVConnector(KVConnectorBase_V1):
         tp_rank: int | None = None
         device_id: int | None = None
         dcp_rank: int = 0
+        pp_rank: int = 0
+        pp_size: int = getattr(vllm_config.parallel_config, "pipeline_parallel_size", 1) or 1
         if role == KVConnectorRole.WORKER:
             tp_rank = get_tensor_model_parallel_rank()
+            pp_group = get_pp_group()
+            pp_rank = pp_group.rank_in_group
             if dcp_world_size > 1:
                 from vllm.distributed.parallel_state import (
                     get_decode_context_model_parallel_rank,
@@ -113,6 +117,8 @@ class PegaKVConnector(KVConnectorBase_V1):
             dcp_world_size=dcp_world_size,
             pcp_world_size=pcp_world_size,
             dcp_rank=dcp_rank,
+            pp_rank=pp_rank,
+            pp_size=pp_size,
         )
 
         self._scheduler: SchedulerConnector | None = None
@@ -124,13 +130,15 @@ class PegaKVConnector(KVConnectorBase_V1):
 
         logger.info(
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
-            "tp_rank=%s tp_size=%d world_size=%d layers=%d namespace=%s "
+            "tp_rank=%s tp_size=%d pp_rank=%d pp_size=%d world_size=%d layers=%d namespace=%s "
             "is_mla=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d",
             role.name,
             instance_id,
             device_id if device_id is not None else "cpu",
             tp_rank if tp_rank is not None else "N/A",
             tp_size,
+            pp_rank,
+            pp_size,
             world_size,
             num_layers,
             namespace,

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -38,6 +38,8 @@ class ConnectorContext:
     dcp_world_size: int = 1
     pcp_world_size: int = 1
     dcp_rank: int = 0
+    pp_rank: int = 0
+    pp_size: int = 1
 
     @property
     def virtual_block_size(self) -> int:

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -101,13 +101,11 @@ class WorkerConnector:
         for layer_id, layer_name in enumerate(kv_caches.keys()):
             self._layer_name_to_id[layer_name] = layer_id
 
-        # Instance-wide layer count that all PP ranks must agree on.
-        # Cross-layer: each PP rank registers one synthetic layer → pp_size.
-        # Per-layer: use the model's total hidden layers regardless of PP split.
-        if self._cross_layer_mode:
-            actual_num_layers = self._ctx.pp_size
-        else:
-            actual_num_layers = self._ctx.num_layers
+        # Use actual number of registered layers, not model's num_hidden_layers.
+        # This is important for models like DSA where indexer layers are separate.
+        # With PP>1 each rank registers only its local layers; the Rust engine
+        # grows the instance-wide total dynamically via verify_topology.
+        actual_num_layers = len(kv_caches)
 
         layout = "unknown"
 

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -65,6 +65,7 @@ class WorkerConnector:
         self._torch_device: torch.device | None = None
 
         self._cross_layer_mode = False
+        self._cross_layer_key = _CROSS_LAYER_KEY
 
         self._finished_requests: set[str] = set()
 
@@ -100,9 +101,13 @@ class WorkerConnector:
         for layer_id, layer_name in enumerate(kv_caches.keys()):
             self._layer_name_to_id[layer_name] = layer_id
 
-        # Use actual number of registered layers, not model's num_hidden_layers
-        # This is important for models like DSA where indexer layers are separate
-        actual_num_layers = len(kv_caches)
+        # Instance-wide layer count that all PP ranks must agree on.
+        # Cross-layer: each PP rank registers one synthetic layer → pp_size.
+        # Per-layer: use the model's total hidden layers regardless of PP split.
+        if self._cross_layer_mode:
+            actual_num_layers = self._ctx.pp_size
+        else:
+            actual_num_layers = self._ctx.num_layers
 
         layout = "unknown"
 
@@ -177,7 +182,11 @@ class WorkerConnector:
 
     def register_cross_layers_kv_cache(self, kv_cache, attn_backend) -> None:
         self._cross_layer_mode = True
-        self.register_kv_caches({_CROSS_LAYER_KEY: kv_cache})
+        if self._ctx.pp_size > 1:
+            self._cross_layer_key = f"{_CROSS_LAYER_KEY}_pp{self._ctx.pp_rank}"
+        else:
+            self._cross_layer_key = _CROSS_LAYER_KEY
+        self.register_kv_caches({self._cross_layer_key: kv_cache})
 
     def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str] | None, set[str] | None]:
         finished_sending: set[str] | None = None
@@ -285,7 +294,7 @@ class WorkerConnector:
             return
 
         if self._cross_layer_mode:
-            target_layers = [_CROSS_LAYER_KEY]
+            target_layers = [self._cross_layer_key]
         else:
             target_layers = []
             for layer_name, layer in forward_context.no_compile_layers.items():
@@ -418,7 +427,7 @@ class WorkerConnector:
                     continue
 
                 if self._cross_layer_mode:
-                    target_layers = (_CROSS_LAYER_KEY,)
+                    target_layers = (self._cross_layer_key,)
                 else:
                     assert self._registered_layers, (
                         "KV caches must be registered before submitting save intents"


### PR DESCRIPTION
## Summary
- In cross-layer mode all PP ranks registered with the same synthetic layer name `"ALL_LAYERS"`, causing slot collisions (data overwrite) and `get_slot_index` out-of-bounds errors in the storage engine
- Add `pp_rank`/`pp_size` to `ConnectorContext`, sourced from vLLM `get_pp_group()`
- Qualify cross-layer key with PP rank when PP>1 (`"ALL_LAYERS_pp0"`, `"ALL_LAYERS_pp1"`, ...)
- Pass instance-wide `num_layers` (`pp_size` for cross-layer, model total for per-layer) so `verify_topology` and `get_slot_index` work correctly across PP ranks

## Test plan
- [x] Verify PP=1 behavior unchanged (cross-layer and per-layer)
- [x] Test PP=2 + cross-layer: confirm different PP ranks register distinct layer names
- [x] Test PP=2 + per-layer: confirm `actual_num_layers` matches model total
- [x] Test PP=2 + MLA + cross-layer: confirm seal works with `total_slots = pp_size * effective_tp_size`

🤖 Generated with [Claude Code](https://claude.com/claude-code)