### PR TITLE
feat(metrics): expose HLL hit-rate over multiple sliding windows

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -114,6 +114,29 @@ PegaFlow exposes the following metrics for monitoring KV cache operations:
   - Current bytes referenced by pinned_for_load (unique blocks; sum of footprints)
   - Use case: Attribute pinned pool usage to load-path pins
 
+### HLL Reuse Metrics
+- **pegaflow_hll_cardinality** (Gauge)
+  - Estimated distinct block hashes observed in a configured sliding window
+  - Labels: `window` (`15m`, `1h`, `1d` by default)
+  - Use case: Derive approximate prefix reuse over longer windows without
+    storing every block hash
+
+- **pegaflow_hll_total_requests** (Gauge)
+  - Total block hash observations in the same configured sliding window
+  - Labels: `window` (`15m`, `1h`, `1d` by default)
+  - Use case: Denominator for HLL-based estimated hit-rate PromQL
+
+PegaFlow does not export a separate HLL hit-rate gauge. Use PromQL so the
+ratio is computed from values in the same scrape:
+
+```promql
+1 - (
+  pegaflow_hll_cardinality{window="1h"}
+  /
+  clamp_min(pegaflow_hll_total_requests{window="1h"}, 1)
+)
+```
+
 ### Save Metrics (GPU → CPU)
 - **pegaflow_save_bytes_total** (Counter)
   - Total bytes saved from GPU to CPU storage
@@ -195,6 +218,17 @@ tier counters.
 
 - `--metrics-period-secs`: Metric export interval in seconds (default: `5`)
   - Only used when `--metrics-otel-endpoint` is set
+
+- `--metric-hll-windows`: Comma-separated HLL sliding windows for estimated
+  prefix reuse (default: `15m,1h,24h`)
+  - Supported units: `s`, `m`, `h`, `d`
+  - Each configured duration becomes a canonical `window` label. For example,
+    the default config exports `window="15m"`, `window="1h"`, and `window="1d"`.
+  - Empty entries such as `15m,,1h` and duplicate durations such as `1h,60m`
+    are rejected at startup.
+
+- `--metric-hll-bucket-bits`: HLL bucket index bits (default: `14`)
+  - Higher values use more memory and lower estimation error.
 
 **Example: Prometheus Metrics**
 ```bash
@@ -397,6 +431,20 @@ rate(pegaflow_save_bytes_total[1m]) / 1e6
 
 # Pool memory utilization
 pegaflow_pool_used_bytes / pegaflow_pool_capacity_bytes
+
+# HLL estimated hit rate for the 1h window
+1 - (
+  pegaflow_hll_cardinality{window="1h"}
+  /
+  clamp_min(pegaflow_hll_total_requests{window="1h"}, 1)
+)
+
+# HLL estimated hit rate for every configured window
+1 - (
+  pegaflow_hll_cardinality
+  /
+  clamp_min(pegaflow_hll_total_requests, 1)
+)
 ```
 
 ## Troubleshooting

