### PR TITLE
chore(test): auto-start pegaflow-server in e2e test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,15 @@ Notes:
 - `prek` is the local check entrypoint.
 - `prek run` will fail on `master` or `main` because of the `no-commit-to-branch` hook in `prek.toml`.
 
+### E2E Correctness Test
+
+```bash
+pytest python/tests/test_vllm_e2e_correctness.py -v -s
+pytest python/tests/test_vllm_e2e_correctness.py -v -s --model /path/to/model --max-model-len 4096
+```
+
+pegaflow-server is auto-started via `cargo run -r` and stopped by the test. No manual setup needed.
+
 ### Benchmarks and Examples
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,15 @@ Run all CI checks locally before committing:
 ./scripts/check.sh       # Run fmt, typos, clippy, and cargo check
 ```
 
+### E2E Correctness Test
+
+```bash
+pytest python/tests/test_vllm_e2e_correctness.py -v -s
+pytest python/tests/test_vllm_e2e_correctness.py -v -s --model /path/to/model --max-model-len 4096
+```
+
+pegaflow-server is auto-started via `cargo run -r` and stopped by the test. No manual setup needed.
+
 ### Running Benchmarks
 
 ```bash

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -81,7 +81,8 @@ class SchedulerConnector:
         block_hashes = request.block_hashes
 
         # request.block_hashes are already at virtual_block_size granularity
-        # (vLLM hashes every scheduler_block_size = block_size * dcp tokens).
+        # (vLLM hashes every scheduler_block_size =
+        # block_size * dcp_world_size * pcp_world_size).
         # Skip blocks that are already computed locally.
         computed_blocks = num_computed_tokens // self._ctx.virtual_block_size
         remaining_hashes = block_hashes[computed_blocks:]
@@ -151,7 +152,8 @@ class SchedulerConnector:
         self._requests[req_id] = request
 
         # request.block_hashes are already at virtual_block_size granularity
-        # (1 hash per scheduler block = block_size * dcp_world_size tokens).
+        # (1 hash per scheduler block =
+        # block_size * dcp_world_size * pcp_world_size tokens).
         # They are 1-to-1 with block_ids from the scheduler.
         self._block_hashes[req_id] = tuple(request.block_hashes)
         if req_id not in self._allocated_blocks:

--- a/python/pegaflow/connector/state_manager.py
+++ b/python/pegaflow/connector/state_manager.py
@@ -1,8 +1,9 @@
 """
 Simple service state management for PegaFlow connector fault tolerance.
 
-When Query fails, marks service unavailable and starts health check.
-All operations bypass connector until service recovers.
+Current implementation scope:
+- scheduler query path can bypass remote lookup while service is unavailable
+- worker load/save paths do not consult this state
 """
 
 import threading
@@ -22,7 +23,7 @@ class ServiceStateManager:
     Simple service state manager with health checking.
 
     When service becomes unavailable:
-    - Query bypass the connector
+    - Scheduler query bypasses remote lookup
     - Background thread checks health periodically
     - Service recovers when health check passes
     """

--- a/python/tests/test_vllm_e2e_correctness.py
+++ b/python/tests/test_vllm_e2e_correctness.py
@@ -14,11 +14,9 @@ Covers all critical KV cache paths in one deterministic test:
 - Cache metrics (directional assertions)
 
 Usage:
-    # Requires pegaflow-server running with metrics enabled:
-    cargo run -r --bin pegaflow-server -- \
-        --addr 0.0.0.0:50055 --device 0 --pool-size 30gb --http-addr 0.0.0.0:9091
+    pytest python/tests/test_vllm_e2e_correctness.py -v -s
 
-    cd python && pytest tests/test_vllm_e2e_correctness.py -v -s
+    pegaflow-server is auto-started (via cargo run -r) and stopped by the test.
 """
 
 from __future__ import annotations
@@ -28,9 +26,9 @@ from pathlib import Path
 import pytest
 
 from .vllm_helpers import (
+    PegaFlowServer,
     VLLMServer,
     call_openai_api,
-    check_pegaflow_server,
     fetch_pegaflow_metrics,
 )
 
@@ -224,6 +222,12 @@ class TestE2ECorrectness:
         return tmp_path_factory.mktemp("e2e_logs")
 
     @pytest.fixture(scope="class")
