### PR TITLE
feat(metaserver): add heartbeat liveness and graceful Bye for prompt node cleanup

### DIFF
--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -1,12 +1,16 @@
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
 
 use log::{debug, error, info, warn};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
-    InsertBlockHashesRequest, NodePrefixResult, QueryPrefixBlocksRequest, RemoveBlockHashesRequest,
+    ByeRequest, HeartbeatRequest, InsertBlockHashesRequest, NodePrefixResult,
+    QueryPrefixBlocksRequest, RemoveBlockHashesRequest,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 use tonic::transport::{Channel, Endpoint};
+use uuid::Uuid;
 
 use crate::metrics::core_metrics;
 
@@ -28,6 +32,7 @@ impl std::fmt::Display for ClientError {
 
 const INITIAL_BACKOFF_MS: u64 = 100;
 const MAX_BACKOFF_MS: u64 = 30_000;
+const HEARTBEAT_INTERVAL_SECS: u64 = 10;
 
 pub struct MetaServerClientConfig {
     pub metaserver_addr: String,
@@ -67,19 +72,31 @@ pub struct MetaServerClient {
     command_tx: mpsc::Sender<MetaServerCommand>,
     /// Lazy-connect query client
     query_client: MetaServerGrpcClient<Channel>,
+    /// Unique epoch per process start
+    epoch: String,
+    /// Advertise address for this server
+    advertise_addr: String,
 }
 
 impl MetaServerClient {
-    /// Create a new client and spawn the background registration loop.
+    /// Create a new client and spawn the background registration loop and heartbeat loop.
     ///
     /// Must be called from within a tokio runtime context.
-    pub fn new(config: MetaServerClientConfig) -> Self {
+    pub fn new(config: MetaServerClientConfig, shutdown: Arc<Notify>) -> Self {
         let (command_tx, rx) = mpsc::channel(config.queue_depth);
+        let epoch = Uuid::new_v4().to_string();
 
         tokio::spawn(registration_loop(
             rx,
             config.metaserver_addr.clone(),
-            config.advertise_addr,
+            config.advertise_addr.clone(),
+        ));
+
+        tokio::spawn(heartbeat_loop(
+            config.metaserver_addr.clone(),
+            config.advertise_addr.clone(),
+            epoch.clone(),
+            shutdown,
         ));
 
         // Lazy-connect query client: connects on first RPC, not here
@@ -89,13 +106,15 @@ impl MetaServerClient {
         let query_client = MetaServerGrpcClient::new(channel);
 
         info!(
-            "MetaServer client started (queue_depth={}, addr={})",
-            config.queue_depth, config.metaserver_addr
+            "MetaServer client started (queue_depth={}, addr={}, epoch={})",
+            config.queue_depth, config.metaserver_addr, epoch
         );
 
         Self {
             command_tx,
             query_client,
+            epoch,
+            advertise_addr: config.advertise_addr,
         }
     }
 
@@ -199,6 +218,58 @@ impl MetaServerClient {
         );
 
         Ok(resp.nodes)
+    }
+
+    /// Send a Bye RPC to MetaServer for graceful shutdown.
+    /// This triggers immediate purge of all block entries for this node.
+    pub async fn bye(&self) {
+        let req = ByeRequest {
+            node: self.advertise_addr.clone(),
+            epoch: self.epoch.clone(),
+        };
+        match self.query_client.clone().bye(req).await {
+            Ok(_) => info!(
+                "Sent Bye to MetaServer (node={}, epoch={})",
+                self.advertise_addr, self.epoch
+            ),
+            Err(e) => warn!("Failed to send Bye to MetaServer: {e}"),
+        }
+    }
+}
+
+async fn heartbeat_loop(
+    metaserver_addr: String,
+    node: String,
+    epoch: String,
+    shutdown: Arc<Notify>,
+) {
+    let channel = Endpoint::from_shared(metaserver_addr)
+        .expect("valid metaserver_addr URI")
+        .connect_lazy();
+    let mut client = MetaServerGrpcClient::new(channel);
+    let mut interval = tokio::time::interval(Duration::from_secs(HEARTBEAT_INTERVAL_SECS));
+
+    info!(
+        "Heartbeat loop started (node={}, epoch={}, interval={}s)",
+        node, epoch, HEARTBEAT_INTERVAL_SECS
+    );
+
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                let req = HeartbeatRequest {
+                    node: node.clone(),
+                    epoch: epoch.clone(),
+                };
+                if let Err(e) = client.heartbeat(req).await {
+                    warn!("Heartbeat to MetaServer failed: {e}");
+                }
+            }
+            _ = shutdown.notified() => {
+                info!("Heartbeat loop shutting down");
+                break;
+            }
+        }
     }
 }
 

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -76,15 +76,18 @@ pub struct MetaServerClient {
     epoch: String,
     /// Advertise address for this server
     advertise_addr: String,
+    /// Dedicated shutdown signal for the heartbeat loop.
+    heartbeat_shutdown: Arc<Notify>,
 }
 
 impl MetaServerClient {
     /// Create a new client and spawn the background registration loop and heartbeat loop.
     ///
     /// Must be called from within a tokio runtime context.
-    pub fn new(config: MetaServerClientConfig, shutdown: Arc<Notify>) -> Self {
+    pub fn new(config: MetaServerClientConfig) -> Self {
         let (command_tx, rx) = mpsc::channel(config.queue_depth);
         let epoch = Uuid::new_v4().to_string();
+        let heartbeat_shutdown = Arc::new(Notify::new());
 
         tokio::spawn(registration_loop(
             rx,
@@ -96,7 +99,7 @@ impl MetaServerClient {
             config.metaserver_addr.clone(),
             config.advertise_addr.clone(),
             epoch.clone(),
-            shutdown,
+            Arc::clone(&heartbeat_shutdown),
         ));
 
         // Lazy-connect query client: connects on first RPC, not here
@@ -115,6 +118,7 @@ impl MetaServerClient {
             query_client,
             epoch,
             advertise_addr: config.advertise_addr,
+            heartbeat_shutdown,
         }
     }
 
@@ -221,8 +225,9 @@ impl MetaServerClient {
     }
 
     /// Send a Bye RPC to MetaServer for graceful shutdown.
-    /// This triggers immediate purge of all block entries for this node.
+    /// Stops the heartbeat loop first to prevent heartbeats after Bye.
     pub async fn bye(&self) {
+        self.heartbeat_shutdown.notify_waiters();
         let req = ByeRequest {
             node: self.advertise_addr.clone(),
             epoch: self.epoch.clone(),
@@ -254,6 +259,9 @@ async fn heartbeat_loop(
         node, epoch, HEARTBEAT_INTERVAL_SECS
     );
 
+    let shutdown_fut = shutdown.notified();
+    tokio::pin!(shutdown_fut);
+
     loop {
         tokio::select! {
             _ = interval.tick() => {
@@ -265,7 +273,7 @@ async fn heartbeat_loop(
                     warn!("Heartbeat to MetaServer failed: {e}");
                 }
             }
-            _ = shutdown.notified() => {
+            _ = &mut shutdown_fut => {
                 info!("Heartbeat loop shutting down");
                 break;
             }

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -647,4 +647,9 @@ impl PegaEngine {
         info!("RDMA handshake accepted: client={client_addr}");
         Ok(server_meta.to_bytes())
     }
+
+    /// Send Bye to MetaServer for graceful shutdown.
+    pub async fn metaserver_bye(&self) {
+        self.storage.metaserver_bye().await;
+    }
 }

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -54,8 +54,6 @@ pub struct StorageConfig {
     pub metaserver_queue_depth: usize,
     /// Number of shards for the pinned memory pool (reduces allocator lock contention).
     pub pool_shards: usize,
-    /// Shutdown notifier for background tasks (heartbeat loop, etc.).
-    pub shutdown: Option<Arc<tokio::sync::Notify>>,
 }
 
 impl Default for StorageConfig {
@@ -73,7 +71,6 @@ impl Default for StorageConfig {
             advertise_addr: None,
             metaserver_queue_depth: crate::internode::DEFAULT_METASERVER_QUEUE_DEPTH,
             pool_shards: 1,
-            shutdown: None,
         }
     }
 }
@@ -106,7 +103,6 @@ impl StorageEngine {
         let transfer_lock_timeout = config.transfer_lock_timeout;
 
         // Create MetaServer client if configured
-        let shutdown = config.shutdown.clone();
         let metaserver_client = config.metaserver_addr.as_ref().map(|addr| {
             let advertise = config
                 .advertise_addr
@@ -118,10 +114,7 @@ impl StorageEngine {
             );
             let ms_config = MetaServerClientConfig::new(addr.clone(), advertise)
                 .with_queue_depth(config.metaserver_queue_depth);
-            let shutdown_notify = shutdown
-                .clone()
-                .unwrap_or_else(|| Arc::new(tokio::sync::Notify::new()));
-            Arc::new(MetaServerClient::new(ms_config, shutdown_notify))
+            Arc::new(MetaServerClient::new(ms_config))
         });
 
         if blockwise_alloc {

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -54,6 +54,8 @@ pub struct StorageConfig {
     pub metaserver_queue_depth: usize,
     /// Number of shards for the pinned memory pool (reduces allocator lock contention).
     pub pool_shards: usize,
+    /// Shutdown notifier for background tasks (heartbeat loop, etc.).
+    pub shutdown: Option<Arc<tokio::sync::Notify>>,
 }
 
 impl Default for StorageConfig {
@@ -71,6 +73,7 @@ impl Default for StorageConfig {
             advertise_addr: None,
             metaserver_queue_depth: crate::internode::DEFAULT_METASERVER_QUEUE_DEPTH,
             pool_shards: 1,
+            shutdown: None,
         }
     }
 }
@@ -103,6 +106,7 @@ impl StorageEngine {
         let transfer_lock_timeout = config.transfer_lock_timeout;
 
         // Create MetaServer client if configured
+        let shutdown = config.shutdown.clone();
         let metaserver_client = config.metaserver_addr.as_ref().map(|addr| {
             let advertise = config
                 .advertise_addr
@@ -114,7 +118,10 @@ impl StorageEngine {
             );
             let ms_config = MetaServerClientConfig::new(addr.clone(), advertise)
                 .with_queue_depth(config.metaserver_queue_depth);
-            Arc::new(MetaServerClient::new(ms_config))
+            let shutdown_notify = shutdown
+                .clone()
+                .unwrap_or_else(|| Arc::new(tokio::sync::Notify::new()));
+            Arc::new(MetaServerClient::new(ms_config, shutdown_notify))
         });
 
         if blockwise_alloc {
@@ -522,6 +529,13 @@ impl StorageEngine {
 
     pub(crate) fn rdma_transport(&self) -> Option<&Arc<RdmaTransport>> {
         self.rdma_transport.as_ref()
+    }
+
+    /// Send Bye to MetaServer for graceful shutdown.
+    pub(crate) async fn metaserver_bye(&self) {
+        if let Some(client) = &self.metaserver_client {
+            client.bye().await;
+        }
     }
 }
 

--- a/pegaflow-metaserver/README.md
+++ b/pegaflow-metaserver/README.md
@@ -73,8 +73,11 @@ cargo run -p pegaflow-metaserver -- --help
 ### Server Options
 
 - `--addr <ADDR>`: Bind address (default: `127.0.0.1:50056`)
+- `--http-addr <ADDR>`: HTTP server address for health check and Prometheus metrics (default: `0.0.0.0:9092`)
 - `--log-level <LEVEL>`: Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`)
 - `--ttl-minutes <MINUTES>`: Cache entry TTL in minutes (default: `120`)
+- `--suspect-secs <SECONDS>`: Heartbeat suspect threshold — nodes that haven't sent a heartbeat within this period are excluded from query results (default: `30`)
+- `--hard-delete-secs <SECONDS>`: Heartbeat hard-delete threshold — nodes silent for this long are purged along with all their block entries during the periodic sweep (default: `90`)
 
 ### Storage Configuration
 
@@ -82,6 +85,8 @@ The MetaServer uses a DashMap-based in-memory store with the following character
 
 - **Multi-owner**: A block hash can be registered by multiple nodes simultaneously
 - **TTL (Time-To-Live)**: 120 minutes default (configurable via `--ttl-minutes`). A background task sweeps expired entries every 10 minutes to prevent leaks from crashed nodes.
+- **Node liveness**: Nodes must send periodic `Heartbeat` RPCs. Nodes silent beyond `--suspect-secs` are excluded from query results; nodes silent beyond `--hard-delete-secs` are purged (liveness + block entries) during the sweep.
+- **Graceful shutdown**: Nodes send a `Bye` RPC on shutdown to immediately purge their entries (epoch-guarded to prevent stale Bye from old processes).
 - **Conditional removal**: `RemoveBlockHashes` only removes the requesting node's ownership; other nodes' entries are untouched.
 - **Memory**: Scales with unique blocks across all nodes. No hard capacity cap — memory is naturally bounded by the total number of blocks in the cluster.
 
@@ -155,14 +160,47 @@ message QueryPrefixBlocksResponse {
 }
 ```
 
-### 4. Health
+### 4. Heartbeat
+
+Periodic liveness signal from a node. Must be sent at intervals shorter than `--suspect-secs`.
+
+**Request:**
+```protobuf
+message HeartbeatRequest {
+  string node = 1;   // Node gRPC address
+  string epoch = 2;  // Process epoch (UUID, changes on restart)
+}
+```
+
+**Response:** `HeartbeatResponse {}`
+
+**Behavior:**
+- New node: registers liveness
+- Same epoch: refreshes `last_seen`
+- Different epoch: purges old entries, re-registers
+
+### 5. Bye
+
+Graceful shutdown notification. Immediately purges all block entries for the node.
+
+**Request:**
+```protobuf
+message ByeRequest {
+  string node = 1;
+  string epoch = 2;  // Must match current epoch (prevents stale Bye)
+}
+```
+
+**Response:** `ByeResponse {}`
+
+### 6. Health
 
 Health check endpoint.
 
 **Request:** `HealthRequest {}`
 **Response:** `HealthResponse { status }`
 
-### 5. Shutdown
+### 7. Shutdown
 
 Graceful shutdown trigger.
 
@@ -174,7 +212,8 @@ Graceful shutdown trigger.
 - **Data structure**: `DashMap<BlockKey, HashMap<Arc<str>, Instant>>` — each block key maps to a set of owning nodes with their registration timestamps
 - **BlockKey**: `{ namespace: String, hash: Vec<u8> }` — matches pegaflow-core's BlockKey
 - **Multi-owner**: Multiple nodes can register the same block hash (e.g., after replication or shared prefill)
-- **TTL sweep**: Background task runs every 10 minutes, removing per-node registrations older than the configured TTL
+- **TTL sweep**: Background task runs every 10 minutes, removing per-node registrations older than the configured TTL and purging dead nodes past the hard-delete threshold
+- **Liveness**: `DashMap<Arc<str>, NodeLiveness>` — tracks epoch and last heartbeat time per node
 - **Concurrency**: DashMap uses shard-level locking for high-throughput concurrent access
 - **Persistence**: In-memory only (restart clears state)
 

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -136,13 +136,20 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(10 * 60));
             loop {
                 interval.tick().await;
-                let (expired, purged_nodes) = store.sweep_expired();
-                if expired > 0 {
-                    metric::record_ttl_sweep(expired as u64);
+                let (ttl_expired, purge_removed, purged_nodes) = store.sweep_expired();
+                if ttl_expired > 0 {
+                    metric::record_ttl_sweep(ttl_expired as u64);
                     info!(
-                        "TTL sweep: removed {} stale block keys, {} remaining",
-                        expired,
+                        "TTL sweep: removed {} expired block keys, {} remaining",
+                        ttl_expired,
                         store.entry_count()
+                    );
+                }
+                if purge_removed > 0 {
+                    metric::record_purge_sweep(purge_removed as u64);
+                    info!(
+                        "TTL sweep: purged {} dead nodes, {} block entries",
+                        purged_nodes, purge_removed
                     );
                 }
                 if purged_nodes > 0 {

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -42,6 +42,14 @@ pub struct Cli {
     /// Cache entry TTL in minutes
     #[arg(long, default_value = "120")]
     pub ttl_minutes: u64,
+
+    /// Heartbeat suspect threshold in seconds (node marked suspect after this)
+    #[arg(long, default_value = "30")]
+    pub suspect_secs: u64,
+
+    /// Heartbeat hard-delete threshold in seconds (node purged after this)
+    #[arg(long, default_value = "90")]
+    pub hard_delete_secs: u64,
 }
 
 fn init_metrics() -> Result<(SdkMeterProvider, Registry), Box<dyn Error>> {
@@ -103,8 +111,17 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     // Initialize metrics
     let (meter_provider, prometheus_registry) = init_metrics()?;
 
-    // Create the block hash store with TTL
-    let store = Arc::new(BlockHashStore::with_ttl(cli.ttl_minutes));
+    info!(
+        "Liveness config: suspect={}s, hard_delete={}s",
+        cli.suspect_secs, cli.hard_delete_secs
+    );
+
+    // Create the block hash store with TTL and liveness config
+    let store = Arc::new(BlockHashStore::with_liveness_config(
+        cli.ttl_minutes,
+        cli.suspect_secs,
+        cli.hard_delete_secs,
+    ));
 
     // Register store observable gauges
     metric::register_store_gauges(&store);
@@ -127,6 +144,22 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                 }
             }
         });
+    }
+
+    // Spawn liveness sweep task (every 5s)
+    {
+        let store = Arc::clone(&store);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+            loop {
+                interval.tick().await;
+                let (suspect, purged) = store.sweep_liveness();
+                if suspect > 0 || purged > 0 {
+                    metric::record_liveness_sweep(suspect as u64, purged as u64);
+                }
+            }
+        });
+        info!("Liveness sweep task started (interval=5s)");
     }
 
     // Create shutdown notifier

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -136,24 +136,24 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(10 * 60));
             loop {
                 interval.tick().await;
-                let (ttl_expired, purge_removed, purged_nodes) = store.sweep_expired();
-                if ttl_expired > 0 {
-                    metric::record_ttl_sweep(ttl_expired as u64);
+                let result = store.sweep_expired();
+                if result.ttl_expired > 0 {
+                    metric::record_ttl_sweep(result.ttl_expired as u64);
                     info!(
                         "TTL sweep: removed {} expired block keys, {} remaining",
-                        ttl_expired,
+                        result.ttl_expired,
                         store.entry_count()
                     );
                 }
-                if purge_removed > 0 {
-                    metric::record_purge_sweep(purge_removed as u64);
+                if result.purge_removed > 0 {
+                    metric::record_purge_sweep(result.purge_removed as u64);
                     info!(
                         "TTL sweep: purged {} dead nodes, {} block entries",
-                        purged_nodes, purge_removed
+                        result.purged_nodes, result.purge_removed
                     );
                 }
-                if purged_nodes > 0 {
-                    metric::record_node_purge(purged_nodes as u64);
+                if result.purged_nodes > 0 {
+                    metric::record_node_purge(result.purged_nodes as u64);
                 }
             }
         });

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -129,40 +129,27 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     // Create shutdown notifier (before spawning background tasks)
     let shutdown = Arc::new(Notify::new());
 
-    // Spawn background TTL sweep task (every 10 minutes)
+    // Spawn background sweep task (TTL expiry + dead node purge, every 10 minutes)
     {
         let store = Arc::clone(&store);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(10 * 60));
             loop {
                 interval.tick().await;
-                let removed = store.sweep_expired();
-                if removed > 0 {
-                    metric::record_ttl_sweep(removed as u64);
+                let (expired, purged_nodes) = store.sweep_expired();
+                if expired > 0 {
+                    metric::record_ttl_sweep(expired as u64);
                     info!(
                         "TTL sweep: removed {} stale block keys, {} remaining",
-                        removed,
+                        expired,
                         store.entry_count()
                     );
                 }
-            }
-        });
-    }
-
-    // Spawn liveness sweep task (every 5s)
-    {
-        let store = Arc::clone(&store);
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
-            loop {
-                interval.tick().await;
-                let (suspect, purged) = store.sweep_liveness();
-                if suspect > 0 || purged > 0 {
-                    metric::record_liveness_sweep(suspect as u64, purged as u64);
+                if purged_nodes > 0 {
+                    metric::record_node_purge(purged_nodes as u64);
                 }
             }
         });
-        info!("Liveness sweep task started (interval=5s)");
     }
 
     // Start HTTP server for health check and metrics

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -132,25 +132,18 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     // Spawn background TTL sweep task (every 10 minutes)
     {
         let store = Arc::clone(&store);
-        let shutdown = Arc::clone(&shutdown);
         tokio::spawn(async move {
-            let shutdown_fut = shutdown.notified();
-            tokio::pin!(shutdown_fut);
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(10 * 60));
             loop {
-                tokio::select! {
-                    _ = interval.tick() => {
-                        let removed = store.sweep_expired();
-                        if removed > 0 {
-                            metric::record_ttl_sweep(removed as u64);
-                            info!(
-                                "TTL sweep: removed {} stale block keys, {} remaining",
-                                removed,
-                                store.entry_count()
-                            );
-                        }
-                    }
-                    _ = &mut shutdown_fut => break,
+                interval.tick().await;
+                let removed = store.sweep_expired();
+                if removed > 0 {
+                    metric::record_ttl_sweep(removed as u64);
+                    info!(
+                        "TTL sweep: removed {} stale block keys, {} remaining",
+                        removed,
+                        store.entry_count()
+                    );
                 }
             }
         });
@@ -159,20 +152,13 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     // Spawn liveness sweep task (every 5s)
     {
         let store = Arc::clone(&store);
-        let shutdown = Arc::clone(&shutdown);
         tokio::spawn(async move {
-            let shutdown_fut = shutdown.notified();
-            tokio::pin!(shutdown_fut);
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
             loop {
-                tokio::select! {
-                    _ = interval.tick() => {
-                        let (suspect, purged) = store.sweep_liveness();
-                        if suspect > 0 || purged > 0 {
-                            metric::record_liveness_sweep(suspect as u64, purged as u64);
-                        }
-                    }
-                    _ = &mut shutdown_fut => break,
+                interval.tick().await;
+                let (suspect, purged) = store.sweep_liveness();
+                if suspect > 0 || purged > 0 {
+                    metric::record_liveness_sweep(suspect as u64, purged as u64);
                 }
             }
         });

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -126,21 +126,31 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     // Register store observable gauges
     metric::register_store_gauges(&store);
 
+    // Create shutdown notifier (before spawning background tasks)
+    let shutdown = Arc::new(Notify::new());
+
     // Spawn background TTL sweep task (every 10 minutes)
     {
         let store = Arc::clone(&store);
+        let shutdown = Arc::clone(&shutdown);
         tokio::spawn(async move {
+            let shutdown_fut = shutdown.notified();
+            tokio::pin!(shutdown_fut);
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(10 * 60));
             loop {
-                interval.tick().await;
-                let removed = store.sweep_expired();
-                if removed > 0 {
-                    metric::record_ttl_sweep(removed as u64);
-                    info!(
-                        "TTL sweep: removed {} stale block keys, {} remaining",
-                        removed,
-                        store.entry_count()
-                    );
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let removed = store.sweep_expired();
+                        if removed > 0 {
+                            metric::record_ttl_sweep(removed as u64);
+                            info!(
+                                "TTL sweep: removed {} stale block keys, {} remaining",
+                                removed,
+                                store.entry_count()
+                            );
+                        }
+                    }
+                    _ = &mut shutdown_fut => break,
                 }
             }
         });
@@ -149,21 +159,25 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     // Spawn liveness sweep task (every 5s)
     {
         let store = Arc::clone(&store);
+        let shutdown = Arc::clone(&shutdown);
         tokio::spawn(async move {
+            let shutdown_fut = shutdown.notified();
+            tokio::pin!(shutdown_fut);
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
             loop {
-                interval.tick().await;
-                let (suspect, purged) = store.sweep_liveness();
-                if suspect > 0 || purged > 0 {
-                    metric::record_liveness_sweep(suspect as u64, purged as u64);
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let (suspect, purged) = store.sweep_liveness();
+                        if suspect > 0 || purged > 0 {
+                            metric::record_liveness_sweep(suspect as u64, purged as u64);
+                        }
+                    }
+                    _ = &mut shutdown_fut => break,
                 }
             }
         });
         info!("Liveness sweep task started (interval=5s)");
     }
-
-    // Create shutdown notifier
-    let shutdown = Arc::new(Notify::new());
 
     // Start HTTP server for health check and metrics
     let _http_handle =

--- a/pegaflow-metaserver/src/metric.rs
+++ b/pegaflow-metaserver/src/metric.rs
@@ -67,6 +67,24 @@ pub fn record_ttl_sweep(removed: u64) {
 }
 
 // ---------------------------------------------------------------------------
+// Purge sweep counter (block keys removed due to dead-node hard-delete)
+// ---------------------------------------------------------------------------
+
+static PURGE_SWEEP_REMOVED: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    let meter = global::meter("pegaflow_metaserver");
+    meter
+        .u64_counter("pegaflow_metaserver_purge_sweep_removed")
+        .with_description("Total block keys removed by dead-node purge sweep")
+        .build()
+});
+
+pub fn record_purge_sweep(removed: u64) {
+    if removed > 0 {
+        PURGE_SWEEP_REMOVED.add(removed, &[]);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Node purge counter
 // ---------------------------------------------------------------------------
 

--- a/pegaflow-metaserver/src/metric.rs
+++ b/pegaflow-metaserver/src/metric.rs
@@ -67,34 +67,20 @@ pub fn record_ttl_sweep(removed: u64) {
 }
 
 // ---------------------------------------------------------------------------
-// Liveness sweep metrics
+// Node purge counter
 // ---------------------------------------------------------------------------
 
-struct LivenessMetrics {
-    suspect: Counter<u64>,
-    purged: Counter<u64>,
-}
-
-static LIVENESS_METRICS: LazyLock<LivenessMetrics> = LazyLock::new(|| {
+static NODE_PURGED: LazyLock<Counter<u64>> = LazyLock::new(|| {
     let meter = global::meter("pegaflow_metaserver");
-    LivenessMetrics {
-        suspect: meter
-            .u64_counter("pegaflow_metaserver_node_suspect_total")
-            .with_description("Total times a node entered suspect state")
-            .build(),
-        purged: meter
-            .u64_counter("pegaflow_metaserver_node_purged_total")
-            .with_description("Total nodes hard-deleted (timeout or bye)")
-            .build(),
-    }
+    meter
+        .u64_counter("pegaflow_metaserver_node_purged_total")
+        .with_description("Total nodes purged (timeout or bye)")
+        .build()
 });
 
-pub fn record_liveness_sweep(suspect: u64, purged: u64) {
-    if suspect > 0 {
-        LIVENESS_METRICS.suspect.add(suspect, &[]);
-    }
-    if purged > 0 {
-        LIVENESS_METRICS.purged.add(purged, &[]);
+pub fn record_node_purge(count: u64) {
+    if count > 0 {
+        NODE_PURGED.add(count, &[]);
     }
 }
 

--- a/pegaflow-metaserver/src/metric.rs
+++ b/pegaflow-metaserver/src/metric.rs
@@ -31,8 +31,8 @@ pub fn register_store_gauges(store: &Arc<BlockHashStore>) {
             })
             .build();
         let active_nodes = meter
-            .u64_observable_gauge("pegaflow_metaserver_active_nodes")
-            .with_description("Number of currently tracked nodes (healthy + suspect)")
+            .u64_observable_gauge("pegaflow_metaserver_healthy_nodes")
+            .with_description("Number of currently healthy nodes")
             .with_callback(move |observer| {
                 observer.observe(s2.node_count() as u64, &[]);
             })
@@ -63,7 +63,9 @@ static SWEEP_METRICS: LazyLock<SweepMetrics> = LazyLock::new(|| {
 });
 
 pub fn record_ttl_sweep(removed: u64) {
-    SWEEP_METRICS.removed.add(removed, &[]);
+    if removed > 0 {
+        SWEEP_METRICS.removed.add(removed, &[]);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/pegaflow-metaserver/src/metric.rs
+++ b/pegaflow-metaserver/src/metric.rs
@@ -12,23 +12,35 @@ use crate::store::BlockHashStore;
 
 struct StoreGaugeHandles {
     _entries: ObservableGauge<u64>,
+    _active_nodes: ObservableGauge<u64>,
 }
 
 static STORE_GAUGES: OnceLock<StoreGaugeHandles> = OnceLock::new();
 
 /// Register observable gauges backed by the given store.
 pub fn register_store_gauges(store: &Arc<BlockHashStore>) {
-    let s = Arc::clone(store);
+    let s1 = Arc::clone(store);
+    let s2 = Arc::clone(store);
     STORE_GAUGES.get_or_init(|| {
         let meter = global::meter("pegaflow_metaserver");
         let entries = meter
             .u64_observable_gauge("pegaflow_metaserver_store_entries")
             .with_description("Number of unique block keys in the store")
             .with_callback(move |observer| {
-                observer.observe(s.entry_count(), &[]);
+                observer.observe(s1.entry_count(), &[]);
             })
             .build();
-        StoreGaugeHandles { _entries: entries }
+        let active_nodes = meter
+            .u64_observable_gauge("pegaflow_metaserver_active_nodes")
+            .with_description("Number of currently tracked nodes (healthy + suspect)")
+            .with_callback(move |observer| {
+                observer.observe(s2.node_count() as u64, &[]);
+            })
+            .build();
+        StoreGaugeHandles {
+            _entries: entries,
+            _active_nodes: active_nodes,
+        }
     });
 }
 
@@ -52,6 +64,38 @@ static SWEEP_METRICS: LazyLock<SweepMetrics> = LazyLock::new(|| {
 
 pub fn record_ttl_sweep(removed: u64) {
     SWEEP_METRICS.removed.add(removed, &[]);
+}
+
+// ---------------------------------------------------------------------------
+// Liveness sweep metrics
+// ---------------------------------------------------------------------------
+
+struct LivenessMetrics {
+    suspect: Counter<u64>,
+    purged: Counter<u64>,
+}
+
+static LIVENESS_METRICS: LazyLock<LivenessMetrics> = LazyLock::new(|| {
+    let meter = global::meter("pegaflow_metaserver");
+    LivenessMetrics {
+        suspect: meter
+            .u64_counter("pegaflow_metaserver_node_suspect_total")
+            .with_description("Total times a node entered suspect state")
+            .build(),
+        purged: meter
+            .u64_counter("pegaflow_metaserver_node_purged_total")
+            .with_description("Total nodes hard-deleted (timeout or bye)")
+            .build(),
+    }
+});
+
+pub fn record_liveness_sweep(suspect: u64, purged: u64) {
+    if suspect > 0 {
+        LIVENESS_METRICS.suspect.add(suspect, &[]);
+    }
+    if purged > 0 {
+        LIVENESS_METRICS.purged.add(purged, &[]);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -1,9 +1,9 @@
 use crate::metric::record_rpc_result;
 use crate::proto::engine::meta_server_server::MetaServer;
 use crate::proto::engine::{
-    InsertBlockHashesRequest, InsertBlockHashesResponse, NodePrefixResult,
-    QueryPrefixBlocksRequest, QueryPrefixBlocksResponse, RemoveBlockHashesRequest,
-    RemoveBlockHashesResponse, ResponseStatus,
+    ByeRequest, ByeResponse, HeartbeatRequest, HeartbeatResponse, InsertBlockHashesRequest,
+    InsertBlockHashesResponse, NodePrefixResult, QueryPrefixBlocksRequest,
+    QueryPrefixBlocksResponse, RemoveBlockHashesRequest, RemoveBlockHashesResponse, ResponseStatus,
 };
 use crate::store::BlockHashStore;
 use log::{debug, info};
@@ -30,6 +30,14 @@ impl GrpcMetaService {
 
     fn error_status(message: String) -> ResponseStatus {
         ResponseStatus { ok: false, message }
+    }
+
+    fn validate_node_epoch(node: &str, epoch: &str) -> Result<(), Status> {
+        if node.is_empty() || epoch.is_empty() {
+            Err(Status::invalid_argument("node and epoch are required"))
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -184,6 +192,48 @@ impl MetaServer for GrpcMetaService {
         record_rpc_result("query_prefix_blocks", &result, start);
         result
     }
+
+    async fn heartbeat(
+        &self,
+        request: Request<HeartbeatRequest>,
+    ) -> Result<Response<HeartbeatResponse>, Status> {
+        let start = Instant::now();
+        let req = request.into_inner();
+
+        debug!("RPC [heartbeat]: node={} epoch={}", req.node, req.epoch);
+
+        if let Err(e) = Self::validate_node_epoch(&req.node, &req.epoch) {
+            let result: Result<Response<HeartbeatResponse>, Status> = Err(e);
+            record_rpc_result("heartbeat", &result, start);
+            return result;
+        }
+
+        self.store.heartbeat(&req.node, &req.epoch);
+
+        let result = Ok(Response::new(HeartbeatResponse {}));
+        record_rpc_result("heartbeat", &result, start);
+        result
+    }
+
+    async fn bye(&self, request: Request<ByeRequest>) -> Result<Response<ByeResponse>, Status> {
+        let start = Instant::now();
+        let req = request.into_inner();
+
+        info!("RPC [bye]: node={} epoch={}", req.node, req.epoch);
+
+        if let Err(e) = Self::validate_node_epoch(&req.node, &req.epoch) {
+            let result: Result<Response<ByeResponse>, Status> = Err(e);
+            record_rpc_result("bye", &result, start);
+            return result;
+        }
+
+        let purged = self.store.bye(&req.node, &req.epoch);
+        info!("RPC [bye]: node={} purged={} entries", req.node, purged);
+
+        let result = Ok(Response::new(ByeResponse {}));
+        record_rpc_result("bye", &result, start);
+        result
+    }
 }
 
 #[cfg(test)]
@@ -193,6 +243,14 @@ mod tests {
 
     fn make_service() -> GrpcMetaService {
         GrpcMetaService::new(Arc::new(BlockHashStore::new()))
+    }
+
+    fn make_service_with_liveness(suspect_secs: u64, hard_delete_secs: u64) -> GrpcMetaService {
+        GrpcMetaService::new(Arc::new(BlockHashStore::with_liveness_config(
+            120,
+            suspect_secs,
+            hard_delete_secs,
+        )))
     }
 
     #[tokio::test]
@@ -341,5 +399,107 @@ mod tests {
             nodes,
             vec![(node_a.to_string(), 4), (node_b.to_string(), 3),]
         );
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat_rpc() {
+        let svc = make_service();
+
+        let resp = svc
+            .heartbeat(Request::new(HeartbeatRequest {
+                node: "node-a".into(),
+                epoch: "epoch-1".into(),
+            }))
+            .await;
+        assert!(resp.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat_rpc_empty_fields_rejected() {
+        let svc = make_service();
+
+        let resp = svc
+            .heartbeat(Request::new(HeartbeatRequest {
+                node: "".into(),
+                epoch: "epoch-1".into(),
+            }))
+            .await;
+        assert!(resp.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_bye_rpc_purges_entries() {
+        let svc = make_service();
+
+        // Register heartbeat + insert blocks
+        svc.heartbeat(Request::new(HeartbeatRequest {
+            node: "node-a".into(),
+            epoch: "epoch-1".into(),
+        }))
+        .await
+        .unwrap();
+
+        svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
+            namespace: "ns".into(),
+            block_hashes: vec![vec![1], vec![2]],
+            node: "node-a".into(),
+        }))
+        .await
+        .unwrap();
+
+        // Bye → purge
+        let resp = svc
+            .bye(Request::new(ByeRequest {
+                node: "node-a".into(),
+                epoch: "epoch-1".into(),
+            }))
+            .await;
+        assert!(resp.is_ok());
+
+        // Query should return empty
+        let query_resp = svc
+            .query_prefix_blocks(Request::new(QueryPrefixBlocksRequest {
+                namespace: "ns".into(),
+                block_hashes: vec![vec![1], vec![2]],
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(query_resp.nodes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_query_excludes_suspect_after_sweep() {
+        // suspect_threshold=0 → immediately suspect
+        let svc = make_service_with_liveness(0, 3600);
+
+        svc.heartbeat(Request::new(HeartbeatRequest {
+            node: "node-a".into(),
+            epoch: "epoch-1".into(),
+        }))
+        .await
+        .unwrap();
+
+        svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
+            namespace: "ns".into(),
+            block_hashes: vec![vec![1]],
+            node: "node-a".into(),
+        }))
+        .await
+        .unwrap();
+
+        // Trigger sweep → node-a becomes suspect
+        svc.store.sweep_liveness();
+
+        // Query should filter out suspect node
+        let query_resp = svc
+            .query_prefix_blocks(Request::new(QueryPrefixBlocksRequest {
+                namespace: "ns".into(),
+                block_hashes: vec![vec![1]],
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(query_resp.nodes.is_empty());
     }
 }

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -1,4 +1,4 @@
-use crate::metric::{record_liveness_sweep, record_rpc_result};
+use crate::metric::{record_node_purge, record_rpc_result};
 use crate::proto::engine::meta_server_server::MetaServer;
 use crate::proto::engine::{
     ByeRequest, ByeResponse, HeartbeatRequest, HeartbeatResponse, InsertBlockHashesRequest,
@@ -231,7 +231,7 @@ impl MetaServer for GrpcMetaService {
         info!("RPC [bye]: node={} purged={} entries", req.node, purged);
 
         if purged > 0 {
-            record_liveness_sweep(0, 1);
+            record_node_purge(1);
         }
 
         let result = Ok(Response::new(ByeResponse {}));
@@ -473,8 +473,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_query_excludes_suspect_after_sweep() {
-        // suspect_threshold=0 → immediately suspect
+    async fn test_query_excludes_stale_node() {
+        // suspect_threshold=0 → stale immediately after heartbeat
         let svc = make_service_with_liveness(0, 3600);
 
         svc.heartbeat(Request::new(HeartbeatRequest {
@@ -492,10 +492,7 @@ mod tests {
         .await
         .unwrap();
 
-        // Trigger sweep → node-a becomes suspect
-        svc.store.sweep_liveness();
-
-        // Query should filter out suspect node
+        // No sweep needed — query_prefix checks last_seen inline
         let query_resp = svc
             .query_prefix_blocks(Request::new(QueryPrefixBlocksRequest {
                 namespace: "ns".into(),

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -1,4 +1,4 @@
-use crate::metric::record_rpc_result;
+use crate::metric::{record_liveness_sweep, record_rpc_result};
 use crate::proto::engine::meta_server_server::MetaServer;
 use crate::proto::engine::{
     ByeRequest, ByeResponse, HeartbeatRequest, HeartbeatResponse, InsertBlockHashesRequest,
@@ -229,6 +229,10 @@ impl MetaServer for GrpcMetaService {
 
         let purged = self.store.bye(&req.node, &req.epoch);
         info!("RPC [bye]: node={} purged={} entries", req.node, purged);
+
+        if purged > 0 {
+            record_liveness_sweep(0, 1);
+        }
 
         let result = Ok(Response::new(ByeResponse {}));
         record_rpc_result("bye", &result, start);

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -1,4 +1,4 @@
-use crate::metric::{record_node_purge, record_rpc_result};
+use crate::metric::{record_node_purge, record_purge_sweep, record_rpc_result};
 use crate::proto::engine::meta_server_server::MetaServer;
 use crate::proto::engine::{
     ByeRequest, ByeResponse, HeartbeatRequest, HeartbeatResponse, InsertBlockHashesRequest,
@@ -230,9 +230,8 @@ impl MetaServer for GrpcMetaService {
         let purged = self.store.bye(&req.node, &req.epoch);
         info!("RPC [bye]: node={} purged={} entries", req.node, purged);
 
-        if purged > 0 {
-            record_node_purge(1);
-        }
+        record_node_purge(1);
+        record_purge_sweep(purged as u64);
 
         let result = Ok(Response::new(ByeResponse {}));
         record_rpc_result("bye", &result, start);

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -97,6 +97,7 @@ impl BlockHashStore {
                 false
             };
             if should_remove_key {
+                // Only remove if still empty (another thread may have inserted)
                 self.map.remove_if(&key, |_, nodes| nodes.is_empty());
             }
         }
@@ -199,8 +200,10 @@ impl BlockHashStore {
     }
 
     /// Sweep expired entries and dead nodes.
+    ///
     /// 1. Removes per-node block registrations older than TTL.
     /// 2. Purges nodes past `hard_delete_threshold` and removes their block entries.
+    ///
     /// Returns (expired_keys_removed, dead_nodes_purged).
     pub fn sweep_expired(&self) -> (usize, usize) {
         let now = Instant::now();
@@ -214,7 +217,7 @@ impl BlockHashStore {
 
         // Purge dead nodes (past hard_delete_threshold)
         let mut purged_nodes: Vec<Arc<str>> = Vec::new();
-        for entry in self.nodes.iter() {
+        for entry in &self.nodes {
             if entry.last_seen.elapsed() >= self.hard_delete_threshold {
                 purged_nodes.push(entry.key().clone());
             }
@@ -267,7 +270,7 @@ impl BlockHashStore {
     fn is_node_healthy(&self, node: &Arc<str>) -> bool {
         match self.nodes.get(node) {
             Some(entry) => entry.last_seen.elapsed() < self.suspect_threshold,
-            None => true,
+            None => false,
         }
     }
 

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -22,6 +22,12 @@ pub struct NodeLiveness {
     pub last_seen: Instant,
 }
 
+pub struct SweepResult {
+    pub ttl_expired: usize,
+    pub purge_removed: usize,
+    pub purged_nodes: usize,
+}
+
 /// Async thread-safe block hash storage using DashMap.
 /// Stores BlockKeys (namespace + hash) mapped to a set of owning node URLs with
 /// registration timestamps, enabling multi-owner tracking and periodic TTL sweep.
@@ -145,7 +151,7 @@ impl BlockHashStore {
             } else {
                 let old_epoch = entry.epoch.clone();
                 drop(entry);
-                let purged = self.purge_node(node);
+                let purged = self.purge_node_before(node, now);
                 info!(
                     "Node {} epoch changed ({} -> {}), purged {} entries",
                     node, old_epoch, epoch, purged
@@ -174,22 +180,28 @@ impl BlockHashStore {
     /// Only acts if the epoch matches (prevents stale Bye from old process).
     pub fn bye(&self, node: &str, epoch: &str) -> usize {
         let node_key: Arc<str> = Arc::from(node);
+        let cutoff = Instant::now();
         let removed = self
             .nodes
             .remove_if(&node_key, |_, liveness| liveness.epoch == epoch);
         if removed.is_some() {
-            self.purge_node(node)
+            self.purge_node_before(node, cutoff)
         } else {
             0
         }
     }
 
-    /// Remove all block entries owned by a specific node.
-    /// Returns the number of block entries removed.
-    pub fn purge_node(&self, node: &str) -> usize {
+    /// Remove block entries owned by `node` that were registered at or before
+    /// `cutoff`. Entries inserted after `cutoff` (e.g. by a re-registered node)
+    /// are preserved, preventing the race where purge deletes freshly-inserted
+    /// entries.
+    fn purge_node_before(&self, node: &str, cutoff: Instant) -> usize {
         let mut purged = 0;
         self.map.retain(|_, owners| {
-            if owners.remove(node).is_some() {
+            if let Some(registered_at) = owners.get(node)
+                && *registered_at <= cutoff
+            {
+                owners.remove(node);
                 purged += 1;
             }
             !owners.is_empty()
@@ -201,9 +213,7 @@ impl BlockHashStore {
     ///
     /// 1. Removes per-node block registrations older than TTL.
     /// 2. Purges nodes past `hard_delete_threshold` and removes their block entries.
-    ///
-    /// Returns (ttl_expired_keys, purge_removed_keys, dead_nodes_purged).
-    pub fn sweep_expired(&self) -> (usize, usize, usize) {
+    pub fn sweep_expired(&self) -> SweepResult {
         let now = Instant::now();
         let ttl = self.ttl;
         let before = self.map.len();
@@ -214,28 +224,27 @@ impl BlockHashStore {
         let expired_keys = before.saturating_sub(self.map.len());
         let mut purge_removed_keys = 0;
 
-        // Purge dead nodes (past hard_delete_threshold)
+        // Purge dead nodes (past hard_delete_threshold).
+        // retain holds the shard write-lock so check + removal is atomic per entry.
         let mut purged_nodes: Vec<Arc<str>> = Vec::new();
-        for entry in &self.nodes {
-            if entry.last_seen.elapsed() >= self.hard_delete_threshold {
-                purged_nodes.push(entry.key().clone());
+        self.nodes.retain(|node_key, liveness| {
+            if liveness.last_seen.elapsed() >= self.hard_delete_threshold {
+                purged_nodes.push(node_key.clone());
+                false
+            } else {
+                true
             }
-        }
-
-        // Re-validate with remove_if to avoid TOCTOU with concurrent heartbeats
-        purged_nodes.retain(|node_key| {
-            self.nodes
-                .remove_if(node_key, |_, liveness| {
-                    liveness.last_seen.elapsed() >= self.hard_delete_threshold
-                })
-                .is_some()
         });
 
         if !purged_nodes.is_empty() {
             let before_purge = self.map.len();
             self.map.retain(|_, owners| {
                 for node in &purged_nodes {
-                    owners.remove(node.as_ref());
+                    if let Some(registered_at) = owners.get(node.as_ref())
+                        && *registered_at <= now
+                    {
+                        owners.remove(node.as_ref());
+                    }
                 }
                 !owners.is_empty()
             });
@@ -245,7 +254,11 @@ impl BlockHashStore {
             }
         }
 
-        (expired_keys, purge_removed_keys, purged_nodes.len())
+        SweepResult {
+            ttl_expired: expired_keys,
+            purge_removed: purge_removed_keys,
+            purged_nodes: purged_nodes.len(),
+        }
     }
 
     /// Get the number of unique block keys
@@ -253,9 +266,12 @@ impl BlockHashStore {
         self.map.len() as u64
     }
 
-    /// Get the number of tracked nodes
+    /// Get the number of healthy (non-suspect) nodes.
     pub fn node_count(&self) -> usize {
-        self.nodes.len()
+        self.nodes
+            .iter()
+            .filter(|entry| entry.last_seen.elapsed() < self.suspect_threshold)
+            .count()
     }
 
     fn is_node_healthy(&self, node: &Arc<str>) -> bool {
@@ -410,8 +426,8 @@ mod tests {
         assert_eq!(store.entry_count(), 2);
 
         // Instant::now() is already past the zero-TTL deadline
-        let (removed, _, _) = store.sweep_expired();
-        assert_eq!(removed, 2);
+        let result = store.sweep_expired();
+        assert_eq!(result.ttl_expired, 2);
         assert_eq!(store.entry_count(), 0);
     }
 
@@ -420,8 +436,8 @@ mod tests {
         let store = BlockHashStore::with_ttl(120); // 120 min TTL
         store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
 
-        let (removed, _, _) = store.sweep_expired();
-        assert_eq!(removed, 0);
+        let result = store.sweep_expired();
+        assert_eq!(result.ttl_expired, 0);
         assert_eq!(store.entry_count(), 2);
     }
 
@@ -602,9 +618,9 @@ mod tests {
         store.heartbeat("node-a", "epoch-1");
         store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
 
-        let (_, purge_removed, purged_nodes) = store.sweep_expired();
-        assert_eq!(purged_nodes, 1);
-        assert_eq!(purge_removed, 2);
+        let result = store.sweep_expired();
+        assert_eq!(result.purged_nodes, 1);
+        assert_eq!(result.purge_removed, 2);
         assert_eq!(store.node_count(), 0);
         assert_eq!(store.entry_count(), 0);
     }
@@ -616,8 +632,8 @@ mod tests {
         store.heartbeat("node-a", "epoch-1");
         store.insert_hashes("ns", &[vec![1]], "node-a");
 
-        let (_, _, purged_nodes) = store.sweep_expired();
-        assert_eq!(purged_nodes, 0);
+        let result = store.sweep_expired();
+        assert_eq!(result.purged_nodes, 0);
         assert_eq!(store.node_count(), 1);
         assert_eq!(store.entry_count(), 1);
     }
@@ -690,7 +706,7 @@ mod tests {
         let store = BlockHashStore::new();
         store.insert_hashes("ns", &[vec![1], vec![2], vec![3]], "node-a");
 
-        let purged = store.purge_node("node-a");
+        let purged = store.purge_node_before("node-a", Instant::now());
         assert_eq!(purged, 3);
     }
 
@@ -699,7 +715,7 @@ mod tests {
         let store = BlockHashStore::new();
         store.insert_hashes("ns", &[vec![1]], "node-a");
 
-        store.purge_node("node-a");
+        store.purge_node_before("node-a", Instant::now());
         assert_eq!(store.entry_count(), 0);
     }
 
@@ -709,11 +725,25 @@ mod tests {
         store.insert_hashes("ns", &[vec![1]], "node-a");
         store.insert_hashes("ns", &[vec![1]], "node-b");
 
-        store.purge_node("node-a");
+        store.purge_node_before("node-a", Instant::now());
         assert_eq!(store.entry_count(), 1);
 
         let result = store.query_prefix("ns", &[vec![1]]);
         assert_eq!(result[0].nodes.len(), 1);
         assert_eq!(result[0].nodes[0].as_ref(), "node-b");
+    }
+
+    #[test]
+    fn test_purge_preserves_entries_after_cutoff() {
+        let store = BlockHashStore::new();
+        let cutoff = Instant::now();
+
+        // Insert after cutoff — should NOT be purged
+        std::thread::sleep(Duration::from_millis(1));
+        store.insert_hashes("ns", &[vec![1]], "node-a");
+
+        let purged = store.purge_node_before("node-a", cutoff);
+        assert_eq!(purged, 0);
+        assert_eq!(store.entry_count(), 1);
     }
 }

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -213,7 +213,7 @@ impl BlockHashStore {
             nodes.retain(|_, registered_at| now.duration_since(*registered_at) < ttl);
             !nodes.is_empty()
         });
-        let expired_keys = before.saturating_sub(self.map.len());
+        let mut expired_keys = before.saturating_sub(self.map.len());
 
         // Purge dead nodes (past hard_delete_threshold)
         let mut purged_nodes: Vec<Arc<str>> = Vec::new();
@@ -233,23 +233,23 @@ impl BlockHashStore {
         });
 
         if !purged_nodes.is_empty() {
-            let mut total_purged_entries = 0;
+            let before_purge = self.map.len();
             self.map.retain(|_, owners| {
                 for node in &purged_nodes {
-                    if owners.remove(node.as_ref()).is_some() {
-                        total_purged_entries += 1;
-                    }
+                    owners.remove(node.as_ref());
                 }
                 !owners.is_empty()
             });
+            let purge_removed = before_purge.saturating_sub(self.map.len());
+            expired_keys += purge_removed;
             for node_key in &purged_nodes {
                 info!("Hard-deleted node {}", node_key);
             }
-            if total_purged_entries > 0 {
+            if purge_removed > 0 {
                 info!(
                     "Sweep: purged {} dead nodes, {} block entries",
                     purged_nodes.len(),
-                    total_purged_entries
+                    purge_removed
                 );
             }
         }

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -1,4 +1,5 @@
 use dashmap::DashMap;
+use log::{info, warn};
 use pegaflow_common::BlockKey;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -6,12 +7,26 @@ use std::time::{Duration, Instant};
 
 /// Default TTL for cache entries (120 minutes)
 pub const DEFAULT_TTL_MINUTES: u64 = 120;
+pub const DEFAULT_SUSPECT_SECS: u64 = 30;
+pub const DEFAULT_HARD_DELETE_SECS: u64 = 90;
 
 /// A prefix query result: one block hash and all nodes that own it.
 #[derive(Debug, Clone)]
 pub struct PrefixEntry {
     pub block_hash: Vec<u8>,
     pub nodes: Vec<Arc<str>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum NodeState {
+    Healthy,
+    Suspect,
+}
+
+pub struct NodeLiveness {
+    pub epoch: String,
+    pub last_seen: Instant,
+    pub state: NodeState,
 }
 
 /// Async thread-safe block hash storage using DashMap.
@@ -21,19 +36,39 @@ pub struct BlockHashStore {
     /// Key: BlockKey, Value: { node_url → registration_time }
     map: DashMap<BlockKey, HashMap<Arc<str>, Instant>>,
     ttl: Duration,
+    /// Per-node liveness tracking
+    nodes: DashMap<Arc<str>, NodeLiveness>,
+    suspect_threshold: Duration,
+    hard_delete_threshold: Duration,
 }
 
 impl BlockHashStore {
     /// Create a new block hash store with default TTL (120 minutes)
     pub fn new() -> Self {
-        Self::with_ttl(DEFAULT_TTL_MINUTES)
+        Self::with_liveness_config(
+            DEFAULT_TTL_MINUTES,
+            DEFAULT_SUSPECT_SECS,
+            DEFAULT_HARD_DELETE_SECS,
+        )
     }
 
     /// Create a new block hash store with specified TTL in minutes
     pub fn with_ttl(ttl_minutes: u64) -> Self {
+        Self::with_liveness_config(ttl_minutes, DEFAULT_SUSPECT_SECS, DEFAULT_HARD_DELETE_SECS)
+    }
+
+    /// Create a new block hash store with full configuration
+    pub fn with_liveness_config(
+        ttl_minutes: u64,
+        suspect_secs: u64,
+        hard_delete_secs: u64,
+    ) -> Self {
         Self {
             map: DashMap::new(),
             ttl: Duration::from_secs(ttl_minutes * 60),
+            nodes: DashMap::new(),
+            suspect_threshold: Duration::from_secs(suspect_secs),
+            hard_delete_threshold: Duration::from_secs(hard_delete_secs),
         }
     }
 
@@ -69,7 +104,6 @@ impl BlockHashStore {
                 false
             };
             if should_remove_key {
-                // Only remove if still empty (another thread may have inserted)
                 self.map.remove_if(&key, |_, nodes| nodes.is_empty());
             }
         }
@@ -77,24 +111,165 @@ impl BlockHashStore {
     }
 
     /// Query the longest prefix of `hashes` that exists in the store.
-    /// Stops at the first hash not found on any node.
+    /// Stops at the first hash not found on any healthy node.
+    /// Suspect nodes are filtered out of results.
     pub fn query_prefix(&self, namespace: &str, hashes: &[Vec<u8>]) -> Vec<PrefixEntry> {
         let mut result = Vec::new();
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
-            if let Some(nodes) = self.map.get(&key) {
-                if nodes.is_empty() {
+            if let Some(owners) = self.map.get(&key) {
+                let healthy_nodes: Vec<Arc<str>> = owners
+                    .keys()
+                    .filter(|n| self.is_node_healthy(n))
+                    .cloned()
+                    .collect();
+                if healthy_nodes.is_empty() {
                     break;
                 }
                 result.push(PrefixEntry {
                     block_hash: hash.clone(),
-                    nodes: nodes.keys().cloned().collect(),
+                    nodes: healthy_nodes,
                 });
             } else {
                 break;
             }
         }
         result
+    }
+
+    /// Process a heartbeat from a node.
+    /// - New node: register as Healthy
+    /// - Same epoch + Suspect: recover to Healthy
+    /// - Same epoch + Healthy: refresh last_seen
+    /// - Different epoch: purge old entries, register as Healthy
+    pub fn heartbeat(&self, node: &str, epoch: &str) {
+        let node_key: Arc<str> = Arc::from(node);
+        let now = Instant::now();
+
+        if let Some(mut entry) = self.nodes.get_mut(&node_key) {
+            if entry.epoch == epoch {
+                if entry.state == NodeState::Suspect {
+                    info!("Node {} recovered from suspect (epoch={})", node, epoch);
+                }
+                entry.last_seen = now;
+                entry.state = NodeState::Healthy;
+            } else {
+                let old_epoch = entry.epoch.clone();
+                drop(entry);
+                let purged = self.purge_node(node);
+                info!(
+                    "Node {} epoch changed ({} -> {}), purged {} entries",
+                    node, old_epoch, epoch, purged
+                );
+                self.nodes.insert(
+                    node_key,
+                    NodeLiveness {
+                        epoch: epoch.to_string(),
+                        last_seen: now,
+                        state: NodeState::Healthy,
+                    },
+                );
+            }
+        } else {
+            self.nodes.insert(
+                node_key,
+                NodeLiveness {
+                    epoch: epoch.to_string(),
+                    last_seen: now,
+                    state: NodeState::Healthy,
+                },
+            );
+        }
+    }
+
+    /// Process a Bye from a node. Purges all entries and removes liveness tracking.
+    /// Only acts if the epoch matches (prevents stale Bye from old process).
+    pub fn bye(&self, node: &str, epoch: &str) -> usize {
+        let node_key: Arc<str> = Arc::from(node);
+        if let Some(entry) = self.nodes.get(&node_key) {
+            if entry.epoch != epoch {
+                return 0;
+            }
+            drop(entry);
+            let purged = self.purge_node(node);
+            self.nodes.remove(&node_key);
+            purged
+        } else {
+            0
+        }
+    }
+
+    /// Remove all block entries owned by a specific node.
+    /// Returns the number of block entries removed.
+    pub fn purge_node(&self, node: &str) -> usize {
+        let mut purged = 0;
+        self.map.retain(|_, owners| {
+            if owners.remove(node).is_some() {
+                purged += 1;
+            }
+            !owners.is_empty()
+        });
+        purged
+    }
+
+    /// Sweep node liveness states.
+    /// Marks healthy nodes as suspect after suspect_threshold.
+    /// Purges suspect nodes after hard_delete_threshold.
+    /// Returns (suspect_count, purged_count).
+    pub fn sweep_liveness(&self) -> (usize, usize) {
+        if self.nodes.is_empty() {
+            return (0, 0);
+        }
+
+        let now = Instant::now();
+        let mut suspect_count = 0;
+        let mut purged_nodes: Vec<Arc<str>> = Vec::new();
+
+        for mut entry in self.nodes.iter_mut() {
+            let elapsed = now.duration_since(entry.last_seen);
+
+            if elapsed >= self.hard_delete_threshold {
+                purged_nodes.push(entry.key().clone());
+            } else if elapsed >= self.suspect_threshold && entry.state == NodeState::Healthy {
+                entry.state = NodeState::Suspect;
+                suspect_count += 1;
+                warn!(
+                    "Node {} marked suspect (no heartbeat for {:?})",
+                    entry.key(),
+                    elapsed
+                );
+            }
+        }
+
+        if purged_nodes.is_empty() {
+            return (suspect_count, 0);
+        }
+
+        // Single-pass purge: remove all dead nodes from the block map in one retain()
+        // instead of calling purge_node() per node (which would be O(N * total_blocks)).
+        let mut total_purged_entries = 0;
+        self.map.retain(|_, owners| {
+            for node in &purged_nodes {
+                if owners.remove(node.as_ref()).is_some() {
+                    total_purged_entries += 1;
+                }
+            }
+            !owners.is_empty()
+        });
+
+        let purged_count = purged_nodes.len();
+        for node_key in &purged_nodes {
+            self.nodes.remove(node_key);
+            info!("Hard-deleted node {}", node_key);
+        }
+        if total_purged_entries > 0 {
+            info!(
+                "Liveness sweep: purged {} nodes, {} block entries",
+                purged_count, total_purged_entries
+            );
+        }
+
+        (suspect_count, purged_count)
     }
 
     /// Sweep expired entries. Removes per-node registrations older than TTL,
@@ -117,10 +292,26 @@ impl BlockHashStore {
         self.map.len() as u64
     }
 
+    /// Get the number of tracked nodes
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Check if a node is in Healthy state (or not tracked, which means
+    /// it has no liveness entry — treat as healthy for backwards compatibility
+    /// with nodes that haven't sent a heartbeat yet).
+    fn is_node_healthy(&self, node: &Arc<str>) -> bool {
+        match self.nodes.get(node) {
+            Some(entry) => entry.state == NodeState::Healthy,
+            None => true,
+        }
+    }
+
     /// Clear all entries (for testing or maintenance)
     #[allow(dead_code)]
     pub fn invalidate_all(&self) {
         self.map.clear();
+        self.nodes.clear();
     }
 }
 
@@ -331,5 +522,270 @@ mod tests {
         let existing = store.query_prefix(namespace, &hashes);
         assert_eq!(existing.len(), 0);
         assert_eq!(store.entry_count(), 0);
+    }
+
+    // --- Heartbeat tests ---
+
+    #[test]
+    fn test_heartbeat_new_node() {
+        let store = BlockHashStore::new();
+        assert_eq!(store.node_count(), 0);
+
+        store.heartbeat("node-a", "epoch-1");
+        assert_eq!(store.node_count(), 1);
+
+        let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
+        assert_eq!(entry.epoch, "epoch-1");
+        assert_eq!(entry.state, NodeState::Healthy);
+    }
+
+    #[test]
+    fn test_heartbeat_refresh_healthy() {
+        let store = BlockHashStore::new();
+        store.heartbeat("node-a", "epoch-1");
+
+        let first_seen = store
+            .nodes
+            .get(&Arc::<str>::from("node-a"))
+            .unwrap()
+            .last_seen;
+
+        std::thread::sleep(Duration::from_millis(10));
+        store.heartbeat("node-a", "epoch-1");
+
+        let second_seen = store
+            .nodes
+            .get(&Arc::<str>::from("node-a"))
+            .unwrap()
+            .last_seen;
+        assert!(second_seen > first_seen);
+
+        let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
+        assert_eq!(entry.state, NodeState::Healthy);
+    }
+
+    #[test]
+    fn test_heartbeat_recover_from_suspect() {
+        // suspect_threshold=0 so sweep immediately marks suspect
+        let store = BlockHashStore::with_liveness_config(120, 0, 3600);
+        store.heartbeat("node-a", "epoch-1");
+        store.insert_hashes("ns", &[vec![1]], "node-a");
+
+        // Sweep marks suspect
+        let (suspect, _) = store.sweep_liveness();
+        assert_eq!(suspect, 1);
+
+        // Query should filter out suspect
+        let result = store.query_prefix("ns", &[vec![1]]);
+        assert_eq!(result.len(), 0);
+
+        // Heartbeat with same epoch recovers
+        store.heartbeat("node-a", "epoch-1");
+        let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
+        assert_eq!(entry.state, NodeState::Healthy);
+
+        // Query should return the node again
+        let result = store.query_prefix("ns", &[vec![1]]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].nodes[0].as_ref(), "node-a");
+    }
+
+    #[test]
+    fn test_heartbeat_new_epoch_purges() {
+        let store = BlockHashStore::new();
+        store.heartbeat("node-a", "epoch-1");
+        store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
+        assert_eq!(store.entry_count(), 2);
+
+        // Heartbeat with new epoch purges old entries
+        store.heartbeat("node-a", "epoch-2");
+        assert_eq!(store.entry_count(), 0);
+        assert_eq!(store.node_count(), 1);
+
+        let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
+        assert_eq!(entry.epoch, "epoch-2");
+        assert_eq!(entry.state, NodeState::Healthy);
+    }
+
+    // --- Bye tests ---
+
+    #[test]
+    fn test_bye_matching_epoch() {
+        let store = BlockHashStore::new();
+        store.heartbeat("node-a", "epoch-1");
+        store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
+
+        let purged = store.bye("node-a", "epoch-1");
+        assert_eq!(purged, 2);
+        assert_eq!(store.entry_count(), 0);
+        assert_eq!(store.node_count(), 0);
+    }
+
+    #[test]
+    fn test_bye_mismatched_epoch_is_noop() {
+        let store = BlockHashStore::new();
+        store.heartbeat("node-a", "epoch-1");
+        store.insert_hashes("ns", &[vec![1]], "node-a");
+
+        let purged = store.bye("node-a", "epoch-wrong");
+        assert_eq!(purged, 0);
+        assert_eq!(store.entry_count(), 1);
+        assert_eq!(store.node_count(), 1);
+    }
+
+    #[test]
+    fn test_bye_unknown_node_is_noop() {
+        let store = BlockHashStore::new();
+        let purged = store.bye("node-unknown", "epoch-1");
+        assert_eq!(purged, 0);
+    }
+
+    // --- Liveness sweep tests ---
+
+    #[test]
+    fn test_sweep_marks_suspect() {
+        // suspect_threshold=0 → immediately suspect
+        let store = BlockHashStore::with_liveness_config(120, 0, 3600);
+        store.heartbeat("node-a", "epoch-1");
+
+        let (suspect, purged) = store.sweep_liveness();
+        assert_eq!(suspect, 1);
+        assert_eq!(purged, 0);
+
+        let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
+        assert_eq!(entry.state, NodeState::Suspect);
+    }
+
+    #[test]
+    fn test_sweep_healthy_within_threshold() {
+        // suspect_threshold=120s → way in the future
+        let store = BlockHashStore::with_liveness_config(120, 120, 3600);
+        store.heartbeat("node-a", "epoch-1");
+
+        let (suspect, purged) = store.sweep_liveness();
+        assert_eq!(suspect, 0);
+        assert_eq!(purged, 0);
+
+        let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
+        assert_eq!(entry.state, NodeState::Healthy);
+    }
+
+    #[test]
+    fn test_sweep_hard_deletes() {
+        // Both thresholds=0 → immediately suspect then hard-delete
+        let store = BlockHashStore::with_liveness_config(120, 0, 0);
+        store.heartbeat("node-a", "epoch-1");
+        store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
+
+        let (_, purged) = store.sweep_liveness();
+        assert_eq!(purged, 1);
+        assert_eq!(store.node_count(), 0);
+        assert_eq!(store.entry_count(), 0);
+    }
+
+    #[test]
+    fn test_sweep_does_not_delete_fresh_suspect() {
+        // suspect=0, hard_delete=3600 → becomes suspect but not purged
+        let store = BlockHashStore::with_liveness_config(120, 0, 3600);
+        store.heartbeat("node-a", "epoch-1");
+        store.insert_hashes("ns", &[vec![1]], "node-a");
+
+        let (suspect, purged) = store.sweep_liveness();
+        assert_eq!(suspect, 1);
+        assert_eq!(purged, 0);
+        assert_eq!(store.node_count(), 1);
+        assert_eq!(store.entry_count(), 1);
+    }
+
+    // --- Query filtering tests ---
+
+    #[test]
+    fn test_query_filters_suspect_nodes() {
+        let store = BlockHashStore::with_liveness_config(120, 0, 3600);
+        store.heartbeat("node-a", "epoch-a");
+        store.heartbeat("node-b", "epoch-b");
+        store.insert_hashes("ns", &[vec![1]], "node-a");
+        store.insert_hashes("ns", &[vec![1]], "node-b");
+
+        // Mark node-a suspect
+        store.sweep_liveness();
+        // Refresh node-b to healthy
+        store.heartbeat("node-b", "epoch-b");
+
+        let result = store.query_prefix("ns", &[vec![1]]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].nodes.len(), 1);
+        assert_eq!(result[0].nodes[0].as_ref(), "node-b");
+    }
+
+    #[test]
+    fn test_query_suspect_only_owner_breaks_prefix() {
+        let store = BlockHashStore::with_liveness_config(120, 0, 3600);
+        store.heartbeat("node-a", "epoch-a");
+        store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
+
+        // Mark suspect
+        store.sweep_liveness();
+
+        // All blocks owned by suspect → prefix is empty
+        let result = store.query_prefix("ns", &[vec![1], vec![2]]);
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_query_mixed_healthy_suspect() {
+        let store = BlockHashStore::with_liveness_config(120, 0, 3600);
+
+        store.heartbeat("node-a", "epoch-a");
+        store.heartbeat("node-b", "epoch-b");
+
+        // h1 owned by both, h2 owned only by node-a
+        store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
+        store.insert_hashes("ns", &[vec![1]], "node-b");
+
+        // Mark both suspect, then recover node-b
+        store.sweep_liveness();
+        store.heartbeat("node-b", "epoch-b");
+
+        // h1: node-a(suspect) + node-b(healthy) → node-b visible
+        // h2: node-a(suspect) only → prefix stops
+        let result = store.query_prefix("ns", &[vec![1], vec![2]]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].nodes.len(), 1);
+        assert_eq!(result[0].nodes[0].as_ref(), "node-b");
+    }
+
+    // --- purge_node tests ---
+
+    #[test]
+    fn test_purge_removes_from_all_blocks() {
+        let store = BlockHashStore::new();
+        store.insert_hashes("ns", &[vec![1], vec![2], vec![3]], "node-a");
+
+        let purged = store.purge_node("node-a");
+        assert_eq!(purged, 3);
+    }
+
+    #[test]
+    fn test_purge_drops_empty_keys() {
+        let store = BlockHashStore::new();
+        store.insert_hashes("ns", &[vec![1]], "node-a");
+
+        store.purge_node("node-a");
+        assert_eq!(store.entry_count(), 0);
+    }
+
+    #[test]
+    fn test_purge_keeps_other_owners() {
+        let store = BlockHashStore::new();
+        store.insert_hashes("ns", &[vec![1]], "node-a");
+        store.insert_hashes("ns", &[vec![1]], "node-b");
+
+        store.purge_node("node-a");
+        assert_eq!(store.entry_count(), 1);
+
+        let result = store.query_prefix("ns", &[vec![1]]);
+        assert_eq!(result[0].nodes.len(), 1);
+        assert_eq!(result[0].nodes[0].as_ref(), "node-b");
     }
 }

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -1,5 +1,5 @@
 use dashmap::DashMap;
-use log::{info, warn};
+use log::info;
 use pegaflow_common::BlockKey;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -17,16 +17,9 @@ pub struct PrefixEntry {
     pub nodes: Vec<Arc<str>>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum NodeState {
-    Healthy,
-    Suspect,
-}
-
 pub struct NodeLiveness {
     pub epoch: String,
     pub last_seen: Instant,
-    pub state: NodeState,
 }
 
 /// Async thread-safe block hash storage using DashMap.
@@ -138,21 +131,16 @@ impl BlockHashStore {
     }
 
     /// Process a heartbeat from a node.
-    /// - New node: register as Healthy
-    /// - Same epoch + Suspect: recover to Healthy
-    /// - Same epoch + Healthy: refresh last_seen
-    /// - Different epoch: purge old entries, register as Healthy
+    /// - New node: register with current timestamp
+    /// - Same epoch: refresh last_seen
+    /// - Different epoch: purge old entries, re-register
     pub fn heartbeat(&self, node: &str, epoch: &str) {
         let node_key: Arc<str> = Arc::from(node);
         let now = Instant::now();
 
         if let Some(mut entry) = self.nodes.get_mut(&node_key) {
             if entry.epoch == epoch {
-                if entry.state == NodeState::Suspect {
-                    info!("Node {} recovered from suspect (epoch={})", node, epoch);
-                }
                 entry.last_seen = now;
-                entry.state = NodeState::Healthy;
             } else {
                 let old_epoch = entry.epoch.clone();
                 drop(entry);
@@ -166,7 +154,6 @@ impl BlockHashStore {
                     NodeLiveness {
                         epoch: epoch.to_string(),
                         last_seen: now,
-                        state: NodeState::Healthy,
                     },
                 );
             }
@@ -176,7 +163,6 @@ impl BlockHashStore {
                 NodeLiveness {
                     epoch: epoch.to_string(),
                     last_seen: now,
-                    state: NodeState::Healthy,
                 },
             );
         }
@@ -212,87 +198,11 @@ impl BlockHashStore {
         purged
     }
 
-    /// Sweep node liveness states.
-    /// Marks healthy nodes as suspect after suspect_threshold.
-    /// Purges suspect nodes after hard_delete_threshold.
-    /// Returns (suspect_count, purged_count).
-    pub fn sweep_liveness(&self) -> (usize, usize) {
-        if self.nodes.is_empty() {
-            return (0, 0);
-        }
-
-        let now = Instant::now();
-        let mut suspect_count = 0;
-        let mut candidates: Vec<Arc<str>> = Vec::new();
-
-        for mut entry in self.nodes.iter_mut() {
-            let elapsed = now.duration_since(entry.last_seen);
-
-            if elapsed >= self.hard_delete_threshold {
-                candidates.push(entry.key().clone());
-            } else if elapsed >= self.suspect_threshold && entry.state == NodeState::Healthy {
-                entry.state = NodeState::Suspect;
-                suspect_count += 1;
-                warn!(
-                    "Node {} marked suspect (no heartbeat for {:?})",
-                    entry.key(),
-                    elapsed
-                );
-            }
-        }
-
-        if candidates.is_empty() {
-            return (suspect_count, 0);
-        }
-
-        // Re-validate staleness with remove_if to avoid purging a node that
-        // received a heartbeat between the scan above and now.
-        let mut purged_nodes: Vec<Arc<str>> = Vec::new();
-        for node_key in &candidates {
-            if self
-                .nodes
-                .remove_if(node_key, |_, liveness| {
-                    now.duration_since(liveness.last_seen) >= self.hard_delete_threshold
-                })
-                .is_some()
-            {
-                purged_nodes.push(node_key.clone());
-                info!("Hard-deleted node {}", node_key);
-            }
-        }
-
-        if purged_nodes.is_empty() {
-            return (suspect_count, 0);
-        }
-
-        // Single-pass purge: remove all dead nodes from the block map in one retain()
-        // instead of calling purge_node() per node (which would be O(N * total_blocks)).
-        let mut total_purged_entries = 0;
-        self.map.retain(|_, owners| {
-            for node in &purged_nodes {
-                if owners.remove(node.as_ref()).is_some() {
-                    total_purged_entries += 1;
-                }
-            }
-            !owners.is_empty()
-        });
-
-        let purged_count = purged_nodes.len();
-        if total_purged_entries > 0 {
-            info!(
-                "Liveness sweep: purged {} nodes, {} block entries",
-                purged_count, total_purged_entries
-            );
-        }
-
-        (suspect_count, purged_count)
-    }
-
-    /// Sweep expired entries. Removes per-node registrations older than TTL,
-    /// then drops block keys with no remaining owners.
-    /// Called periodically from a background task.
-    /// Returns the number of block keys fully removed.
-    pub fn sweep_expired(&self) -> usize {
+    /// Sweep expired entries and dead nodes.
+    /// 1. Removes per-node block registrations older than TTL.
+    /// 2. Purges nodes past `hard_delete_threshold` and removes their block entries.
+    /// Returns (expired_keys_removed, dead_nodes_purged).
+    pub fn sweep_expired(&self) -> (usize, usize) {
         let now = Instant::now();
         let ttl = self.ttl;
         let before = self.map.len();
@@ -300,7 +210,48 @@ impl BlockHashStore {
             nodes.retain(|_, registered_at| now.duration_since(*registered_at) < ttl);
             !nodes.is_empty()
         });
-        before.saturating_sub(self.map.len())
+        let expired_keys = before.saturating_sub(self.map.len());
+
+        // Purge dead nodes (past hard_delete_threshold)
+        let mut purged_nodes: Vec<Arc<str>> = Vec::new();
+        for entry in self.nodes.iter() {
+            if entry.last_seen.elapsed() >= self.hard_delete_threshold {
+                purged_nodes.push(entry.key().clone());
+            }
+        }
+
+        // Re-validate with remove_if to avoid TOCTOU with concurrent heartbeats
+        purged_nodes.retain(|node_key| {
+            self.nodes
+                .remove_if(node_key, |_, liveness| {
+                    liveness.last_seen.elapsed() >= self.hard_delete_threshold
+                })
+                .is_some()
+        });
+
+        if !purged_nodes.is_empty() {
+            let mut total_purged_entries = 0;
+            self.map.retain(|_, owners| {
+                for node in &purged_nodes {
+                    if owners.remove(node.as_ref()).is_some() {
+                        total_purged_entries += 1;
+                    }
+                }
+                !owners.is_empty()
+            });
+            for node_key in &purged_nodes {
+                info!("Hard-deleted node {}", node_key);
+            }
+            if total_purged_entries > 0 {
+                info!(
+                    "Sweep: purged {} dead nodes, {} block entries",
+                    purged_nodes.len(),
+                    total_purged_entries
+                );
+            }
+        }
+
+        (expired_keys, purged_nodes.len())
     }
 
     /// Get the number of unique block keys
@@ -313,12 +264,9 @@ impl BlockHashStore {
         self.nodes.len()
     }
 
-    /// Check if a node is in Healthy state (or not tracked, which means
-    /// it has no liveness entry — treat as healthy for backwards compatibility
-    /// with nodes that haven't sent a heartbeat yet).
     fn is_node_healthy(&self, node: &Arc<str>) -> bool {
         match self.nodes.get(node) {
-            Some(entry) => entry.state == NodeState::Healthy,
+            Some(entry) => entry.last_seen.elapsed() < self.suspect_threshold,
             None => true,
         }
     }
@@ -463,7 +411,7 @@ mod tests {
         assert_eq!(store.entry_count(), 2);
 
         // Instant::now() is already past the zero-TTL deadline
-        let removed = store.sweep_expired();
+        let (removed, _) = store.sweep_expired();
         assert_eq!(removed, 2);
         assert_eq!(store.entry_count(), 0);
     }
@@ -473,7 +421,7 @@ mod tests {
         let store = BlockHashStore::with_ttl(120); // 120 min TTL
         store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
 
-        let removed = store.sweep_expired();
+        let (removed, _) = store.sweep_expired();
         assert_eq!(removed, 0);
         assert_eq!(store.entry_count(), 2);
     }
@@ -552,11 +500,10 @@ mod tests {
 
         let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
         assert_eq!(entry.epoch, "epoch-1");
-        assert_eq!(entry.state, NodeState::Healthy);
     }
 
     #[test]
-    fn test_heartbeat_refresh_healthy() {
+    fn test_heartbeat_refresh() {
         let store = BlockHashStore::new();
         store.heartbeat("node-a", "epoch-1");
 
@@ -575,32 +522,24 @@ mod tests {
             .unwrap()
             .last_seen;
         assert!(second_seen > first_seen);
-
-        let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
-        assert_eq!(entry.state, NodeState::Healthy);
     }
 
     #[test]
-    fn test_heartbeat_recover_from_suspect() {
-        // suspect_threshold=0 so sweep immediately marks suspect
-        let store = BlockHashStore::with_liveness_config(120, 0, 3600);
+    fn test_heartbeat_recovers_stale_node() {
+        let store = BlockHashStore {
+            suspect_threshold: Duration::from_millis(50),
+            ..BlockHashStore::with_liveness_config(120, 1, 3600)
+        };
         store.heartbeat("node-a", "epoch-1");
         store.insert_hashes("ns", &[vec![1]], "node-a");
 
-        // Sweep marks suspect
-        let (suspect, _) = store.sweep_liveness();
-        assert_eq!(suspect, 1);
-
-        // Query should filter out suspect
+        // Wait until node-a becomes stale
+        std::thread::sleep(Duration::from_millis(60));
         let result = store.query_prefix("ns", &[vec![1]]);
         assert_eq!(result.len(), 0);
 
-        // Heartbeat with same epoch recovers
+        // Heartbeat refreshes last_seen → node visible again
         store.heartbeat("node-a", "epoch-1");
-        let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
-        assert_eq!(entry.state, NodeState::Healthy);
-
-        // Query should return the node again
         let result = store.query_prefix("ns", &[vec![1]]);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].nodes[0].as_ref(), "node-a");
@@ -620,7 +559,6 @@ mod tests {
 
         let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
         assert_eq!(entry.epoch, "epoch-2");
-        assert_eq!(entry.state, NodeState::Healthy);
     }
 
     // --- Bye tests ---
@@ -656,59 +594,30 @@ mod tests {
         assert_eq!(purged, 0);
     }
 
-    // --- Liveness sweep tests ---
+    // --- Sweep + dead node purge tests ---
 
     #[test]
-    fn test_sweep_marks_suspect() {
-        // suspect_threshold=0 → immediately suspect
-        let store = BlockHashStore::with_liveness_config(120, 0, 3600);
-        store.heartbeat("node-a", "epoch-1");
-
-        let (suspect, purged) = store.sweep_liveness();
-        assert_eq!(suspect, 1);
-        assert_eq!(purged, 0);
-
-        let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
-        assert_eq!(entry.state, NodeState::Suspect);
-    }
-
-    #[test]
-    fn test_sweep_healthy_within_threshold() {
-        // suspect_threshold=120s → way in the future
-        let store = BlockHashStore::with_liveness_config(120, 120, 3600);
-        store.heartbeat("node-a", "epoch-1");
-
-        let (suspect, purged) = store.sweep_liveness();
-        assert_eq!(suspect, 0);
-        assert_eq!(purged, 0);
-
-        let entry = store.nodes.get(&Arc::<str>::from("node-a")).unwrap();
-        assert_eq!(entry.state, NodeState::Healthy);
-    }
-
-    #[test]
-    fn test_sweep_hard_deletes() {
-        // Both thresholds=0 → immediately suspect then hard-delete
-        let store = BlockHashStore::with_liveness_config(120, 0, 0);
+    fn test_sweep_expired_purges_dead_nodes() {
+        // hard_delete=0 → immediately dead
+        let store = BlockHashStore::with_liveness_config(120, 30, 0);
         store.heartbeat("node-a", "epoch-1");
         store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
 
-        let (_, purged) = store.sweep_liveness();
-        assert_eq!(purged, 1);
+        let (_, purged_nodes) = store.sweep_expired();
+        assert_eq!(purged_nodes, 1);
         assert_eq!(store.node_count(), 0);
         assert_eq!(store.entry_count(), 0);
     }
 
     #[test]
-    fn test_sweep_does_not_delete_fresh_suspect() {
-        // suspect=0, hard_delete=3600 → becomes suspect but not purged
-        let store = BlockHashStore::with_liveness_config(120, 0, 3600);
+    fn test_sweep_expired_keeps_fresh_nodes() {
+        // hard_delete=3600 → node survives
+        let store = BlockHashStore::with_liveness_config(120, 30, 3600);
         store.heartbeat("node-a", "epoch-1");
         store.insert_hashes("ns", &[vec![1]], "node-a");
 
-        let (suspect, purged) = store.sweep_liveness();
-        assert_eq!(suspect, 1);
-        assert_eq!(purged, 0);
+        let (_, purged_nodes) = store.sweep_expired();
+        assert_eq!(purged_nodes, 0);
         assert_eq!(store.node_count(), 1);
         assert_eq!(store.entry_count(), 1);
     }
@@ -716,16 +625,18 @@ mod tests {
     // --- Query filtering tests ---
 
     #[test]
-    fn test_query_filters_suspect_nodes() {
-        let store = BlockHashStore::with_liveness_config(120, 0, 3600);
+    fn test_query_filters_stale_nodes() {
+        let store = BlockHashStore {
+            suspect_threshold: Duration::from_millis(50),
+            ..BlockHashStore::with_liveness_config(120, 1, 3600)
+        };
         store.heartbeat("node-a", "epoch-a");
         store.heartbeat("node-b", "epoch-b");
         store.insert_hashes("ns", &[vec![1]], "node-a");
         store.insert_hashes("ns", &[vec![1]], "node-b");
 
-        // Mark node-a suspect
-        store.sweep_liveness();
-        // Refresh node-b to healthy
+        // Wait until both are stale, then refresh only node-b
+        std::thread::sleep(Duration::from_millis(60));
         store.heartbeat("node-b", "epoch-b");
 
         let result = store.query_prefix("ns", &[vec![1]]);
@@ -735,22 +646,23 @@ mod tests {
     }
 
     #[test]
-    fn test_query_suspect_only_owner_breaks_prefix() {
+    fn test_query_stale_only_owner_breaks_prefix() {
+        // suspect_threshold=0 → stale immediately
         let store = BlockHashStore::with_liveness_config(120, 0, 3600);
         store.heartbeat("node-a", "epoch-a");
         store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
 
-        // Mark suspect
-        store.sweep_liveness();
-
-        // All blocks owned by suspect → prefix is empty
+        // node-a is stale → prefix is empty
         let result = store.query_prefix("ns", &[vec![1], vec![2]]);
         assert_eq!(result.len(), 0);
     }
 
     #[test]
-    fn test_query_mixed_healthy_suspect() {
-        let store = BlockHashStore::with_liveness_config(120, 0, 3600);
+    fn test_query_mixed_healthy_stale() {
+        let store = BlockHashStore {
+            suspect_threshold: Duration::from_millis(50),
+            ..BlockHashStore::with_liveness_config(120, 1, 3600)
+        };
 
         store.heartbeat("node-a", "epoch-a");
         store.heartbeat("node-b", "epoch-b");
@@ -759,12 +671,12 @@ mod tests {
         store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
         store.insert_hashes("ns", &[vec![1]], "node-b");
 
-        // Mark both suspect, then recover node-b
-        store.sweep_liveness();
+        // Wait until both stale, then refresh only node-b
+        std::thread::sleep(Duration::from_millis(60));
         store.heartbeat("node-b", "epoch-b");
 
-        // h1: node-a(suspect) + node-b(healthy) → node-b visible
-        // h2: node-a(suspect) only → prefix stops
+        // h1: node-a(stale) + node-b(fresh) → node-b visible
+        // h2: node-a(stale) only → prefix stops
         let result = store.query_prefix("ns", &[vec![1], vec![2]]);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].nodes.len(), 1);

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -159,6 +159,7 @@ impl BlockHashStore {
                 );
             }
         } else {
+            info!("Detected node {}", node);
             self.nodes.insert(
                 node_key,
                 NodeLiveness {
@@ -173,14 +174,11 @@ impl BlockHashStore {
     /// Only acts if the epoch matches (prevents stale Bye from old process).
     pub fn bye(&self, node: &str, epoch: &str) -> usize {
         let node_key: Arc<str> = Arc::from(node);
-        if let Some(entry) = self.nodes.get(&node_key) {
-            if entry.epoch != epoch {
-                return 0;
-            }
-            drop(entry);
-            let purged = self.purge_node(node);
-            self.nodes.remove(&node_key);
-            purged
+        let removed = self
+            .nodes
+            .remove_if(&node_key, |_, liveness| liveness.epoch == epoch);
+        if removed.is_some() {
+            self.purge_node(node)
         } else {
             0
         }
@@ -204,8 +202,8 @@ impl BlockHashStore {
     /// 1. Removes per-node block registrations older than TTL.
     /// 2. Purges nodes past `hard_delete_threshold` and removes their block entries.
     ///
-    /// Returns (expired_keys_removed, dead_nodes_purged).
-    pub fn sweep_expired(&self) -> (usize, usize) {
+    /// Returns (ttl_expired_keys, purge_removed_keys, dead_nodes_purged).
+    pub fn sweep_expired(&self) -> (usize, usize, usize) {
         let now = Instant::now();
         let ttl = self.ttl;
         let before = self.map.len();
@@ -213,7 +211,8 @@ impl BlockHashStore {
             nodes.retain(|_, registered_at| now.duration_since(*registered_at) < ttl);
             !nodes.is_empty()
         });
-        let mut expired_keys = before.saturating_sub(self.map.len());
+        let expired_keys = before.saturating_sub(self.map.len());
+        let mut purge_removed_keys = 0;
 
         // Purge dead nodes (past hard_delete_threshold)
         let mut purged_nodes: Vec<Arc<str>> = Vec::new();
@@ -240,21 +239,13 @@ impl BlockHashStore {
                 }
                 !owners.is_empty()
             });
-            let purge_removed = before_purge.saturating_sub(self.map.len());
-            expired_keys += purge_removed;
+            purge_removed_keys = before_purge.saturating_sub(self.map.len());
             for node_key in &purged_nodes {
                 info!("Hard-deleted node {}", node_key);
             }
-            if purge_removed > 0 {
-                info!(
-                    "Sweep: purged {} dead nodes, {} block entries",
-                    purged_nodes.len(),
-                    purge_removed
-                );
-            }
         }
 
-        (expired_keys, purged_nodes.len())
+        (expired_keys, purge_removed_keys, purged_nodes.len())
     }
 
     /// Get the number of unique block keys
@@ -270,7 +261,12 @@ impl BlockHashStore {
     fn is_node_healthy(&self, node: &Arc<str>) -> bool {
         match self.nodes.get(node) {
             Some(entry) => entry.last_seen.elapsed() < self.suspect_threshold,
-            None => false,
+            // Backward compatibility: nodes may own blocks in `self.map`
+            // without ever being registered in `self.nodes` via heartbeat.
+            // Treat those untracked nodes as healthy so prefix queries keep
+            // returning existing owners unless/until explicit liveness data
+            // marks them suspect or they are removed by normal TTL cleanup.
+            None => true,
         }
     }
 
@@ -414,7 +410,7 @@ mod tests {
         assert_eq!(store.entry_count(), 2);
 
         // Instant::now() is already past the zero-TTL deadline
-        let (removed, _) = store.sweep_expired();
+        let (removed, _, _) = store.sweep_expired();
         assert_eq!(removed, 2);
         assert_eq!(store.entry_count(), 0);
     }
@@ -424,7 +420,7 @@ mod tests {
         let store = BlockHashStore::with_ttl(120); // 120 min TTL
         store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
 
-        let (removed, _) = store.sweep_expired();
+        let (removed, _, _) = store.sweep_expired();
         assert_eq!(removed, 0);
         assert_eq!(store.entry_count(), 2);
     }
@@ -606,8 +602,9 @@ mod tests {
         store.heartbeat("node-a", "epoch-1");
         store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
 
-        let (_, purged_nodes) = store.sweep_expired();
+        let (_, purge_removed, purged_nodes) = store.sweep_expired();
         assert_eq!(purged_nodes, 1);
+        assert_eq!(purge_removed, 2);
         assert_eq!(store.node_count(), 0);
         assert_eq!(store.entry_count(), 0);
     }
@@ -619,7 +616,7 @@ mod tests {
         store.heartbeat("node-a", "epoch-1");
         store.insert_hashes("ns", &[vec![1]], "node-a");
 
-        let (_, purged_nodes) = store.sweep_expired();
+        let (_, _, purged_nodes) = store.sweep_expired();
         assert_eq!(purged_nodes, 0);
         assert_eq!(store.node_count(), 1);
         assert_eq!(store.entry_count(), 1);

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -223,13 +223,13 @@ impl BlockHashStore {
 
         let now = Instant::now();
         let mut suspect_count = 0;
-        let mut purged_nodes: Vec<Arc<str>> = Vec::new();
+        let mut candidates: Vec<Arc<str>> = Vec::new();
 
         for mut entry in self.nodes.iter_mut() {
             let elapsed = now.duration_since(entry.last_seen);
 
             if elapsed >= self.hard_delete_threshold {
-                purged_nodes.push(entry.key().clone());
+                candidates.push(entry.key().clone());
             } else if elapsed >= self.suspect_threshold && entry.state == NodeState::Healthy {
                 entry.state = NodeState::Suspect;
                 suspect_count += 1;
@@ -238,6 +238,26 @@ impl BlockHashStore {
                     entry.key(),
                     elapsed
                 );
+            }
+        }
+
+        if candidates.is_empty() {
+            return (suspect_count, 0);
+        }
+
+        // Re-validate staleness with remove_if to avoid purging a node that
+        // received a heartbeat between the scan above and now.
+        let mut purged_nodes: Vec<Arc<str>> = Vec::new();
+        for node_key in &candidates {
+            if self
+                .nodes
+                .remove_if(node_key, |_, liveness| {
+                    now.duration_since(liveness.last_seen) >= self.hard_delete_threshold
+                })
+                .is_some()
+            {
+                purged_nodes.push(node_key.clone());
+                info!("Hard-deleted node {}", node_key);
             }
         }
 
@@ -258,10 +278,6 @@ impl BlockHashStore {
         });
 
         let purged_count = purged_nodes.len();
-        for node_key in &purged_nodes {
-            self.nodes.remove(node_key);
-            info!("Hard-deleted node {}", node_key);
-        }
         if total_purged_entries > 0 {
             info!(
                 "Liveness sweep: purged {} nodes, {} block entries",

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -222,8 +222,24 @@ message QueryPrefixBlocksResponse {
   repeated NodePrefixResult nodes = 1;
 }
 
+message HeartbeatRequest {
+  string node = 1;
+  string epoch = 2;
+}
+
+message HeartbeatResponse {}
+
+message ByeRequest {
+  string node = 1;
+  string epoch = 2;
+}
+
+message ByeResponse {}
+
 service MetaServer {
   rpc InsertBlockHashes(InsertBlockHashesRequest) returns (InsertBlockHashesResponse);
   rpc RemoveBlockHashes(RemoveBlockHashesRequest) returns (RemoveBlockHashesResponse);
   rpc QueryPrefixBlocks(QueryPrefixBlocksRequest) returns (QueryPrefixBlocksResponse);
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
+  rpc Bye(ByeRequest) returns (ByeResponse);
 }

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -452,7 +452,6 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         advertise_addr,
         metaserver_queue_depth: cli.metaserver_queue_depth,
         pool_shards: cli.pool_shards,
-        shutdown: Some(Arc::clone(&shutdown)),
     };
 
     if cli.pool_shards > 1 {

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -437,6 +437,8 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         None
     };
 
+    let shutdown = Arc::new(Notify::new());
+
     let storage_config = pegaflow_core::StorageConfig {
         enable_lfu_admission: cli.enable_lfu_admission,
         hint_value_size_bytes: cli.hint_value_size,
@@ -450,6 +452,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         advertise_addr,
         metaserver_queue_depth: cli.metaserver_queue_depth,
         pool_shards: cli.pool_shards,
+        shutdown: Some(Arc::clone(&shutdown)),
     };
 
     if cli.pool_shards > 1 {
@@ -488,8 +491,6 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         ),
     ));
     crate::metric::register_hll_gauges(&hll_tracker);
-
-    let shutdown = Arc::new(Notify::new());
 
     runtime.block_on(async move {
         // Create PegaEngine inside tokio runtime context (needed for SSD cache tokio::spawn)
@@ -588,6 +589,9 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         }
 
         info!("Server stopped");
+
+        // Send Bye to MetaServer before full shutdown
+        engine.metaserver_bye().await;
 
         // Stop HTTP server
         shutdown.notify_waiters();


### PR DESCRIPTION
## Summary

- Add **Heartbeat/Bye RPCs** to MetaServer for server liveness tracking
- **Suspect filtering**: nodes missing heartbeats for 30s are excluded from `query_prefix` results (entries preserved for instant recovery)
- **Hard-delete purge**: nodes missing heartbeats for 90s have all block entries purged via batched single-pass `map.retain()`
- **Bye RPC**: graceful SIGTERM triggers immediate epoch-matched cleanup
- **Epoch-based restart detection**: new process at same address auto-purges stale entries from old process
- Client-side: 10s heartbeat loop with shutdown-aware `tokio::select!`, `bye()` called during server shutdown
- Liveness metrics: suspect/purged counters, active_nodes gauge

## Motivation

Previously, when a pegaflow-server went offline, its block hash entries in MetaServer lingered until the 120-minute TTL expired. During that window, `query_prefix` could route requests to dead nodes, causing transfer failures.

## Test plan

- [x] 20+ unit tests in `pegaflow-metaserver/src/store.rs` covering all liveness state transitions, sweep, purge, epoch handling
- [x] 3 integration tests in `pegaflow-metaserver/src/service.rs` (heartbeat RPC, bye purge, suspect filtering)
- [ ] `cargo test -p pegaflow-metaserver` passes
- [ ] `cargo check -p pegaflow-server` passes (full build requires RDMA libs)

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)