### PR TITLE
feat(metaserver): add RemoveBlockHashes RPC for cache eviction notifications

### DIFF
--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -305,8 +305,13 @@ async fn registration_loop(
             core_metrics()
                 .metaserver_registration_failures
                 .add(dropped as u64, &[]);
+            let remove_total: usize = removes.values().map(|v| v.len()).sum();
+            if remove_total > 0 {
+                core_metrics()
+                    .metaserver_removal_failures
+                    .add(remove_total as u64, &[]);
+            }
             client = None;
-            // Re-borrow after setting client = None would fail, skip removes this round.
             continue;
         }
 

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -4,6 +4,7 @@ use log::{debug, error, info, warn};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
     InsertBlockHashesRequest, NodePrefixResult, QueryPrefixBlocksRequest,
+    RemoveBlockHashesRequest,
 };
 use tokio::sync::mpsc;
 use tonic::transport::{Channel, Endpoint};
@@ -50,15 +51,21 @@ impl MetaServerClientConfig {
     }
 }
 
-/// A batch of (namespace, block_hash) pairs to register with MetaServer.
-struct RegistrationBatch {
+/// A batch of (namespace, block_hash) pairs for MetaServer operations.
+struct BlockHashBatch {
     entries: Vec<(String, Vec<u8>)>,
+}
+
+/// Command sent to the background MetaServer loop.
+enum MetaServerCommand {
+    Insert(BlockHashBatch),
+    Remove(BlockHashBatch),
 }
 
 /// Unified MetaServer client handling both insert (fire-and-forget) and query (direct RPC).
 pub struct MetaServerClient {
-    /// Fire-and-forget insert channel (same pattern as old registrar)
-    insert_tx: mpsc::Sender<RegistrationBatch>,
+    /// Fire-and-forget command channel for insert/remove operations.
+    command_tx: mpsc::Sender<MetaServerCommand>,
     /// Lazy-connect query client
     query_client: MetaServerGrpcClient<Channel>,
 }
@@ -68,7 +75,7 @@ impl MetaServerClient {
     ///
     /// Must be called from within a tokio runtime context.
     pub fn new(config: MetaServerClientConfig) -> Self {
-        let (insert_tx, rx) = mpsc::channel(config.queue_depth);
+        let (command_tx, rx) = mpsc::channel(config.queue_depth);
 
         tokio::spawn(registration_loop(
             rx,
@@ -88,7 +95,7 @@ impl MetaServerClient {
         );
 
         Self {
-            insert_tx,
+            command_tx,
             query_client,
         }
     }
@@ -102,8 +109,8 @@ impl MetaServerClient {
             return;
         }
         let count = entries.len();
-        let batch = RegistrationBatch { entries };
-        match self.insert_tx.try_send(batch) {
+        let batch = BlockHashBatch { entries };
+        match self.command_tx.try_send(MetaServerCommand::Insert(batch)) {
             Ok(()) => {
                 core_metrics()
                     .metaserver_registration_blocks
@@ -125,6 +132,44 @@ impl MetaServerClient {
                 );
                 core_metrics()
                     .metaserver_registration_queue_full
+                    .add(count as u64, &[]);
+            }
+        }
+    }
+
+    /// Fire-and-forget removal of block hashes.
+    ///
+    /// Called after LRU eviction to notify MetaServer that this node no longer
+    /// holds these blocks. Losing an occasional remove message is acceptable —
+    /// TTL still serves as the ultimate fallback for node failures.
+    pub(crate) fn try_unregister(&self, entries: Vec<(String, Vec<u8>)>) {
+        if entries.is_empty() {
+            return;
+        }
+        let count = entries.len();
+        let batch = BlockHashBatch { entries };
+        match self.command_tx.try_send(MetaServerCommand::Remove(batch)) {
+            Ok(()) => {
+                core_metrics()
+                    .metaserver_removal_blocks
+                    .add(count as u64, &[]);
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                warn!(
+                    "MetaServer removal queue full, dropping {} hashes",
+                    count
+                );
+                core_metrics()
+                    .metaserver_removal_queue_full
+                    .add(count as u64, &[]);
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                error!(
+                    "MetaServer removal loop has exited, dropping {} hashes",
+                    count
+                );
+                core_metrics()
+                    .metaserver_removal_queue_full
                     .add(count as u64, &[]);
             }
         }
@@ -162,24 +207,36 @@ impl MetaServerClient {
 }
 
 async fn registration_loop(
-    mut rx: mpsc::Receiver<RegistrationBatch>,
+    mut rx: mpsc::Receiver<MetaServerCommand>,
     metaserver_addr: String,
     advertise_addr: String,
 ) {
     let mut client: Option<MetaServerGrpcClient<Channel>> = None;
     let mut backoff_ms: u64 = INITIAL_BACKOFF_MS;
 
-    while let Some(batch) = rx.recv().await {
-        // Drain all pending batches for coalescing
-        let mut all_entries = batch.entries;
+    while let Some(cmd) = rx.recv().await {
+        // Drain all pending commands for coalescing, separating inserts from removes.
+        let mut all_cmds = vec![cmd];
         while let Ok(more) = rx.try_recv() {
-            all_entries.extend(more.entries);
+            all_cmds.push(more);
         }
 
-        // Group by namespace
-        let mut grouped: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
-        for (namespace, hash) in all_entries {
-            grouped.entry(namespace).or_default().push(hash);
+        let mut inserts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+        let mut removes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+
+        for cmd in all_cmds {
+            match cmd {
+                MetaServerCommand::Insert(batch) => {
+                    for (ns, hash) in batch.entries {
+                        inserts.entry(ns).or_default().push(hash);
+                    }
+                }
+                MetaServerCommand::Remove(batch) => {
+                    for (ns, hash) in batch.entries {
+                        removes.entry(ns).or_default().push(hash);
+                    }
+                }
+            }
         }
 
         // Lazy-connect with exponential backoff
@@ -192,7 +249,8 @@ async fn registration_loop(
                 }
                 Err(e) => {
                     error!("Failed to connect to MetaServer: {e}");
-                    let total: usize = grouped.values().map(|v| v.len()).sum();
+                    let total: usize = inserts.values().map(|v| v.len()).sum::<usize>()
+                        + removes.values().map(|v| v.len()).sum::<usize>();
                     core_metrics()
                         .metaserver_registration_failures
                         .add(total as u64, &[]);
@@ -205,10 +263,11 @@ async fn registration_loop(
 
         let c = client.as_mut().expect("client is Some after lazy-connect");
 
-        let namespaces: Vec<(String, Vec<Vec<u8>>)> = grouped.into_iter().collect();
-        let mut failed_at = None;
+        // Process inserts
+        let insert_namespaces: Vec<(String, Vec<Vec<u8>>)> = inserts.into_iter().collect();
+        let mut insert_failed_at = None;
 
-        for (i, (namespace, hashes)) in namespaces.iter().enumerate() {
+        for (i, (namespace, hashes)) in insert_namespaces.iter().enumerate() {
             let count = hashes.len();
             let request = InsertBlockHashesRequest {
                 namespace: namespace.clone(),
@@ -229,18 +288,49 @@ async fn registration_loop(
                         "MetaServer insert_block_hashes failed (namespace={}, count={}): {e}",
                         namespace, count
                     );
-                    failed_at = Some(i);
+                    insert_failed_at = Some(i);
                     break;
                 }
             }
         }
 
-        if let Some(idx) = failed_at {
-            let dropped: usize = namespaces[idx..].iter().map(|(_, h)| h.len()).sum();
+        if let Some(idx) = insert_failed_at {
+            let dropped: usize = insert_namespaces[idx..].iter().map(|(_, h)| h.len()).sum();
             core_metrics()
                 .metaserver_registration_failures
                 .add(dropped as u64, &[]);
             client = None;
+            // Re-borrow after setting client = None would fail, skip removes this round.
+            continue;
+        }
+
+        // Process removes (independent of inserts — failures don't reset the client)
+        for (namespace, hashes) in removes {
+            let count = hashes.len();
+            let request = RemoveBlockHashesRequest {
+                namespace: namespace.clone(),
+                block_hashes: hashes,
+                node: advertise_addr.clone(),
+            };
+
+            match c.remove_block_hashes(request).await {
+                Ok(resp) => {
+                    let inner = resp.into_inner();
+                    debug!(
+                        "Removed {} block hashes from MetaServer (namespace={}, removed={})",
+                        count, namespace, inner.removed_count
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        "MetaServer remove_block_hashes failed (namespace={}, count={}): {e}",
+                        namespace, count
+                    );
+                    core_metrics()
+                        .metaserver_removal_failures
+                        .add(count as u64, &[]);
+                }
+            }
         }
     }
 

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -216,15 +216,10 @@ async fn registration_loop(
 
     while let Some(cmd) = rx.recv().await {
         // Drain all pending commands for coalescing, separating inserts from removes.
-        let mut all_cmds = vec![cmd];
-        while let Ok(more) = rx.try_recv() {
-            all_cmds.push(more);
-        }
-
         let mut inserts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
         let mut removes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
 
-        for cmd in all_cmds {
+        for cmd in std::iter::once(cmd).chain(std::iter::from_fn(|| rx.try_recv().ok())) {
             match cmd {
                 MetaServerCommand::Insert(batch) => {
                     for (ns, hash) in batch.entries {
@@ -249,11 +244,14 @@ async fn registration_loop(
                 }
                 Err(e) => {
                     error!("Failed to connect to MetaServer: {e}");
-                    let total: usize = inserts.values().map(|v| v.len()).sum::<usize>()
-                        + removes.values().map(|v| v.len()).sum::<usize>();
+                    let insert_total: usize = inserts.values().map(|v| v.len()).sum();
+                    let remove_total: usize = removes.values().map(|v| v.len()).sum();
                     core_metrics()
                         .metaserver_registration_failures
-                        .add(total as u64, &[]);
+                        .add(insert_total as u64, &[]);
+                    core_metrics()
+                        .metaserver_removal_failures
+                        .add(remove_total as u64, &[]);
                     tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
                     backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);
                     continue;
@@ -304,12 +302,15 @@ async fn registration_loop(
             continue;
         }
 
-        // Process removes (independent of inserts — failures don't reset the client)
-        for (namespace, hashes) in removes {
+        // Process removes
+        let remove_namespaces: Vec<(String, Vec<Vec<u8>>)> = removes.into_iter().collect();
+        let mut remove_failed_at = None;
+
+        for (i, (namespace, hashes)) in remove_namespaces.iter().enumerate() {
             let count = hashes.len();
             let request = RemoveBlockHashesRequest {
                 namespace: namespace.clone(),
-                block_hashes: hashes,
+                block_hashes: hashes.clone(),
                 node: advertise_addr.clone(),
             };
 
@@ -326,11 +327,18 @@ async fn registration_loop(
                         "MetaServer remove_block_hashes failed (namespace={}, count={}): {e}",
                         namespace, count
                     );
-                    core_metrics()
-                        .metaserver_removal_failures
-                        .add(count as u64, &[]);
+                    remove_failed_at = Some(i);
+                    break;
                 }
             }
+        }
+
+        if let Some(idx) = remove_failed_at {
+            let dropped: usize = remove_namespaces[idx..].iter().map(|(_, h)| h.len()).sum();
+            core_metrics()
+                .metaserver_removal_failures
+                .add(dropped as u64, &[]);
+            client = None;
         }
     }
 

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -215,22 +215,34 @@ async fn registration_loop(
     let mut backoff_ms: u64 = INITIAL_BACKOFF_MS;
 
     while let Some(cmd) = rx.recv().await {
-        // Drain all pending commands for coalescing, separating inserts from removes.
-        let mut inserts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
-        let mut removes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+        // Drain all pending commands. For each (namespace, hash), keep only the last
+        // operation (last-write-wins), so [Remove(X), Insert(X)] correctly resolves
+        // to Insert(X) rather than being reversed by separate-bucket processing.
+        let mut net: HashMap<(String, Vec<u8>), bool> = HashMap::new(); // true=insert, false=remove
 
         for cmd in std::iter::once(cmd).chain(std::iter::from_fn(|| rx.try_recv().ok())) {
             match cmd {
                 MetaServerCommand::Insert(batch) => {
                     for (ns, hash) in batch.entries {
-                        inserts.entry(ns).or_default().push(hash);
+                        net.insert((ns, hash), true);
                     }
                 }
                 MetaServerCommand::Remove(batch) => {
                     for (ns, hash) in batch.entries {
-                        removes.entry(ns).or_default().push(hash);
+                        net.insert((ns, hash), false);
                     }
                 }
+            }
+        }
+
+        let mut inserts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+        let mut removes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+
+        for ((ns, hash), is_insert) in net {
+            if is_insert {
+                inserts.entry(ns).or_default().push(hash);
+            } else {
+                removes.entry(ns).or_default().push(hash);
             }
         }
 

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 use log::{debug, error, info, warn};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
-    InsertBlockHashesRequest, NodePrefixResult, QueryPrefixBlocksRequest,
-    RemoveBlockHashesRequest,
+    InsertBlockHashesRequest, NodePrefixResult, QueryPrefixBlocksRequest, RemoveBlockHashesRequest,
 };
 use tokio::sync::mpsc;
 use tonic::transport::{Channel, Endpoint};
@@ -155,10 +154,7 @@ impl MetaServerClient {
                     .add(count as u64, &[]);
             }
             Err(mpsc::error::TrySendError::Full(_)) => {
-                warn!(
-                    "MetaServer removal queue full, dropping {} hashes",
-                    count
-                );
+                warn!("MetaServer removal queue full, dropping {} hashes", count);
                 core_metrics()
                     .metaserver_removal_queue_full
                     .add(count as u64, &[]);

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -57,6 +57,11 @@ pub(crate) struct CoreMetrics {
     pub metaserver_registration_failures: Counter<u64>,
     pub metaserver_registration_queue_full: Counter<u64>,
 
+    // MetaServer removal
+    pub metaserver_removal_blocks: Counter<u64>,
+    pub metaserver_removal_failures: Counter<u64>,
+    pub metaserver_removal_queue_full: Counter<u64>,
+
     // Cross-node transfer lock (serving side)
     pub transfer_lock_active: UpDownCounter<i64>,
     pub transfer_lock_timeouts_total: Counter<u64>,
@@ -308,6 +313,20 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
             metaserver_registration_queue_full: meter
                 .u64_counter("pegaflow_metaserver_registration_queue_full")
                 .with_description("Block hashes dropped due to full registration queue")
+                .build(),
+
+            // MetaServer removal
+            metaserver_removal_blocks: meter
+                .u64_counter("pegaflow_metaserver_removal_blocks")
+                .with_description("Block hashes sent to MetaServer for removal")
+                .build(),
+            metaserver_removal_failures: meter
+                .u64_counter("pegaflow_metaserver_removal_failures")
+                .with_description("MetaServer removal RPC failures")
+                .build(),
+            metaserver_removal_queue_full: meter
+                .u64_counter("pegaflow_metaserver_removal_queue_full")
+                .with_description("Block hashes dropped due to full removal queue")
                 .build(),
 
             // Transfer lock

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -389,6 +389,15 @@ impl StorageEngine {
                 break;
             }
 
+            // Notify MetaServer that evicted blocks are no longer available for RDMA fetch.
+            if let Some(client) = &self.metaserver_client {
+                let entries: Vec<(String, Vec<u8>)> = evicted
+                    .iter()
+                    .map(|(key, _)| (key.namespace.clone(), key.hash.clone()))
+                    .collect();
+                client.try_unregister(entries);
+            }
+
             let mut batch_bytes = 0u64;
             let mut still_referenced = 0u64;
             for (_key, block) in &evicted {

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -1,8 +1,9 @@
 use crate::proto::engine::meta_server_server::MetaServer;
 use crate::proto::engine::{
     HealthRequest, HealthResponse, InsertBlockHashesRequest, InsertBlockHashesResponse,
-    NodePrefixResult, QueryPrefixBlocksRequest, QueryPrefixBlocksResponse, ResponseStatus,
-    ShutdownRequest, ShutdownResponse,
+    NodePrefixResult, QueryPrefixBlocksRequest, QueryPrefixBlocksResponse,
+    RemoveBlockHashesRequest, RemoveBlockHashesResponse, ResponseStatus, ShutdownRequest,
+    ShutdownResponse,
 };
 use crate::store::BlockHashStore;
 use log::{debug, info};
@@ -79,6 +80,46 @@ impl MetaServer for GrpcMetaService {
         };
 
         Ok(Response::new(response))
+    }
+
+    async fn remove_block_hashes(
+        &self,
+        request: Request<RemoveBlockHashesRequest>,
+    ) -> Result<Response<RemoveBlockHashesResponse>, Status> {
+        let start = Instant::now();
+        let req = request.into_inner();
+
+        debug!(
+            "RPC [remove_block_hashes]: namespace={} node={} hashes_count={}",
+            req.namespace,
+            req.node,
+            req.block_hashes.len()
+        );
+
+        if req.block_hashes.is_empty() {
+            return Ok(Response::new(RemoveBlockHashesResponse {
+                status: Some(Self::error_status(
+                    "block_hashes cannot be empty".to_string(),
+                )),
+                removed_count: 0,
+            }));
+        }
+
+        let removed = self
+            .store
+            .remove_hashes(&req.namespace, &req.block_hashes, &req.node)
+            .await;
+
+        let elapsed = start.elapsed();
+        info!(
+            "RPC [remove_block_hashes]: namespace={} node={} removed={} hashes in {:?}",
+            req.namespace, req.node, removed, elapsed
+        );
+
+        Ok(Response::new(RemoveBlockHashesResponse {
+            status: Some(Self::ok_status()),
+            removed_count: removed as u64,
+        }))
     }
 
     /// Given an ordered list of block hashes, find the longest contiguous prefix
@@ -162,5 +203,110 @@ impl MetaServer for GrpcMetaService {
             status: Some(Self::ok_status()),
         };
         Ok(Response::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::BlockHashStore;
+
+    fn make_service() -> GrpcMetaService {
+        GrpcMetaService::new(Arc::new(BlockHashStore::new()), Arc::new(Notify::new()))
+    }
+
+    #[tokio::test]
+    async fn test_remove_block_hashes_own_blocks() {
+        let svc = make_service();
+
+        // Insert
+        svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
+            namespace: "ns".into(),
+            block_hashes: vec![vec![1, 2, 3]],
+            node: "node-a".into(),
+        }))
+        .await
+        .unwrap();
+
+        // Remove with matching owner
+        let resp = svc
+            .remove_block_hashes(Request::new(RemoveBlockHashesRequest {
+                namespace: "ns".into(),
+                block_hashes: vec![vec![1, 2, 3]],
+                node: "node-a".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(resp.status.unwrap().ok);
+        assert_eq!(resp.removed_count, 1);
+
+        // Verify gone
+        let query_resp = svc
+            .query_prefix_blocks(Request::new(QueryPrefixBlocksRequest {
+                namespace: "ns".into(),
+                block_hashes: vec![vec![1, 2, 3]],
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(query_resp.nodes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_remove_block_hashes_wrong_owner_is_noop() {
+        let svc = make_service();
+
+        svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
+            namespace: "ns".into(),
+            block_hashes: vec![vec![1, 2, 3]],
+            node: "node-b".into(),
+        }))
+        .await
+        .unwrap();
+
+        // Remove with non-matching owner
+        let resp = svc
+            .remove_block_hashes(Request::new(RemoveBlockHashesRequest {
+                namespace: "ns".into(),
+                block_hashes: vec![vec![1, 2, 3]],
+                node: "node-a".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(resp.status.unwrap().ok);
+        assert_eq!(resp.removed_count, 0);
+
+        // Verify still present
+        let query_resp = svc
+            .query_prefix_blocks(Request::new(QueryPrefixBlocksRequest {
+                namespace: "ns".into(),
+                block_hashes: vec![vec![1, 2, 3]],
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(query_resp.nodes.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_remove_block_hashes_empty_request_returns_error() {
+        let svc = make_service();
+
+        let resp = svc
+            .remove_block_hashes(Request::new(RemoveBlockHashesRequest {
+                namespace: "ns".into(),
+                block_hashes: vec![],
+                node: "node-a".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(!resp.status.unwrap().ok);
+        assert_eq!(resp.removed_count, 0);
     }
 }

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -69,6 +69,39 @@ impl BlockHashStore {
         inserted
     }
 
+    /// Remove hashes owned by the given node (conditional delete).
+    /// Only removes an entry if its current owner matches `node`, preventing
+    /// races where node A evicts but node B has since re-registered the same block.
+    /// Returns the number of removed entries.
+    pub async fn remove_hashes(&self, namespace: &str, hashes: &[Vec<u8>], node: &str) -> usize {
+        use moka::ops::compute::Op;
+        let node: Arc<str> = Arc::from(node);
+        let mut removed = 0;
+        for hash in hashes {
+            let key = BlockKey::new(namespace.to_string(), hash.clone());
+            let node_clone = Arc::clone(&node);
+            let result = self
+                .cache
+                .entry(key)
+                .and_compute_with(|maybe_entry| {
+                    let node_clone = Arc::clone(&node_clone);
+                    async move {
+                        match maybe_entry {
+                            Some(entry) if entry.value().as_ref() == node_clone.as_ref() => {
+                                Op::Remove
+                            }
+                            _ => Op::Nop,
+                        }
+                    }
+                })
+                .await;
+            if matches!(result, moka::ops::compute::CompResult::Removed(_)) {
+                removed += 1;
+            }
+        }
+        removed
+    }
+
     /// Query the longest prefix of `hashes` that exists in the store.
     /// Stops at the first hash not found on any node.
     pub async fn query_prefix(&self, namespace: &str, hashes: &[Vec<u8>]) -> Vec<CrossNodeBlock> {
@@ -226,6 +259,87 @@ mod tests {
         // Some entries should have been evicted (LRU)
         let existing = store.query_prefix(namespace, &hashes).await;
         assert!(existing.len() < 100, "Expected some entries to be evicted");
+    }
+
+    #[tokio::test]
+    async fn test_remove_own_blocks() {
+        let store = BlockHashStore::new();
+        let namespace = "model-a";
+        let hash = vec![1, 2, 3, 4];
+
+        store.insert_hashes(namespace, &[hash.clone()], "node-a").await;
+        store.run_pending_tasks().await;
+
+        // owner matches → should remove
+        let removed = store.remove_hashes(namespace, &[hash.clone()], "node-a").await;
+        assert_eq!(removed, 1);
+        store.run_pending_tasks().await;
+        assert_eq!(store.query_prefix(namespace, &[hash]).await.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_remove_other_nodes_block_is_noop() {
+        let store = BlockHashStore::new();
+        let namespace = "model-a";
+        let hash = vec![1, 2, 3, 4];
+
+        store.insert_hashes(namespace, &[hash.clone()], "node-b").await;
+        store.run_pending_tasks().await;
+
+        // owner does not match → should not remove
+        let removed = store.remove_hashes(namespace, &[hash.clone()], "node-a").await;
+        assert_eq!(removed, 0);
+        store.run_pending_tasks().await;
+        assert_eq!(store.query_prefix(namespace, &[hash]).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_remove_nonexistent_is_noop() {
+        let store = BlockHashStore::new();
+
+        let removed = store
+            .remove_hashes("ns", &[vec![9, 9, 9]], "node-a")
+            .await;
+        assert_eq!(removed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_insert_and_remove() {
+        let store = Arc::new(BlockHashStore::new());
+        let hash = vec![1, 2, 3, 4];
+
+        for _ in 0..100 {
+            // Reset: node-a owns the block
+            store.insert_hashes("ns", &[hash.clone()], "node-a").await;
+            store.run_pending_tasks().await;
+
+            let store_a = Arc::clone(&store);
+            let store_b = Arc::clone(&store);
+            let hash_a = hash.clone();
+            let hash_b = hash.clone();
+
+            tokio::join!(
+                async move {
+                    store_a.remove_hashes("ns", &[hash_a], "node-a").await;
+                },
+                async move {
+                    store_b.insert_hashes("ns", &[hash_b], "node-b").await;
+                },
+            );
+
+            store.run_pending_tasks().await;
+
+            // Both operations completed. insert always runs to completion, so:
+            // 1. remove first → node-b inserts after → key exists, owner=node-b
+            // 2. insert first → remove sees owner=node-b, skips → key exists, owner=node-b
+            let existing = store.query_prefix("ns", &[hash.clone()]).await;
+            assert_eq!(existing.len(), 1, "key must exist after concurrent insert+remove");
+            assert_eq!(
+                existing[0].node.as_ref(),
+                "node-b",
+                "owner must be node-b"
+            );
+        }
     }
 
     #[tokio::test]

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -263,13 +263,13 @@ mod tests {
         let hash = vec![1, 2, 3, 4];
 
         store
-            .insert_hashes(namespace, &[hash.clone()], "node-a")
+            .insert_hashes(namespace, std::slice::from_ref(&hash), "node-a")
             .await;
         store.run_pending_tasks().await;
 
         // owner matches → should remove
         let removed = store
-            .remove_hashes(namespace, &[hash.clone()], "node-a")
+            .remove_hashes(namespace, std::slice::from_ref(&hash), "node-a")
             .await;
         assert_eq!(removed, 1);
         store.run_pending_tasks().await;
@@ -283,13 +283,13 @@ mod tests {
         let hash = vec![1, 2, 3, 4];
 
         store
-            .insert_hashes(namespace, &[hash.clone()], "node-b")
+            .insert_hashes(namespace, std::slice::from_ref(&hash), "node-b")
             .await;
         store.run_pending_tasks().await;
 
         // owner does not match → should not remove
         let removed = store
-            .remove_hashes(namespace, &[hash.clone()], "node-a")
+            .remove_hashes(namespace, std::slice::from_ref(&hash), "node-a")
             .await;
         assert_eq!(removed, 0);
         store.run_pending_tasks().await;
@@ -311,7 +311,9 @@ mod tests {
 
         for _ in 0..100 {
             // Reset: node-a owns the block
-            store.insert_hashes("ns", &[hash.clone()], "node-a").await;
+            store
+                .insert_hashes("ns", std::slice::from_ref(&hash), "node-a")
+                .await;
             store.run_pending_tasks().await;
 
             let store_a = Arc::clone(&store);
@@ -333,7 +335,7 @@ mod tests {
             // Both operations completed. insert always runs to completion, so:
             // 1. remove first → node-b inserts after → key exists, owner=node-b
             // 2. insert first → remove sees owner=node-b, skips → key exists, owner=node-b
-            let existing = store.query_prefix("ns", &[hash.clone()]).await;
+            let existing = store.query_prefix("ns", std::slice::from_ref(&hash)).await;
             assert_eq!(
                 existing.len(),
                 1,

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -83,15 +83,10 @@ impl BlockHashStore {
             let result = self
                 .cache
                 .entry(key)
-                .and_compute_with(|maybe_entry| {
-                    let node_clone = Arc::clone(&node_clone);
-                    async move {
-                        match maybe_entry {
-                            Some(entry) if entry.value().as_ref() == node_clone.as_ref() => {
-                                Op::Remove
-                            }
-                            _ => Op::Nop,
-                        }
+                .and_compute_with(move |maybe_entry| async move {
+                    match maybe_entry {
+                        Some(entry) if entry.value().as_ref() == node_clone.as_ref() => Op::Remove,
+                        _ => Op::Nop,
                     }
                 })
                 .await;

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -262,11 +262,15 @@ mod tests {
         let namespace = "model-a";
         let hash = vec![1, 2, 3, 4];
 
-        store.insert_hashes(namespace, &[hash.clone()], "node-a").await;
+        store
+            .insert_hashes(namespace, &[hash.clone()], "node-a")
+            .await;
         store.run_pending_tasks().await;
 
         // owner matches → should remove
-        let removed = store.remove_hashes(namespace, &[hash.clone()], "node-a").await;
+        let removed = store
+            .remove_hashes(namespace, &[hash.clone()], "node-a")
+            .await;
         assert_eq!(removed, 1);
         store.run_pending_tasks().await;
         assert_eq!(store.query_prefix(namespace, &[hash]).await.len(), 0);
@@ -278,11 +282,15 @@ mod tests {
         let namespace = "model-a";
         let hash = vec![1, 2, 3, 4];
 
-        store.insert_hashes(namespace, &[hash.clone()], "node-b").await;
+        store
+            .insert_hashes(namespace, &[hash.clone()], "node-b")
+            .await;
         store.run_pending_tasks().await;
 
         // owner does not match → should not remove
-        let removed = store.remove_hashes(namespace, &[hash.clone()], "node-a").await;
+        let removed = store
+            .remove_hashes(namespace, &[hash.clone()], "node-a")
+            .await;
         assert_eq!(removed, 0);
         store.run_pending_tasks().await;
         assert_eq!(store.query_prefix(namespace, &[hash]).await.len(), 1);
@@ -292,9 +300,7 @@ mod tests {
     async fn test_remove_nonexistent_is_noop() {
         let store = BlockHashStore::new();
 
-        let removed = store
-            .remove_hashes("ns", &[vec![9, 9, 9]], "node-a")
-            .await;
+        let removed = store.remove_hashes("ns", &[vec![9, 9, 9]], "node-a").await;
         assert_eq!(removed, 0);
     }
 
@@ -328,12 +334,12 @@ mod tests {
             // 1. remove first → node-b inserts after → key exists, owner=node-b
             // 2. insert first → remove sees owner=node-b, skips → key exists, owner=node-b
             let existing = store.query_prefix("ns", &[hash.clone()]).await;
-            assert_eq!(existing.len(), 1, "key must exist after concurrent insert+remove");
             assert_eq!(
-                existing[0].node.as_ref(),
-                "node-b",
-                "owner must be node-b"
+                existing.len(),
+                1,
+                "key must exist after concurrent insert+remove"
             );
+            assert_eq!(existing[0].node.as_ref(), "node-b", "owner must be node-b");
         }
     }
 

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -195,6 +195,19 @@ message InsertBlockHashesResponse {
   uint64 inserted_count = 2;
 }
 
+message RemoveBlockHashesRequest {
+  string namespace = 1;
+  repeated bytes block_hashes = 2;
+  // Only remove entries whose current owner matches this node address.
+  // Prevents races where node A evicts but node B has since re-registered.
+  string node = 3;
+}
+
+message RemoveBlockHashesResponse {
+  ResponseStatus status = 1;
+  uint64 removed_count = 2;
+}
+
 message QueryPrefixBlocksRequest {
   string namespace = 1;
   repeated bytes block_hashes = 2;  // ordered by prefix position
@@ -211,6 +224,7 @@ message QueryPrefixBlocksResponse {
 
 service MetaServer {
   rpc InsertBlockHashes(InsertBlockHashesRequest) returns (InsertBlockHashesResponse);
+  rpc RemoveBlockHashes(RemoveBlockHashesRequest) returns (RemoveBlockHashesResponse);
   rpc QueryPrefixBlocks(QueryPrefixBlocksRequest) returns (QueryPrefixBlocksResponse);
   rpc Health(HealthRequest) returns (HealthResponse);
   rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);


### PR DESCRIPTION
## Summary

Implements #209 — adds a `RemoveBlockHashes` RPC so PegaFlow nodes explicitly notify MetaServer on LRU eviction, instead of relying solely on TTL expiry.

- **Proto**: new `RemoveBlockHashes` RPC with conditional remove (only removes entry if current owner matches `node` field, preventing races)
- **MetaServer store**: `remove_hashes()` uses `and_compute_with` for atomic owner-check-then-remove, no TOCTOU race
- **MetaServer service**: implements the new RPC handler
- **Client**: `try_unregister()` reuses the existing fire-and-forget mpsc channel; background loop uses last-write-wins per `(namespace, hash)` to preserve channel ordering across inserts and removes
- **StorageEngine**: calls `try_unregister()` after `remove_lru_batch`
- **Metrics**: new `metaserver_removal_blocks`, `metaserver_removal_failures`, `metaserver_removal_queue_full` counters

## Impact

- TTL can now be tuned purely for node-failure detection rather than double-duty as eviction cleanup
- Cross-node RDMA fetch failure rate drops — MetaServer no longer routes requests to nodes that have already evicted the block
- MetaServer capacity utilization improves — stale entries cleaned up immediately

## Test plan

- [ ] Unit tests pass (`cargo test -p pegaflow-metaserver`)
- [ ] `RemoveBlockHashes` only removes entry when `node` matches owner (conditional remove)
- [ ] Metrics counters increment correctly on queue-full, RPC failure, and success paths
- [ ] E2E: LRU eviction no longer causes stale MetaServer entries that redirect RDMA fetches to evicting node

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)