--- a/pegaflow-common/src/hll.rs
+++ b/pegaflow-common/src/hll.rs
@@ -366,7 +366,7 @@ impl HllTracker {
 
 /// Tracks the same hash stream across multiple sliding windows in parallel.
 ///
-/// Each window is identified by a human-readable label (`"15m"`, `"1h"`, `"24h"`).
+/// Each window is identified by a human-readable label (`"15m"`, `"1h"`, `"1d"`).
 /// `record_hashes` feeds all windows under a single lock; metric collection
 /// returns one snapshot per window with the label preserved for Prometheus.
 pub struct MultiWindowHllTracker {
@@ -377,8 +377,8 @@ impl MultiWindowHllTracker {
     /// Build a multi-window tracker. `windows` is a list of `(label, window_duration)`
     /// pairs. Slot duration is derived per-window as `clamp(window / 24, 1min, 1h)`.
     ///
-    /// Panics if `windows` is empty, contains a duplicate label, or any window
-    /// is shorter than 1 minute.
+    /// Panics if `windows` is empty, contains a duplicate duration, or any
+    /// window is shorter than 1 minute.
     pub fn new(windows: Vec<(String, Duration)>, bucket_bits: u8) -> Self {
         assert!(
             !windows.is_empty(),
@@ -393,9 +393,9 @@ impl MultiWindowHllTracker {
         for i in 0..windows.len() {
             for j in (i + 1)..windows.len() {
                 assert_ne!(
-                    windows[i].0, windows[j].0,
-                    "duplicate window label: {}",
-                    windows[i].0
+                    windows[i].1, windows[j].1,
+                    "duplicate window duration: {:?}",
+                    windows[i].1
                 );
             }
         }
@@ -423,10 +423,6 @@ impl MultiWindowHllTracker {
             .iter_mut()
             .map(|(label, tracker)| (label.clone(), tracker.metric()))
             .collect()
-    }
-
-    pub fn labels(&self) -> Vec<String> {
-        self.windows.iter().map(|(l, _)| l.clone()).collect()
     }
 }
 
@@ -817,12 +813,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "duplicate window label")]
-    fn multi_window_rejects_duplicate_labels() {
+    #[should_panic(expected = "duplicate window duration")]
+    fn multi_window_rejects_duplicate_durations() {
         MultiWindowHllTracker::new(
             vec![
                 ("1h".into(), Duration::from_secs(3600)),
-                ("1h".into(), Duration::from_secs(3600)),
+                ("60m".into(), Duration::from_secs(3600)),
             ],
             14,
         );

--- a/pegaflow-common/src/hll.rs
+++ b/pegaflow-common/src/hll.rs
@@ -361,6 +361,83 @@ impl HllTracker {
 }
 
 // ============================================================================
+// Multi-window tracker
+// ============================================================================
+
+/// Tracks the same hash stream across multiple sliding windows in parallel.
+///
+/// Each window is identified by a human-readable label (`"15m"`, `"1h"`, `"24h"`).
+/// `record_hashes` feeds all windows under a single lock; metric collection
+/// returns one snapshot per window with the label preserved for Prometheus.
+pub struct MultiWindowHllTracker {
+    windows: Vec<(String, HllTracker)>,
+}
+
+impl MultiWindowHllTracker {
+    /// Build a multi-window tracker. `windows` is a list of `(label, window_duration)`
+    /// pairs. Slot duration is derived per-window as `clamp(window / 24, 1min, 1h)`.
+    ///
+    /// Panics if `windows` is empty, contains a duplicate label, or any window
+    /// is shorter than 1 minute.
+    pub fn new(windows: Vec<(String, Duration)>, bucket_bits: u8) -> Self {
+        assert!(
+            !windows.is_empty(),
+            "MultiWindowHllTracker needs at least one window"
+        );
+        for (label, win) in &windows {
+            assert!(
+                *win >= Duration::from_secs(60),
+                "window {label} ({win:?}) must be at least 1 minute"
+            );
+        }
+        for i in 0..windows.len() {
+            for j in (i + 1)..windows.len() {
+                assert_ne!(
+                    windows[i].0, windows[j].0,
+                    "duplicate window label: {}",
+                    windows[i].0
+                );
+            }
+        }
+
+        let trackers = windows
+            .into_iter()
+            .map(|(label, window)| {
+                let slot = derive_slot_duration(window);
+                (label, HllTracker::new(slot, window, bucket_bits))
+            })
+            .collect();
+
+        Self { windows: trackers }
+    }
+
+    pub fn record_hashes(&mut self, hashes: &[Vec<u8>]) {
+        for (_, tracker) in &mut self.windows {
+            tracker.record_hashes(hashes);
+        }
+    }
+
+    /// Snapshot every window. Returned in insertion order.
+    pub fn metrics(&mut self) -> Vec<(String, HllMetric)> {
+        self.windows
+            .iter_mut()
+            .map(|(label, tracker)| (label.clone(), tracker.metric()))
+            .collect()
+    }
+
+    pub fn labels(&self) -> Vec<String> {
+        self.windows.iter().map(|(l, _)| l.clone()).collect()
+    }
+}
+
+fn derive_slot_duration(window: Duration) -> Duration {
+    const MIN_SLOT: Duration = Duration::from_secs(60);
+    const MAX_SLOT: Duration = Duration::from_secs(3600);
+    let target = window / 24;
+    target.clamp(MIN_SLOT, MAX_SLOT)
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -683,6 +760,84 @@ mod tests {
                 "n={n}: estimated={est:.0}, actual={actual:.0}, error={error:.4}"
             );
         }
+    }
+
+    // ---- MultiWindowHllTracker tests ----
+
+    #[test]
+    fn multi_window_records_into_each_window() {
+        let mut tracker = MultiWindowHllTracker::new(
+            vec![
+                ("15m".into(), Duration::from_secs(15 * 60)),
+                ("1h".into(), Duration::from_secs(3600)),
+                ("24h".into(), Duration::from_secs(86400)),
+            ],
+            14,
+        );
+
+        for i in 0u32..1000 {
+            let hash = sha256_like(i);
+            tracker.record_hashes(&[hash.to_vec()]);
+            tracker.record_hashes(&[hash.to_vec()]);
+        }
+
+        let metrics = tracker.metrics();
+        assert_eq!(metrics.len(), 3);
+        assert_eq!(metrics[0].0, "15m");
+        assert_eq!(metrics[1].0, "1h");
+        assert_eq!(metrics[2].0, "24h");
+        for (label, m) in metrics {
+            assert_eq!(m.total_requests, 2000, "{label}: total");
+            assert!(
+                (900.0..1100.0).contains(&m.cardinality),
+                "{label}: cardinality {} not ~1000",
+                m.cardinality
+            );
+        }
+    }
+
+    #[test]
+    fn derive_slot_clamps() {
+        assert_eq!(
+            derive_slot_duration(Duration::from_secs(15 * 60)),
+            Duration::from_secs(60)
+        );
+        assert_eq!(
+            derive_slot_duration(Duration::from_secs(3600)),
+            Duration::from_secs(150)
+        );
+        assert_eq!(
+            derive_slot_duration(Duration::from_secs(86400)),
+            Duration::from_secs(3600)
+        );
+        assert_eq!(
+            derive_slot_duration(Duration::from_secs(7 * 86400)),
+            Duration::from_secs(3600)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate window label")]
+    fn multi_window_rejects_duplicate_labels() {
+        MultiWindowHllTracker::new(
+            vec![
+                ("1h".into(), Duration::from_secs(3600)),
+                ("1h".into(), Duration::from_secs(3600)),
+            ],
+            14,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one window")]
+    fn multi_window_rejects_empty() {
+        MultiWindowHllTracker::new(vec![], 14);
+    }
+
+    #[test]
+    #[should_panic(expected = "at least 1 minute")]
+    fn multi_window_rejects_sub_minute_window() {
+        MultiWindowHllTracker::new(vec![("30s".into(), Duration::from_secs(30))], 14);
     }
 
     /// Generate a pseudo-SHA256 hash from an integer for testing.

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -157,13 +157,11 @@ pub struct Cli {
     #[arg(long, default_value_t = pegaflow_core::DEFAULT_METASERVER_QUEUE_DEPTH)]
     pub metaserver_queue_depth: usize,
 
-    /// HLL time-slot rotation interval in seconds (default: 3600 = 1 hour)
-    #[arg(long, default_value_t = 3600)]
-    pub metric_hll_slot_secs: u64,
-
-    /// HLL sliding window duration in seconds (default: 86400 = 24 hours)
-    #[arg(long, default_value_t = 86400)]
-    pub metric_hll_window_secs: u64,
+    /// HLL sliding-window list for hit-rate estimation. Comma-separated humantime
+    /// durations; each becomes a labeled window in metrics (e.g. `15m,1h,24h`).
+    /// Slot duration is derived as `clamp(window/24, 1min, 1h)`.
+    #[arg(long, default_value = "15m,1h,24h", value_parser = parse_hll_windows)]
+    pub metric_hll_windows: Vec<(String, Duration)>,
 
     /// HLL bucket index bits 4–18 (default: 14 → 16384 buckets, ~0.8% error)
     #[arg(long, default_value_t = 14, value_parser = parse_hll_bucket_bits)]
@@ -184,6 +182,46 @@ fn parse_hll_bucket_bits(s: &str) -> Result<u8, String> {
         ));
     }
     Ok(v)
+}
+
+/// Parse a comma-separated list of humantime windows (e.g. `15m,1h,24h`).
+/// Each entry becomes `(label, duration)` where label is the original token.
+fn parse_hll_windows(s: &str) -> Result<Vec<(String, Duration)>, String> {
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for token in s.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+        let dur = parse_humantime(token)?;
+        if dur < Duration::from_secs(60) {
+            return Err(format!("HLL window {token} must be at least 1 minute"));
+        }
+        if !seen.insert(token.to_string()) {
+            return Err(format!("duplicate HLL window label: {token}"));
+        }
+        out.push((token.to_string(), dur));
+    }
+    if out.is_empty() {
+        return Err("--metric-hll-windows must list at least one window".into());
+    }
+    Ok(out)
+}
+
+/// Minimal humantime parser: `<number><unit>` where unit ∈ {s, m, h, d}.
+fn parse_humantime(s: &str) -> Result<Duration, String> {
+    let (num_str, unit) = s.split_at(
+        s.find(|c: char| !c.is_ascii_digit())
+            .ok_or_else(|| format!("missing time unit in {s}"))?,
+    );
+    let n: u64 = num_str
+        .parse()
+        .map_err(|e| format!("invalid number in {s}: {e}"))?;
+    let secs = match unit {
+        "s" => n,
+        "m" => n * 60,
+        "h" => n * 3600,
+        "d" => n * 86400,
+        _ => return Err(format!("unknown time unit {unit:?} in {s}; use s/m/h/d")),
+    };
+    Ok(Duration::from_secs(secs))
 }
 
 fn parse_sample_rate(s: &str) -> Result<f64, String> {
@@ -482,9 +520,8 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     })?;
 
     let hll_tracker = Arc::new(std::sync::Mutex::new(
-        pegaflow_common::hll::HllTracker::new(
-            Duration::from_secs(cli.metric_hll_slot_secs),
-            Duration::from_secs(cli.metric_hll_window_secs),
+        pegaflow_common::hll::MultiWindowHllTracker::new(
+            cli.metric_hll_windows.clone(),
             cli.metric_hll_bucket_bits,
         ),
     ));

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -158,7 +158,7 @@ pub struct Cli {
     pub metaserver_queue_depth: usize,
 
     /// HLL sliding-window list for hit-rate estimation. Comma-separated humantime
-    /// durations; each becomes a labeled window in metrics (e.g. `15m,1h,24h`).
+    /// durations; each becomes a canonical `window` label in metrics (e.g. `15m,1h,1d`).
     /// Slot duration is derived as `clamp(window/24, 1min, 1h)`.
     #[arg(long, default_value = "15m,1h,24h", value_parser = parse_hll_windows)]
     pub metric_hll_windows: Vec<(String, Duration)>,
@@ -185,19 +185,29 @@ fn parse_hll_bucket_bits(s: &str) -> Result<u8, String> {
 }
 
 /// Parse a comma-separated list of humantime windows (e.g. `15m,1h,24h`).
-/// Each entry becomes `(label, duration)` where label is the original token.
+/// Each entry becomes `(label, duration)` where label is canonicalized from
+/// the parsed duration.
 fn parse_hll_windows(s: &str) -> Result<Vec<(String, Duration)>, String> {
     let mut out = Vec::new();
     let mut seen = std::collections::HashSet::new();
-    for token in s.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+    for (idx, token) in s.split(',').map(str::trim).enumerate() {
+        if token.is_empty() {
+            return Err(format!(
+                "--metric-hll-windows contains an empty window at position {}",
+                idx + 1
+            ));
+        }
         let dur = parse_humantime(token)?;
         if dur < Duration::from_secs(60) {
             return Err(format!("HLL window {token} must be at least 1 minute"));
         }
-        if !seen.insert(token.to_string()) {
-            return Err(format!("duplicate HLL window label: {token}"));
+        if !seen.insert(dur) {
+            return Err(format!(
+                "duplicate HLL window duration: {token} ({})",
+                format_hll_window_label(dur)
+            ));
         }
-        out.push((token.to_string(), dur));
+        out.push((format_hll_window_label(dur), dur));
     }
     if out.is_empty() {
         return Err("--metric-hll-windows must list at least one window".into());
@@ -214,14 +224,33 @@ fn parse_humantime(s: &str) -> Result<Duration, String> {
     let n: u64 = num_str
         .parse()
         .map_err(|e| format!("invalid number in {s}: {e}"))?;
-    let secs = match unit {
+    let unit_secs = match unit {
         "s" => n,
-        "m" => n * 60,
-        "h" => n * 3600,
-        "d" => n * 86400,
+        "m" => n
+            .checked_mul(60)
+            .ok_or_else(|| format!("duration overflows seconds in {s}"))?,
+        "h" => n
+            .checked_mul(3600)
+            .ok_or_else(|| format!("duration overflows seconds in {s}"))?,
+        "d" => n
+            .checked_mul(86400)
+            .ok_or_else(|| format!("duration overflows seconds in {s}"))?,
         _ => return Err(format!("unknown time unit {unit:?} in {s}; use s/m/h/d")),
     };
-    Ok(Duration::from_secs(secs))
+    Ok(Duration::from_secs(unit_secs))
+}
+
+fn format_hll_window_label(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    if secs.is_multiple_of(86400) {
+        format!("{}d", secs / 86400)
+    } else if secs.is_multiple_of(3600) {
+        format!("{}h", secs / 3600)
+    } else if secs.is_multiple_of(60) {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{secs}s")
+    }
 }
 
 fn parse_sample_rate(s: &str) -> Result<f64, String> {
@@ -642,4 +671,37 @@ pub fn run() -> Result<(), Box<dyn Error>> {
 
         Ok(())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_hll_windows_canonicalizes_labels() {
+        let windows = parse_hll_windows("15m,60m,24h").unwrap();
+
+        assert_eq!(
+            windows,
+            vec![
+                ("15m".to_string(), Duration::from_secs(15 * 60)),
+                ("1h".to_string(), Duration::from_secs(60 * 60)),
+                ("1d".to_string(), Duration::from_secs(24 * 60 * 60)),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_hll_windows_rejects_empty_tokens() {
+        let err = parse_hll_windows("15m,,1h").unwrap_err();
+
+        assert!(err.contains("empty window"), "{err}");
+    }
+
+    #[test]
+    fn parse_hll_windows_rejects_duplicate_durations() {
+        let err = parse_hll_windows("1h,60m").unwrap_err();
+
+        assert!(err.contains("duplicate HLL window duration"), "{err}");
+    }
 }

--- a/pegaflow-server/src/metric.rs
+++ b/pegaflow-server/src/metric.rs
@@ -1,43 +1,37 @@
 use opentelemetry::metrics::{Counter, Histogram, ObservableGauge};
 use opentelemetry::{KeyValue, global};
-use pegaflow_common::hll::HllTracker;
+use pegaflow_common::hll::MultiWindowHllTracker;
 use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use std::time::Instant;
 use tonic::Status;
 
 struct HllGaugeHandles {
-    _hit_rate: ObservableGauge<f64>,
     _cardinality: ObservableGauge<f64>,
     _total_requests: ObservableGauge<u64>,
 }
 
 static HLL_GAUGES: OnceLock<HllGaugeHandles> = OnceLock::new();
 
-/// Register HLL observable gauges backed by the given tracker.
-pub fn register_hll_gauges(tracker: &Arc<Mutex<HllTracker>>) {
-    let t1 = Arc::clone(tracker);
-    let t2 = Arc::clone(tracker);
-    let t3 = Arc::clone(tracker);
+/// Register HLL observable gauges backed by the multi-window tracker.
+///
+/// Emits one time series per configured window, labeled with `window=<label>`.
+/// Hit rate is intentionally not exported — derive it in Prometheus via
+/// `1 - pegaflow_hll_cardinality / pegaflow_hll_total_requests`.
+pub fn register_hll_gauges(tracker: &Arc<Mutex<MultiWindowHllTracker>>) {
+    let t_card = Arc::clone(tracker);
+    let t_total = Arc::clone(tracker);
 
     HLL_GAUGES.get_or_init(|| {
         let meter = global::meter("pegaflow-core");
-
-        let hit_rate = meter
-            .f64_observable_gauge("pegaflow_hll_estimated_hit_rate")
-            .with_description("Estimated cache hit rate assuming infinite cache [0.0, 1.0]")
-            .with_callback(move |observer| {
-                if let Ok(mut t) = t1.lock() {
-                    observer.observe(t.metric().estimated_hit_rate, &[]);
-                }
-            })
-            .build();
 
         let cardinality = meter
             .f64_observable_gauge("pegaflow_hll_cardinality")
             .with_description("Estimated distinct blocks seen in the sliding window")
             .with_callback(move |observer| {
-                if let Ok(mut t) = t2.lock() {
-                    observer.observe(t.metric().cardinality, &[]);
+                if let Ok(mut t) = t_card.lock() {
+                    for (label, m) in t.metrics() {
+                        observer.observe(m.cardinality, &[KeyValue::new("window", label)]);
+                    }
                 }
             })
             .build();
@@ -46,14 +40,15 @@ pub fn register_hll_gauges(tracker: &Arc<Mutex<HllTracker>>) {
             .u64_observable_gauge("pegaflow_hll_total_requests")
             .with_description("Total block requests in the sliding window")
             .with_callback(move |observer| {
-                if let Ok(mut t) = t3.lock() {
-                    observer.observe(t.metric().total_requests, &[]);
+                if let Ok(mut t) = t_total.lock() {
+                    for (label, m) in t.metrics() {
+                        observer.observe(m.total_requests, &[KeyValue::new("window", label)]);
+                    }
                 }
             })
             .build();
 
         HllGaugeHandles {
-            _hit_rate: hit_rate,
             _cardinality: cardinality,
             _total_requests: total_requests,
         }

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -29,7 +29,7 @@ pub struct GrpcEngineService {
     engine: Arc<PegaEngine>,
     registry: Arc<Mutex<CudaTensorRegistry>>,
     shutdown: Arc<Notify>,
-    hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::HllTracker>>,
+    hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::MultiWindowHllTracker>>,
     session_registry: Arc<SessionRegistry>,
 }
 
@@ -38,7 +38,7 @@ impl GrpcEngineService {
         engine: Arc<PegaEngine>,
         registry: Arc<Mutex<CudaTensorRegistry>>,
         shutdown: Arc<Notify>,
-        hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::HllTracker>>,
+        hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::MultiWindowHllTracker>>,
     ) -> Self {
         Self {
             engine,

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -157,9 +157,8 @@ async fn spawn_engine_server(engine: Arc<PegaEngine>, port: u16) {
     let registry = Arc::new(Mutex::new(registry));
     let shutdown = Arc::new(Notify::new());
     let hll_tracker = Arc::new(std::sync::Mutex::new(
-        pegaflow_common::hll::HllTracker::new(
-            Duration::from_secs(3600),
-            Duration::from_secs(86400),
+        pegaflow_common::hll::MultiWindowHllTracker::new(
+            vec![("24h".into(), Duration::from_secs(86400))],
             14,
         ),
     ));


### PR DESCRIPTION
## Why

The single 24h HLL gauge is too smooth on Grafana and can only answer one question: *"what's the weighted hit ratio over the past 24 hours?"*. It does not show short-term workload shifts.

## What

Replace the single sliding-window HLL with a multi-window tracker. By default we publish three windows under a single mutex. Operators can override the set of windows via CLI.

### CLI

- **Removed:** `--metric-hll-slot-secs`, `--metric-hll-window-secs`
- **Added:** `--metric-hll-windows` (comma-separated humantime list, default `15m,1h,24h`; units `s/m/h/d`)
- **Unchanged:** `--metric-hll-bucket-bits` (default 14)

`--metric-hll-windows` is validated at startup:

- Empty entries such as `15m,,1h` are rejected.
- Duplicate durations such as `1h,60m` are rejected.
- Each accepted duration gets a canonical Prometheus `window` label. The default config exports `window="15m"`, `window="1h"`, and `window="1d"`.

Slot duration per window is derived automatically as `clamp(window/24, 1min, 1h)`. For the defaults: 15m -> 1min slots, 1h -> 2.5min slots, 24h -> 1h slots.

### Metrics

Each gauge carries a `window` label:

- `pegaflow_hll_cardinality{window="15m|1h|1d"}`
- `pegaflow_hll_total_requests{window="15m|1h|1d"}`

The previous `pegaflow_hll_estimated_hit_rate` gauge is **removed**. It is derived in Prometheus from values in the same scrape.

Recommended PromQL for a specific window:

```promql
1 - (
  pegaflow_hll_cardinality{window="1h"}
  /
  clamp_min(pegaflow_hll_total_requests{window="1h"}, 1)
)
```

Recommended PromQL for every configured window:

```promql
1 - (
  pegaflow_hll_cardinality
  /
  clamp_min(pegaflow_hll_total_requests, 1)
)
```

### Internals

- New `MultiWindowHllTracker` in `pegaflow-common::hll` owns one `HllTracker` per window.
- `record_hashes` feeds all windows under the caller's single lock, so there is no extra lock fan-out on the hot path.
- `MultiWindowHllTracker::labels()` was removed because it had no call sites.
- Duplicate window validation is based on duration, not input label text.
- Memory: with default 14 bucket_bits, each window costs about 16KB per slot. The three default windows are only a few hundred KB total.

## Docs

`docs/metrics.md` now documents:

- HLL metric names and the `window` label.
- `--metric-hll-windows` validation rules.
- The recommended PromQL queries above.

## Tests

- `cargo test -p pegaflow-common --lib hll`
- `cargo check -p pegaflow-server`
- `cargo test -p pegaflow-server --lib parse_hll_windows`
- `cargo clippy -p pegaflow-server --all-targets -- -D warnings`
- Commit hooks passed, including `cargo clippy` and `cargo test --release`.

## Migration

Dashboards should be updated to:

1. Select the desired `window` label. The old 24h behavior maps to `window="1d"`.
2. Compute hit rate from `pegaflow_hll_cardinality` and `pegaflow_hll_total_requests` instead of using the removed `pegaflow_hll_estimated_hit_rate` gauge.