### PR TITLE
fix(test): rewrite vLLM e2e test and fix save intent block index slicing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "colored",
  "libc",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "ahash",
  "bytesize",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "clap",
  "log",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "prost",
  "tonic",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "axum",
  "clap",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bincode",
  "clap",

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -321,8 +321,10 @@ class SchedulerConnector:
         base_block_idx = self._block_index_offsets.get(req_id, 0)
         start_block_idx = self._next_stored_block_idx.get(req_id, base_block_idx)
 
-        # allocated only contains local blocks, but block_hashes are indexed
-        # against the full request. Convert local progress to a global block idx.
+        # _allocated_blocks tracks request block IDs in global request order.
+        # In external-hit cases, the prefix-loaded block IDs are still present at
+        # the front, so save intents must slice by global block index rather than
+        # rebasing to a local-only view.
         local_saveable = min(
             len(allocated),
             scheduled // self._ctx.virtual_block_size,
@@ -333,16 +335,15 @@ class SchedulerConnector:
             return None
 
         self._next_stored_block_idx[req_id] = saveable_block_idx
-        local_start = start_block_idx - base_block_idx
         hash_start = start_block_idx
         save_hashes = block_hashes[hash_start : hash_start + new_blocks]
-        save_block_ids = allocated[local_start : local_start + new_blocks]
+        save_block_ids = allocated[hash_start : hash_start + new_blocks]
 
         logger.info(
             "[PegaKVConnector] req=%s save_intent: start=%d hash_start=%d "
             "base_block_idx=%d saveable_block_idx=%d new_blocks=%d total_hashes=%d",
             req_id,
-            local_start,
+            hash_start,
             hash_start,
             base_block_idx,
             saveable_block_idx,

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -331,6 +331,7 @@ class PegaServerProcess:
 
         env = os.environ.copy()
         env["PYO3_PYTHON"] = sys.executable
+        env["PYTHONHOME"] = sys.base_prefix
 
         # Add libpython to LD_LIBRARY_PATH if available
         if libdir := sysconfig.get_config_var("LIBDIR"):
@@ -347,7 +348,7 @@ class PegaServerProcess:
             f"127.0.0.1:{self.port}",
             "--pool-size",
             self.pool_size,
-            "--device",
+            "--devices",
             "0",
         ]
 
@@ -358,7 +359,7 @@ class PegaServerProcess:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd="/tmp",
-                preexec_fn=os.setsid if sys.platform != "win32" else None,
+                preexec_fn=os.setsid,
             )
         except (FileNotFoundError, PermissionError):
             return False
@@ -370,17 +371,11 @@ class PegaServerProcess:
         if self.process is None:
             return
         try:
-            if sys.platform != "win32":
-                os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
-            else:
-                self.process.terminate()
+            os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
             self.process.wait(timeout=5)
         except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
             if self.process:
-                if sys.platform != "win32":
-                    os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
-                else:
-                    self.process.kill()
+                os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
                 self.process.wait(timeout=2)
         finally:
             self.process = None
