### PR TITLE
feat(server): session-stream liveness for vllm crash cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,6 +2232,7 @@ dependencies = [
  "axum",
  "clap",
  "cudarc",
+ "dashmap",
  "fastrace",
  "log",
  "opentelemetry",

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -114,6 +114,20 @@ message HealthResponse {
   ResponseStatus status = 1;
 }
 
+// Liveness session: vllm opens a server-streaming RPC at startup and holds
+// it for the lifetime of the instance. Server detects client disconnect
+// (process death → TCP FIN) and auto-releases the instance's CUDA IPC
+// mappings. Stream events are reserved for future server→client hints.
+message SessionRequest {
+  string instance_id = 1;
+  string namespace   = 2;
+  uint32 tp_size     = 3;
+  uint32 world_size  = 4;
+}
+
+message SessionEvent {
+}
+
 // Cross-node transfer: per-slot RDMA metadata
 message TransferSlotInfo {
   uint64 k_ptr = 1;      // Remote pinned memory address for K segment
@@ -180,6 +194,9 @@ service Engine {
   rpc RdmaHandshake(RdmaHandshakeRequest) returns (RdmaHandshakeResponse);
   rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
   rpc Health(HealthRequest) returns (HealthResponse);
+  // Liveness channel: server drops the instance's CUDA IPC mappings when
+  // this stream closes (vllm process dies or disconnects).
+  rpc Session(SessionRequest) returns (stream SessionEvent);
 }
 
 // MetaServer service for managing block hash keys across multi-node instances

--- a/pegaflow-server/Cargo.toml
+++ b/pegaflow-server/Cargo.toml
@@ -35,6 +35,7 @@ tokio.workspace = true
 clap.workspace = true
 log.workspace = true
 parking_lot.workspace = true
+dashmap.workspace = true
 axum.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod metric;
 pub mod proto;
 pub mod registry;
 pub mod service;
+pub mod session;
 #[cfg(feature = "tracing")]
 mod trace;
 #[cfg(not(feature = "tracing"))]

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -7,17 +7,20 @@ use crate::proto::engine::{
     QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, QueryRequest, QueryResponse,
     RdmaHandshakeRequest, RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse,
     ReleaseTransferLockRequest, ReleaseTransferLockResponse, ResponseStatus, SaveRequest,
-    SaveResponse, ShutdownRequest, ShutdownResponse, TransferBlockInfo, TransferSlotInfo,
-    UnpinRequest, UnpinResponse, UnregisterRequest, UnregisterResponse,
+    SaveResponse, SessionEvent, SessionRequest, ShutdownRequest, ShutdownResponse,
+    TransferBlockInfo, TransferSlotInfo, UnpinRequest, UnpinResponse, UnregisterRequest,
+    UnregisterResponse,
 };
 use crate::registry::CudaTensorRegistry;
+use crate::session::SessionRegistry;
 use log::{debug, info, warn};
 use parking_lot::Mutex;
 use pegaflow_core::{EngineError, LayerSave, PegaEngine, PrefetchStatus};
 use pyo3::{PyErr, Python};
 use std::sync::Arc;
 use std::time::Instant;
-use tokio::sync::Notify;
+use tokio::sync::{Notify, mpsc};
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, async_trait};
 
 #[derive(Clone)]
@@ -26,6 +29,7 @@ pub struct GrpcEngineService {
     registry: Arc<Mutex<CudaTensorRegistry>>,
     shutdown: Arc<Notify>,
     hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::HllTracker>>,
+    session_registry: Arc<SessionRegistry>,
 }
 
 impl GrpcEngineService {
@@ -40,6 +44,35 @@ impl GrpcEngineService {
             registry,
             shutdown,
             hll_tracker,
+            session_registry: SessionRegistry::new(),
+        }
+    }
+
+    /// Drop CUDA IPC tensors and engine-side instance state for `instance_id`.
+    /// Idempotent — safe to call after the instance is already gone.
+    fn cleanup_instance(
+        engine: &PegaEngine,
+        registry: &Mutex<CudaTensorRegistry>,
+        instance_id: &str,
+        reason: &'static str,
+    ) {
+        let removed = {
+            let mut registry = registry.lock();
+            registry.drop_instance(instance_id)
+        };
+        if removed > 0 {
+            info!(
+                "Session cleanup ({}): dropped {} CUDA tensors for instance {}",
+                reason, removed, instance_id
+            );
+        }
+        if let Err(err) = engine.unregister_instance(instance_id) {
+            // `InstanceMissing` is normal if the instance was never registered
+            // (vllm died before any register_context_batch). Log at debug.
+            debug!(
+                "Session cleanup ({}): engine.unregister_instance({}) returned {}",
+                reason, instance_id, err
+            );
         }
     }
 
@@ -780,6 +813,59 @@ impl Engine for GrpcEngineService {
         }
         record_rpc_result("health", &result, start);
         result
+    }
+
+    type SessionStream = ReceiverStream<Result<SessionEvent, Status>>;
+
+    async fn session(
+        &self,
+        request: Request<SessionRequest>,
+    ) -> Result<Response<Self::SessionStream>, Status> {
+        let req = request.into_inner();
+        let instance_id = req.instance_id;
+        if instance_id.is_empty() {
+            return Err(Status::invalid_argument("instance_id must not be empty"));
+        }
+
+        let token = self.session_registry.install(instance_id.clone());
+        info!(
+            "Session opened: instance_id={} namespace={} tp_size={} world_size={} token={}",
+            instance_id, req.namespace, req.tp_size, req.world_size, token
+        );
+
+        // Channel capacity is 1: we don't emit events yet, and a tight capacity
+        // makes backpressure explicit if we ever do.
+        let (tx, rx) = mpsc::channel::<Result<SessionEvent, Status>>(1);
+
+        // Hand a clone to the watcher; it observes `closed()` when the tonic
+        // runtime drops the receiver side after client disconnect. We keep the
+        // original `tx` alive until this function returns `Response`; once the
+        // handler future is dropped by tonic on client cancel, both `tx` and
+        // `rx` are dropped → `cleanup_tx.closed()` resolves.
+        let cleanup_tx = tx.clone();
+
+        let session_registry = Arc::clone(&self.session_registry);
+        let engine = Arc::clone(&self.engine);
+        let cuda_registry = Arc::clone(&self.registry);
+        let id_for_watcher = instance_id.clone();
+
+        tokio::spawn(async move {
+            cleanup_tx.closed().await;
+            if session_registry.take(&id_for_watcher, token) {
+                info!(
+                    "Session closed: instance_id={} token={} — running cleanup",
+                    id_for_watcher, token
+                );
+                Self::cleanup_instance(&engine, &cuda_registry, &id_for_watcher, "stream closed");
+            } else {
+                debug!(
+                    "Session closed: instance_id={} token={} superseded — skip cleanup",
+                    id_for_watcher, token
+                );
+            }
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
     }
 }
 

--- a/pegaflow-server/src/session.rs
+++ b/pegaflow-server/src/session.rs
@@ -1,0 +1,46 @@
+//! Liveness session registry.
+//!
+//! Tracks an active `Session` RPC per instance_id. Each install produces a
+//! monotonically increasing token; a new session for the same instance_id
+//! supersedes the previous token, so a stale session's cleanup hook becomes
+//! a no-op.
+
+use dashmap::DashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Default)]
+pub struct SessionRegistry {
+    sessions: DashMap<String, u64>,
+    next_token: AtomicU64,
+}
+
+impl SessionRegistry {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Install a new session for `instance_id`, returning the token that
+    /// identifies it. Overwrites any existing token (the old session's
+    /// cleanup will observe `is_current == false` and skip).
+    pub fn install(&self, instance_id: String) -> u64 {
+        let token = self.next_token.fetch_add(1, Ordering::Relaxed) + 1;
+        self.sessions.insert(instance_id, token);
+        token
+    }
+
+    /// CAS-remove: only removes if `token` is still the current one.
+    /// Returns true if this caller owns the cleanup.
+    pub fn take(&self, instance_id: &str, token: u64) -> bool {
+        let mut owned = false;
+        self.sessions.remove_if(instance_id, |_, current| {
+            if *current == token {
+                owned = true;
+                true
+            } else {
+                false
+            }
+        });
+        owned
+    }
+}

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -125,6 +125,11 @@ class PegaKVConnector(KVConnectorBase_V1):
         self._worker: WorkerConnector | None = None
         if role == KVConnectorRole.SCHEDULER:
             self._scheduler = SchedulerConnector(self._ctx)
