### PR TITLE
fix: resolve #170 — docs(python): remove outdated API examples from README

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -31,27 +31,7 @@ pip install pegaflow
 
 ## Usage
 
-### Basic KV Storage
-
-```python
-from pegaflow import PegaEngine
-
-# Create a new engine
-engine = PegaEngine()
-
-# Store key-value pairs
-engine.put("name", "PegaFlow")
-engine.put("version", "0.1.0")
-
-# Retrieve values
-name = engine.get("name")  # Returns "PegaFlow"
-missing = engine.get("nonexistent")  # Returns None
-
-# Remove keys
-removed = engine.remove("name")  # Returns "PegaFlow"
-```
-
-#### Sglang Examples:
+### Sglang Examples:
 
 example 1:
 


### PR DESCRIPTION
## Summary

fix: resolve #170 — docs(python): remove outdated API examples from README

## Problem

**Severity**: `Medium` | **File**: `python/README.md`

The `python/README.md` file contains an outdated "Basic KV Storage" section (lines 37-52) that shows `engine.put()` / `engine.get()` / `engine.remove()` API examples which do not exist in the current codebase. The actual PegaEngine API is `register_context_layer()` / `batch_load_kv_blocks()`. Since users don't directly call the Python binding API (they use vLLM or SGLang), this section should be removed entirely.

## Solution



## Changes

- `python/README.md` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*