@@ -467,6 +462,41 @@ def registered_instance(client_context: ClientContext) -> Generator[str, None, N
 
 
 # =============================================================================
+# Fixtures: E2E / Fuzz shared options
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def model(request) -> str:
+    return request.config.getoption("--model")
+
+
+@pytest.fixture(scope="module")
+def base_port(request) -> int:
+    return request.config.getoption("--e2e-port")
+
+
+@pytest.fixture(scope="module")
+def pega_metrics_port(request) -> int:
+    return request.config.getoption("--pega-metrics-port")
+
+
+@pytest.fixture(scope="module")
+def tensor_parallel_size(request) -> int:
+    return request.config.getoption("--tensor-parallel-size")
+
+
+@pytest.fixture(scope="module")
+def pipeline_parallel_size(request) -> int:
+    return request.config.getoption("--pipeline-parallel-size")
+
+
+@pytest.fixture(scope="module")
+def max_model_len(request) -> int | None:
+    return request.config.getoption("--max-model-len")
+
+
+# =============================================================================
 # Pytest Configuration
 # =============================================================================
 
@@ -506,6 +536,13 @@ def pytest_addoption(parser):
         default=1,
         type=int,
         help="Pipeline parallel size for vLLM servers in E2E/Fuzz tests (tp * pp <= 4)",
+    )
+    parser.addoption(
+        "--max-model-len",
+        action="store",
+        default=None,
+        type=int,
+        help="Max model length for vLLM servers (e.g. 16384 for large models on small GPUs)",
     )
     # Fuzz test options
     parser.addoption(

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -224,6 +224,7 @@ class TestDecodeHashRefresh:
         blocks = _make_fake_blocks([10, 11, 12, 13])
 
         sc.update_state_after_alloc(req, blocks, num_external_tokens=0)
+        sc._allocated_blocks["r1"] = [10, 11, 12, 13]
         sc._scheduled_tokens["r1"] = 128  # 4 * 32
 
         intent = sc._consume_save_intent("r1")
@@ -239,6 +240,7 @@ class TestDecodeHashRefresh:
         blocks = _make_fake_blocks([10, 11, 12, 13])
 
         sc.update_state_after_alloc(req, blocks, num_external_tokens=0)
+        sc._allocated_blocks["r1"] = [10, 11, 12, 13]
         sc._scheduled_tokens["r1"] = 128  # 4 * 32
 
         # Save initial 4 blocks
@@ -279,3 +281,30 @@ class TestDecodeHashRefresh:
         assert "r1" not in sc._requests
         assert "r1" not in sc._block_hashes
         assert "r1" not in sc._allocated_blocks
+
+    def test_external_hit_save_uses_global_block_indices(self):
+        """Save intents must skip prefix-loaded block IDs on external-hit requests."""
+        sc = self._make_connector(dcp_world_size=1)
+        block_hashes = tuple(_hash(i) for i in range(9))
+
+        sc._block_hashes["r1"] = block_hashes
+        sc._block_index_offsets["r1"] = 6
+        sc._next_stored_block_idx["r1"] = 6
+        sc._scheduled_tokens["r1"] = 48  # 3 virtual blocks beyond the external hit
+        sc._allocated_blocks["r1"] = [
+            100,
+            101,
+            102,
+            103,
+            104,
+            105,
+            200,
+            201,
+            202,
+        ]
+
+        intent = sc._consume_save_intent("r1")
+
+        assert intent is not None
+        assert intent.block_hashes == block_hashes[6:9]
+        assert intent.block_ids == (200, 201, 202)

--- a/python/tests/test_vllm_e2e_correctness.py
+++ b/python/tests/test_vllm_e2e_correctness.py
@@ -1,10 +1,17 @@
 """E2E correctness test: verify PegaFlow produces identical outputs to baseline vLLM.
 
-This is the "canary" test - the single most important test for PegaFlow.
-It verifies the core contract:
+The single most important test for PegaFlow. Verifies the core contract:
 
-    Given the same prompt + model + sampling params,
+    Given the same prompt + model + greedy sampling,
     output must be identical with or without PegaFlow.
+
+Covers all critical KV cache paths in one deterministic test:
+- Cold save + warm load (basic round-trip)
+- Multi-block prompts (block boundary alignment)
+- Prefix extension (cached "A B C" -> request "A B C D E")
+- Prefix rollback (cached "A B C D" -> request "A B")
+- Multi-round decode (growing context across rounds)
+- Cache metrics (directional assertions)
 
 Usage:
     # Requires pegaflow-server running with metrics enabled:
@@ -12,12 +19,10 @@ Usage:
         --addr 0.0.0.0:50055 --device 0 --pool-size 30gb --http-addr 0.0.0.0:9091
 
     cd python && pytest tests/test_vllm_e2e_correctness.py -v -s
-
-    # Or with a specific model:
-    pytest tests/test_vllm_e2e_correctness.py -v -s --model /path/to/model
 """
 
-import time
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest
@@ -29,79 +34,228 @@ from .vllm_helpers import (
     fetch_pegaflow_metrics,
 )
 
-# Test prompts - varied lengths and domains to test different code paths
-TEST_PROMPTS = [
-    # Short prompts
-    ("short_fact", "The capital of France is"),
-    ("short_math", "2 + 2 ="),
-    # Medium prompts
+# ---------------------------------------------------------------------------
+# Prompt design
+#
+# Each prompt group exercises a different cache path. Prompts are long enough
+# to span multiple blocks (block_size=16 tokens typically) so that partial
+# hits are meaningful, not degenerate single-block cases.
+# ---------------------------------------------------------------------------
+
+# Short prompt (likely < 1 full block) — edge case for incomplete blocks
+SHORT_PROMPT = "2 + 2 ="
+
+# Long prompt (multi-block) — tests block boundary alignment during save/load
+LONG_PROMPT = (
+    "Machine learning is a subset of artificial intelligence that focuses on "
+    "building systems that can learn from and make decisions based on data. "
+    "Deep learning, a further subset of machine learning, uses artificial "
+    "neural networks with many layers to model complex patterns in large "
+    "amounts of data. The key advantage of deep learning over traditional "
+    "machine learning methods is its ability to automatically discover "
+    "representations needed for feature detection or classification from "
+    "raw data. This eliminates the need for manual feature engineering, "
+    "which has traditionally been one of the most time-consuming aspects "
+    "of applying machine learning to real-world problems. Convolutional "
+    "neural networks have proven particularly effective for image recognition "
+    "tasks, while recurrent neural networks and transformers have shown "
+    "remarkable results in natural language processing. The transformer "
+    "architecture, introduced in the paper Attention Is All You Need, has "
+    "become the foundation for modern large language models. The main idea is"
+)
+
+# Prefix family: extension
+# prefix_base is a strict prefix of prefix_extend.
+# After caching prefix_base, requesting prefix_extend should partially hit.
+PREFIX_BASE = (
+    "The history of computing begins with mechanical calculators in the 17th "
+    "century. Blaise Pascal built the Pascaline in 1642, which could perform "
+    "addition and subtraction. Gottfried Wilhelm Leibniz later improved upon "
+    "this design with the Stepped Reckoner, which could also multiply and "
+    "divide. Charles Babbage conceived the Difference Engine in the 1820s and "
+    "later designed the more ambitious Analytical Engine, which contained many "
+    "features of modern computers including an arithmetic logic unit, control "
+    "flow through conditional branching, and memory. Ada Lovelace wrote what "
+    "is considered the first computer program for the Analytical Engine. The "
+    "next major breakthrough came with"
+)
+
+PREFIX_EXTEND = (
+    PREFIX_BASE + " the development of electronic computers in the mid-20th century. "
+    "Alan Turing formalized the concept of computation with his theoretical "
+    "Turing machine in 1936. During World War II, several electronic computing "
+    "devices were built including Colossus and ENIAC. The invention of the "
+    "transistor at Bell Labs in 1947 revolutionized electronics and led to "
+    "increasingly powerful and compact computers. The integrated circuit, "
+    "developed independently by Jack Kilby and Robert Noyce, further accelerated "
+    "this trend. The impact of these innovations on modern society is"
+)
+
+# Prefix family: rollback
+# rollback_long is cached first, then rollback_short (a strict prefix of
+# rollback_long) requests a subset — the reverse of prefix extension.
+ROLLBACK_LONG = (
+    "In computer science, a hash table is a data structure that implements an "
+    "associative array, also called a dictionary or map. A hash table uses a "
+    "hash function to compute an index, also called a hash code, into an array "
+    "of buckets or slots, from which the desired value can be found. During "
+    "lookup, the key is hashed and the resulting hash indicates where the "
+    "corresponding value is stored. Ideally, the hash function will assign each "
+    "key to a unique bucket, but most hash table designs employ an imperfect "
+    "hash function, which might cause hash collisions where the hash function "
+    "generates the same index for more than one key. Such collisions are "
+    "typically accommodated by chaining or open addressing. The main advantage is"
+)
+
+ROLLBACK_SHORT = (
+    "In computer science, a hash table is a data structure that implements an "
+    "associative array, also called a dictionary or map. A hash table uses a "
+    "hash function to compute an index, also called a hash code, into an array "
+    "of buckets or slots, from which the desired value can be found. During "
+    "lookup, the key is hashed and the resulting hash indicates where the "
+    "corresponding value is stored. Ideally, the hash function will assign each "
+    "key to a unique bucket, but most hash table designs employ an imperfect "
+    "hash function, which might cause hash collisions where the hash function "
+    "generates the same index for more than one key. Such collisions are"
+)
+
+# Multi-round decode: three prompts where each is a prefix of the next.
+# Simulates growing chat context across decode rounds.
+_MULTI_ROUND_STEM = (
+    "Quantum computing leverages quantum mechanical phenomena such as "
+    "superposition and entanglement to perform computation. Unlike classical "
+    "bits that exist in a state of either 0 or 1, quantum bits or qubits can "
+    "exist in a superposition of both states simultaneously. This property "
+    "allows quantum computers to explore many possible solutions at once. "
+    "Quantum entanglement enables qubits that are entangled to be correlated "
+    "with each other in ways that have no classical equivalent. When combined, "
+    "these properties give quantum computers the potential to solve certain "
+    "problems exponentially faster than classical computers. "
+)
+
+MULTI_ROUND = [
+    _MULTI_ROUND_STEM + "The current state of quantum hardware is",
     (
-        "medium_cs",
-        "In computer science, a hash table is a data structure that implements "
-        "an associative array. The main advantage of hash tables is",
+        _MULTI_ROUND_STEM + "Key algorithms include Shor's algorithm for factoring large numbers "
+        "and Grover's algorithm for searching unsorted databases. Current "
+        "quantum computers face significant challenges including decoherence, "
+        "error rates, and the need for extreme cooling. The path forward involves"
     ),
     (
-        "medium_code",
-        "def fibonacci(n):\n    '''Return the nth Fibonacci number.'''\n    if n <= 1:\n        return n\n    return",
-    ),
-    # Longer prompts to test block boundaries
-    (
-        "long_ml",
-        "Machine learning is a subset of artificial intelligence that focuses on "
-        "building systems that can learn from data. Deep learning, a subset of machine "
-        "learning, uses neural networks with many layers. The key benefit of deep learning is",
-    ),
-    (
-        "long_history",
-        "The Industrial Revolution began in Britain in the late 18th century "
-        "and transformed manufacturing processes. Key inventions included the steam engine, "
-        "spinning jenny, and power loom. The social impact of industrialization was",
+        _MULTI_ROUND_STEM + "Key algorithms include Shor's algorithm for factoring large numbers "
+        "and Grover's algorithm for searching unsorted databases. Current "
+        "quantum computers face significant challenges including decoherence, "
+        "error rates, and the need for extreme cooling. Major tech companies "
+        "including Google, IBM, and Microsoft are investing heavily in quantum "
+        "computing research. Google claimed quantum supremacy in 2019 with its "
+        "Sycamore processor. IBM has been steadily increasing qubit counts with "
+        "its Eagle, Osprey, and Condor processors. The most promising applications are"
     ),
 ]
 
 
-@pytest.fixture(scope="module")
-def model(request) -> str:
-    """Get model from command line or use default."""
-    return request.config.getoption("--model")
+# Ordered execution plan for PegaFlow phase.
+# Each entry: (label, prompt, cache_expectation)
+# cache_expectation: "cold" = first time, "warm" = exact repeat, "partial" = prefix hit
+EXECUTION_PLAN: list[tuple[str, str, str]] = [
+    # Round 1: cold saves — fill the cache
+    ("short_cold", SHORT_PROMPT, "cold"),
+    ("long_cold", LONG_PROMPT, "cold"),
+    ("prefix_base", PREFIX_BASE, "cold"),
+    ("rollback_long", ROLLBACK_LONG, "cold"),
+    ("multi_r1", MULTI_ROUND[0], "cold"),
+    # Round 2: warm hits — exact same prompts
+    ("short_warm", SHORT_PROMPT, "warm"),
+    ("long_warm", LONG_PROMPT, "warm"),
+    # Round 3: prefix operations
+    ("prefix_extend", PREFIX_EXTEND, "partial"),
+    ("rollback_short", ROLLBACK_SHORT, "partial"),
+    # Round 4: multi-round growth
+    ("multi_r2", MULTI_ROUND[1], "partial"),
+    ("multi_r3", MULTI_ROUND[2], "partial"),
+]
+
+# All unique prompts for baseline collection
+ALL_PROMPTS: dict[str, str] = {
+    "short": SHORT_PROMPT,
+    "long": LONG_PROMPT,
+    "prefix_base": PREFIX_BASE,
+    "prefix_extend": PREFIX_EXTEND,
+    "rollback_long": ROLLBACK_LONG,
+    "rollback_short": ROLLBACK_SHORT,
+    "multi_r1": MULTI_ROUND[0],
+    "multi_r2": MULTI_ROUND[1],
+    "multi_r3": MULTI_ROUND[2],
+}
+
+# Map execution plan labels to their baseline prompt key
+_LABEL_TO_BASELINE: dict[str, str] = {
+    "short_cold": "short",
+    "long_cold": "long",
+    "prefix_base": "prefix_base",
+    "rollback_long": "rollback_long",
+    "multi_r1": "multi_r1",
+    "short_warm": "short",
+    "long_warm": "long",
+    "prefix_extend": "prefix_extend",
+    "rollback_short": "rollback_short",
+    "multi_r2": "multi_r2",
+    "multi_r3": "multi_r3",
+}
 
 
-@pytest.fixture(scope="module")
-def base_port(request) -> int:
-    """Get base port from command line."""
-    return request.config.getoption("--e2e-port")
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="module")
-def pega_metrics_port(request) -> int:
-    """Get PegaFlow metrics port from command line."""
-    return request.config.getoption("--pega-metrics-port")
-
-
-@pytest.fixture(scope="module")
-def tensor_parallel_size(request) -> int:
-    """Get tensor parallel size from command line."""
-    return request.config.getoption("--tensor-parallel-size")
-
-
-@pytest.fixture(scope="module")
-def pipeline_parallel_size(request) -> int:
-    """Get pipeline parallel size from command line."""
-    return request.config.getoption("--pipeline-parallel-size")
-
-
+@pytest.mark.e2e
 class TestE2ECorrectness:
-    """E2E correctness tests for PegaFlow.
+    """E2E correctness: baseline vLLM vs PegaFlow-enabled vLLM.
 
-    These tests verify that PegaFlow produces identical outputs to baseline vLLM.
+    Two-phase structure:
+      Phase 1 — run all unique prompts through baseline vLLM, collect golden outputs.
+      Phase 2 — run execution plan through PegaFlow vLLM, collect outputs + metrics.
+    Each test method asserts one cache path independently.
     """
 
     @pytest.fixture(scope="class")
     def log_dir(self, tmp_path_factory) -> Path:
-        """Create a temporary directory for server logs."""
-        return tmp_path_factory.mktemp("vllm_logs")
+        return tmp_path_factory.mktemp("e2e_logs")
 
-    def test_cache_roundtrip_correctness(
+    @pytest.fixture(scope="class")
+    def baseline_outputs(
+        self,
+        model: str,
+        base_port: int,
+        log_dir: Path,
+        tensor_parallel_size: int,
+        pipeline_parallel_size: int,
+        max_model_len: int | None,
+    ) -> dict[str, str]:
+        """Phase 1: collect golden outputs from baseline vLLM (no PegaFlow)."""
+        print("\n[Phase 1] Baseline vLLM — collecting golden outputs")
+        outputs: dict[str, str] = {}
+
+        with VLLMServer(
+            model,
+            base_port,
+            use_pegaflow=False,
+            log_file=log_dir / "baseline.log",
+            tensor_parallel_size=tensor_parallel_size,
+            pipeline_parallel_size=pipeline_parallel_size,
+            max_model_len=max_model_len,
+        ):
+            for key, prompt in ALL_PROMPTS.items():
+                result = call_openai_api(base_port, model, prompt)
+                outputs[key] = result["text"]
+                print(f"  [{key}] {len(result['text'])} chars")
+
+        print(f"[Phase 1] Done — {len(outputs)} golden outputs collected\n")
+        return outputs
+
+    @pytest.fixture(scope="class")
+    def pegaflow_results(
         self,
         model: str,
         base_port: int,
@@ -109,108 +263,135 @@ class TestE2ECorrectness:
         log_dir: Path,
         tensor_parallel_size: int,
         pipeline_parallel_size: int,
-    ):
-        """Core contract: baseline, cold cache, and warm cache must produce identical outputs.
-
-        This is THE canary test. If this fails, something is fundamentally broken.
-        """
-        # Pre-check: Ensure PegaFlow server is running with metrics enabled
+        max_model_len: int | None,
+    ) -> dict:
+        """Phase 2: run execution plan through PegaFlow vLLM."""
         if not check_pegaflow_server(pega_metrics_port):
             pytest.skip(
                 f"PegaFlow server not reachable (metrics port {pega_metrics_port}). "
                 "Start with --http-addr flag."
             )
 
-        results = {"baseline": [], "pegaflow_cold": [], "pegaflow_warm": []}
+        print("[Phase 2] PegaFlow vLLM — executing cache plan")
+        pega_port = base_port + 1
+        outputs: dict[str, str] = {}
 
-        # Phase 1: Baseline vLLM (no PegaFlow)
-        print("\n[Phase 1] Baseline vLLM")
-        baseline_log = log_dir / "baseline.log"
         with VLLMServer(
             model,
-            base_port,
-            use_pegaflow=False,
-            log_file=baseline_log,
-            tensor_parallel_size=tensor_parallel_size,
-            pipeline_parallel_size=pipeline_parallel_size,
-        ):
-            for _, prompt in TEST_PROMPTS:
-                result = call_openai_api(base_port, model, prompt)
-                results["baseline"].append(result)
-
-        # Phase 2: PegaFlow vLLM (cold + warm cache)
-        print("[Phase 2] PegaFlow vLLM (cold + warm)")
-        metrics_before_cold = fetch_pegaflow_metrics(pega_metrics_port)
-
-        pegaflow_log = log_dir / "pegaflow.log"
-        with VLLMServer(
-            model,
-            base_port + 1,
+            pega_port,
             use_pegaflow=True,
-            log_file=pegaflow_log,
+            log_file=log_dir / "pegaflow.log",
             tensor_parallel_size=tensor_parallel_size,
             pipeline_parallel_size=pipeline_parallel_size,
+            max_model_len=max_model_len,
         ):
-            # Cold cache run
-            cold_total_time = 0.0
-            for _, prompt in TEST_PROMPTS:
-                start = time.time()
-                result = call_openai_api(base_port + 1, model, prompt)
-                cold_total_time += time.time() - start
-                results["pegaflow_cold"].append(result)
+            metrics_start = fetch_pegaflow_metrics(pega_metrics_port)
 
-            # Verify SAVE operations
-            metrics_after_cold = fetch_pegaflow_metrics(pega_metrics_port)
-            save_bytes = metrics_after_cold.get(
-                "pegaflow_save_bytes_total", 0
-            ) - metrics_before_cold.get("pegaflow_save_bytes_total", 0)
-            insertions = metrics_after_cold.get(
-                "pegaflow_cache_block_insertions_total", 0
-            ) - metrics_before_cold.get("pegaflow_cache_block_insertions_total", 0)
-            assert save_bytes > 0 or insertions > 0, (
-                f"Cold cache did not SAVE: save_bytes={save_bytes}, insertions={insertions}"
-            )
+            for label, prompt, expectation in EXECUTION_PLAN:
+                result = call_openai_api(pega_port, model, prompt)
+                outputs[label] = result["text"]
+                print(f"  [{label}] ({expectation}) {len(result['text'])} chars")
 
-            # Warm cache run
-            metrics_before_warm = fetch_pegaflow_metrics(pega_metrics_port)
-            warm_total_time = 0.0
-            for _, prompt in TEST_PROMPTS:
-                start = time.time()
-                result = call_openai_api(base_port + 1, model, prompt)
-                warm_total_time += time.time() - start
-                results["pegaflow_warm"].append(result)
+            metrics_end = fetch_pegaflow_metrics(pega_metrics_port)
 
-            # Verify LOAD operations
-            metrics_after_warm = fetch_pegaflow_metrics(pega_metrics_port)
-            load_bytes = metrics_after_warm.get(
-                "pegaflow_load_bytes_total", 0
-            ) - metrics_before_warm.get("pegaflow_load_bytes_total", 0)
-            hits = metrics_after_warm.get(
-                "pegaflow_cache_block_hits_total", 0
-            ) - metrics_before_warm.get("pegaflow_cache_block_hits_total", 0)
-            assert load_bytes > 0 or hits > 0, (
-                f"Warm cache did not LOAD: load_bytes={load_bytes}, hits={hits}"
-            )
+        print("[Phase 2] Done\n")
+        return {
+            "outputs": outputs,
+            "metrics_start": metrics_start,
+            "metrics_end": metrics_end,
+        }
 
-            print(
-                f"[Metrics] SAVE: {save_bytes / 1e6:.1f}MB, LOAD: {load_bytes / 1e6:.1f}MB, "
-                f"Speedup: {cold_total_time / warm_total_time:.2f}x"
-            )
+    # -- Individual test methods: each asserts one cache path --
 
-        # Phase 3: Verify correctness
-        print("[Phase 3] Verifying outputs")
-        for i, (prompt_id, _) in enumerate(TEST_PROMPTS):
-            baseline = results["baseline"][i]["text"]
-            cold = results["pegaflow_cold"][i]["text"]
-            warm = results["pegaflow_warm"][i]["text"]
+    def _assert_match(
+        self,
+        baseline_outputs: dict[str, str],
+        pegaflow_results: dict,
+        label: str,
+    ):
+        baseline_key = _LABEL_TO_BASELINE[label]
+        baseline = baseline_outputs[baseline_key]
+        pegaflow = pegaflow_results["outputs"][label]
+        assert baseline == pegaflow, (
+            f"[{label}] Output mismatch:\n"
+            f"  baseline ({len(baseline)} chars): {baseline[:120]}...\n"
+            f"  pegaflow ({len(pegaflow)} chars): {pegaflow[:120]}..."
+        )
 
-            assert cold == warm, (
-                f"[{prompt_id}] Cold vs Warm mismatch:\n  Cold: {cold[:100]}\n  Warm: {warm[:100]}"
-            )
-            assert baseline == cold, (
-                f"[{prompt_id}] Baseline vs PegaFlow mismatch:\n"
-                f"  Baseline: {baseline[:100]}\n"
-                f"  PegaFlow: {cold[:100]}"
-            )
+    def test_cold_short(self, baseline_outputs, pegaflow_results):
+        """Short prompt cold save — incomplete block edge case."""
+        self._assert_match(baseline_outputs, pegaflow_results, "short_cold")
 
-        print("[PASS] All outputs match!")
+    def test_cold_long(self, baseline_outputs, pegaflow_results):
+        """Long prompt cold save — multi-block boundary alignment."""
+        self._assert_match(baseline_outputs, pegaflow_results, "long_cold")
+
+    def test_warm_short(self, baseline_outputs, pegaflow_results):
+        """Short prompt warm hit — same prompt, full cache hit."""
+        self._assert_match(baseline_outputs, pegaflow_results, "short_warm")
+
+    def test_warm_long(self, baseline_outputs, pegaflow_results):
+        """Long prompt warm hit — same prompt, full cache hit."""
+        self._assert_match(baseline_outputs, pegaflow_results, "long_warm")
+
+    def test_prefix_base(self, baseline_outputs, pegaflow_results):
+        """Prefix base — cold save of prefix stem."""
+        self._assert_match(baseline_outputs, pegaflow_results, "prefix_base")
+
+    def test_prefix_extend(self, baseline_outputs, pegaflow_results):
+        """Prefix extension — cached 'A B C', now requesting 'A B C D E'.
+
+        This is the exact path changed by PR #204: external hit prefix
+        + new block computation with correct global index alignment.
+        """
+        self._assert_match(baseline_outputs, pegaflow_results, "prefix_extend")
+
+    def test_prefix_rollback(self, baseline_outputs, pegaflow_results):
+        """Prefix rollback — cached 'A B C D', now requesting shorter 'A B'.
+
+        Tests that a shorter request correctly reuses a subset of
+        a longer cached prefix without index misalignment.
+        """
+        self._assert_match(baseline_outputs, pegaflow_results, "rollback_short")
+
+    def test_rollback_long_cold(self, baseline_outputs, pegaflow_results):
+        """Rollback long prompt — cold save baseline."""
+        self._assert_match(baseline_outputs, pegaflow_results, "rollback_long")
+
+    def test_multi_round_r1(self, baseline_outputs, pegaflow_results):
+        """Multi-round decode R1 — cold save of initial context."""
+        self._assert_match(baseline_outputs, pegaflow_results, "multi_r1")
+
+    def test_multi_round_r2(self, baseline_outputs, pegaflow_results):
+        """Multi-round decode R2 — extends R1 context, partial cache hit."""
+        self._assert_match(baseline_outputs, pegaflow_results, "multi_r2")
+
+    def test_multi_round_r3(self, baseline_outputs, pegaflow_results):
+        """Multi-round decode R3 — extends R2 context, deeper partial hit."""
+        self._assert_match(baseline_outputs, pegaflow_results, "multi_r3")
+
+    def test_cache_metrics(self, pegaflow_results, pega_metrics_port):
+        """Directional cache metrics — saves happened on cold, hits on warm/partial."""
+        if not check_pegaflow_server(pega_metrics_port):
+            pytest.skip("PegaFlow metrics not available")
+
+        m_start = pegaflow_results["metrics_start"]
+        m_end = pegaflow_results["metrics_end"]
+
+        def delta(key: str) -> float:
+            return m_end.get(key, 0) - m_start.get(key, 0)
+
+        save_bytes = delta("pegaflow_save_bytes_total")
+        insertions = delta("pegaflow_cache_block_insertions_total")
+        load_bytes = delta("pegaflow_load_bytes_total")
+        hits = delta("pegaflow_cache_block_hits_total")
+
+        assert save_bytes > 0 or insertions > 0, (
+            f"No SAVE activity: save_bytes={save_bytes}, insertions={insertions}"
+        )
+        assert load_bytes > 0 or hits > 0, f"No LOAD activity: load_bytes={load_bytes}, hits={hits}"
+
+        print(
+            f"\n[Metrics] saves={insertions:.0f} blocks ({save_bytes / 1e6:.1f}MB), "
+            f"hits={hits:.0f} blocks ({load_bytes / 1e6:.1f}MB)"
+        )

--- a/python/tests/test_vllm_fuzz.py
+++ b/python/tests/test_vllm_fuzz.py
@@ -123,36 +123,6 @@ def generate_access_sequence(
     return sequence
 
 
-@pytest.fixture(scope="module")
-def model(request) -> str:
-    """Get model from command line or use default."""
-    return request.config.getoption("--model")
-
-
-@pytest.fixture(scope="module")
-def base_port(request) -> int:
-    """Get base port from command line."""
-    return request.config.getoption("--e2e-port")
-
-
-@pytest.fixture(scope="module")
-def pega_metrics_port(request) -> int:
-    """Get PegaFlow metrics port from command line."""
-    return request.config.getoption("--pega-metrics-port")
-
-
-@pytest.fixture(scope="module")
-def tensor_parallel_size(request) -> int:
-    """Get tensor parallel size from command line."""
-    return request.config.getoption("--tensor-parallel-size")
-
-
-@pytest.fixture(scope="module")
-def pipeline_parallel_size(request) -> int:
-    """Get pipeline parallel size from command line."""
-    return request.config.getoption("--pipeline-parallel-size")
-
-
 @pytest.mark.fuzz
 class TestFuzzCorrectness:
     """Fuzz tests for PegaFlow using Zipf-distributed ShareGPT prompts."""

--- a/python/tests/vllm_helpers.py
+++ b/python/tests/vllm_helpers.py
@@ -53,6 +53,12 @@ class VLLMServer:
         env = os.environ.copy()
         env["VLLM_BATCH_INVARIANT"] = "1"
 
+        # Resolve vllm binary from the current Python environment's bin dir
+        import sys
+
+        venv_bin = str(Path(sys.executable).parent)
+        env["PATH"] = venv_bin + ":" + env.get("PATH", "")
+
         cmd = [
             "vllm",
             "serve",
@@ -93,6 +99,7 @@ class VLLMServer:
                 stdout=self.log_handle,
                 stderr=subprocess.STDOUT,
                 env=env,
+                preexec_fn=os.setsid,
             )
         else:
             self.process = subprocess.Popen(
@@ -100,23 +107,24 @@ class VLLMServer:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 env=env,
+                preexec_fn=os.setsid,
             )
 
         self._wait_for_ready()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Stop the vLLM server."""
+        """Stop the vLLM server and all child processes."""
         if self.process:
             server_label = "PegaFlow" if self.use_pegaflow else "Baseline"
             print(f"\n[{server_label}] Stopping vLLM server...")
-            self.process.send_signal(signal.SIGTERM)
             try:
+                os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
                 self.process.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                print("Server didn't stop gracefully, forcing...")
-                self.process.kill()
-                self.process.wait()
+            except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
+                if self.process:
+                    os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
+                    self.process.wait(timeout=5)
             print("Server stopped.\n")
 
         if self.log_handle:


### PR DESCRIPTION
## Summary

- **Fix scheduler `_consume_save_intent`**: was using `local_start = start_block_idx - base_block_idx` to slice `allocated_blocks`, but `allocated_blocks` contains ALL block IDs (including external-hit prefix). This caused hash/block_id misalignment on prefix extend/rollback paths. Changed to slice with global `hash_start` index directly.
- **Rewrite `test_vllm_e2e_correctness.py`**: two-phase structure (baseline golden outputs vs pegaflow), 11 correctness + 1 metrics test covering cold/warm/prefix-extend/rollback/multi-round decode paths.
- **Fix ROLLBACK_SHORT**: was not actually a string prefix of ROLLBACK_LONG (diverged after shared stem). Now a strict truncation, symmetrical with PREFIX_BASE/PREFIX_EXTEND.
- **Deduplicate fixtures**: moved shared `model`/`base_port`/`pega_metrics_port`/`tensor_parallel_size`/`pipeline_parallel_size`/`max_model_len` fixtures into `conftest.py`.
- **Fix VLLMServer/PegaServerProcess cleanup**: `preexec_fn=os.setsid` + `os.killpg` to kill entire process group, preventing zombie vLLM workers.
- **Add unit test** `test_external_hit_save_uses_global_block_indices` directly verifying the save intent fix.

## Test plan

- [x] All Rust tests pass (`cargo test --release`)
- [x] Pre-commit hooks pass (ruff, isort, codespell, typos, commitizen)
- [x] New unit test covers the exact bug scenario (6 external-hit blocks, save should start at global index 6)
- [x] Run `pytest tests/test_vllm_e2e_correctness.py -v -s -m e2e` with pegaflow-server + vLLM on GPU node

🤖 Generated with [Claude Code](https://claude.com/claude-code)