+            # Open the liveness stream from the scheduler process only. One
+            # stream per vllm replica is enough — if any tp worker crashes,
+            # the scheduler dies too, closing this stream and triggering
+            # server-side cleanup of the instance's CUDA IPC mappings.
+            engine_client.start_session_watcher(instance_id, namespace, tp_size, world_size)
         else:
             self._worker = WorkerConnector(self._ctx)
 

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -244,6 +244,32 @@ class EngineRpcClient:
         """
         ...
 
+    def start_session_watcher(
+        self,
+        instance_id: str,
+        namespace: str,
+        tp_size: int,
+        world_size: int,
+    ) -> None:
+        """Open a liveness Session stream to the engine server.
+
+        The client holds a server-streaming RPC open for the lifetime of
+        this process. When the process dies, the kernel closes the TCP
+        socket; the server observes disconnect and auto-releases the
+        instance's CUDA IPC mappings. No polling on the Python side — the
+        hyper connection driver keeps the underlying HTTP/2 connection
+        alive on its own.
+
+        Call once, typically from the scheduler role. Calling again
+        replaces the previous stream; the server supersedes the prior
+        session and the old one becomes a no-op on close.
+
+        Raises:
+            PegaFlowServiceError: If the server is unavailable.
+            PegaFlowBusinessError: If the request is rejected.
+        """
+        ...
+
 class PyLoadState:
     """Batch-level synchronization for async KV cache loading via shared memory.
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,7 +1,8 @@
 use pegaflow_core::LoadState;
 use pegaflow_proto::proto::engine::{
     HealthRequest, LoadRequest, QueryRequest, RegisterContextRequest, ResponseStatus, SaveLayer,
-    SaveRequest, ShutdownRequest, UnpinRequest, UnregisterRequest, engine_client::EngineClient,
+    SaveRequest, SessionEvent, SessionRequest, ShutdownRequest, UnpinRequest, UnregisterRequest,
+    engine_client::EngineClient,
 };
 use pyo3::{
     create_exception,
@@ -10,12 +11,12 @@ use pyo3::{
 };
 use std::{
     future::Future,
-    sync::{Arc, OnceLock},
+    sync::{Arc, Mutex, OnceLock},
     time::Duration,
 };
 use tokio::runtime::{Handle, Runtime};
 use tonic::{
-    Code, Status as GrpcStatus,
+    Code, Status as GrpcStatus, Streaming,
     transport::{Channel, Endpoint},
 };
 
@@ -108,6 +109,13 @@ struct EngineRpcClient {
     endpoint: String,
     client: EngineClient<Channel>,
     rt_handle: Handle,
+    /// Holds the server-streaming Session response if `start_session_watcher`
+    /// was called. We never poll it — the hyper connection driver keeps the
+    /// underlying HTTP/2 connection alive on its own. Keeping the Streaming
+    /// alive here (instead of dropping it) is what keeps the stream open on
+    /// the wire, so server-side disconnect detection only fires when this
+    /// process actually dies.
+    session_stream: Mutex<Option<Streaming<SessionEvent>>>,
 }
 
 impl EngineRpcClient {
@@ -161,6 +169,7 @@ impl EngineRpcClient {
             endpoint,
             client,
             rt_handle,
+            session_stream: Mutex::new(None),
         })
     }
 
