### PR TITLE
feat(connector): switch most connector logs to debug and bump 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,7 +2135,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "colored",
  "libc",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "ahash",
  "bytesize",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "axum",
  "clap",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "prost",
  "tonic",
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "axum",
  "clap",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.19.1"
+version = "0.20.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -98,7 +98,7 @@ class PegaKVConnector(KVConnectorBase_V1):
         ) or vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.port", 50055)
         self._engine_endpoint = f"{server_host}:{server_port}"
         engine_client = EngineRpcClient(self._engine_endpoint)
-        logger.info("[PegaKVConnector] Connected to engine server at %s", self._engine_endpoint)
+        logger.debug("[PegaKVConnector] Connected to engine server at %s", self._engine_endpoint)
 
         self._state_manager = ServiceStateManager(engine_client)
 
@@ -128,7 +128,7 @@ class PegaKVConnector(KVConnectorBase_V1):
         else:
             self._worker = WorkerConnector(self._ctx)
 
-        logger.info(
+        logger.debug(
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
             "tp_rank=%s tp_size=%d pp_rank=%d pp_size=%d world_size=%d layers=%d namespace=%s "
             "is_mla=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d",

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -142,13 +142,13 @@ def resolve_instance_id(vllm_config, dp_rank_suffix: bool = True) -> str:
     """Resolve or generate connector instance_id with optional DP rank suffix."""
     instance_id = vllm_config.kv_transfer_config.engine_id
     if instance_id:
-        logger.info("[PegaKVConnector] Using kv_transfer_config.engine_id: %s", instance_id)
+        logger.debug("[PegaKVConnector] Using kv_transfer_config.engine_id: %s", instance_id)
         return instance_id
 
     instance_id = vllm_config.instance_id or os.environ.get("PEGAFLOW_INSTANCE_ID", "")
     if not instance_id:
         instance_id = uuid.uuid4().hex
-        logger.info(
+        logger.debug(
             "[PegaKVConnector] No instance_id from vLLM; generated fallback %s",
             instance_id,
         )
@@ -159,7 +159,7 @@ def resolve_instance_id(vllm_config, dp_rank_suffix: bool = True) -> str:
             local_dp_rank = parallel_config.data_parallel_rank_local
             if local_dp_rank is not None:
                 instance_id = f"{instance_id}_dp{local_dp_rank}"
-                logger.info(
+                logger.debug(
                     "[PegaKVConnector] Appended DP rank to instance_id: %s (dp_size=%d, local_dp_rank=%d)",
                     instance_id,
                     parallel_config.data_parallel_size,

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -98,7 +98,7 @@ class SchedulerConnector:
         if num_remaining_blocks < self.BYPASS_BLOCKS and pending >= self.HIGH_LOAD_THRESHOLD:
             self._external_matched_blocks[req_id] = computed_blocks
             self._bypass_count += 1
-            logger.info(
+            logger.debug(
                 "[PegaKVConnector] req=%s bypass: remaining_blocks=%d "
                 "pending_prefetches=%d bypass_count=%d",
                 req_id,
@@ -122,7 +122,7 @@ class SchedulerConnector:
         # Each hit block = 1 virtual block = virtual_block_size global tokens.
         num_hit_tokens = hit_blocks * self._ctx.virtual_block_size
 
-        logger.info(
+        logger.debug(
             "[PegaKVConnector] req=%s cache_lookup: hit_blocks=%d computed_blocks=%d "
             "hit_tokens=%d num_tokens=%d lookup_us=%.0f total_query_hashes=%d",
             req_id,
@@ -186,7 +186,7 @@ class SchedulerConnector:
                 num_tokens=num_external_tokens,
             )
             self._pending_load_intents[req_id] = load_intent
-            logger.info(
+            logger.debug(
                 "[PegaKVConnector] req=%s alloc: total_blocks=%d computed_blocks=%d "
                 "load_blocks=%d start_block_idx=%d load_tokens=%d pending_loads=%d",
                 req_id,
@@ -341,7 +341,7 @@ class SchedulerConnector:
         save_hashes = block_hashes[hash_start : hash_start + new_blocks]
         save_block_ids = allocated[hash_start : hash_start + new_blocks]
 
-        logger.info(
+        logger.debug(
             "[PegaKVConnector] req=%s save_intent: start=%d hash_start=%d "
             "base_block_idx=%d saveable_block_idx=%d new_blocks=%d total_hashes=%d",
             req_id,
@@ -461,7 +461,7 @@ class SchedulerConnector:
                 if req_id not in self._prefetch_start_times:
                     self._prefetch_start_times[req_id] = time.perf_counter()
                     self._prefetch_tracker.on_prefetch_start()
-                    logger.info(
+                    logger.debug(
                         "[PegaKVConnector] Prefetch started: req=%s pending_prefetches=%d",
                         req_id,
                         self._prefetch_tracker.pending_prefetches,
@@ -475,7 +475,7 @@ class SchedulerConnector:
                 ) * 1000
                 self._prefetch_tracker.on_prefetch_complete(prefetch_duration_ms, hit_blocks)
 
-                logger.info(
+                logger.debug(
                     "[PegaKVConnector] Prefetch completed: req=%s hit_blocks=%d "
                     "prefetch_duration_ms=%.2f pending_prefetches=%d",
                     req_id,

--- a/python/pegaflow/connector/state_manager.py
+++ b/python/pegaflow/connector/state_manager.py
@@ -69,7 +69,7 @@ class ServiceStateManager:
             name="PegaHealthCheck",
         )
         self._thread.start()
-        logger.info(
+        logger.debug(
             "[PegaKVConnector] Started health check (interval=%.1fs)",
             self._interval,
         )
@@ -87,7 +87,7 @@ class ServiceStateManager:
                 if ok:
                     with self._lock:
                         self._available = True
-                    logger.info("[PegaKVConnector] Service recovered")
+                    logger.debug("[PegaKVConnector] Service recovered")
                     return
             except Exception as e:
                 logger.debug("[PegaKVConnector] Health check failed: %s", e)

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -171,7 +171,7 @@ class WorkerConnector:
         if not ok:
             raise RuntimeError(f"Register context failed for {layer_name}: {message}")
 
-        logger.info(
+        logger.debug(
             "[PegaKVConnector] Registered %d KV cache layers (%s layout) instance=%s",
             len(kv_caches),
             layout,
@@ -224,7 +224,7 @@ class WorkerConnector:
                             state,
                         )
                     else:
-                        logger.info(
+                        logger.debug(
                             "[PegaKVConnector] async_load_completed: reqs=%s",
                             req_ids,
                         )
@@ -254,7 +254,7 @@ class WorkerConnector:
                     self._stats.record_load(duration, num_blocks, success)
 
         if finished_sending:
-            logger.info(
+            logger.debug(
                 "[PegaKVConnector] async_save_completed: reqs=%s",
                 finished_sending,
             )
@@ -386,7 +386,7 @@ class WorkerConnector:
         self._save_queue.put(SaveTask(metadata=metadata, request_ids=request_ids))
 
     def _save_worker(self) -> None:
-        logger.info("[PegaKVConnector] Save worker thread started")
+        logger.debug("[PegaKVConnector] Save worker thread started")
 
         while True:
             task = self._save_queue.get()
@@ -401,7 +401,7 @@ class WorkerConnector:
                     if t is None:
                         self._process_save_batch(batch)
                         self._save_queue.task_done()
-                        logger.info("[PegaKVConnector] Save worker thread stopped")
+                        logger.debug("[PegaKVConnector] Save worker thread stopped")
                         return
                     batch.append(t)
                 except queue.Empty:
@@ -411,7 +411,7 @@ class WorkerConnector:
             for _ in batch:
                 self._save_queue.task_done()
 
-        logger.info("[PegaKVConnector] Save worker thread stopped")
+        logger.debug("[PegaKVConnector] Save worker thread stopped")
 
     def _process_save_batch(self, batch: list[SaveTask]) -> None:
         saves_by_layer: dict[str, tuple[list[int], list[bytes]]] = {}
@@ -536,16 +536,16 @@ class WorkerConnector:
                     events_to_wait.append((req_id, event))
 
         if events_to_wait:
-            logger.info(
+            logger.debug(
                 "[PegaKVConnector] preemption: waiting for %d requests' saves: %s",
                 len(events_to_wait),
                 [req_id for req_id, _ in events_to_wait],
             )
             for req_id, event in events_to_wait:
                 event.wait()
-                logger.info("[PegaKVConnector] preemption: req=%s save completed", req_id)
+                logger.debug("[PegaKVConnector] preemption: req=%s save completed", req_id)
         else:
-            logger.info(
+            logger.debug(
                 "[PegaKVConnector] preemption: %d requests (no pending saves)",
                 len(preempted_req_ids),
             )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.19.1"
+version = "0.20.0"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -105,6 +105,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.19.1"
+version = "0.20.0"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## What changed
- Switched connector logging verbosity in `python/pegaflow/connector/*` from `logger.info` to `logger.debug` for high-volume runtime logs.
- Bumped release version from `0.19.1` to `0.20.0` in:
  - `Cargo.toml`
  - `Cargo.lock` (workspace package entries)
  - `python/pyproject.toml` (`project.version` and `tool.commitizen.version`)

## Why
Connector runtime logs were too chatty at info level during normal serving paths. Moving most operational messages to debug keeps default logs cleaner while preserving details when debug logging is enabled.

## Impact
- Lower default log volume for connector scheduler/worker/state paths.
- Version advanced to `0.20.0` for the release bump.

## Validation
- `prek run`
- commit hooks passed, including `cargo test --release`, `cargo clippy`, `ruff`, `typos`, and `commitizen check`.
