### PR TITLE
fix: make query prefetch probe idempotent

### DIFF
--- a/docs/vllm-request-state-machine.md
+++ b/docs/vllm-request-state-machine.md
@@ -1,0 +1,462 @@
+# vLLM Request State Machine Notes
+
+This note summarizes the vLLM V1 scheduler request lifecycle relevant to
+PegaFlow's KV connector integration. It focuses on asynchronous KV loading,
+preemption, abort handling, and the implications for server-side reservation
+state.
+
+The code references below are based on vLLM V1:
+
+- `vllm/v1/request.py`
+- `vllm/v1/core/sched/scheduler.py`
+- `vllm/distributed/kv_transfer/kv_connector/v1/base.py`
+- `vllm/v1/worker/gpu/kv_connector.py`
+
+## Request Statuses
+
+vLLM defines request states in `RequestStatus`:
+
+```text
+WAITING
+WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+WAITING_FOR_REMOTE_KVS
+WAITING_FOR_STREAMING_REQ
+RUNNING
+PREEMPTED
+FINISHED_STOPPED
+FINISHED_LENGTH_CAPPED
+FINISHED_ABORTED
+FINISHED_IGNORED
+FINISHED_ERROR
+FINISHED_REPETITION
+```
+
+Any status after `PREEMPTED` is considered finished by
+`RequestStatus.is_finished()`.
+
+New requests normally start in `WAITING`. Requests using structured output may
+start in `WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR` until grammar initialization
+finishes.
+
+## Scheduler Queues
+
+The scheduler keeps two waiting queues plus a running list:
+
+- `waiting`: schedulable requests, including new and preempted requests.
+- `skipped_waiting`: blocked requests that should be revisited later.
+- `running`: requests with allocated KV blocks that are actively participating
+  in model execution.
+
+Blocked waiting states are:
+
+```text
+WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+WAITING_FOR_REMOTE_KVS
+WAITING_FOR_STREAMING_REQ
+```
+
+Blocked requests are placed in `skipped_waiting`. During scheduling, vLLM tries
+to promote blocked requests back to a schedulable state before considering new
+work.
+
+## Normal Scheduling Flow
+
+The scheduler first schedules existing `RUNNING` requests. It then schedules
+requests from `waiting` and `skipped_waiting`.
+
+For a waiting request with `num_computed_tokens == 0`, vLLM performs prefix
+cache checks in this order:
+
+1. Local KV cache lookup through `kv_cache_manager.get_computed_blocks()`.
+2. External KV lookup through
+   `connector.get_num_new_matched_tokens(request, num_new_local_computed_tokens)`.
+
+The connector returns:
+
+```text
+(num_external_tokens | None, load_kv_async)
+```
+
+`None` means the connector needs more time. The request remains waiting and is
+queried again in a later scheduler step. This is why
+`get_num_new_matched_tokens()` must tolerate repeated calls for the same request
+without committing resources.
+
+After the scheduler computes local and external cached token counts, it calls
+`kv_cache_manager.allocate_slots()`. Only after allocation succeeds does vLLM
+call:
+
+```python
+connector.update_state_after_alloc(request, blocks, num_external_tokens)
+```
+
+This is the first point where the connector can treat the scheduler decision as
+committed for that step.
+
+## State Transition Diagram
+
+The following diagram captures the request transitions relevant to KV connector
+behavior. It omits structured-output and streaming-input details except where
+they block normal scheduling.
+
+```mermaid
+stateDiagram-v2
+    [*] --> WAITING: add_request
+    [*] --> WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR: structured output init
+
+    WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR --> WAITING: grammar ready
+    WAITING_FOR_STREAMING_REQ --> WAITING: next input chunk arrives
+
+    WAITING --> WAITING: connector probe returns None
+    WAITING --> WAITING: allocation fails before commit
+    WAITING --> WAITING_FOR_REMOTE_KVS: async external KV committed
+    WAITING --> RUNNING: scheduled for local/sync work
+
+    WAITING_FOR_REMOTE_KVS --> WAITING: load finished, no prior preemption
+    WAITING_FOR_REMOTE_KVS --> PREEMPTED: load finished after preemption marker
+    WAITING_FOR_REMOTE_KVS --> WAITING: load failed, recompute enabled
+    WAITING_FOR_REMOTE_KVS --> FINISHED_ERROR: load failed, recompute disabled
+
+    RUNNING --> RUNNING: next decode/prefill step scheduled
+    RUNNING --> PREEMPTED: KV allocation pressure
+    PREEMPTED --> RUNNING: resumed and scheduled
+
+    RUNNING --> WAITING_FOR_STREAMING_REQ: resumable request needs input
+
+    WAITING --> FINISHED_ABORTED: abort
+    WAITING_FOR_REMOTE_KVS --> FINISHED_ABORTED: abort, delayed free possible
+    RUNNING --> FINISHED_ABORTED: abort
+    PREEMPTED --> FINISHED_ABORTED: abort
+
+    RUNNING --> FINISHED_STOPPED: stop condition
+    RUNNING --> FINISHED_LENGTH_CAPPED: length cap
+    RUNNING --> FINISHED_ERROR: execution or grammar error
+    RUNNING --> FINISHED_REPETITION: repetition detector
+```
+
+For a future two-phase PegaFlow reservation protocol, the corresponding resource
+lifecycle would be:
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoState
+    NoState --> Probed: QueryPrefetch(instance, req, hashes)
+    Probed --> Probed: repeated QueryPrefetch, same digest
+    Probed --> Probed: QueryPrefetch, new digest/generation
+    Probed --> Reserved: ReserveLoadBlocks succeeds
+    Probed --> NoState: probe TTL expires
+    Probed --> NoState: request finishes before reserve
+
+    Reserved --> Consumed: Load consumes reservation
+    Reserved --> Released: ReleaseReservation
+    Reserved --> Released: request abort/preemption cleanup
+    Reserved --> Released: reservation TTL expires
+    Reserved --> Failed: Load submission fails
+
+    Consumed --> [*]
+    Released --> [*]
+    Failed --> [*]
+```
+
+## Async KV Load Flow
+
+When `get_num_new_matched_tokens()` returns external tokens with
+`load_kv_async=True`, the scheduler:
+
+1. Allocates destination KV blocks with `delay_cache_blocks=True`.
+2. Calls `update_state_after_alloc()`.
+3. Moves the request to `WAITING_FOR_REMOTE_KVS`.
+4. Stores the externally computed token count in `request.num_computed_tokens`.
+5. Places the request in `skipped_waiting`.
+
+The request is not runnable while it is in `WAITING_FOR_REMOTE_KVS`.
+
+On the worker side, `pre_forward()` binds connector metadata, calls
+`handle_preemptions()`, then starts load through `start_load_kv()`. After the
+forward pass, `post_forward()` collects:
+
+```text
+finished_sending
+finished_recving
+invalid_block_ids
+```
+
+The scheduler receives this through `update_from_output()`.
+
+When a worker reports `finished_recving`, vLLM records the request ID in
+`finished_recving_kv_req_ids`. On a later scheduler pass, promotion of
+`WAITING_FOR_REMOTE_KVS` does the following:
+
+- If load succeeded, cache the loaded blocks and move the request to `WAITING`
+  or `PREEMPTED`.
+- If load failed and recompute recovery is enabled, cache the valid prefix or
+  free the allocation, then move the request back to a schedulable state.
+
+For a full external prompt hit, vLLM decreases `num_computed_tokens` by one so
+the model recomputes the last token before sampling.
+
+## Load Failure Recovery
+
+The connector reports load failures through
+`get_block_ids_with_load_errors()`. The base connector contract says:
+
+- It applies to both sync and async loading.
+- For async loading, failed block IDs must be reported no later than the same
+  pass where the request ID is returned by `get_finished()`.
+- The request must still be reported as finished receiving even when failures
+  occur.
+
+The scheduler maps invalid block IDs back to affected requests and truncates
+each request to the longest valid prefix:
+
+```text
+request.num_computed_tokens = first_invalid_block_index * block_size
+```
+
+For async loading, affected requests are tracked in
+`failed_recving_kv_req_ids`. When `finished_recving` later promotes the request,
+vLLM either caches the valid prefix or frees the allocated destination blocks.
+
+The recovery behavior depends on `recompute_kv_load_failures`:
+
+- Recompute enabled: requests are rescheduled and the invalid suffix is computed
+  locally.
+- Recompute disabled: affected requests are finished with `FINISHED_ERROR`.
+
+This failure path is a useful fallback for PegaFlow reservation races: a reserve
+or load failure can be surfaced as invalid block IDs and vLLM will restore a
+correct prefix before retrying or failing the request.
+
+## Preemption
+
+Preemption only applies to `RUNNING` requests. When KV allocation fails for
+another request, vLLM may preempt a lower-priority or later-running request.
+
+Preemption does the following:
+
+1. Frees the request's KV cache allocation.
+2. Frees encoder cache state.
+3. Sets status to `PREEMPTED`.
+4. Resets `num_computed_tokens` to `0`.
+5. Clears speculative tokens.
+6. Increments `num_preemptions`.
+7. Prepends the request to `waiting`.
+
+The next successful scheduling pass treats the request as a resumed request and
+moves it back to `RUNNING`.
+
+`SchedulerOutput.preempted_req_ids` is sent to workers. The worker-side KV
+connector receives it through `handle_preemptions()` before overwritten blocks
+are reused. Connectors that perform async saving must use this hook to finish or
+flush work that depends on those blocks.
+
+Because preemption resets `num_computed_tokens`, any PegaFlow server-side state
+that is keyed by request ID must tolerate a later query for the same request ID
+with a different hash slice or generation.
+
+## Abort and Finished Requests
+
+External aborts call:
+
+```python
+scheduler.finish_requests(request_ids, RequestStatus.FINISHED_ABORTED)
+```
+
+`finish_requests()` removes requests from `running`, `waiting`, and
+`skipped_waiting`, sets the finished status, and calls `_free_request()`.
+
+For requests in `WAITING_FOR_REMOTE_KVS`, vLLM may delay freeing KV blocks:
+
+```text
+delay_free_blocks = request_id not in finished_recving_kv_req_ids
+```
+
+This keeps the request object and blocks alive until async KV transfer finishes.
+When `finished_recving` later arrives for an already finished request, vLLM frees
+the blocks.
+
+The connector is notified through `request_finished()`. For async connector work,
+`request_finished()` may return `True` to delay block freeing until the connector
+later reports the request through `finished_sending`.
+
+For PegaFlow, abort handling needs to release server-side reservations that were
+created after allocation but not consumed by load. A server-side TTL is still
+needed because process failure may prevent an explicit release call.
+
+## Connector Contract Points
+
+The most relevant KV connector methods are:
+
+- `get_num_new_matched_tokens()`: scheduler-side query. vLLM may call it
+  multiple times for the same request and expects it to behave like a
+  side-effect-free probe. PegaFlow's current one-RPC implementation still pins
+  on `QueryPrefetch`, so the connector memoizes uncommitted positive probes to
+  avoid repeating that pinning side effect.
+- `update_state_after_alloc()`: scheduler-side commit point after KV block
+  allocation succeeds.
+- `build_connector_meta()`: packages per-step load/save metadata and resets
+  connector scheduler-side transient state.
+- `handle_preemptions()`: worker-side hook before preempted blocks are
+  overwritten.
+- `start_load_kv()`: worker-side load submission.
+- `get_finished()`: worker-side completion reporting for async save/load.
+- `get_block_ids_with_load_errors()`: worker-side failure reporting.
+- `request_finished()`: scheduler-side cleanup hook for finished or aborted
+  requests.
+
+For a future two-phase PegaFlow protocol, the important split would be:
+
+```text
+get_num_new_matched_tokens(): probe only
+update_state_after_alloc(): reserve exact load blocks
+start_load_kv(): consume reservation and submit load
+request_finished()/preemption/release/TTL: clean up unconsumed reservations
+```
+
+## Implications for PegaFlow Server-Side State
+
+PegaFlow currently uses the older one-RPC contract where `QueryPrefetch` both
+reports prefix hits and pins the hit blocks for the later load. The current
+mitigation for repeated scheduler probes is intentionally narrower: the
+scheduler-side connector memoizes an uncommitted positive probe for the same
+request/hash slice and reuses that result instead of issuing another
+`QueryPrefetch`.
+
+The memoized scheduler state has two separate lifetimes:
+
+- Pending query probe: a positive `QueryPrefetch` result that has not yet
+  reached `update_state_after_alloc()`. Repeating the same
+  `(req_id, computed_blocks, remaining_hashes)` lookup reuses this probe and
+  does not call `QueryPrefetch` again.
+- Pending query release: an uncommitted probe that the scheduler no longer wants
+  to use, but whose compensating `unpin` did not fully succeed. The connector
+  retries those releases from later scheduler calls and from shutdown. Each
+  release is a single `unpin` RPC that asks the server to release all worker
+  refs for each pinned hash; the connector does not issue a new probe for the
+  same request ID until the older release is cleared.
+
+When `update_state_after_alloc()` commits an external hit, the connector checks
+that the load hashes exactly match the pending probe's pinned hash prefix. The
+probe is then transferred to the normal load path and is not unpinned by the
+scheduler cleanup path. During connector shutdown, any still-uncommitted
+positive probes are released before retrying failed releases.
+
+The current `QueryPrefetch` request already contains:
+
+```text
+instance_id
+req_id
+block_hashes
+```
+
+This can identify repeated probes, but request ID alone is not enough. The same
+vLLM request can be queried again after preemption or scheduling retry with a
+different effective hash slice. A robust server-side key should include:
+
+```text
+instance_id + req_id + digest(block_hashes)
+```
+
+A cleaner future protocol is:
+
+1. `QueryPrefetch`: probe available prefix and possibly start backing-store
+   prefetch. It records lightweight per-request probe state but does not pin.
+2. `ReserveLoadBlocks`: called from `update_state_after_alloc()`. It atomically
+   re-checks the exact load hashes and pins them all-or-none.
+3. `Load`: consumes the reservation and submits the GPU load.
+4. `ReleaseReservation`: releases a reservation on abort, preemption, or
+   scheduler-side cancellation before load.
+5. TTL cleanup: expires stale probe and reserved states.
+
+The gap between probe and reserve is real. Blocks may be evicted after
+`QueryPrefetch` and before `ReserveLoadBlocks`. Correct handling is to make
+reserve atomic and report failure through vLLM's existing invalid-block/load
+failure path. That turns the race into a cache hit-rate loss rather than a
+correctness or pin-lifetime bug.
+
+## Future Safety Invariants and Proof Sketch
+
+A future two-phase reservation protocol should preserve the following
+invariants.
+
+### Invariant 1: Probe Has No Resource Ownership
+
+`QueryPrefetch` may create or refresh lightweight request state, but it must not
+increase pin refcounts or take ownership of cache blocks.
+
+This matches vLLM's contract that `get_num_new_matched_tokens()` may be called
+multiple times for the same request. Repeated probe calls can only affect
+observability or prefetch progress, not resource lifetime.
+
+### Invariant 2: Reserve Is Atomic
+
+`ReserveLoadBlocks(instance_id, req_id, hashes)` either pins every requested
+block or pins none of them.
+
+This avoids partial external-prefix commitments. vLLM has already allocated
+destination blocks based on the token count returned earlier, and
+`update_state_after_alloc()` cannot reduce that token count. All-or-none reserve
+keeps the connector metadata consistent with the scheduler decision.
+
+### Invariant 3: Load Consumes Exactly One Reservation
+
+`Load` must consume an existing matching reservation before it submits GPU work.
+After consumption, the reservation is no longer available for another load.
+
+This prevents duplicate consumption and bounds pin lifetime. The load path owns
+the block references needed by the transfer task, and the reservation refcount is
+released exactly once.
+
+### Invariant 4: Every Reserved State Eventually Terminates
+
+Every reservation must reach one of:
+
+```text
+Consumed
+Released
+Failed
+Expired
+```
+
+Explicit release handles aborts, preemptions, and scheduler-side cancellation.
+TTL cleanup handles process death or missed cleanup messages.
+
+### Invariant 5: Failed Reserve or Load Is Reported to vLLM
+
+When reserve or load cannot satisfy the previously promised external prefix, the
+connector reports affected destination block IDs through
+`get_block_ids_with_load_errors()` and still reports the request through
+`finished_recving` for async loading.
+
+vLLM then truncates `request.num_computed_tokens` to the longest valid prefix and
+either reschedules local recomputation or finishes the request with
+`FINISHED_ERROR`, depending on the configured policy.
+
+### Proof Sketch
+
+No pin leak from repeated probe:
+
+Repeated calls to `get_num_new_matched_tokens()` map to repeated
+`QueryPrefetch` calls. By Invariant 1, probe never increments pin refcounts.
+Therefore repeated scheduler probes cannot create unbalanced pins.
+
+No use-after-eviction after the probe/reserve gap:
+
+Blocks may be evicted between `QueryPrefetch` and `ReserveLoadBlocks`.
+`ReserveLoadBlocks` re-checks availability under the cache lock and pins
+all requested blocks atomically. A successful reserve prevents eviction until
+load consumes or release expires the reservation. A failed reserve creates no
+load metadata and is reported through vLLM's failure path.
+
+No incorrect KV reuse:
+
+The reserve key includes `instance_id`, `req_id`, and `digest(block_hashes)`.
+A stale probe with a different hash slice cannot satisfy a later reserve for a
+new generation. The loaded blocks are selected by exact hashes, not by request
+ID alone.
+
+No indefinite request-owned resource:
+
+After reserve, all exits are explicit or time-bounded: load consumes,
+abort/preemption releases, load failure releases, and TTL cleanup covers missed
+messages. Thus every server-side reservation has a terminating transition.

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -402,14 +402,37 @@ impl PegaEngine {
         instance_id: &str,
         block_hashes: &[Vec<u8>],
     ) -> Result<usize, EngineError> {
+        self.unpin_block_refs(instance_id, block_hashes, 1)
+    }
+
+    /// Unpin multiple refs for each block hash that was pinned during query.
+    ///
+    /// Used when scheduler-side query ownership is cancelled before load
+    /// consumption by any worker.
+    pub fn unpin_block_refs(
+        &self,
+        instance_id: &str,
+        block_hashes: &[Vec<u8>],
+        release_refs_per_hash: usize,
+    ) -> Result<usize, EngineError> {
+        if release_refs_per_hash == 0 {
+            return Err(EngineError::InvalidArgument(
+                "release_refs_per_hash must be greater than 0".to_string(),
+            ));
+        }
         let instance = self.get_instance(instance_id)?;
         let namespace = instance.namespace();
-        let unpinned = self
-            .storage
-            .unpin_blocks(instance_id, namespace, block_hashes);
+        let unpinned = self.storage.unpin_block_refs(
+            instance_id,
+            namespace,
+            block_hashes,
+            release_refs_per_hash,
+        );
         debug!(
-            "unpin_blocks: instance_id={instance_id} blocks={} unpinned={unpinned}",
-            block_hashes.len()
+            "unpin_block_refs: instance_id={instance_id} blocks={} release_refs_per_hash={} \
+             unpinned={unpinned}",
+            block_hashes.len(),
+            release_refs_per_hash,
         );
         Ok(unpinned)
     }

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -343,15 +343,20 @@ impl StorageEngine {
             .consume_pinned_blocks(instance_id, namespace, block_hashes)
     }
 
-    /// Unpin blocks (cancellation path before consume).
-    pub(crate) fn unpin_blocks(
+    /// Unpin multiple refs for each block hash in one cancellation operation.
+    pub(crate) fn unpin_block_refs(
         &self,
         instance_id: &str,
         namespace: &str,
         block_hashes: &[Vec<u8>],
+        release_refs_per_hash: usize,
     ) -> usize {
-        self.read_cache
-            .unpin_blocks(instance_id, namespace, block_hashes)
+        self.read_cache.unpin_block_refs(
+            instance_id,
+            namespace,
+            block_hashes,
+            release_refs_per_hash,
+        )
     }
 
     /// Check prefix blocks and schedule backing-store reads if needed.
@@ -593,13 +598,30 @@ mod tests {
         assert_eq!(storage.test_pin_count("inst1", &key), 2);
 
         // Unpin once (simulating one worker cancellation)
-        let unpinned = storage.unpin_blocks("inst1", "ns", &[vec![1]]);
+        let unpinned = storage.unpin_block_refs("inst1", "ns", &[vec![1]], 1);
         assert_eq!(unpinned, 1);
         assert_eq!(storage.test_pin_count("inst1", &key), 1);
 
         // Unpin again
-        let unpinned = storage.unpin_blocks("inst1", "ns", &[vec![1]]);
+        let unpinned = storage.unpin_block_refs("inst1", "ns", &[vec![1]], 1);
         assert_eq!(unpinned, 1);
+        assert_eq!(storage.test_pin_count("inst1", &key), 0);
+    }
+
+    #[tokio::test]
+    async fn unpin_block_refs_releases_multiple_worker_refs() {
+        let storage = make_engine();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        let block = Arc::new(SealedBlock::from_slots(Vec::new()));
+
+        storage.test_insert_cache(key.clone(), block.clone());
+        storage
+            .read_cache
+            .pin_blocks("inst1", 3, &[(key.clone(), block)]);
+        assert_eq!(storage.test_pin_count("inst1", &key), 3);
+
+        let unpinned = storage.unpin_block_refs("inst1", "ns", &[vec![1]], 3);
+        assert_eq!(unpinned, 3);
         assert_eq!(storage.test_pin_count("inst1", &key), 0);
     }
 

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -205,11 +205,15 @@ impl ReadCache {
     /// Unpin blocks (cancellation path, before `consume_pinned_blocks`).
     ///
     /// Returns count of entries that were successfully unpinned.
-    pub(super) fn unpin_blocks(
+    /// Unpin multiple refs for each block hash in one cache operation.
+    ///
+    /// Returns count of refs that were successfully unpinned.
+    pub(super) fn unpin_block_refs(
         &self,
         instance_id: &str,
         namespace: &str,
         block_hashes: &[Vec<u8>],
+        release_refs_per_hash: usize,
     ) -> usize {
         let instance_id_owned = instance_id.to_string();
         let namespace_owned = namespace.to_string();
@@ -227,7 +231,10 @@ impl ReadCache {
         let mut unpinned = 0usize;
 
         for pin_key in &pin_keys {
-            if inner.decrement_pin(pin_key) {
+            for _ in 0..release_refs_per_hash {
+                if !inner.decrement_pin(pin_key) {
+                    break;
+                }
                 unpinned += 1;
             }
         }

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -90,6 +90,8 @@ message QueryResponse {
 message UnpinRequest {
   string instance_id = 1;
   repeated bytes block_hashes = 2;
+  // Number of pin refs to release for each block hash. Must be >= 1.
+  uint32 release_refs_per_hash = 3;
 }
 
 message UnpinResponse {

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -596,15 +596,16 @@ impl Engine for GrpcEngineService {
         let start = Instant::now();
         let req = request.into_inner();
         let hash_count = req.block_hashes.len();
+        let release_refs_per_hash = req.release_refs_per_hash as usize;
 
         let result: Result<Response<UnpinResponse>, Status> = async {
             debug!(
-                "RPC [unpin]: instance_id={} block_hashes={}",
-                req.instance_id, hash_count
+                "RPC [unpin]: instance_id={} block_hashes={} release_refs_per_hash={}",
+                req.instance_id, hash_count, release_refs_per_hash
             );
 
             self.engine
-                .unpin_blocks(&req.instance_id, &req.block_hashes)
+                .unpin_block_refs(&req.instance_id, &req.block_hashes, release_refs_per_hash)
                 .map_err(Self::map_engine_error)?;
 
             Ok(Response::new(UnpinResponse {
@@ -616,8 +617,8 @@ impl Engine for GrpcEngineService {
         let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
         match &result {
             Ok(_) => debug!(
-                "RPC [unpin] completed: ok blocks={} elapsed_ms={:.2}",
-                hash_count, elapsed_ms
+                "RPC [unpin] completed: ok blocks={} release_refs_per_hash={} elapsed_ms={:.2}",
+                hash_count, release_refs_per_hash, elapsed_ms
             ),
             Err(status) => warn!(
                 "RPC [unpin] failed: code={} message={} elapsed_ms={:.2}",

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -310,6 +310,8 @@ class PegaKVConnector(KVConnectorBase_V1):
         return None
 
     def shutdown(self):
+        if self._scheduler:
+            self._scheduler.shutdown()
         if self._worker:
             self._worker.shutdown()
         if self._state_manager:

--- a/python/pegaflow/connector/connector_metrics.py
+++ b/python/pegaflow/connector/connector_metrics.py
@@ -96,8 +96,6 @@ class PegaKVConnectorStats(KVConnectorStats):
     Metrics collected:
     - Scheduler-side (gauge):
         - pending_prefetches: number of requests waiting for SSD prefetch
-    - Scheduler-side (counter):
-        - bypass_count: requests that bypassed cache lookup
     - Scheduler-side (histogram):
         - prefetch_duration: prefetch operation duration in milliseconds
         - prefetch_blocks: number of blocks per prefetch operation
@@ -122,8 +120,6 @@ class PegaKVConnectorStats(KVConnectorStats):
         self.data: dict = {
             # Scheduler-side gauges
             "pending_prefetches": 0,
-            # Scheduler-side counters
-            "bypass_count": 0,
             # Scheduler-side prefetch histogram data
             "prefetch_duration": [],  # list[float] in ms
             "prefetch_blocks": [],  # list[int]
@@ -167,7 +163,6 @@ class PegaKVConnectorStats(KVConnectorStats):
 
         # Counter-like metrics: sum them
         for key in [
-            "bypass_count",
             "load_success_count",
             "load_failure_count",
             "save_success_count",
@@ -198,7 +193,6 @@ class PegaKVConnectorStats(KVConnectorStats):
         result: dict[str, int | float | str] = {
             "pending_prefetches": self.data.get("pending_prefetches", 0),
             "pending_save_requests": self.data.get("pending_save_requests", 0),
-            "bypass_count": self.data.get("bypass_count", 0),
         }
 
         # Prefetch stats (scheduler-side)
@@ -243,7 +237,6 @@ class PegaKVConnectorStats(KVConnectorStats):
         return (
             self.data.get("pending_prefetches", 0) == 0
             and self.data.get("pending_save_requests", 0) == 0
-            and self.data.get("bypass_count", 0) == 0
             and len(self.data.get("prefetch_duration", [])) == 0
             and len(self.data.get("load_duration", [])) == 0
             and self.data.get("load_success_count", 0) == 0
@@ -281,9 +274,7 @@ class PegaPromMetrics(KVConnectorPromMetrics):
             documentation="Number of requests waiting for SSD prefetch to complete.",
             labelnames=labelnames,
         )
-        self.gauge_pending_prefetches = _bind_metric_per_engine(
-            self, gauge_pending_prefetches
-        )
+        self.gauge_pending_prefetches = _bind_metric_per_engine(self, gauge_pending_prefetches)
 
         # Gauge metrics for worker-side state
         gauge_pending_save_requests = self._gauge_cls(
@@ -294,14 +285,6 @@ class PegaPromMetrics(KVConnectorPromMetrics):
         self.gauge_pending_save_requests = _bind_metric_per_engine(
             self, gauge_pending_save_requests
         )
-
-        # Counter for bypass events (scheduler-side)
-        counter_bypass = self._counter_cls(
-            name="vllm:pega_bypass_total",
-            documentation="Number of requests that bypassed cache lookup due to short request.",
-            labelnames=labelnames,
-        )
-        self.counter_bypass = _bind_metric_per_engine(self, counter_bypass)
 
         # Histogram for prefetch operations (scheduler-side)
         # Optimized for fast SSD: typical range 10-500ms
@@ -324,9 +307,7 @@ class PegaPromMetrics(KVConnectorPromMetrics):
             buckets=blocks_buckets,
             labelnames=labelnames,
         )
-        self.histogram_prefetch_blocks = _bind_metric_per_engine(
-            self, histogram_prefetch_blocks
-        )
+        self.histogram_prefetch_blocks = _bind_metric_per_engine(self, histogram_prefetch_blocks)
 
         # Histogram for load operations (worker-side)
         # Optimized for fast SSD: typical range 1-50ms
@@ -338,9 +319,7 @@ class PegaPromMetrics(KVConnectorPromMetrics):
             buckets=duration_buckets,
             labelnames=labelnames,
         )
-        self.histogram_load_duration = _bind_metric_per_engine(
-            self, histogram_load_duration
-        )
+        self.histogram_load_duration = _bind_metric_per_engine(self, histogram_load_duration)
 
         histogram_load_blocks = self._histogram_cls(
             name="vllm:pega_load_blocks",
@@ -348,27 +327,21 @@ class PegaPromMetrics(KVConnectorPromMetrics):
             buckets=blocks_buckets,
             labelnames=labelnames,
         )
-        self.histogram_load_blocks = _bind_metric_per_engine(
-            self, histogram_load_blocks
-        )
+        self.histogram_load_blocks = _bind_metric_per_engine(self, histogram_load_blocks)
 
         counter_load_success = self._counter_cls(
             name="vllm:pega_load_success_total",
             documentation="Number of successful KV cache load operations.",
             labelnames=labelnames,
         )
-        self.counter_load_success = _bind_metric_per_engine(
-            self, counter_load_success
-        )
+        self.counter_load_success = _bind_metric_per_engine(self, counter_load_success)
 
         counter_load_failure = self._counter_cls(
             name="vllm:pega_load_failure_total",
             documentation="Number of failed KV cache load operations.",
             labelnames=labelnames,
         )
-        self.counter_load_failure = _bind_metric_per_engine(
-            self, counter_load_failure
-        )
+        self.counter_load_failure = _bind_metric_per_engine(self, counter_load_failure)
 
         # Histogram for save operations
         histogram_save_duration = self._histogram_cls(
@@ -377,9 +350,7 @@ class PegaPromMetrics(KVConnectorPromMetrics):
             buckets=duration_buckets,
             labelnames=labelnames,
         )
-        self.histogram_save_duration = _bind_metric_per_engine(
-            self, histogram_save_duration
-        )
+        self.histogram_save_duration = _bind_metric_per_engine(self, histogram_save_duration)
 
         histogram_save_blocks = self._histogram_cls(
             name="vllm:pega_save_blocks",
@@ -387,36 +358,28 @@ class PegaPromMetrics(KVConnectorPromMetrics):
             buckets=blocks_buckets,
             labelnames=labelnames,
         )
-        self.histogram_save_blocks = _bind_metric_per_engine(
-            self, histogram_save_blocks
-        )
+        self.histogram_save_blocks = _bind_metric_per_engine(self, histogram_save_blocks)
 
         counter_save_success = self._counter_cls(
             name="vllm:pega_save_success_total",
             documentation="Number of successful KV cache save operations.",
             labelnames=labelnames,
         )
-        self.counter_save_success = _bind_metric_per_engine(
-            self, counter_save_success
-        )
+        self.counter_save_success = _bind_metric_per_engine(self, counter_save_success)
 
         counter_save_failure = self._counter_cls(
             name="vllm:pega_save_failure_total",
             documentation="Number of failed KV cache save operations.",
             labelnames=labelnames,
         )
-        self.counter_save_failure = _bind_metric_per_engine(
-            self, counter_save_failure
-        )
+        self.counter_save_failure = _bind_metric_per_engine(self, counter_save_failure)
 
         counter_save_dropped = self._counter_cls(
             name="vllm:pega_save_dropped_total",
             documentation="Number of save operations dropped due to queue limit.",
             labelnames=labelnames,
         )
-        self.counter_save_dropped = _bind_metric_per_engine(
-            self, counter_save_dropped
-        )
+        self.counter_save_dropped = _bind_metric_per_engine(self, counter_save_dropped)
 
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
         """Record stats to Prometheus metrics."""
@@ -429,11 +392,6 @@ class PegaPromMetrics(KVConnectorPromMetrics):
         self.gauge_pending_save_requests[engine_idx].set(
             transfer_stats_data.get("pending_save_requests", 0)
         )
-
-        # Counter: bypass (scheduler-side)
-        bypass_count = transfer_stats_data.get("bypass_count", 0)
-        if bypass_count > 0:
-            self.counter_bypass[engine_idx].inc(bypass_count)
 
         # Histogram: prefetch duration (scheduler-side)
         # prefetch_duration is in ms, convert to seconds for Prometheus

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -41,12 +41,6 @@ class _PendingQueryProbe:
 class SchedulerConnector:
     """Holds scheduler-only state and behaviors."""
 
-    # Bypass thresholds (configurable via environment variables).
-    # Default 0 means disabled - bypass strategy only activates when explicitly set.
-    # NOTE: Read from environment at module import time.
-    BYPASS_BLOCKS: int = parse_env_int("PEGA_BYPASS_BLOCKS", 0)
-    HIGH_LOAD_THRESHOLD: int = parse_env_int("PEGA_HIGH_LOAD_THRESHOLD", 0)
-
     # Maximum number of requests that can have pending saves simultaneously.
     # Default 0 means unlimited - drop strategy only activates when explicitly set.
     # When this limit is reached, new save intents will be dropped (shorter first).
@@ -61,11 +55,8 @@ class SchedulerConnector:
         self._pending_query_probes: dict[str, _PendingQueryProbe] = {}
         self._pending_query_probe_releases: dict[str, _PendingQueryProbe] = {}
 
-        # Prefetch tracking (for metrics and bypass decisions)
+        # Prefetch tracking (for metrics)
         self._prefetch_tracker = PrefetchTracker()
-
-        # Bypass statistics
-        self._bypass_count: int = 0
 
         # Save state (per-request)
         self._block_hashes: dict[str, tuple[bytes, ...]] = {}
@@ -109,25 +100,6 @@ class SchedulerConnector:
             if not self._release_pending_query_probe(req_id):
                 return (None, False)
             self._external_matched_blocks[req_id] = computed_blocks
-            return (0, False)
-
-        # Check if request should bypass remote cache lookup
-        # Bypass short requests when queue is busy to avoid blocking long-running queries
-        num_remaining_blocks = len(remaining_hashes)
-        pending = self._prefetch_tracker.pending_prefetches
-        if num_remaining_blocks < self.BYPASS_BLOCKS and pending >= self.HIGH_LOAD_THRESHOLD:
-            self._external_matched_blocks[req_id] = computed_blocks
-            self._bypass_count += 1
-            if not self._release_pending_query_probe(req_id):
-                return (None, False)
-            logger.debug(
-                "[PegaKVConnector] req=%s bypass: remaining_blocks=%d "
-                "pending_prefetches=%d bypass_count=%d",
-                req_id,
-                num_remaining_blocks,
-                pending,
-                self._bypass_count,
-            )
             return (0, False)
 
         remaining_hashes_tuple = tuple(remaining_hashes)
@@ -565,7 +537,6 @@ class SchedulerConnector:
 
         data: dict = {
             "pending_prefetches": prefetch_stats["pending_prefetches"],
-            "bypass_count": self._bypass_count,
             "prefetch_duration": prefetch_stats["prefetch_duration"],
             "prefetch_blocks": prefetch_stats["prefetch_blocks"],
         }
@@ -574,9 +545,6 @@ class SchedulerConnector:
         if self._save_dropped_count > 0:
             data["save_dropped_count"] = self._save_dropped_count
             self._save_dropped_count = 0
-
-        # Reset bypass count after reporting (it's a counter)
-        self._bypass_count = 0
 
         stats = PegaKVConnectorStats(data=data)
         if stats.is_empty():

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -4,6 +4,7 @@ Scheduler-side connector logic.
 
 import time
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from pegaflow.connector.common import (
@@ -23,6 +24,18 @@ if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
     from vllm.v1.outputs import KVConnectorOutput
     from vllm.v1.request import Request
+
+
+@dataclass(frozen=True)
+class _PendingQueryProbe:
+    computed_blocks: int
+    remaining_hashes: tuple[bytes, ...]
+    hit_blocks: int
+    release_refs_per_hash: int
+
+    @property
+    def pinned_hashes(self) -> tuple[bytes, ...]:
+        return self.remaining_hashes[: self.hit_blocks]
 
 
 class SchedulerConnector:
@@ -45,6 +58,8 @@ class SchedulerConnector:
         # Load state
         self._pending_load_intents: dict[str, LoadIntent] = {}
         self._prefetch_start_times: dict[str, float] = {}
+        self._pending_query_probes: dict[str, _PendingQueryProbe] = {}
+        self._pending_query_probe_releases: dict[str, _PendingQueryProbe] = {}
 
         # Prefetch tracking (for metrics and bypass decisions)
         self._prefetch_tracker = PrefetchTracker()
@@ -77,6 +92,9 @@ class SchedulerConnector:
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
         req_id = request.request_id
+        if not self._drain_pending_query_probe_releases(req_id):
+            return (None, False)
+
         num_tokens = request.num_tokens
         block_hashes = request.block_hashes
 
@@ -88,6 +106,8 @@ class SchedulerConnector:
         remaining_hashes = block_hashes[computed_blocks:]
 
         if not remaining_hashes:
+            if not self._release_pending_query_probe(req_id):
+                return (None, False)
             self._external_matched_blocks[req_id] = computed_blocks
             return (0, False)
 
@@ -98,6 +118,8 @@ class SchedulerConnector:
         if num_remaining_blocks < self.BYPASS_BLOCKS and pending >= self.HIGH_LOAD_THRESHOLD:
             self._external_matched_blocks[req_id] = computed_blocks
             self._bypass_count += 1
+            if not self._release_pending_query_probe(req_id):
+                return (None, False)
             logger.debug(
                 "[PegaKVConnector] req=%s bypass: remaining_blocks=%d "
                 "pending_prefetches=%d bypass_count=%d",
@@ -108,6 +130,31 @@ class SchedulerConnector:
             )
             return (0, False)
 
+        remaining_hashes_tuple = tuple(remaining_hashes)
+        pending_probe = self._pending_query_probes.get(req_id)
+        if (
+            pending_probe is not None
+            and pending_probe.computed_blocks == computed_blocks
+            and pending_probe.remaining_hashes == remaining_hashes_tuple
+        ):
+            hit_blocks = pending_probe.hit_blocks
+            self._external_matched_blocks[req_id] = computed_blocks + hit_blocks
+            num_hit_tokens = hit_blocks * self._ctx.virtual_block_size
+            logger.info(
+                "[PegaKVConnector] req=%s cache_lookup_reuse: hit_blocks=%d "
+                "computed_blocks=%d hit_tokens=%d num_tokens=%d total_query_hashes=%d",
+                req_id,
+                hit_blocks,
+                computed_blocks,
+                num_hit_tokens,
+                num_tokens,
+                len(remaining_hashes),
+            )
+            return (num_hit_tokens, True)
+
+        if pending_probe is not None and not self._release_pending_query_probe(req_id):
+            return (None, False)
+
         lookup_start = time.perf_counter()
         hit_blocks = self._count_available_block_prefix(remaining_hashes, req_id)
         lookup_end = time.perf_counter()
@@ -117,12 +164,20 @@ class SchedulerConnector:
         if hit_blocks is None:
             return (None, False)
 
+        if hit_blocks > 0:
+            self._pending_query_probes[req_id] = _PendingQueryProbe(
+                computed_blocks=computed_blocks,
+                remaining_hashes=remaining_hashes_tuple,
+                hit_blocks=hit_blocks,
+                release_refs_per_hash=max(1, self._ctx.world_size),
+            )
+
         self._external_matched_blocks[req_id] = computed_blocks + hit_blocks
 
         # Each hit block = 1 virtual block = virtual_block_size global tokens.
         num_hit_tokens = hit_blocks * self._ctx.virtual_block_size
 
-        logger.debug(
+        logger.info(
             "[PegaKVConnector] req=%s cache_lookup: hit_blocks=%d computed_blocks=%d "
             "hit_tokens=%d num_tokens=%d lookup_us=%.0f total_query_hashes=%d",
             req_id,
@@ -185,7 +240,15 @@ class SchedulerConnector:
                 ),
                 num_tokens=num_external_tokens,
             )
+            pending_probe = self._pending_query_probes.get(req_id)
+            if (
+                pending_probe is not None
+                and load_intent.block_hashes != pending_probe.pinned_hashes
+            ):
+                self._release_pending_query_probe(req_id)
+                raise RuntimeError(f"req {req_id} load hashes do not match pending query probe")
             self._pending_load_intents[req_id] = load_intent
+            self._pending_query_probes.pop(req_id, None)
             logger.debug(
                 "[PegaKVConnector] req=%s alloc: total_blocks=%d computed_blocks=%d "
                 "load_blocks=%d start_block_idx=%d load_tokens=%d pending_loads=%d",
@@ -199,6 +262,8 @@ class SchedulerConnector:
             )
 
     def build_connector_meta(self, scheduler_output: "SchedulerOutput") -> PegaConnectorMetadata:
+        self._drain_pending_query_probe_releases()
+
         # Collect potential save intents first, then apply drop decision
         potential_saves: dict[str, SaveIntent] = {}
 
@@ -390,6 +455,7 @@ class SchedulerConnector:
 
     def _cleanup_request(self, req_id: str) -> None:
         """Clean up all state for a completed request."""
+        self._release_pending_query_probe(req_id)
         self._requests.pop(req_id, None)
         self._block_hashes.pop(req_id, None)
         self._external_matched_blocks.pop(req_id, None)
@@ -492,6 +558,8 @@ class SchedulerConnector:
 
     def get_stats(self) -> PegaKVConnectorStats | None:
         """Get current connector stats for metrics exposure."""
+        self._drain_pending_query_probe_releases()
+
         # Get stats from prefetch tracker
         prefetch_stats = self._prefetch_tracker.get_stats()
 
@@ -514,6 +582,70 @@ class SchedulerConnector:
         if stats.is_empty():
             return None
         return stats
+
+    def shutdown(self) -> None:
+        for req_id in list(self._pending_query_probes):
+            self._release_pending_query_probe(req_id)
+        self._drain_pending_query_probe_releases()
+
+    def _release_pending_query_probe(self, req_id: str) -> bool:
+        probe = self._pending_query_probes.pop(req_id, None)
+        if probe is None:
+            return self._drain_pending_query_probe_releases(req_id)
+
+        remaining_probe = self._unpin_query_probe_refs(req_id, probe)
+        if remaining_probe is None:
+            return True
+
+        self._pending_query_probe_releases[req_id] = remaining_probe
+        return False
+
+    def _drain_pending_query_probe_releases(self, req_id: str | None = None) -> bool:
+        req_ids = [req_id] if req_id is not None else list(self._pending_query_probe_releases)
+        all_released = True
+        for release_req_id in req_ids:
+            probe = self._pending_query_probe_releases.pop(release_req_id, None)
+            if probe is None:
+                continue
+
+            remaining_probe = self._unpin_query_probe_refs(release_req_id, probe)
+            if remaining_probe is not None:
+                self._pending_query_probe_releases[release_req_id] = remaining_probe
+                all_released = False
+
+        return all_released
+
+    def _unpin_query_probe_refs(
+        self,
+        req_id: str,
+        probe: _PendingQueryProbe,
+    ) -> _PendingQueryProbe | None:
+        pinned_hashes = probe.pinned_hashes
+        if not pinned_hashes:
+            return None
+
+        pinned_hash_list = list(pinned_hashes)
+        try:
+            ok, message = self._ctx.engine_client.unpin(
+                self._ctx.instance_id,
+                pinned_hash_list,
+                probe.release_refs_per_hash,
+            )
+            if ok:
+                return None
+            logger.warning(
+                "[PegaKVConnector] pending query unpin failed: req=%s message=%s",
+                req_id,
+                message,
+            )
+        except Exception as e:
+            logger.warning(
+                "[PegaKVConnector] pending query unpin exception: req=%s error=%s",
+                req_id,
+                e,
+            )
+
+        return probe
 
 
 __all__ = ["SchedulerConnector"]

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -203,6 +203,7 @@ class EngineRpcClient:
         self,
         instance_id: str,
         block_hashes: list[bytes],
+        release_refs_per_hash: int,
     ) -> tuple[bool, str]:
         """Unpin blocks that were pinned during query.
 
@@ -212,6 +213,7 @@ class EngineRpcClient:
         Args:
             instance_id: Model instance ID.
             block_hashes: List of block hashes to unpin.
+            release_refs_per_hash: Number of pin refs to release for each hash.
 
         Returns:
             Tuple of (ok, message) indicating success/failure.

--- a/python/pegaflow/sglang/peagflow_radix_cache.py
+++ b/python/pegaflow/sglang/peagflow_radix_cache.py
@@ -331,7 +331,7 @@ class PeagflowRadixCache(RadixCache):
         if not block_hashes:
             return
         try:
-            ok, message = self.engine_client.unpin(self.instance_id, block_hashes)
+            ok, message = self.engine_client.unpin(self.instance_id, block_hashes, 1)
             if not ok:
                 logger.warning(f"[PeagflowRadixCache] unpin failed: {message}")
         except Exception as e:

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -405,6 +405,7 @@ impl EngineRpcClient {
     /// Args:
     ///     instance_id: Model instance ID
     ///     block_hashes: List of block hashes to unpin
+    ///     release_refs_per_hash: Number of pin refs to release for each hash
     ///
     /// Returns: (ok: bool, message: str)
     fn unpin(
@@ -412,12 +413,14 @@ impl EngineRpcClient {
         py: Python<'_>,
         instance_id: String,
         block_hashes: Vec<Vec<u8>>,
+        release_refs_per_hash: u32,
     ) -> PyResult<(bool, String)> {
         self.call(py, "unpin", |mut c| async move {
             let resp = c
                 .unpin(UnpinRequest {
                     instance_id,
                     block_hashes,
+                    release_refs_per_hash,
                 })
                 .await?;
             Ok(resp.into_inner())

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -10,11 +10,24 @@ from __future__ import annotations
 import hashlib
 import sys
 import types
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 # ---------------------------------------------------------------------------
 # Stub the native extension *before* anything imports pegaflow.
 # ---------------------------------------------------------------------------
+
+
+class _FakeLoadState:
+    def shm_name(self) -> str:
+        return "test-shm"
+
+    def is_ready(self) -> bool:
+        return False
+
+    def get_state(self) -> int:
+        return 0
+
 
 _EXT_NAME = "pegaflow.pegaflow"
 if _EXT_NAME not in sys.modules:
@@ -23,8 +36,23 @@ if _EXT_NAME not in sys.modules:
     _ext_stub.PegaFlowBusinessError = type("PegaFlowBusinessError", (Exception,), {})  # type: ignore[attr-defined]
     _ext_stub.PegaFlowError = type("PegaFlowError", (Exception,), {})  # type: ignore[attr-defined]
     _ext_stub.PegaFlowServiceError = type("PegaFlowServiceError", (Exception,), {})  # type: ignore[attr-defined]
-    _ext_stub.PyLoadState = MagicMock  # type: ignore[attr-defined]
+    _ext_stub.PyLoadState = _FakeLoadState  # type: ignore[attr-defined]
+    _ext_stub.__version__ = "test"  # type: ignore[attr-defined]
     sys.modules[_EXT_NAME] = _ext_stub
+else:
+    _ext_stub = sys.modules[_EXT_NAME]
+    if not hasattr(_ext_stub, "EngineRpcClient"):
+        _ext_stub.EngineRpcClient = MagicMock  # type: ignore[attr-defined]
+    if not hasattr(_ext_stub, "PegaFlowBusinessError"):
+        _ext_stub.PegaFlowBusinessError = type("PegaFlowBusinessError", (Exception,), {})  # type: ignore[attr-defined]
+    if not hasattr(_ext_stub, "PegaFlowError"):
+        _ext_stub.PegaFlowError = type("PegaFlowError", (Exception,), {})  # type: ignore[attr-defined]
+    if not hasattr(_ext_stub, "PegaFlowServiceError"):
+        _ext_stub.PegaFlowServiceError = type("PegaFlowServiceError", (Exception,), {})  # type: ignore[attr-defined]
+    if not hasattr(_ext_stub, "PyLoadState"):
+        _ext_stub.PyLoadState = _FakeLoadState  # type: ignore[attr-defined]
+    if not hasattr(_ext_stub, "__version__"):
+        _ext_stub.__version__ = "test"  # type: ignore[attr-defined]
 
 from pegaflow.connector.common import ConnectorContext  # noqa: E402
 from pegaflow.connector.scheduler import SchedulerConnector  # noqa: E402
@@ -308,3 +336,147 @@ class TestDecodeHashRefresh:
         assert intent is not None
         assert intent.block_hashes == block_hashes[6:9]
         assert intent.block_ids == (200, 201, 202)
+
+
+class TestSchedulerQueryProbeReuse:
+    """Repeated scheduler probes should not repeat server-side query pins."""
+
+    def _make_connector(self, world_size: int = 1) -> tuple[SchedulerConnector, MagicMock]:
+        engine_client = MagicMock()
+        engine_client.query_prefetch.return_value = {
+            "ok": True,
+            "message": "ok",
+            "hit_blocks": 2,
+            "prefetch_state": "done",
+            "loading_blocks": 0,
+            "missing_blocks": 0,
+        }
+        engine_client.unpin.return_value = (True, "ok")
+        state_manager = MagicMock()
+        state_manager.is_available.return_value = True
+        ctx = _make_ctx(
+            engine_client=engine_client,
+            state_manager=state_manager,
+            world_size=world_size,
+        )
+        return SchedulerConnector(ctx), engine_client
+
+    def test_repeated_same_probe_reuses_query_result(self):
+        sc, engine_client = self._make_connector()
+        req = _make_fake_request("r1", [_hash(i) for i in range(4)])
+
+        first = sc.get_num_new_matched_tokens(req, num_computed_tokens=0)
+        second = sc.get_num_new_matched_tokens(req, num_computed_tokens=0)
+
+        assert first == (32, True)
+        assert second == (32, True)
+        engine_client.query_prefetch.assert_called_once()
+        engine_client.unpin.assert_not_called()
+
+    def test_committed_probe_is_not_unpinned_on_cleanup(self):
+        sc, engine_client = self._make_connector()
+        req = _make_fake_request("r1", [_hash(i) for i in range(2)])
+        blocks = _make_fake_blocks([10, 11])
+        blocks.blocks = [[SimpleNamespace(block_hash=None), SimpleNamespace(block_hash=None)]]
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
+        sc.update_state_after_alloc(req, blocks, num_external_tokens=32)
+        sc._cleanup_request("r1")
+
+        engine_client.unpin.assert_not_called()
+
+    def test_different_probe_releases_previous_uncommitted_probe(self):
+        sc, engine_client = self._make_connector()
+        req = _make_fake_request("r1", [_hash(i) for i in range(4)])
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
+        req.block_hashes = [_hash(i) for i in range(10, 14)]
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
+
+        assert engine_client.query_prefetch.call_count == 2
+        engine_client.unpin.assert_called_once_with("test", [_hash(0), _hash(1)], 1)
+
+    def test_uncommitted_probe_release_matches_world_size_pin_count(self):
+        sc, engine_client = self._make_connector(world_size=3)
+        req = _make_fake_request("r1", [_hash(i) for i in range(4)])
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
+        sc._cleanup_request("r1")
+
+        engine_client.unpin.assert_called_once_with("test", [_hash(0), _hash(1)], 3)
+
+    def test_failed_unpin_rpc_remains_tracked(self):
+        sc, engine_client = self._make_connector(world_size=3)
+        req = _make_fake_request("r1", [_hash(i) for i in range(4)])
+        engine_client.unpin.side_effect = RuntimeError("temporary")
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
+        sc._cleanup_request("r1")
+
+        engine_client.unpin.assert_called_once_with("test", [_hash(0), _hash(1)], 3)
+        assert "r1" not in sc._pending_query_probes
+        assert sc._pending_query_probe_releases["r1"].release_refs_per_hash == 3
+
+    def test_different_probe_does_not_overwrite_failed_release(self):
+        sc, engine_client = self._make_connector(world_size=2)
+        req = _make_fake_request("r1", [_hash(i) for i in range(4)])
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
+
+        engine_client.unpin.side_effect = RuntimeError("temporary")
+        req.block_hashes = [_hash(i) for i in range(10, 14)]
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (None, False)
+        assert engine_client.query_prefetch.call_count == 1
+        assert "r1" not in sc._pending_query_probes
+        assert sc._pending_query_probe_releases["r1"].remaining_hashes == tuple(
+            _hash(i) for i in range(4)
+        )
+        assert sc._pending_query_probe_releases["r1"].release_refs_per_hash == 2
+
+    def test_failed_release_must_clear_before_new_probe(self):
+        sc, engine_client = self._make_connector(world_size=2)
+        req = _make_fake_request("r1", [_hash(i) for i in range(4)])
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
+
+        engine_client.unpin.side_effect = RuntimeError("temporary")
+        req.block_hashes = [_hash(i) for i in range(10, 14)]
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (None, False)
+
+        engine_client.unpin.side_effect = None
+        engine_client.unpin.return_value = (True, "ok")
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
+
+        assert engine_client.query_prefetch.call_count == 2
+        assert "r1" not in sc._pending_query_probe_releases
+        assert sc._pending_query_probes["r1"].remaining_hashes == tuple(
+            _hash(i) for i in range(10, 14)
+        )
+
+    def test_cleanup_release_retry_is_drained_by_stats(self):
+        sc, engine_client = self._make_connector(world_size=1)
+        req = _make_fake_request("r1", [_hash(i) for i in range(4)])
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
+
+        engine_client.unpin.side_effect = [RuntimeError("temporary")]
+        sc._cleanup_request("r1")
+        assert sc._pending_query_probe_releases["r1"].release_refs_per_hash == 1
+
+        engine_client.unpin.side_effect = None
+        engine_client.unpin.return_value = (True, "ok")
+        sc.get_stats()
+
+        assert "r1" not in sc._pending_query_probe_releases
+
+    def test_shutdown_releases_uncommitted_probe(self):
+        sc, engine_client = self._make_connector(world_size=2)
+        req = _make_fake_request("r1", [_hash(i) for i in range(4)])
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
+        sc.shutdown()
+
+        assert "r1" not in sc._pending_query_probes
+        assert "r1" not in sc._pending_query_probe_releases
+        engine_client.unpin.assert_called_once_with("test", [_hash(0), _hash(1)], 2)

--- a/python/tests/test_vllm_query_probe_stress.py
+++ b/python/tests/test_vllm_query_probe_stress.py
@@ -1,0 +1,164 @@
+"""Stress E2E for scheduler query-probe idempotency.
+
+This test intentionally creates warm-hit traffic under constrained KV capacity.
+It is not a replacement for the correctness E2E; it is an observability-heavy
+proof that repeated scheduler probes reuse the memoized query result and that
+abandoned probes do not leave obvious release failures in the logs.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import requests
+
+from .vllm_helpers import (
+    PegaFlowServer,
+    VLLMServer,
+    call_openai_api,
+    fetch_pegaflow_metrics,
+)
+
+STRESS_PROMPT = (
+    "Distributed systems often rely on caching to reduce latency and improve "
+    "throughput, but cache correctness depends on carefully managed ownership. "
+    "A request may observe that a prefix is available, wait while other work is "
+    "scheduled, and later attempt to use that same prefix after allocation. "
+    "During this gap, the cache layer must avoid double-counting reservations, "
+    "must release abandoned references, and must preserve the exact hash order "
+    "used for the eventual load. " * 24
+)
+
+
+def _post_completion(
+    port: int,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    *,
+    stream: bool,
+    timeout: float,
+) -> str:
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "seed": 42,
+        "stream": stream,
+    }
+    url = f"http://localhost:{port}/v1/completions"
+    if not stream:
+        response = requests.post(url, json=payload, timeout=timeout)
+        response.raise_for_status()
+        return response.json()["choices"][0]["text"]
+
+    with requests.post(url, json=payload, stream=True, timeout=timeout) as response:
+        response.raise_for_status()
+        for line in response.iter_lines():
+            if line:
+                return "stream-started"
+    return "stream-closed"
+
+
+def _grep_log(log_text: str, patterns: tuple[str, ...]) -> str:
+    lines = [line for line in log_text.splitlines() if any(pattern in line for pattern in patterns)]
+    return "\n".join(lines[-80:])
+
+
+def _metric_delta(before: dict[str, float], after: dict[str, float], key: str) -> float:
+    return after.get(key, 0) - before.get(key, 0)
+
+
+def test_query_probe_reuse_under_pressure(
+    model: str,
+    base_port: int,
+    tmp_path: Path,
+    max_model_len: int | None,
+):
+    """Warm-hit concurrent requests should show query-probe reuse in vLLM logs."""
+
+    log_dir = tmp_path / "query_probe_stress_logs"
+    log_dir.mkdir()
+    pega_log = log_dir / "pegaflow-vllm.log"
+    server_log = log_dir / "pegaflow-server.log"
+
+    with PegaFlowServer(log_file=server_log) as pega_server:
+        with VLLMServer(
+            model,
+            base_port,
+            use_pegaflow=True,
+            pegaflow_port=pega_server.grpc_port,
+            log_file=pega_log,
+            max_model_len=max_model_len or 4096,
+            gpu_memory_utilization=0.3,
+            extra_args=["--max-num-seqs", "96"],
+            startup_timeout=240,
+        ):
+            print(f"[Stress] vLLM log: {pega_log}")
+            print(f"[Stress] PegaFlow server log: {server_log}")
+
+            metrics_start = fetch_pegaflow_metrics(pega_server.metrics_port)
+
+            cold = call_openai_api(base_port, model, STRESS_PROMPT, max_tokens=32)["text"]
+            warm = call_openai_api(base_port, model, STRESS_PROMPT, max_tokens=32)["text"]
+            assert warm == cold
+
+            futures = []
+            with ThreadPoolExecutor(max_workers=40) as pool:
+                for idx in range(40):
+                    futures.append(
+                        pool.submit(
+                            _post_completion,
+                            base_port,
+                            model,
+                            STRESS_PROMPT,
+                            192 if idx < 32 else 64,
+                            stream=False,
+                            timeout=120,
+                        )
+                    )
+
+                completed = 0
+                for future in as_completed(futures, timeout=240):
+                    future.result()
+                    completed += 1
+
+            assert completed == len(futures)
+
+            final = call_openai_api(base_port, model, STRESS_PROMPT, max_tokens=32)["text"]
+            assert final == cold
+
+            metrics_end = fetch_pegaflow_metrics(pega_server.metrics_port)
+
+        pega_text = pega_log.read_text(errors="replace")
+        server_text = server_log.read_text(errors="replace")
+        interesting = _grep_log(
+            pega_text,
+            (
+                "cache_lookup",
+                "pending query unpin",
+                "Preempt",
+                "preempt",
+                "abort",
+            ),
+        )
+        print("[Stress] Interesting vLLM log lines:\n" + interesting)
+
+        assert "cache_lookup_reuse" in pega_text, (
+            "Expected repeated scheduler probe reuse in vLLM log.\n"
+            f"vLLM log: {pega_log}\n"
+            f"PegaFlow log: {server_log}\n"
+            f"Interesting lines:\n{interesting}"
+        )
+        assert "cache_lookup: hit_blocks=0" in pega_text
+        assert "pending query unpin failed" not in pega_text
+        assert "pending query unpin exception" not in pega_text
+
+        hits = _metric_delta(metrics_start, metrics_end, "pegaflow_cache_block_hits_total")
+        loads = _metric_delta(metrics_start, metrics_end, "pegaflow_load_bytes_total")
+        assert hits > 0 or loads > 0, (
+            f"Expected warm-hit/load activity, got hits={hits}, loads={loads}.\n"
+            f"Server log tail:\n{_grep_log(server_text, ('hit=', 'load', 'unpin'))}"
+        )

--- a/python/tests/vllm_helpers.py
+++ b/python/tests/vllm_helpers.py
@@ -30,6 +30,9 @@ class VLLMServer:
         max_model_len: int | None = None,
         tensor_parallel_size: int = 1,
         pipeline_parallel_size: int = 1,
+        gpu_memory_utilization: float = 0.8,
+        extra_args: list[str] | None = None,
+        startup_timeout: int = 180,
     ):
         self.model = model
         self.port = port
@@ -39,6 +42,9 @@ class VLLMServer:
         self.max_model_len = max_model_len
         self.tensor_parallel_size = tensor_parallel_size
         self.pipeline_parallel_size = pipeline_parallel_size
+        self.gpu_memory_utilization = gpu_memory_utilization
+        self.extra_args = extra_args or []
+        self.startup_timeout = startup_timeout
         self.health_endpoints = ["/health", "/v1/models"]
         self.process: subprocess.Popen | None = None
         self.log_handle = None
@@ -54,6 +60,7 @@ class VLLMServer:
             )
 
         env = os.environ.copy()
+        env["PYTHONHASHSEED"] = "0"
         env["VLLM_BATCH_INVARIANT"] = "1"
 
         if self.use_pegaflow and self.pegaflow_port is not None:
@@ -74,7 +81,7 @@ class VLLMServer:
             "--trust-remote-code",
             "--no-enable-prefix-caching",
             "--gpu-memory-utilization",
-            "0.8",
+            str(self.gpu_memory_utilization),
             "--attention-backend",
             "FLASH_ATTN",
             "--tensor-parallel-size",
@@ -93,6 +100,8 @@ class VLLMServer:
                 "kv_connector_module_path": "pegaflow.connector",
             }
             cmd.extend(["--kv-transfer-config", json.dumps(kv_config)])
+
+        cmd.extend(self.extra_args)
 
         server_label = "PegaFlow" if self.use_pegaflow else "Baseline"
         print(f"\n[{server_label}] Starting vLLM server on port {self.port}")
@@ -116,7 +125,7 @@ class VLLMServer:
                 preexec_fn=os.setsid,
             )
 
-        self._wait_for_ready()
+        self._wait_for_ready(timeout=self.startup_timeout)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -243,6 +252,7 @@ class PegaFlowServer:
         import sysconfig
 
         env = os.environ.copy()
+        env["PYTHONHASHSEED"] = "0"
         env["PYO3_PYTHON"] = sys.executable
         env["PYTHONHOME"] = sys.base_prefix
         if libdir := sysconfig.get_config_var("LIBDIR"):


### PR DESCRIPTION
## Summary

- Make vLLM scheduler `query_prefetch` probes idempotent per active request/query identity, so repeated `get_num_new_matched_tokens` calls reuse the same positive probe instead of re-pinning the same blocks on PegaFlow server.
- Release abandoned positive probes through one batched `unpin` RPC with an explicit `release_refs_per_hash` field.
- Add commit-time hash invariant checks before consuming a memoized probe.
- Document the vLLM request state machine and add a pressure E2E that exercises repeated query probes.

## Why

vLLM documents `get_num_new_matched_tokens` as side-effect-free, but PegaFlow's server-side `query_prefetch` pins local-hit blocks. Under pressure, vLLM can call the query path repeatedly for the same request before allocation/load. On `master`, every repeated positive query increments `pinned_for_load`; the eventual load only consumes one ref per block, leaving leaked server-side pins.

## Metrics proof

I ran the same pressure workload twice and intentionally kept `pegaflow-server` alive after stopping vLLM, then curled `/metrics` directly.

Master:

```text
pid=115758
metrics=http://127.0.0.1:40543/metrics
server_log=/tmp/pegaflow_metrics_leak_master/pegaflow-server.log
vllm_log=/tmp/pegaflow_metrics_leak_master/pegaflow-vllm.log
```

```text
pegaflow_cache_block_hits_total 66269
pegaflow_load_bytes_total 10186129408
pegaflow_pinned_for_load_unique_bytes 242221056
```

Fix branch:

```text
pid=117271
metrics=http://127.0.0.1:51005/metrics
server_log=/tmp/pegaflow_metrics_leak_fix/pegaflow-server.log
vllm_log=/tmp/pegaflow_metrics_leak_fix/pegaflow-vllm.log
```

```text
pegaflow_cache_block_hits_total 5428
pegaflow_load_bytes_total 9960423424
pegaflow_pinned_for_load_unique_bytes 0
```

This shows master leaves PegaFlow server-side `pinned_for_load` bytes after all requests finish and vLLM exits, while the fix drains the pins under comparable load traffic.

## Additional log evidence

From the earlier same-workload aggregation on server logs:

```text
fix    hit_reqs 42  repeated_reqs 3  positive_queries 45   extra_refs_lower_bound 386
master hit_reqs 42  repeated_reqs 9  positive_queries 532  extra_refs_lower_bound 60994
```

One master request repeated the same positive server-side query 148 times:

```text
req=cmpl-ad870751c8a97766-0-be1ce27a
148 queries
123 hit_blocks
extra_pin_refs >= (148 - 1) * 123 = 18081
```

## Validation

- `cd python && maturin develop --release`
- `uv run pytest python/tests/test_combine_hashes.py python/tests/test_connector_fault_tolerance.py -q` -> 33 passed
- `cargo test -p pegaflow-core -p pegaflow-server -p pegaflow-proto unpin --release` -> passed
- `prek run --files docs/vllm-request-state-machine.md pegaflow-core/src/lib.rs pegaflow-core/src/storage/mod.rs pegaflow-core/src/storage/read_cache.rs pegaflow-proto/proto/engine.proto pegaflow-server/src/service.rs python/pegaflow/connector/__init__.py python/pegaflow/connector/scheduler.py python/pegaflow/pegaflow.pyi python/pegaflow/sglang/peagflow_radix_cache.py python/src/lib.rs python/tests/test_combine_hashes.py python/tests/test_vllm_query_probe_stress.py python/tests/vllm_helpers.py` -> passed
- `uv run pytest python/tests/test_vllm_e2e_correctness.py -v -s --max-model-len 4096` -> 12 passed
- `uv run pytest python/tests/test_vllm_query_probe_stress.py -v -s --max-model-len 4096` -> passed