@@ -434,6 +443,44 @@ impl EngineRpcClient {
             Ok(resp.into_inner())
         })
         .and_then(|r| status_tuple("shutdown", r.status))
+    }
+
+    /// Open a liveness session with the engine server.
+    ///
+    /// Sends one `Session` RPC and retains the resulting server-streaming
+    /// response. No polling — the hyper connection driver keeps the HTTP/2
+    /// connection alive. When this process dies, the kernel closes the TCP
+    /// socket; the server observes disconnect and auto-releases CUDA IPC
+    /// mappings for `instance_id`.
+    ///
+    /// Call once per client, typically from the scheduler role. Calling
+    /// again replaces the previous stream (the old Streaming drops and the
+    /// server's old session is superseded by the new one).
+    #[pyo3(signature = (instance_id, namespace, tp_size, world_size))]
+    fn start_session_watcher(
+        &self,
+        py: Python<'_>,
+        instance_id: String,
+        namespace: String,
+        tp_size: u32,
+        world_size: u32,
+    ) -> PyResult<()> {
+        let mut client = self.client.clone();
+        let req = SessionRequest {
+            instance_id,
+            namespace,
+            tp_size,
+            world_size,
+        };
+        let stream = self.call(py, "session", move |_| async move {
+            let resp = client.session(req).await?;
+            Ok(resp.into_inner())
+        })?;
+        *self
+            .session_stream
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("session_stream mutex poisoned"))? = Some(stream);
+        Ok(())
     }
 }
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -13,6 +13,7 @@ import socket
 import subprocess
 import sys
 import sysconfig
