### PR TITLE
fix(storage): avoid false pool exhaustion on NUMA slow path

### DIFF
--- a/pegaflow-core/src/offload.rs
+++ b/pegaflow-core/src/offload.rs
@@ -225,7 +225,7 @@ impl PegaEngine {
 
             let blocks_to_save: Vec<(usize, Vec<u8>)> = block_ids
                 .into_iter()
-                .zip(block_hashes.into_iter())
+                .zip(block_hashes)
                 .filter(|(id, _)| *id >= 0)
                 .filter_map(|(id, hash)| {
                     let idx = id as usize;

--- a/pegaflow-core/src/pinned_pool.rs
+++ b/pegaflow-core/src/pinned_pool.rs
@@ -478,6 +478,17 @@ impl NumaAwarePinnedPools {
         self.pools.get(&numa_node.0)?.allocate(size).map(Arc::new)
     }
 
+    /// Largest contiguous free region for a specific NUMA node.
+    fn largest_free_allocation_for_node(&self, numa_node: NumaNode) -> u64 {
+        if numa_node.is_unknown() {
+            return 0;
+        }
+        self.pools
+            .get(&numa_node.0)
+            .map(|pool| pool.largest_free_allocation())
+            .unwrap_or(0)
+    }
+
     /// Return all backing memory regions across all NUMA nodes and shards.
     fn memory_regions(&self) -> Vec<(NonNull<u8>, usize)> {
         self.pools
@@ -585,18 +596,14 @@ impl PinnedAllocator {
         }
     }
 
-    /// Get the largest contiguous free region available.
+    /// Largest contiguous free region for the requested allocation target.
     ///
-    /// For NUMA allocators, returns the minimum largest free region across all nodes.
-    pub(crate) fn largest_free_allocation(&self) -> u64 {
+    /// For global allocators, `numa_node` is ignored.
+    /// For NUMA allocators, this checks only the target node's pool.
+    pub(crate) fn largest_free_allocation_for_node(&self, numa_node: NumaNode) -> u64 {
         match self {
             Self::Global(pool) => pool.largest_free_allocation(),
-            Self::Numa(pools) => pools
-                .pools
-                .values()
-                .map(|p| p.largest_free_allocation())
-                .min()
-                .unwrap_or(0),
+            Self::Numa(pools) => pools.largest_free_allocation_for_node(numa_node),
         }
     }
 
@@ -618,3 +625,57 @@ impl PinnedAllocator {
 // both of which are Send + Sync.
 unsafe impl Send for PinnedAllocator {}
 unsafe impl Sync for PinnedAllocator {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numa_largest_free_for_node_is_not_global_min() {
+        let mut pools = HashMap::new();
+        pools.insert(
+            0,
+            ShardedPinnedPool::new(4096, 1, false, false, NonZeroU64::new(512)),
+        );
+        pools.insert(
+            1,
+            ShardedPinnedPool::new(4096, 1, false, false, NonZeroU64::new(512)),
+        );
+        let allocator = PinnedAllocator::Numa(NumaAwarePinnedPools { pools });
+
+        let pinned = match &allocator {
+            PinnedAllocator::Numa(pools) => pools.pools.get(&0).unwrap(),
+            _ => unreachable!(),
+        };
+        let _held = pinned.allocate(NonZeroU64::new(3584).unwrap()).unwrap();
+
+        let global_min = match &allocator {
+            PinnedAllocator::Numa(pools) => pools
+                .pools
+                .values()
+                .map(|p| p.largest_free_allocation())
+                .min()
+                .unwrap_or(0),
+            _ => unreachable!(),
+        };
+        let node1_largest = allocator.largest_free_allocation_for_node(NumaNode(1));
+
+        assert_eq!(global_min, 512);
+        assert_eq!(node1_largest, 4096);
+    }
+
+    #[test]
+    fn numa_largest_free_for_unknown_node_is_zero() {
+        let mut pools = HashMap::new();
+        pools.insert(
+            0,
+            ShardedPinnedPool::new(4096, 1, false, false, NonZeroU64::new(512)),
+        );
+        let allocator = PinnedAllocator::Numa(NumaAwarePinnedPools { pools });
+
+        assert_eq!(
+            allocator.largest_free_allocation_for_node(NumaNode::UNKNOWN),
+            0
+        );
+    }
+}

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -268,9 +268,13 @@ impl StorageEngine {
             }
 
             let (freed_blocks, _freed_bytes, largest_free) =
-                self.reclaim_until_allocator_can_allocate(requested_bytes);
+                self.reclaim_until_allocator_can_allocate(requested_bytes, node);
 
-            if freed_blocks == 0 || largest_free < requested_bytes {
+            if freed_blocks == 0 && largest_free < requested_bytes {
+                // Final retry: absorb concurrent frees that may have raced with reclaim probing.
+                if let Some(alloc) = self.allocator.allocate(size, node) {
+                    return Some(alloc);
+                }
                 break;
             }
         }
@@ -371,14 +375,22 @@ impl StorageEngine {
             .await
     }
 
-    fn reclaim_until_allocator_can_allocate(&self, required_bytes: u64) -> (usize, u64, u64) {
+    fn reclaim_until_allocator_can_allocate(
+        &self,
+        required_bytes: u64,
+        target_node: NumaNode,
+    ) -> (usize, u64, u64) {
         if required_bytes == 0 {
-            return (0, 0, self.allocator.largest_free_allocation());
+            return (
+                0,
+                0,
+                self.allocator.largest_free_allocation_for_node(target_node),
+            );
         }
 
         let mut freed_blocks = 0usize;
         let mut freed_bytes = 0u64;
-        let mut largest_free = self.allocator.largest_free_allocation();
+        let mut largest_free = self.allocator.largest_free_allocation_for_node(target_node);
 
         while largest_free < required_bytes {
             let used_before = self.allocator.usage().0;
@@ -427,7 +439,7 @@ impl StorageEngine {
                     .add(reclaimed, &[]);
             }
 
-            largest_free = self.allocator.largest_free_allocation();
+            largest_free = self.allocator.largest_free_allocation_for_node(target_node);
         }
 
         if freed_blocks > 0 {


### PR DESCRIPTION
## Summary
- fix allocation slow-path false-negative: only fail when reclaim made no progress **and** target-node largest free is still below request
- add a final allocation retry before reporting pool exhaustion to absorb concurrent frees
- make reclaim capacity checks NUMA-targeted via `largest_free_allocation_for_node` (no cross-NUMA fallback)
- add unit tests for NUMA per-node largest-free semantics

## Validation
- `cargo test -p pegaflow-core allocate_bounded_reclaim_terminates -- --nocapture`
- `cargo test -p pegaflow-core numa_largest_free_for_node_is_not_global_min -- --nocapture`
- `cargo test -p pegaflow-core pinned_pool::tests::numa_largest_free_for_unknown_node_is_zero -- --nocapture`