### PR TITLE
test(python): make default gate self-contained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Run default Python test gate
         working-directory: python
         run: |
-          uv run --isolated --no-project --with pytest --with numpy --with requests pytest
+          uv run --isolated --no-project --with pytest --with numpy --with 'requests>=2.26.0' pytest
 
   cargo-check-variant:
     name: cargo check (${{ matrix.cuda-variant }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,30 +86,16 @@ Notes:
 
 ### Python Test Gates
 
-```bash
-cd python
-uv run --extra test pytest
-```
+| Gate | When to run | Command | Notes |
+|------|-------------|---------|-------|
+| Default unit | Every Python PR before review | `cd python && uv run --extra test pytest` | Must not start vLLM, `pegaflow-server`, or GPU runtime. Collection still imports deselected files, so top-level imports must be in `python[test]` or moved behind fixtures. |
+| Source-only default | CI and dependency-boundary checks | `cd python && uv run --isolated --no-project --with pytest --with numpy --with 'requests>=2.26.0' pytest` | Proves default gate does not need torch, vLLM, CUDA, native extension build, or a running server. |
+| Integration | Server/native/client/session lifecycle changes | `cd python && uv run --extra test pytest -m integration` | Requires built native extension, server binary, and GPU where the test uses CUDA IPC. |
+| vLLM correctness E2E | Python test gates, vLLM connector, connector-visible cache semantics, save/load, query planning, or release-confidence changes | `cd python && uv run --extra test pytest -m e2e tests/test_vllm_e2e_correctness.py --model /data/models/Qwen3-4B --max-model-len 4096` | Merge-before gate: code author runs it, reviewer reruns it on the GPU machine. |
+| Stress | Query probe, preemption, pending unpin, scheduler concurrency | `cd python && uv run --extra test pytest -m stress tests/test_vllm_query_probe_stress.py --model /data/models/Qwen3-4B --max-model-len 4096` | Targeted evidence, not default PR feedback. |
+| Release smoke | Published wheel/image, loader path, installed console script, CUDA runtime | See `python/tests/README.md` | Validates final installed artifact, not the source checkout. |
 
-CI uses the source-only form below so the default Python gate does not compile the native extension or require torch, vLLM, CUDA, or a running server:
-
-```bash
-cd python
-uv run --isolated --no-project --with pytest --with numpy --with requests pytest
-```
-
-Python heavy gates are explicit and resource-bound:
-
-| Change area | Gate command |
-|-------------|--------------|
-| Server/native/client/session lifecycle | `cd python && uv run --extra test pytest -m integration` |
-| vLLM connector correctness, cache semantics, save/load/hit behavior | `cd python && uv run --extra test pytest -m e2e tests/test_vllm_e2e_correctness.py --model /data/models/Qwen3-4B --max-model-len 4096` |
-| Query probe, preemption, pending unpin, scheduler concurrency | `cd python && uv run --extra test pytest -m stress tests/test_vllm_query_probe_stress.py --model /data/models/Qwen3-4B --max-model-len 4096` |
-| Published wheel/image, loader path, installed console script, CUDA runtime | release smoke from `python/tests/README.md` |
-
-Do not default to running all of `python/tests`. The default gate is the dev-friendly PR feedback loop; heavy gates are targeted evidence for the change area.
-
-Do not add an `xtask` or wrapper just to hide command complexity. Current project taste is `uv` + pytest markers for Python and Cargo/CI for Rust. Consider `xtask` only after the command contract is stable and repeated manual execution has become the actual bottleneck.
+Do not default to running all of `python/tests`. Current project taste is `uv` + pytest markers for Python and Cargo/CI for Rust; do not add an `xtask` wrapper until the gate contract is stable and repeated execution is the real bottleneck.
 
 ### Benchmarks and Examples
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,30 +26,16 @@ Run all CI checks locally before committing:
 
 ### Python Test Gates
 
-```bash
-cd python
-uv run --extra test pytest
-```
+| Gate | When to run | Command | Notes |
+|------|-------------|---------|-------|
+| Default unit | Every Python PR before review | `cd python && uv run --extra test pytest` | Must not start vLLM, `pegaflow-server`, or GPU runtime. Collection still imports deselected files, so top-level imports must be in `python[test]` or moved behind fixtures. |
+| Source-only default | CI and dependency-boundary checks | `cd python && uv run --isolated --no-project --with pytest --with numpy --with 'requests>=2.26.0' pytest` | Proves default gate does not need torch, vLLM, CUDA, native extension build, or a running server. |
+| Integration | Server/native/client/session lifecycle changes | `cd python && uv run --extra test pytest -m integration` | Requires built native extension, server binary, and GPU where the test uses CUDA IPC. |
+| vLLM correctness E2E | Python test gates, vLLM connector, connector-visible cache semantics, save/load, query planning, or release-confidence changes | `cd python && uv run --extra test pytest -m e2e tests/test_vllm_e2e_correctness.py --model /data/models/Qwen3-4B --max-model-len 4096` | Merge-before gate: code author runs it, reviewer reruns it on the GPU machine. |
+| Stress | Query probe, preemption, pending unpin, scheduler concurrency | `cd python && uv run --extra test pytest -m stress tests/test_vllm_query_probe_stress.py --model /data/models/Qwen3-4B --max-model-len 4096` | Targeted evidence, not default PR feedback. |
+| Release smoke | Published wheel/image, loader path, installed console script, CUDA runtime | See `python/tests/README.md` | Validates final installed artifact, not the source checkout. |
 
-CI uses the source-only form below so the default Python gate does not compile the native extension or require torch, vLLM, CUDA, or a running server:
-
-```bash
-cd python
-uv run --isolated --no-project --with pytest --with numpy --with requests pytest
-```
-
-Python heavy gates are explicit and resource-bound:
-
-| Change area | Gate command |
-|-------------|--------------|
-| Server/native/client/session lifecycle | `cd python && uv run --extra test pytest -m integration` |
-| vLLM connector correctness, cache semantics, save/load/hit behavior | `cd python && uv run --extra test pytest -m e2e tests/test_vllm_e2e_correctness.py --model /data/models/Qwen3-4B --max-model-len 4096` |
-| Query probe, preemption, pending unpin, scheduler concurrency | `cd python && uv run --extra test pytest -m stress tests/test_vllm_query_probe_stress.py --model /data/models/Qwen3-4B --max-model-len 4096` |
-| Published wheel/image, loader path, installed console script, CUDA runtime | release smoke from `python/tests/README.md` |
-
-Do not default to running all of `python/tests`. The default gate is the dev-friendly PR feedback loop; heavy gates are targeted evidence for the change area.
-
-Do not add an `xtask` or wrapper just to hide command complexity. Current project taste is `uv` + pytest markers for Python and Cargo/CI for Rust. Consider `xtask` only after the command contract is stable and repeated manual execution has become the actual bottleneck.
+Do not default to running all of `python/tests`. Current project taste is `uv` + pytest markers for Python and Cargo/CI for Rust; do not add an `xtask` wrapper until the gate contract is stable and repeated execution is the real bottleneck.
 
 ### Running Benchmarks
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,6 +38,7 @@ test = [
     "pytest-cov>=4.0",
     "pytest-xdist>=3.0",
     "numpy>=1.24",
+    "requests>=2.26.0",
 ]
 dev = [
     "pegaflow-llm[test]",

--- a/python/tests/README.md
+++ b/python/tests/README.md
@@ -7,7 +7,7 @@
 | Change area | Gate | Command | Failure boundary |
 | --- | --- | --- | --- |
 | Connector helper math, scheduler state, worker load failure handling, IPC wrapper compatibility | Default unit | `uv run --extra test pytest` | Python contract or local connector state-machine regression |
-| Clean source-only Python changes, docs touching test layout, CI test dependency changes | Source-only default | `uv run --isolated --no-project --with pytest --with numpy --with requests pytest` | Default test accidentally depends on torch, vLLM, CUDA, or native extension |
+| Clean source-only Python changes, docs touching test layout, CI test dependency changes | Source-only default | `uv run --isolated --no-project --with pytest --with numpy --with 'requests>=2.26.0' pytest` | Default test accidentally depends on torch, vLLM, CUDA, or native extension |
 | Server client, native extension, CUDA IPC registration, session lifecycle | Integration | `uv run --extra test pytest -m integration` | Server/native/GPU lifecycle regression |
 | vLLM connector correctness, cache semantics, save/load/hit behavior, release candidate confidence | vLLM correctness E2E | `uv run --extra test pytest -m e2e tests/test_vllm_e2e_correctness.py --model /data/models/Qwen3-4B` | Real vLLM connector correctness regression |
 | Query probe, preemption, pending unpin, scheduler concurrency or pressure behavior | Stress | `uv run --extra test pytest -m stress tests/test_vllm_query_probe_stress.py --model /data/models/Qwen3-4B` | Concurrent scheduler/query-probe regression |
@@ -22,11 +22,16 @@ cd python
 uv run --extra test pytest
 ```
 
+This command must not start vLLM, `pegaflow-server`, or any GPU runtime. It still
+imports every test module during pytest collection, so any top-level import used
+by deselected heavy tests must be present in the `test` extra or moved behind a
+fixture/helper boundary.
+
 CI uses the source-only variant below so the unit gate does not compile the native extension or require CUDA:
 
 ```bash
 cd python
-uv run --isolated --no-project --with pytest --with numpy --with requests pytest
+uv run --isolated --no-project --with pytest --with numpy --with 'requests>=2.26.0' pytest
 ```
 
 Runs:
@@ -66,6 +71,11 @@ uv run --extra test pytest -m e2e tests/test_vllm_e2e_correctness.py \
 ```
 
 This is the main correctness E2E. It starts baseline vLLM and PegaFlow-enabled vLLM, compares deterministic completions across one execution plan, and checks that PegaFlow metrics show save/load/hit activity.
+
+This gate is required before merging PRs that change Python test gates, the
+vLLM connector, cache semantics visible to the connector, save/load behavior,
+query planning, or release confidence. The code author runs it before requesting
+merge, and review reruns it independently on the GPU machine.
 
 Requirements:
 - vLLM installed in the active environment


### PR DESCRIPTION
## Summary
- add `requests>=2.26.0` to the Python `test` extra so the documented default command is self-contained in a clean `.venv`
- compress `AGENTS.md` / `CLAUDE.md` Python test guidance into one gate table
- document `test_vllm_e2e_correctness.py` as the merge-before gate for Python test-gate, vLLM connector, connector-visible cache semantics, save/load, query-planning, and release-confidence changes

## Dependency compatibility
- vLLM upstream current `requirements/common.txt` declares `requests >= 2.26.0`.
- Local vLLM environment reports `vllm==0.19.1` with `Requires-Dist: requests>=2.26.0` and installed `requests==2.32.5`.
- This PR matches vLLM's lower bound instead of introducing a stricter or incompatible constraint.

## Why
After PR #267 merged, `cd python && uv run --extra test pytest` passed in warm environments but failed in a clean env because deselected heavy test modules still import `requests` at collection time. CI had masked this by passing `--with requests` in the source-only command.

## Verification
- `cd python && rm -rf .venv && uv run --extra test pytest` => 37 collected, 31 selected / 6 deselected, 31 passed
- `cd python && uv run --isolated --no-project --with pytest --with numpy --with 'requests>=2.26.0' pytest -q` => 31 passed / 6 deselected
- `cd python && uv run --extra dev ruff check tests pyproject.toml`
- `cd python && uv run --extra dev ruff format --check tests`
- `typos AGENTS.md CLAUDE.md python/pyproject.toml python/tests/README.md`
- `git diff --check`