### PR TITLE
test(python): pin vllm e2e generation defaults

### DIFF
--- a/python/tests/README.md
+++ b/python/tests/README.md
@@ -65,7 +65,7 @@ uv run --extra test pytest -m e2e tests/test_vllm_e2e_correctness.py \
   --max-model-len 4096
 ```
 
-This is the main correctness E2E. It starts baseline vLLM and PegaFlow-enabled vLLM, compares deterministic completions across one execution plan, and checks that PegaFlow metrics show save/load/hit activity.
+This is the main correctness E2E. It starts baseline vLLM and PegaFlow-enabled vLLM with vLLM's neutral generation defaults, compares deterministic completions across one execution plan, and checks that PegaFlow metrics show save/load/hit activity.
 
 Requirements:
 - vLLM installed in the active environment

--- a/python/tests/vllm_helpers.py
+++ b/python/tests/vllm_helpers.py
@@ -84,6 +84,8 @@ class VLLMServer:
             str(self.gpu_memory_utilization),
             "--attention-backend",
             "FLASH_ATTN",
+            "--generation-config",
+            "vllm",
             "--tensor-parallel-size",
             str(self.tensor_parallel_size),
             "--pipeline-parallel-size",


### PR DESCRIPTION
## Summary
- start both baseline and PegaFlow vLLM E2E servers with `--generation-config vllm`
- document that the E2E correctness gate uses vLLM neutral generation defaults plus request parameters, not model-directory sampling defaults

## Why
`/data/models/Qwen3-4B/generation_config.json` sets sampling defaults (`do_sample=true`, `temperature=0.6`, `top_k=20`, `top_p=0.95`). The E2E test sends `temperature=0.0` and seed, but vLLM still logs that model generation config overrides defaults. That made baseline-vs-PegaFlow text equality depend on model-local sampling config instead of the test's intended deterministic contract.

## Verification
- `cd python && PYTHONPATH=/data/slock_agents/KV-Dev/pegaflow-e2e-fix/python CARGO_TARGET_DIR=/data/slock_agents/KV-Dev/target /data/pegadev/pegaflow/.venv/bin/python -m pytest -m e2e tests/test_vllm_e2e_correctness.py --model /data/models/Qwen3-4B --max-model-len 4096 -vv -s` => 2 passed in 198.88s
- E2E metrics still prove cache path activity: saves=74 blocks, hits=40 blocks
- `cd python && uv run --extra dev ruff check tests/vllm_helpers.py tests/README.md`
- `cd python && uv run --extra dev ruff format --check tests/vllm_helpers.py`
- `git diff --check`