+import tempfile
 import time
 import uuid
 from collections.abc import Generator
@@ -323,6 +324,8 @@ class PegaServerProcess:
         self.endpoint = f"http://127.0.0.1:{port}"
         self.process: subprocess.Popen | None = None
         self._binary_path = find_server_binary()
+        self._log_path: Path | None = None
+        self._log_file = None
 
     def start(self) -> bool:
         """Start the server process. Returns True if successful."""
@@ -352,16 +355,25 @@ class PegaServerProcess:
             "0",
         ]
 
+        # Route logs to a tempfile so the pipe buffer cannot fill up and
+        # block the server mid-startup, and so tests can read the log
+        # contents via read_logs() (used by integration tests that assert
+        # on server-side log signals).
+        fd, path = tempfile.mkstemp(prefix=f"pega-server-{self.port}-", suffix=".log")
+        self._log_path = Path(path)
+        self._log_file = os.fdopen(fd, "wb")
+
         try:
             self.process = subprocess.Popen(
                 cmd,
                 env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stdout=self._log_file,
+                stderr=subprocess.STDOUT,
                 cwd="/tmp",
                 preexec_fn=os.setsid,
             )
         except (FileNotFoundError, PermissionError):
+            self._close_log()
             return False
 
         return wait_for_server_ready(self.endpoint)
@@ -369,6 +381,7 @@ class PegaServerProcess:
     def stop(self) -> None:
         """Stop the server process."""
         if self.process is None:
+            self._close_log()
             return
         try:
             os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
@@ -379,10 +392,28 @@ class PegaServerProcess:
                 self.process.wait(timeout=2)
         finally:
             self.process = None
+            self._close_log()
 
     def is_running(self) -> bool:
         """Check if server process is still running."""
         return self.process is not None and self.process.poll() is None
