### PR TITLE
chore(release): bump version to 0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "colored",
  "libc",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "ahash",
  "bytesize",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "clap",
  "log",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "prost",
  "tonic",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "axum",
  "clap",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.19.0"
+version = "0.19.1"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -105,6 +105,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.19.0"
+version = "0.19.1"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## What changed
- bump the workspace package version from `0.19.0` to `0.19.1`
- bump the Python package version in `python/pyproject.toml` to `0.19.1`
- refresh `Cargo.lock` so workspace crate entries match the new release version

## Why
This prepares the repository for the next patch release based on the latest `master`, aligning the Rust and Python release metadata for `0.19.1`.

## User impact
- release automation and package metadata now resolve to `0.19.1`
- Rust workspace crates and the Python package stay on the same published version

## Validation
- `cargo metadata --no-deps --format-version 1`
- `python3` TOML parse of `python/pyproject.toml`
- `git diff --check`
- `cargo check -q`
- pre-commit hooks during `git commit`, including `cargo test --release`
