### PR TITLE
chore(release): bump version to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,7 +2135,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "colored",
  "libc",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ahash",
  "bytesize",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "axum",
  "clap",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "prost",
  "tonic",
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "axum",
  "clap",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.20.0"
+version = "0.21.0"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -105,6 +105,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.20.0"
+version = "0.21.0"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## What changed
- bump the workspace package version from `0.20.0` to `0.21.0`
- bump the Python package version in `python/pyproject.toml` to `0.21.0`
- refresh `Cargo.lock` so workspace crate entries match the new release version

## Why
Prepare the repository for the next release based on the latest `master`, keeping Rust and Python release metadata aligned at `0.21.0`.

## Validation
- `cargo check -q`
- pre-commit hooks during `git commit`, including `cargo test --release`