### PR TITLE
feat(server): add memory cache cleanup endpoint

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -25,6 +25,14 @@ pegaflow-server
 - `--metrics-otel-endpoint`: OTLP metrics export endpoint (optional, leave unset to disable)
 - `--metrics-period-secs`: Metrics export period in seconds (default: `10`, only used with OTLP)
 
+### HTTP Endpoints
+
+- `GET /health`: Health check.
+- `GET /metrics`: Prometheus metrics, when `--enable-prometheus` is enabled.
+- `GET /instances`: List registered instance IDs.
+- `POST /instances/cleanup[?id=<instance_id>]`: Remove one instance, or all instances when `id` is omitted.
+- `POST /cache/memory/cleanup`: Evict resident in-memory cache blocks while preserving backing-store data. `evicted_bytes` is the cache footprint removed from residency; `reclaimed_bytes` is the pinned-pool memory actually released immediately.
+
 ### SSD Cache
 
 - `--ssd-cache-path`: Enable SSD cache by providing cache file path (optional)

--- a/pegaflow-core/src/cache.rs
+++ b/pegaflow-core/src/cache.rs
@@ -101,6 +101,10 @@ impl TinyLfuCache<BlockKey, ArcSealedBlock> {
     pub(crate) fn remove_lru(&mut self) -> Option<(BlockKey, ArcSealedBlock)> {
         self.lru.remove_lru()
     }
+
+    pub(crate) fn remove_all(&mut self) -> Vec<(BlockKey, ArcSealedBlock)> {
+        self.lru.drain().collect()
+    }
 }
 
 pub(crate) type ArcSealedBlock = Arc<SealedBlock>;

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -40,7 +40,7 @@ pub use pegaflow_common::NumaNode;
 use pegaflow_common::NumaTopology;
 pub use pinned_pool::PinnedAllocation;
 pub use seal_offload::SlotMeta;
-pub use storage::StorageConfig;
+pub use storage::{MemoryCacheCleanupStats, StorageConfig};
 pub use sync_state::{LoadState, LoadStateError};
 pub use trace::{set_trace_sample_rate, should_sample};
 
@@ -435,6 +435,11 @@ impl PegaEngine {
             release_refs_per_hash,
         );
         Ok(unpinned)
+    }
+
+    /// Evict all resident in-memory cache blocks while preserving backing-store data.
+    pub fn cleanup_memory_cache(&self) -> MemoryCacheCleanupStats {
+        self.storage.cleanup_memory_cache()
     }
 
     /// Batch load KV blocks for multiple layers asynchronously.

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -27,6 +27,14 @@ use write_path::{InsertDeps, WritePipeline};
 
 const RECLAIM_BATCH_SIZE: usize = 64;
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryCacheCleanupStats {
+    pub evicted_blocks: usize,
+    pub evicted_bytes: u64,
+    pub reclaimed_bytes: u64,
+    pub still_referenced_blocks: u64,
+}
+
 #[derive(Clone)]
 pub struct StorageConfig {
     pub enable_lfu_admission: bool,
@@ -359,6 +367,73 @@ impl StorageEngine {
         )
     }
 
