### PR TITLE
ci: add Python 3.14 wheel support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
           fi
 
   build-wheel:
-    name: build Python wheel (${{ matrix.cuda-variant }})
+    name: build Python 3.14 wheel (${{ matrix.cuda-variant }})
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -217,10 +217,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
 
       - name: Free up disk space
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         cuda-variant: ['cu12', 'cu13']
         include:
           - cuda-variant: cu12

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 


### PR DESCRIPTION
## Summary
- Build PR CI wheels with Python 3.14.
- Include Python 3.14 in the release wheel matrix for cu12 and cu13.
- Add the Python 3.14 package classifier.

## Testing
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/ci.yml .github/workflows/release.yml`
- `uv run --with tomli python -c 'import tomli; tomli.load(open("python/pyproject.toml", "rb")); print("python/pyproject.toml: ok")'`
- `uvx --from commitizen cz check --rev-range HEAD~1..HEAD`

Full wheel builds are left to GitHub Actions because they require the CI CUDA environment.
