### PR TITLE
fix: preserve KV IPC strides and registered load names

### DIFF
--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -356,10 +356,10 @@ class WorkerConnector:
         if self._cross_layer_mode:
             target_layers = [self._cross_layer_key]
         else:
-            target_layers = []
-            for layer_name, layer in forward_context.no_compile_layers.items():
-                if hasattr(layer, "kv_cache"):
-                    target_layers.append(layer_name)
+            assert self._registered_layers, (
+                "KV caches must be registered before submitting load intents"
+            )
+            target_layers = list(self._registered_layers)
 
         if not target_layers:
             return

--- a/python/pegaflow/ipc_wrapper.py
+++ b/python/pegaflow/ipc_wrapper.py
@@ -24,6 +24,7 @@ class CudaIPCWrapper:
         handle: CUDA IPC handle tuple (device, ipc_handle, size, offset, ...)
         dtype: PyTorch dtype of the tensor
         shape: Shape tuple of the tensor
+        stride: Stride tuple of the tensor
         device_uuid: UUID string of the GPU device
 
     Example:
@@ -118,6 +119,8 @@ class CudaIPCWrapper:
         self.handle = handle
         self.dtype = tensor.dtype
         self.shape = tensor.shape
+        self.stride = tensor.stride()
+        self.storage_offset = tensor.storage_offset()
 
         # Store device UUID instead of device index to handle CUDA_VISIBLE_DEVICES
         device_index = tensor.device.index
@@ -148,11 +151,16 @@ class CudaIPCWrapper:
         # Create empty tensor on the correct device
         t = torch.tensor([], device=device, dtype=self.dtype)
 
