### PR TITLE
fix: resolve #95 — Add Regular (cached) pinned memory allocation strategy

### DIFF
--- a/pegaflow-core/src/pinned_mem.rs
+++ b/pegaflow-core/src/pinned_mem.rs
@@ -164,6 +164,104 @@ impl PinnedMemory {
             return Err(PinnedMemError::ZeroSize);
         }
 
+        let (ptr, actual_size) = match strategy {
+            AllocStrategy::Regular => {
+                let err = rt::cuda::host_alloc(size, rt::cuda::host_alloc_flags::DEFAULT);
+                if err != rt::cudaError::CUDA_SUCCESS {
+                    return Err(PinnedMemError::CudaAllocFailed(err));
+                }
+                let ptr = rt::cuda::host_alloc_ptr(size).expect("allocation succeeded");
+                (NonNull::new(ptr).expect("non-null"), size)
+            }
+            AllocStrategy::WriteCombined => {
+                let err = rt::cuda::host_alloc(
+                    size,
+                    rt::cuda::host_alloc_flags::WRITE_COMBINED,
+                );
+                if err != rt::cudaError::CUDA_SUCCESS {
+                    return Err(PinnedMemError::CudaAllocFailed(err));
+                }
+                let ptr = rt::cuda::host_alloc_ptr(size).expect("allocation succeeded");
+                (NonNull::new(ptr).expect("non-null"), size)
+            }
+            AllocStrategy::HugePages => {
+                return Self::allocate_hugepages_internal(size);
+            }
+        };
+
+        Ok(Self {
+            ptr,
+            size: actual_size,
+            strategy,
+        })
+    }
+
+    fn allocate_hugepages_internal(size: usize) -> Result<Self, PinnedMemError> {
+        let page_size = get_huge_page_size().ok_or(PinnedMemError::HugePageSizeUnavailable)?;
+
+        let aligned_size = (size + page_size - 1) & !(page_size - 1);
+
+        let ptr = unsafe {
+            let null_ptr: *mut libc::c_void = std::ptr::null_mut();
+            libc::mmap(
+                null_ptr,
+                aligned_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_HUGETLB,
+                -1,
+                0,
+            )
+        };
+
+        if ptr == libc::MAP_FAILED {
+            return Err(PinnedMemError::MmapFailed(io::Error::last_os_error()));
+        }
+
+        let err = rt::cuda::host_register(ptr, aligned_size);
+        if err != rt::cudaError::CUDA_SUCCESS {
+            unsafe {
+                libc::munmap(ptr, aligned_size);
+            }
+            return Err(PinnedMemError::CudaRegisterFailed(err));
+        }
+
+        Ok(Self {
+            ptr: NonNull::new(ptr).expect("non-null"),
+            size: aligned_size,
+            strategy: AllocStrategy::HugePages,
+        })
+    }
+
+    /// Get the raw pointer to the pinned memory
+    pub(crate) fn as_ptr(&self) -> *mut u8 {
+        self.ptr.as_ptr()
+    }
+
+    /// Get the size of the allocation in bytes
+    pub(crate) fn size(&self) -> usize {
+        self.size
+    }
+}
+
+impl Drop for PinnedMemory {
+    fn drop(&mut self) {
+        match self.strategy {
+            AllocStrategy::HugePages => {
+                unsafe {
+                    rt::cuda::host_unregister(self.ptr.as_ptr() as *const libc::c_void);
+                    libc::munmap(self.ptr.as_ptr() as *mut libc::c_void, self.size);
+                }
+            }
+            AllocStrategy::Regular | AllocStrategy::WriteCombined => {
+                rt::cuda::free_host(self.ptr.as_ptr() as *mut libc::c_void);
+            }
+        }
+    }
+}l(size: usize, strategy: AllocStrategy) -> Result<Self, PinnedMemError> {
+        if size == 0 {
+            return Err(PinnedMemError::ZeroSize);
+        }
+
         let (ptr, aligned_size) = match strategy {
             AllocStrategy::Regular => {
                 let mut ptr: *mut libc::c_void = std::ptr::null_mut();

--- a/pegaflow-core/src/pinned_pool.rs
+++ b/pegaflow-core/src/pinned_pool.rs
@@ -88,7 +88,14 @@ impl PinnedMemoryPool {
         pool_size: usize,
         use_hugepages: bool,
         ssd_enabled: bool,
-        unit_size_hint: Option<NonZeroU64>,
+    ) -> Result<Self, crate::pinned_mem::PinnedMemError> {
+        let backing = if use_hugepages {
+            PinnedMemory::allocate_hugepages(pool_size)
+        } else if ssd_enabled {
+            PinnedMemory::allocate_regular(pool_size)
+        } else {
+            PinnedMemory::allocate_write_combined(pool_size)
+        }?; unit_size_hint: Option<NonZeroU64>,
     ) -> Self {
         assert!(
             pool_size != 0,


### PR DESCRIPTION
## Summary

fix: resolve #95 — Add Regular (cached) pinned memory allocation strategy

## Problem

**Severity**: `High` | **File**: `pegaflow-core/src/pinned_mem.rs`

Contains the AllocStrategy enum and PinnedMemory::allocate function. Currently has WriteCombined and HugePages variants. Need to add Regular variant that uses cudaHostAllocDefault for bidirectional workloads where CPU cache matters.

## Solution

Add `Regular` variant to AllocStrategy enum and update the `allocate` function to handle the new variant by calling cudaHostAllocDefault instead of cudaHostAllocWriteCombined or mmap with MAP_HUGETLB.

## Changes

- `pegaflow-core/src/pinned_mem.rs` (modified)
- `pegaflow-core/src/pinned_pool.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*