### PR TITLE
fix(storage): avoid pinned pool tail over-allocation

### DIFF
--- a/pegaflow-core/src/allocator.rs
+++ b/pegaflow-core/src/allocator.rs
@@ -78,7 +78,7 @@ impl ScaledOffsetAllocator {
     ) -> Result<Self, AllocatorError> {
         let unit_size = NonZeroU64::new(unit_size).ok_or(AllocatorError::InvalidUnitSize)?;
 
-        let total_units = total_bytes.div_ceil(unit_size.get());
+        let total_units = total_bytes / unit_size.get();
         let total_units_u32 =
             u32::try_from(total_units).map_err(|_| AllocatorError::CapacityTooLarge {
                 total_bytes,
@@ -126,7 +126,7 @@ impl ScaledOffsetAllocator {
         self.inner.free(allocation.raw);
     }
 
-    /// Return the total managed capacity in bytes (rounded up to `unit_size`).
+    /// Return the total managed capacity in bytes (rounded down to `unit_size`).
     pub(crate) fn total_bytes(&self) -> u64 {
         self.unit_size.get() * self.total_units as u64
     }
@@ -178,6 +178,49 @@ mod tests {
         let storage = allocator.storage_report();
         assert_eq!(storage.total_free_bytes, 960);
         assert_eq!(storage.largest_free_allocation_bytes, 960);
+    }
+
+    #[test]
+    fn capacity_is_rounded_down_to_unit_size() {
+        const MIB: u64 = 1024 * 1024;
+        const GIB: u64 = 1024 * MIB;
+        const UNIT_SIZE: u64 = 256 * MIB;
+        let total_bytes = GIB + 123 * MIB;
+
+        let allocator = ScaledOffsetAllocator::new_with_unit_size_and_max_allocs(
+            total_bytes,
+            UNIT_SIZE,
+            128 * 1024,
+        )
+        .unwrap();
+        assert_eq!(allocator.total_units, 4);
+        assert_eq!(allocator.total_bytes(), GIB);
+
+        let storage = allocator.storage_report();
+        assert_eq!(storage.total_free_bytes, GIB);
+        assert_eq!(storage.largest_free_allocation_bytes, GIB);
+    }
+
+    #[test]
+    fn does_not_allocate_past_unaligned_capacity() {
+        const MIB: u64 = 1024 * 1024;
+        const GIB: u64 = 1024 * MIB;
+        const UNIT_SIZE: u64 = 256 * MIB;
+        let total_bytes = GIB + 123 * MIB;
+
+        let mut allocator = ScaledOffsetAllocator::new_with_unit_size_and_max_allocs(
+            total_bytes,
+            UNIT_SIZE,
+            128 * 1024,
+        )
+        .unwrap();
+
+        for idx in 0..4 {
+            let allocation = allocator.allocate(UNIT_SIZE).unwrap().unwrap();
+            assert_eq!(allocation.offset_bytes, idx * UNIT_SIZE);
+            assert_eq!(allocation.size_bytes.get(), UNIT_SIZE);
+        }
+        assert!(allocator.allocate(1).unwrap().is_none());
     }
 
     #[test]

--- a/pegaflow-core/src/pinned_pool.rs
+++ b/pegaflow-core/src/pinned_pool.rs
@@ -61,6 +61,7 @@ pub(crate) struct PinnedMemoryPool {
     /// Backing pinned memory (handles mmap + cudaHostRegister)
     backing: PinnedMemory,
     allocator: Mutex<ScaledOffsetAllocator>,
+    allocatable_bytes: u64,
 }
 
 impl PinnedMemoryPool {
@@ -111,21 +112,24 @@ impl PinnedMemoryPool {
 
         let actual_size = backing.size() as u64;
         let unit_size = Self::compute_unit_size(actual_size, unit_size_hint);
+        let max_units = actual_size / unit_size;
+        let allocatable_bytes = max_units * unit_size;
 
         info!(
-            "Pinned pool: size={}, unit_size={}, max_units={}",
+            "Pinned pool: backing_size={}, unit_size={}, max_units={}, allocatable_size={}",
             ByteSize(actual_size),
             ByteSize(unit_size),
-            actual_size.div_ceil(unit_size)
+            max_units,
+            ByteSize(allocatable_bytes)
         );
 
         let metrics = core_metrics();
-        if let Ok(capacity_i64) = i64::try_from(actual_size) {
+        if let Ok(capacity_i64) = i64::try_from(allocatable_bytes) {
             metrics.pool_capacity_bytes.add(capacity_i64, &[]);
         } else {
             error!(
-                "Pinned pool capacity exceeds i64::MAX; skipping capacity metric update: capacity_bytes={}",
-                actual_size
+                "Pinned pool capacity exceeds i64::MAX; skipping capacity metric update: allocatable_bytes={}",
+                allocatable_bytes
             );
         }
 
@@ -146,6 +150,7 @@ impl PinnedMemoryPool {
         Self {
             backing,
             allocator: Mutex::new(allocator),
+            allocatable_bytes,
         }
     }
 
@@ -170,14 +175,21 @@ impl PinnedMemoryPool {
             }
         };
 
-        let offset: usize = allocation
-            .offset_bytes
-            .try_into()
-            .expect("allocation offset exceeds usize");
+        let size_bytes = allocation.size_bytes.get();
+        let backing_size = self.backing.size() as u64;
+        let allocation_end = allocation.offset_bytes.checked_add(size_bytes);
+        assert!(
+            matches!(allocation_end, Some(end) if end <= backing_size),
+            "pinned allocator returned allocation outside backing memory: offset={} size={} backing_size={}",
+            allocation.offset_bytes,
+            size_bytes,
+            backing_size
+        );
+
+        let offset = allocation.offset_bytes as usize;
         let ptr = unsafe { self.backing.as_ptr().add(offset) };
         let ptr = NonNull::new(ptr as *mut u8).expect("PinnedMemoryPool returned null pointer");
 
-        let size_bytes = allocation.size_bytes.get();
         if let Ok(size_i64) = i64::try_from(size_bytes) {
             core_metrics().pool_used_bytes.add(size_i64, &[]);
         }
@@ -231,13 +243,12 @@ impl PinnedMemoryPool {
 impl Drop for PinnedMemoryPool {
     fn drop(&mut self) {
         let metrics = core_metrics();
-        let capacity_bytes = self.backing.size();
-        if let Ok(capacity_i64) = i64::try_from(capacity_bytes) {
+        if let Ok(capacity_i64) = i64::try_from(self.allocatable_bytes) {
             metrics.pool_capacity_bytes.add(-capacity_i64, &[]);
         } else {
             error!(
-                "Pinned pool capacity exceeds i64::MAX; skipping capacity metric cleanup: capacity_bytes={}",
-                capacity_bytes
+                "Pinned pool capacity exceeds i64::MAX; skipping capacity metric cleanup: allocatable_bytes={}",
+                self.allocatable_bytes
             );
         }
     }


### PR DESCRIPTION
## Summary
- Round `ScaledOffsetAllocator` managed capacity down to the allocator unit size instead of exposing a rounded-up tail.
- Report pinned pool allocatable capacity in logs/metrics.
- Assert allocations stay within backing memory before computing raw pointers.
- Add allocator tests using a GB-scale unaligned pool shape.

## Root Cause
The allocator previously used `div_ceil(total_bytes, unit_size)`, so a pool whose backing size was not an exact multiple of the allocation unit could expose `ceil(size / unit) * unit` bytes. That could let the final allocation extend beyond the actual pinned backing memory. RDMA surfaced this as `remote memory not found in handshake snapshot`, but the underlying issue is in the common pinned pool allocator.

## Impact
This prevents pinned allocations from using bytes outside the actual backing region. Without RDMA, the same overhang could become an out-of-bounds CPU/GPU memory access instead of a snapshot lookup failure.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p pegaflow-core allocator::tests`: 7 passed, 0 failed
- GitHub Actions CI: all checks pass

Note: this PR only fixes the pinned pool capacity bug. The InfiniBand LID/manual RC path issue is separate.