+
+    def read_logs(self) -> str:
+        """Return current server log contents (stdout + stderr merged)."""
+        if not self._log_path or not self._log_path.exists():
+            return ""
+        return self._log_path.read_text(errors="replace")
+
+    def _close_log(self) -> None:
+        import contextlib
+
+        if self._log_file is not None:
+            with contextlib.suppress(OSError):
+                self._log_file.close()
+            self._log_file = None
+        if self._log_path and self._log_path.exists():
+            with contextlib.suppress(OSError):
+                self._log_path.unlink()
 
 
 @pytest.fixture(scope="session")

--- a/python/tests/session_crash_helper.py
+++ b/python/tests/session_crash_helper.py
@@ -1,0 +1,72 @@
+"""Standalone worker used by test_session_watcher::test_crashed_client_releases_ipc.
+
+Allocates a GPU tensor, registers it as a CUDA IPC context with
+pegaflow-server, opens the liveness Session stream, signals the parent
+that it is ready, then blocks forever waiting to be SIGKILLed.
+
+Run as: python session_crash_helper.py <endpoint> <instance_id> <ready_file>
+"""
+
+from __future__ import annotations
+
+import importlib
+import pickle
+import sys
+import time
+
+import torch
+
+from pegaflow.ipc_wrapper import CudaIPCWrapper
+
+
+def main() -> int:
+    endpoint, instance_id, ready_file = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    pegaflow_module = importlib.import_module("pegaflow.pegaflow")
+    client = pegaflow_module.EngineRpcClient(endpoint)
+
+    device = torch.device("cuda:0")
+    kv = torch.rand((2, 16, 16, 8, 128), dtype=torch.bfloat16, device=device).contiguous()
+    wrapper_bytes = pickle.dumps(CudaIPCWrapper(kv))
+
+    shape = tuple(kv.shape)
+    stride = tuple(kv.stride())
+    element_size = kv.element_size()
+    num_blocks = shape[1]
+    bytes_per_block = stride[1] * element_size
+    kv_stride_bytes = stride[0] * element_size
+    segments = 2
+
+    ok, msg = client.register_context_batch(
+        instance_id,
+        "test-ns",
+        0,  # tp_rank
+        1,  # tp_size
+        1,  # world_size
+        0,  # device_id
+        1,  # num_layers
+        ["layer_0"],
+        [wrapper_bytes],
+        [num_blocks],
+        [bytes_per_block],
+        [kv_stride_bytes],
+        [segments],
+    )
+    if not ok:
+        print(f"register_context_batch failed: {msg}", file=sys.stderr)
+        return 1
+
+    client.start_session_watcher(instance_id, "test-ns", 1, 1)
+
+    with open(ready_file, "w") as f:
+        f.write("ready")
+
+    # Block until SIGKILLed. We must not drop the client gracefully —
+    # the test verifies cleanup fires on abrupt process death, not on
+    # orderly shutdown.
+    while True:
+        time.sleep(3600)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/tests/test_session_watcher.py
+++ b/python/tests/test_session_watcher.py
@@ -1,0 +1,90 @@
+"""Contract test for the Session-stream liveness feature.
+
+When a vllm process dies while holding registered CUDA IPC mappings,
+pegaflow-server must release them. Without this, the IPC handles pin
+the GPU memory on the server side and a DaemonSet-restarted vllm will
+OOM at `torch.cuda.init()`.
+
+Approach: spawn a worker subprocess that registers a real GPU tensor
+as an IPC context and opens a session, then SIGKILL it. The server
+logs how many CUDA tensors it dropped on session close; we assert that
+log line appears within a short deadline.
+
+Full GPU-memory-released-to-driver verification (nvidia-smi delta) is
+intentionally not automated — the server's drop path already calls
+`torch.cuda.empty_cache()` after dropping IPC handles, so observing
+"dropped N CUDA tensors" implies release.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import sysconfig
+import time
+from pathlib import Path
+
+import pytest
+
+HELPER = Path(__file__).parent / "session_crash_helper.py"
+READY_TIMEOUT_SEC = 30.0
+CLEANUP_LOG_DEADLINE_SEC = 5.0
+
+
+def _worker_env() -> dict[str, str]:
+    """Match pega_server fixture's environment so the helper finds the
+    same libpython / pegaflow module the server sees."""
+    env = os.environ.copy()
+    if libdir := sysconfig.get_config_var("LIBDIR"):
+        env["LD_LIBRARY_PATH"] = f"{libdir}:{env.get('LD_LIBRARY_PATH', '')}"
+    python_dir = Path(__file__).parent.parent
+    site_packages = next((p for p in sys.path if "site-packages" in p), None)
+    env["PYTHONPATH"] = str(python_dir) + (f":{site_packages}" if site_packages else "")
+    return env
+
+
+def test_crashed_client_releases_ipc(pega_server, tmp_path):
+    instance_id = f"inst-crash-{os.getpid()}"
+    ready_file = tmp_path / "ready"
+
+    worker = subprocess.Popen(
+        [sys.executable, str(HELPER), pega_server.endpoint, instance_id, str(ready_file)],
+        env=_worker_env(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        deadline = time.monotonic() + READY_TIMEOUT_SEC
+        while time.monotonic() < deadline:
+            if ready_file.exists():
+                break
+            if worker.poll() is not None:
+                out, err = worker.communicate()
+                pytest.fail(
+                    f"worker exited early with code {worker.returncode}\n"
+                    f"stdout={out.decode(errors='replace')}\n"
+                    f"stderr={err.decode(errors='replace')}"
+                )
+            time.sleep(0.05)
+        else:
+            pytest.fail(f"worker did not become ready within {READY_TIMEOUT_SEC}s")
+
+        worker.send_signal(signal.SIGKILL)
+        worker.wait(timeout=5)
+    finally:
+        if worker.poll() is None:
+            worker.kill()
+            worker.wait(timeout=5)
+
+    target = f"dropped 1 CUDA tensors for instance {instance_id}"
+    deadline = time.monotonic() + CLEANUP_LOG_DEADLINE_SEC
+    while time.monotonic() < deadline:
+        if target in pega_server.read_logs():
+            return
+        time.sleep(0.05)
+
+    tail = pega_server.read_logs()[-2000:]
+    pytest.fail(f"expected cleanup log not seen within {CLEANUP_LOG_DEADLINE_SEC}s\n---\n{tail}")


### PR DESCRIPTION
## Summary

- 新增 server-streaming `Session` RPC：vllm scheduler 开启后 hold 到进程死；kernel 关 TCP → server 端 `mpsc::Sender::closed()` 触发，跑 `drop_instance` 释放 CUDA IPC 映射。
- 解决 DaemonSet 重启场景：原先 vllm 崩溃后 pegaflow-server 仍持 IPC handle 把 GPU 显存钉住，新 vllm `torch.cuda.init()` OOM 起不来。
- 客户端只 hold Streaming 不 poll，hyper 连接 driver 自维护 HTTP/2，无 background task。同机 CNI 不配 keepalive（没有 silent partition）。

## Test plan

- [x] `cargo fmt --check` / `cargo clippy --all-targets -D warnings` / `cargo check` 全过
- [x] `python/tests/test_session_watcher.py::test_crashed_client_releases_ipc`：subprocess 注册真实 GPU KV tensor + 开 session，父进程 SIGKILL，断言 server 在 5s 内打印 `dropped N CUDA tensors`。本地 5/5 pass ~4s/次，无 flake
- [x] 手工 SIGKILL vllm 验证：日志 `Session opened → closed → cleanup (dropped 1 CUDA tensors) → Unregistered instance`，毫秒级响应
- [x] CI 绿

## Notes

- 二进制 build 注意 `PYO3_PYTHON` 指向目标 venv（否则 stdlib dir 硬编码到错误版本）
- Conftest 把 server 日志 redirect 到 tempfile 而非 PIPE，顺带避免 pipe buffer 填满卡启动

Project doc: `docs/projects/vllm-liveness-session-stream.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)