+    def pegaflow_server(self, log_dir: Path):
+        """Auto-start pegaflow-server with prometheus metrics."""
+        with PegaFlowServer(log_file=log_dir / "pegaflow-server.log") as server:
+            yield server
+
+    @pytest.fixture(scope="class")
     def baseline_outputs(
         self,
         model: str,
@@ -259,19 +263,13 @@ class TestE2ECorrectness:
         self,
         model: str,
         base_port: int,
-        pega_metrics_port: int,
+        pegaflow_server: PegaFlowServer,
         log_dir: Path,
         tensor_parallel_size: int,
         pipeline_parallel_size: int,
         max_model_len: int | None,
     ) -> dict:
         """Phase 2: run execution plan through PegaFlow vLLM."""
-        if not check_pegaflow_server(pega_metrics_port):
-            pytest.skip(
-                f"PegaFlow server not reachable (metrics port {pega_metrics_port}). "
-                "Start with --http-addr flag."
-            )
-
         print("[Phase 2] PegaFlow vLLM — executing cache plan")
         pega_port = base_port + 1
         outputs: dict[str, str] = {}
@@ -280,19 +278,21 @@ class TestE2ECorrectness:
             model,
             pega_port,
             use_pegaflow=True,
+            pegaflow_port=pegaflow_server.grpc_port,
             log_file=log_dir / "pegaflow.log",
             tensor_parallel_size=tensor_parallel_size,
             pipeline_parallel_size=pipeline_parallel_size,
             max_model_len=max_model_len,
         ):
-            metrics_start = fetch_pegaflow_metrics(pega_metrics_port)
+            metrics_port = pegaflow_server.metrics_port
+            metrics_start = fetch_pegaflow_metrics(metrics_port)
 
             for label, prompt, expectation in EXECUTION_PLAN:
                 result = call_openai_api(pega_port, model, prompt)
                 outputs[label] = result["text"]
                 print(f"  [{label}] ({expectation}) {len(result['text'])} chars")
 
