### PR TITLE
fix(transfer): support InfiniBand RC addressing

### DIFF
--- a/pegaflow-transfer/src/rc_backend/runtime.rs
+++ b/pegaflow-transfer/src/rc_backend/runtime.rs
@@ -1,10 +1,11 @@
+use std::fs;
 use std::sync::Arc;
 
 use log::error;
 use pegaflow_common::NumaNode;
 use sideway::ibverbs::address::{Gid, GidType};
 use sideway::ibverbs::device::{DeviceInfo, DeviceList};
-use sideway::ibverbs::device_context::{DeviceContext, Mtu, PortState};
+use sideway::ibverbs::device_context::{DeviceContext, LinkLayer, Mtu, PortState};
 use sideway::ibverbs::protection_domain::ProtectionDomain;
 
 use crate::error::{Result, TransferError};
@@ -14,6 +15,8 @@ pub(crate) struct RcRuntime {
     pub(crate) device_ctx: Arc<DeviceContext>,
     pub(crate) pd: Arc<ProtectionDomain>,
     pub(crate) port_num: u8,
+    pub(crate) link_layer: LinkLayer,
+    pub(crate) local_lid: u16,
     pub(crate) gid_index: u8,
     pub(crate) mtu: Mtu,
     pub(crate) local_gid: Gid,
@@ -37,12 +40,24 @@ impl RcRuntime {
             .alloc_pd()
             .map_err(|error| TransferError::Backend(error.to_string()))?;
 
-        let (port_num, gid_index, mtu, local_gid) = Self::choose_port_and_gid(&device_ctx)?;
+        let (port_num, link_layer, gid_index, mtu, local_gid) =
+            Self::choose_port_and_gid(&device_ctx)?;
+        let local_lid = match link_layer {
+            LinkLayer::InfiniBand => Self::read_port_lid(nic_name, port_num)?,
+            LinkLayer::Ethernet => 0,
+            LinkLayer::Unspecified => {
+                return Err(TransferError::Backend(format!(
+                    "unsupported link layer on nic={nic_name}, port={port_num}: {link_layer:?}"
+                )));
+            }
+        };
         let numa_node = nic_numa_node(nic_name);
         log::info!(
-            "RDMA NIC ready: nic={}, port={}, gid_index={}, mtu={:?}, numa={}",
+            "RDMA NIC ready: nic={}, port={}, link_layer={:?}, local_lid={}, gid_index={}, mtu={:?}, numa={}",
             nic_name,
             port_num,
+            link_layer,
+            local_lid,
             gid_index,
             mtu,
             numa_node,
@@ -52,6 +67,8 @@ impl RcRuntime {
             device_ctx,
             pd,
             port_num,
+            link_layer,
+            local_lid,
             gid_index,
             mtu,
             local_gid,
@@ -60,7 +77,9 @@ impl RcRuntime {
         }))
     }
 
-    fn choose_port_and_gid(device_ctx: &Arc<DeviceContext>) -> Result<(u8, u8, Mtu, Gid)> {
+    fn choose_port_and_gid(
+        device_ctx: &Arc<DeviceContext>,
+    ) -> Result<(u8, LinkLayer, u8, Mtu, Gid)> {
         let dev_attr = device_ctx
             .query_device()
             .map_err(|error| TransferError::Backend(error.to_string()))?;
@@ -75,6 +94,7 @@ impl RcRuntime {
             if port_attr.port_state() != PortState::Active {
                 continue;
             }
+            let link_layer = port_attr.link_layer();
 
             // Pick the best GID: RoCEv2 + IPv4-mapped > IB > any non-link-local.
             // RoCEv1 cannot be routed across L3 — only RoCEv2 works cross-machine.
@@ -107,7 +127,7 @@ impl RcRuntime {
                 (0, gid)
             };
 
-            return Ok((port_num, gid_index, port_attr.active_mtu(), gid));
+            return Ok((port_num, link_layer, gid_index, port_attr.active_mtu(), gid));
         }
 
         error!(
@@ -117,5 +137,24 @@ impl RcRuntime {
         Err(TransferError::Backend(
             "no active port found on selected NIC".to_string(),
         ))
+    }
+
+    fn read_port_lid(nic_name: &str, port_num: u8) -> Result<u16> {
+        let path = format!("/sys/class/infiniband/{nic_name}/ports/{port_num}/lid");
+        let raw = fs::read_to_string(&path)
+            .map_err(|error| TransferError::Backend(format!("failed to read {path}: {error}")))?;
+        let text = raw.trim();
+        let lid = if let Some(hex) = text.strip_prefix("0x") {
+            u16::from_str_radix(hex, 16)
+        } else {
+            text.parse()
+        }
+        .map_err(|error| TransferError::Backend(format!("invalid LID in {path}: {error}")))?;
+        if lid == 0 {
+            return Err(TransferError::Backend(format!(
+                "invalid zero LID for InfiniBand nic={nic_name}, port={port_num}"
+            )));
+        }
+        Ok(lid)
     }
 }

--- a/pegaflow-transfer/src/rc_backend/session.rs
+++ b/pegaflow-transfer/src/rc_backend/session.rs
@@ -13,6 +13,7 @@ use sideway::ibverbs::address::{AddressHandleAttribute, Gid};
 use sideway::ibverbs::completion::{
     GenericCompletionQueue, PollCompletionQueueError, WorkCompletionStatus,
 };
+use sideway::ibverbs::device_context::LinkLayer;
 use sideway::ibverbs::memory_region::MemoryRegion;
 use sideway::ibverbs::queue_pair::{
     GenericQueuePair, PostSendGuard, QueuePair, QueuePairAttribute, QueuePairState, QueuePairType,
@@ -100,7 +101,7 @@ impl RcSession {
         let local_psn = (psn_seed as u32) & PSN_MASK;
         let local_endpoint = RcEndpoint {
             gid: runtime.local_gid.raw,
-            lid: 0, // RoCE v2 doesn't use LID
+            lid: runtime.local_lid,
             qp_num: qp.qp_number(),
             psn: local_psn,
         };
@@ -121,16 +122,42 @@ impl RcSession {
     /// Connect this QP to the remote peer (INIT → RTR → RTS).
     pub(crate) fn connect(&self, runtime: &RcRuntime, remote: &RcEndpoint) -> Result<()> {
         debug!(
-            "rc connect start: local_qpn={}, remote_qpn={}, remote_gid={:?}",
-            self.local_endpoint.qp_num, remote.qp_num, remote.gid
+            "rc connect start: link_layer={:?}, local_qpn={}, local_lid={}, remote_qpn={}, remote_lid={}, remote_gid={:?}",
+            runtime.link_layer,
+            self.local_endpoint.qp_num,
+            self.local_endpoint.lid,
+            remote.qp_num,
+            remote.lid,
+            remote.gid
         );
         let mut ah_attr = AddressHandleAttribute::new();
-        ah_attr
-            .setup_dest_lid(remote.lid)
-            .setup_port(runtime.port_num)
-            .setup_grh_dest_gid(&Gid { raw: remote.gid })
-            .setup_grh_src_gid_index(runtime.gid_index)
-            .setup_grh_hop_limit(64);
+        match runtime.link_layer {
+            LinkLayer::InfiniBand => {
+                if remote.lid == 0 {
+                    return Err(TransferError::InvalidArgument(
+                        "remote LID is zero for InfiniBand connection",
+                    ));
+                }
+                ah_attr
+                    .setup_dest_lid(remote.lid)
+                    .setup_service_level(0)
+                    .setup_port(runtime.port_num);
+            }
+            LinkLayer::Ethernet => {
+                ah_attr
+                    .setup_dest_lid(0)
+                    .setup_port(runtime.port_num)
+                    .setup_grh_dest_gid(&Gid { raw: remote.gid })
+                    .setup_grh_src_gid_index(runtime.gid_index)
+                    .setup_grh_hop_limit(64);
+            }
+            LinkLayer::Unspecified => {
+                return Err(TransferError::Backend(format!(
+                    "unsupported link layer for RC connection: {:?}",
+                    runtime.link_layer
+                )));
+            }
+        }
 
         let mut qp = self.qp.lock();
         let mut rtr_attr = QueuePairAttribute::new();
@@ -156,8 +183,8 @@ impl RcSession {
         qp.modify(&rts_attr)
             .map_err(|error| TransferError::Backend(error.to_string()))?;
         debug!(
-            "rc connect ready: local_qpn={}, remote_qpn={}",
-            self.local_endpoint.qp_num, remote.qp_num
+            "rc connect ready: link_layer={:?}, local_qpn={}, remote_qpn={}, remote_lid={}",
+            runtime.link_layer, self.local_endpoint.qp_num, remote.qp_num, remote.lid
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

- detect the RDMA link layer when opening an RC runtime
- advertise the real local LID for InfiniBand ports
- build RC address handles with LID addressing on InfiniBand while keeping the existing GRH/GID path for RoCE

## Root Cause

The RC endpoint always advertised `lid=0` and always configured GRH addressing. That is appropriate for RoCEv2, but native InfiniBand requires a real remote LID in the QP address handle. On an InfiniBand fabric, the handshake can complete while the later RDMA work requests fail with retry-exceeded send completions.

## Validation

- `cargo fmt --check`
- `git diff --check`
- RDMA CPU bench on an InfiniBand machine: single NIC and all physical IB NICs passed write/read
- RDMA CPU bench on a RoCEv2 machine: single NIC and all RoCE NICs passed write/read

Related: #230