+    /// Evict all blocks from the resident in-memory read cache.
+    ///
+    /// This preserves backing-store copies and load pins. Blocks with
+    /// outstanding references may remain allocated until those holders release
+    /// the last `Arc`.
+    pub(crate) fn cleanup_memory_cache(&self) -> MemoryCacheCleanupStats {
+        let used_before = self.allocator.usage().0;
+        let evicted = self.read_cache.remove_all();
+        if evicted.is_empty() {
+            return MemoryCacheCleanupStats::default();
+        }
+
+        if let Some(client) = &self.metaserver_client {
+            let entries: Vec<(String, Vec<u8>)> = evicted
+                .iter()
+                .map(|(key, _)| (key.namespace.clone(), key.hash.clone()))
+                .collect();
+            client.try_unregister(entries);
+        }
+
+        let mut evicted_bytes = 0u64;
+        let mut still_referenced_blocks = 0u64;
+        for (_key, block) in &evicted {
+            let bytes = block.memory_footprint();
+            evicted_bytes = evicted_bytes.saturating_add(bytes);
+            if Arc::strong_count(block) > 1 {
+                still_referenced_blocks += 1;
+            }
+            core_metrics()
+                .cache_resident_bytes
+                .add(-(bytes as i64), &[]);
+        }
+
+        let evicted_blocks = evicted.len();
+        if still_referenced_blocks > 0 {
+            core_metrics()
+                .cache_block_evictions_still_referenced
+                .add(still_referenced_blocks, &[]);
+        }
+        core_metrics()
+            .cache_block_evictions
+            .add(evicted_blocks as u64, &[]);
+
+        drop(evicted);
+        let reclaimed_bytes = used_before.saturating_sub(self.allocator.usage().0);
+        if reclaimed_bytes > 0 {
+            core_metrics()
+                .cache_eviction_reclaimed_bytes
+                .add(reclaimed_bytes, &[]);
+        }
+
+        info!(
+            "Cleaned resident memory cache: evicted_blocks={} evicted_bytes={} reclaimed_bytes={} still_referenced_blocks={}",
+            evicted_blocks,
+            ByteSize(evicted_bytes),
+            ByteSize(reclaimed_bytes),
+            still_referenced_blocks
+        );
+
+        MemoryCacheCleanupStats {
+            evicted_blocks,
+            evicted_bytes,
+            reclaimed_bytes,
+            still_referenced_blocks,
+        }
+    }
+
     /// Check prefix blocks and schedule backing-store reads if needed.
     pub(crate) async fn check_prefix_and_prefetch(
         &self,
@@ -623,6 +698,26 @@ mod tests {
         let unpinned = storage.unpin_block_refs("inst1", "ns", &[vec![1]], 3);
         assert_eq!(unpinned, 3);
         assert_eq!(storage.test_pin_count("inst1", &key), 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_memory_cache_evicts_all_resident_blocks() {
+        let storage = make_engine();
+        let key1 = BlockKey::new("ns".into(), vec![1]);
+        let key2 = BlockKey::new("ns".into(), vec![2]);
+        let block1 = Arc::new(SealedBlock::from_slots(Vec::new()));
+        let block2 = Arc::new(SealedBlock::from_slots(Vec::new()));
+
+        storage.test_insert_cache(key1, Arc::clone(&block1));
+        storage.test_insert_cache(key2, block2);
+
+        let stats = storage.cleanup_memory_cache();
+        assert_eq!(stats.evicted_blocks, 2);
+        assert_eq!(stats.still_referenced_blocks, 1);
+        assert_eq!(stats.reclaimed_bytes, 0);
+
+        let stats = storage.cleanup_memory_cache();
+        assert_eq!(stats, MemoryCacheCleanupStats::default());
     }
 
     #[tokio::test]

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -262,6 +262,10 @@ impl ReadCache {
             .collect()
     }
 
+    pub(super) fn remove_all(&self) -> Vec<(BlockKey, Arc<SealedBlock>)> {
+        self.inner.lock().cache.remove_all()
+    }
+
     #[cfg(test)]
     pub(super) fn pin_count(&self, instance_id: &str, key: &BlockKey) -> usize {
         let pin_key = (instance_id.to_string(), key.clone());
@@ -358,5 +362,22 @@ mod tests {
         // get_prefix_blocks: stops at key 1 (first miss), returns only key 0
         let (prefix_hit, _) = cache.get_prefix_blocks(&keys);
         assert_eq!(prefix_hit, 1);
+    }
+
+    #[test]
+    fn remove_all_evicts_resident_blocks() {
+        let cache = make_cache();
+        let key1 = BlockKey::new("ns".into(), vec![1]);
+        let key2 = BlockKey::new("ns".into(), vec![2]);
+
+        cache.batch_insert(vec![
+            (key1.clone(), make_block()),
+            (key2.clone(), make_block()),
+        ]);
+
+        let removed = cache.remove_all();
+        assert_eq!(removed.len(), 2);
+        assert_eq!(cache.get_blocks(&[key1, key2]).len(), 0);
+        assert!(cache.remove_all().is_empty());
     }
 }

--- a/pegaflow-server/src/http_server.rs
+++ b/pegaflow-server/src/http_server.rs
@@ -59,6 +59,14 @@ struct CleanupResponse {
     removed_tensors: usize,
 }
 
+#[derive(Serialize)]
+struct MemoryCacheCleanupResponse {
+    evicted_blocks: usize,
+    evicted_bytes: u64,
+    reclaimed_bytes: u64,
+    still_referenced_blocks: u64,
+}
+
 /// POST /instances/cleanup[?id=<instance_id>]
 ///
 /// Without `id`: remove all instances and release all CUDA IPC tensors.
@@ -134,6 +142,21 @@ async fn cleanup_handler(
     }
 }
 
+/// POST /cache/memory/cleanup
+///
+/// Drops resident in-memory cache blocks while preserving backing-store data.
+async fn cleanup_memory_cache_handler(
+    State(state): State<AppState>,
+) -> Json<MemoryCacheCleanupResponse> {
+    let stats = state.engine.cleanup_memory_cache();
+    Json(MemoryCacheCleanupResponse {
+        evicted_blocks: stats.evicted_blocks,
+        evicted_bytes: stats.evicted_bytes,
+        reclaimed_bytes: stats.reclaimed_bytes,
+        still_referenced_blocks: stats.still_referenced_blocks,
+    })
+}
+
 /// Start HTTP server for health check, optional Prometheus metrics, and instance management.
 pub async fn start_http_server(
     addr: std::net::SocketAddr,
@@ -158,17 +181,18 @@ pub async fn start_http_server(
     let mut app = Router::new()
         .route("/health", get(health_handler))
         .route("/instances", get(list_instances_handler))
-        .route("/instances/cleanup", post(cleanup_handler));
+        .route("/instances/cleanup", post(cleanup_handler))
+        .route("/cache/memory/cleanup", post(cleanup_memory_cache_handler));
 
     if enable_prometheus {
         app = app.route("/metrics", get(metrics_handler));
         info!(
-            "Starting HTTP server on {} (/health, /metrics, /instances, /instances/cleanup)",
+            "Starting HTTP server on {} (/health, /metrics, /instances, /instances/cleanup, /cache/memory/cleanup)",
             addr
         );
     } else {
         info!(
-            "Starting HTTP server on {} (/health, /instances, /instances/cleanup)",
+            "Starting HTTP server on {} (/health, /instances, /instances/cleanup, /cache/memory/cleanup)",
             addr
         );
     }


### PR DESCRIPTION
## Summary
- add POST /cache/memory/cleanup to evict resident in-memory cache blocks
- preserve backing-store data and report blocks still held by outstanding references
- report reclaimed_bytes separately from evicted_bytes so callers can distinguish cache residency removal from actual pinned-pool reclamation
- update cache eviction metrics and unregister evicted keys from MetaServer

## Tests
- cargo fmt --all --check
- cargo check -p pegaflow-server
- cargo clippy -p pegaflow-core -p pegaflow-server --all-targets -- -D warnings
- cargo test -p pegaflow-core cleanup_memory_cache
- cargo test -p pegaflow-core remove_all_evicts_resident_blocks
- commit hook: cargo test --release