-            metrics_end = fetch_pegaflow_metrics(pega_metrics_port)
+            metrics_end = fetch_pegaflow_metrics(metrics_port)
 
         print("[Phase 2] Done\n")
         return {
@@ -370,11 +370,8 @@ class TestE2ECorrectness:
         """Multi-round decode R3 — extends R2 context, deeper partial hit."""
         self._assert_match(baseline_outputs, pegaflow_results, "multi_r3")
 
-    def test_cache_metrics(self, pegaflow_results, pega_metrics_port):
+    def test_cache_metrics(self, pegaflow_results):
         """Directional cache metrics — saves happened on cold, hits on warm/partial."""
-        if not check_pegaflow_server(pega_metrics_port):
-            pytest.skip("PegaFlow metrics not available")
-
         m_start = pegaflow_results["metrics_start"]
         m_end = pegaflow_results["metrics_end"]
 

--- a/python/tests/vllm_helpers.py
+++ b/python/tests/vllm_helpers.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import signal
+import socket
 import subprocess
 import time
 from pathlib import Path
@@ -24,6 +25,7 @@ class VLLMServer:
         model: str,
         port: int,
         use_pegaflow: bool = False,
+        pegaflow_port: int | None = None,
         log_file: Path | None = None,
         max_model_len: int | None = None,
         tensor_parallel_size: int = 1,
@@ -32,6 +34,7 @@ class VLLMServer:
         self.model = model
         self.port = port
         self.use_pegaflow = use_pegaflow
+        self.pegaflow_port = pegaflow_port
         self.log_file = log_file
         self.max_model_len = max_model_len
         self.tensor_parallel_size = tensor_parallel_size
@@ -52,6 +55,9 @@ class VLLMServer:
 
         env = os.environ.copy()
         env["VLLM_BATCH_INVARIANT"] = "1"
+
+        if self.use_pegaflow and self.pegaflow_port is not None:
+            env["PEGAFLOW_PORT"] = str(self.pegaflow_port)
 
         # Resolve vllm binary from the current Python environment's bin dir
         import sys
@@ -184,6 +190,124 @@ def check_pegaflow_server(metrics_port: int) -> bool:
         return True
     except requests.exceptions.RequestException:
         return False
+
+
+def find_available_port() -> int:
+    """Find an available TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
+class PegaFlowServer:
+    """Context manager for pegaflow-server lifecycle.
+
+    Auto-starts pegaflow-server with prometheus metrics enabled.
+    Picks random available ports for gRPC and HTTP endpoints.
+    """
+
+    def __init__(self, log_file: Path | None = None, pool_size: str = "30gb"):
+        self.grpc_port = find_available_port()
+        self.http_port = find_available_port()
+        self.pool_size = pool_size
+        self.log_file = log_file
+        self.process: subprocess.Popen | None = None
+        self.log_handle = None
+
+    @property
+    def metrics_port(self) -> int:
+        return self.http_port
+
+    def __enter__(self):
+        project_root = Path(__file__).parent.parent.parent
+
+        cmd = [
+            "cargo",
+            "run",
+            "-r",
+            "--bin",
+            "pegaflow-server",
+            "--",
+            "--addr",
+            f"127.0.0.1:{self.grpc_port}",
+            "--http-addr",
+            f"0.0.0.0:{self.http_port}",
+            "--pool-size",
+            self.pool_size,
+            "--enable-prometheus",
+        ]
+
+        # pegaflow-server embeds Python via PyO3 (for CUDA device detection via torch)
+        import sys
+        import sysconfig
+
+        env = os.environ.copy()
+        env["PYO3_PYTHON"] = sys.executable
+        env["PYTHONHOME"] = sys.base_prefix
+        if libdir := sysconfig.get_config_var("LIBDIR"):
+            env["LD_LIBRARY_PATH"] = f"{libdir}:{env.get('LD_LIBRARY_PATH', '')}"
+        python_dir = str(Path(__file__).parent.parent)
+        site_packages = next((p for p in sys.path if "site-packages" in p), None)
+        env["PYTHONPATH"] = f"{python_dir}" + (f":{site_packages}" if site_packages else "")
+
+        print(f"\n[PegaFlow Server] cargo run -r on gRPC={self.grpc_port}, HTTP={self.http_port}")
+
+        if self.log_file:
+            print(f"[PegaFlow Server] Logging to: {self.log_file}")
+            self.log_handle = open(self.log_file, "w")
+            self.process = subprocess.Popen(
+                cmd,
+                cwd=project_root,
+                env=env,
+                stdout=self.log_handle,
+                stderr=subprocess.STDOUT,
+                preexec_fn=os.setsid,
+            )
+        else:
+            self.process = subprocess.Popen(
+                cmd,
+                cwd=project_root,
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                preexec_fn=os.setsid,
+            )
+
+        self._wait_for_ready()
+        return self
+
+    def _wait_for_ready(self, timeout: int = 300):
+        """Wait for pegaflow-server HTTP health endpoint."""
+        start = time.time()
+        print("Waiting for pegaflow-server to be ready...")
+        while time.time() - start < timeout:
+            if self.process.poll() is not None:
+                raise RuntimeError(f"pegaflow-server exited with code {self.process.returncode}")
+            try:
+                resp = requests.get(f"http://localhost:{self.http_port}/health", timeout=1)
+                if resp.status_code == 200:
+                    print("pegaflow-server is ready!\n")
+                    return
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(2)
+
+        raise TimeoutError(f"pegaflow-server did not become ready within {timeout}s")
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.process:
+            print("\n[PegaFlow Server] Stopping...")
+            try:
+                os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
+                self.process.wait(timeout=10)
+            except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
+                if self.process:
+                    os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
+                    self.process.wait(timeout=5)
+            print("pegaflow-server stopped.\n")
+        if self.log_handle:
+            self.log_handle.close()
 
 
 def call_openai_api(


### PR DESCRIPTION
## Summary
- E2e test now auto-starts/stops pegaflow-server via `cargo run -r`, no manual setup needed
- `VLLMServer` passes `PEGAFLOW_PORT` env var so connector discovers the auto-started server
- Fixes connector comments for scheduler block size formula (`block_size * dcp_world_size * pcp_world_size`)

## Usage

```bash
pytest python/tests/test_vllm_e2e_correctness.py -v -s
pytest python/tests/test_vllm_e2e_correctness.py -v -s --model /path/to/model --max-model-len 4096
```

## Test plan
- [x] 12/12 passed with Qwen3-0.6B (default)
- [x] 12/12 passed with Qwen3-4B (`--max-model-len 4096`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)