-        # Set the tensor to use the shared storage
-        t.set_(storage)
-
-        # Reshape to original shape
-        return t.view(self.shape)
+        # Set the tensor to use the shared storage. Preserve stride because
+        # some KV cache layouts use padded storage where shape.numel() is
+        # smaller than the underlying storage size.
+        stride = getattr(self, "stride", None)
+        storage_offset = getattr(self, "storage_offset", 0)
+        if stride is None:
+            t.set_(storage)
+            return t.view(self.shape)
+        t.set_(storage, storage_offset, self.shape, stride)
+        return t
 
     def __eq__(self, other) -> bool:
         """Check equality with another CudaIPCWrapper.
@@ -169,12 +177,15 @@ class CudaIPCWrapper:
             self.handle == other.handle
             and self.dtype == other.dtype
             and self.shape == other.shape
+            and getattr(self, "stride", None) == getattr(other, "stride", None)
+            and getattr(self, "storage_offset", 0) == getattr(other, "storage_offset", 0)
             and self.device_uuid == other.device_uuid
         )
 
     def __repr__(self) -> str:
         return (
             f"CudaIPCWrapper(shape={self.shape}, dtype={self.dtype}, "
+            f"stride={getattr(self, 'stride', None)}, "
             f"device_uuid={self.device_uuid})"
         )
 

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -47,7 +47,16 @@ class FakeEngineClient:
         block_ids,
         block_hashes,
     ) -> tuple[bool, str]:
-        self.load_calls.append((instance_id, tp_rank, device_id, load_state_shm, list(block_ids)))
+        self.load_calls.append(
+            (
+                instance_id,
+                tp_rank,
+                device_id,
+                load_state_shm,
+                list(layer_names),
+                list(block_ids),
+            )
+        )
         if self.fail_load_with_exception is not None:
             raise self.fail_load_with_exception
         if self.fail_load_with_ok_false:
@@ -55,6 +64,9 @@ class FakeEngineClient:
         return (True, "ok")
 
     def health(self) -> tuple[bool, str]:
+        return (True, "ok")
+
+    def unregister_context(self, instance_id: str) -> tuple[bool, str]:
         return (True, "ok")
 
 
@@ -210,5 +222,24 @@ def test_get_block_ids_with_load_errors_drains_between_calls():
 
     assert worker.get_block_ids_with_load_errors() == {1, 2, 3}
     assert worker.get_block_ids_with_load_errors() == set()
+
+    worker.shutdown()
+
+
+def test_load_uses_registered_layer_names_before_forward_context_names():
+    """Load must use the same layer names registered with the server."""
+    worker, client, _ = _make_worker()
+    worker._cross_layer_mode = False
+    worker._registered_layers = ["registered.layer.0", "registered.layer.1"]
+
+    forward_context = MagicMock()
+    forward_layer = MagicMock()
+    forward_layer.kv_cache = object()
+    forward_context.no_compile_layers = {"model.layers.0.attn": forward_layer}
+
+    worker.start_load_kv(_load_metadata("req_registered_layers", (1, 2)), forward_context)
+
+    assert len(client.load_calls) == 1
+    assert client.load_calls[0][4] == ["registered.layer.0", "registered.layer.1"]
 
     worker.shutdown()

--- a/python/tests/test_ipc_wrapper.py
+++ b/python/tests/test_ipc_wrapper.py
@@ -1,7 +1,6 @@
 import importlib.util
 from pathlib import Path
 
-
 _IPC_WRAPPER_PATH = Path(__file__).resolve().parents[1] / "pegaflow" / "ipc_wrapper.py"
 _IPC_WRAPPER_SPEC = importlib.util.spec_from_file_location("ipc_wrapper", _IPC_WRAPPER_PATH)
 assert _IPC_WRAPPER_SPEC is not None

--- a/python/tests/test_ipc_wrapper.py
+++ b/python/tests/test_ipc_wrapper.py
@@ -1,0 +1,75 @@
+import importlib.util
+from pathlib import Path
+
+
+_IPC_WRAPPER_PATH = Path(__file__).resolve().parents[1] / "pegaflow" / "ipc_wrapper.py"
+_IPC_WRAPPER_SPEC = importlib.util.spec_from_file_location("ipc_wrapper", _IPC_WRAPPER_PATH)
+assert _IPC_WRAPPER_SPEC is not None
+assert _IPC_WRAPPER_SPEC.loader is not None
+ipc_wrapper = importlib.util.module_from_spec(_IPC_WRAPPER_SPEC)
+_IPC_WRAPPER_SPEC.loader.exec_module(ipc_wrapper)
+CudaIPCWrapper = ipc_wrapper.CudaIPCWrapper
+
+
+class FakeTensor:
+    def __init__(self):
+        self.set_args = None
+        self.view_shape = None
+
+    def set_(self, *args):
+        self.set_args = args
+        return self
+
+    def view(self, shape):
+        self.view_shape = shape
+        return self
+
+
+class FakeUntypedStorage:
+    @staticmethod
+    def _new_shared_cuda(device, *handle_args):
+        return ("storage", device, handle_args)
+
+
+class FakeTorch:
+    UntypedStorage = FakeUntypedStorage
+
+    def __init__(self):
+        self.created_tensor = FakeTensor()
+
+    def tensor(self, *args, **kwargs):
+        return self.created_tensor
+
+
+def _wrapper_without_init(stride=None, storage_offset=0):
+    wrapper = CudaIPCWrapper.__new__(CudaIPCWrapper)
+    wrapper.handle = ("ignored_device", "ipc_handle", "size")
+    wrapper.dtype = "fake-dtype"
+    wrapper.shape = (2, 3)
+    wrapper.device_uuid = "GPU-fake"
+    if stride is not None:
+        wrapper.stride = stride
+        wrapper.storage_offset = storage_offset
+    return wrapper
+
+
+def test_to_tensor_preserves_strided_storage(monkeypatch):
+    fake_torch = FakeTorch()
+    monkeypatch.setattr(ipc_wrapper, "torch", fake_torch)
+    monkeypatch.setattr(CudaIPCWrapper, "_get_device_index_from_uuid", staticmethod(lambda _: 7))
+
+    tensor = _wrapper_without_init(stride=(4, 1), storage_offset=5).to_tensor()
+
+    assert tensor.set_args == (("storage", 7, ("ipc_handle", "size")), 5, (2, 3), (4, 1))
+    assert tensor.view_shape is None
+
+
+def test_to_tensor_supports_legacy_pickles_without_stride(monkeypatch):
+    fake_torch = FakeTorch()
+    monkeypatch.setattr(ipc_wrapper, "torch", fake_torch)
+    monkeypatch.setattr(CudaIPCWrapper, "_get_device_index_from_uuid", staticmethod(lambda _: 3))
+
+    tensor = _wrapper_without_init().to_tensor()
+
+    assert tensor.set_args == (("storage", 3, ("ipc_handle", "size")),)
+    assert tensor.view_shape == (2, 3)


### PR DESCRIPTION
## Summary

This PR fixes two DeepSeek-V4-Flash compatibility issues found while running vLLM 0.20.1 with `PegaKVConnector` on 8x H100.

### 1. Preserve strided IPC tensor metadata

DeepSeek-V4 fp8 MLA KV cache tensors can be padded/strided. `CudaIPCWrapper` previously reconstructed tensors with only `shape`, which can fail when the logical tensor shape does not match the underlying storage layout.

Changes:

- store `stride` and `storage_offset` in `CudaIPCWrapper`
- reconstruct IPC tensors with `Tensor.set_(storage, offset, size, stride)` when stride metadata is present
- keep fallback support for older pickled wrappers without stride metadata
- add unit coverage for strided and legacy wrapper reconstruction

Fixes #239.

### 2. Use registered KV-cache layer names for load

In non-cross-layer mode, save already used `self._registered_layers`, but load derived target layers from `forward_context.no_compile_layers`.

That assumes vLLM forward-context layer names match `register_kv_caches(kv_caches)` keys. This is not true for DeepSeek-V4: forward-context names include entries like `model.layers.0.attn`, while the registered KV-cache names come from `kv_cache_config.kv_cache_groups[*].layer_names`.

Changes:

- non-cross-layer `start_load_kv()` now uses `self._registered_layers`, matching save and `register_context_batch`
- add a unit test proving load uses registered KV-cache names even when `forward_context.no_compile_layers` contains a different module name

Related: #242.

## Validation

Unit tests on the H100 host:

```bash
cd /tmp
source /root/develop/xingming/.venv/bin/activate
python -m pytest /tmp/test_connector_fault_tolerance.py
# 5 passed

cd /root/develop/xingming/pegaflow/python
/root/develop/xingming/.venv/bin/python -m pytest tests/test_ipc_wrapper.py -q
# 2 passed
```

End-to-end validation on 8x H100:

- PegaFlow 0.21.2 plus this PR hot-patched into `/root/develop/xingming/.venv`
- vLLM 0.20.1
- model: `deepseek-ai/DeepSeek-V4-Flash`
- flags included `--kv-cache-dtype fp8`, `--block-size 256`, `--tensor-parallel-size 8`, `--enable-expert-parallel`, `--no-enable-prefix-caching`
- `PEGAFLOW_CROSS_LAYER_BLOCKS=0` for the cache-hit validation
- benchmark: two fixed-seed `vllm bench serve` runs with random input-only prompts

Results with `--enforce-eager`:

- round1: 4/4 successful
- round2: 4/4 successful
- `pegaflow_cache_block_hits_total 8`
- `pegaflow_rpc_requests_total{method="load",status="ok"} 32`
- `pegaflow_load_bytes_total 5342773248`
- vLLM reported `External prefix cache hit rate: 50.0%`
- `load_success_count=32`, `load_failure_count=0`

Results without `--enforce-eager`:

- startup took longer due to torch.compile/CUDA graph capture
- round1: 4/4 successful
- round2: 4/4 successful
- `pegaflow_cache_block_hits_total 8`
- `pegaflow_rpc_requests_total{method="load",status="ok"} 32`
- `pegaflow_load_bytes_total 5342773248`
- vLLM reported `External prefix cache hit rate: 50.0%`
- `load_success_count=32`, `load_failure_count=0`

Conclusion: `--enforce-eager` is not required for the layer-name fix.

## Notes

The default cross-layer path is still a separate behavior decision: vLLM did not call `register_cross_layers_kv_cache()` for this DeepSeek-V4 hybrid/fp8 MLA setup, so `ALL_LAYERS` was not registered. This PR fixes the per-layer load path used with `PEGAFLOW_CROSS_LAYER_BLOCKS=0`; #242 tracks the broader cross-layer/default-mode behavior.
