### PR TITLE
test(python): tighten engine client contract

### DIFF
--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,11 +1,1 @@
-"""PegaFlow connector integration test suite.
-
-Requirements:
-- Build Rust extension: maturin develop --release
-- GPU available for PegaServer
-
-Run tests:
-    cd python && pytest tests/ -v
-
-The pega_server fixture automatically starts/stops PegaServer.
-"""
+"""Package marker for PegaFlow Python tests."""

--- a/python/tests/test_engine_client.py
+++ b/python/tests/test_engine_client.py
@@ -17,22 +17,35 @@ import pytest
 pytestmark = [pytest.mark.integration, pytest.mark.gpu]
 
 
-class TestEngineClientQuery:
-    """Test query operations with various inputs."""
+@pytest.mark.parametrize(
+    ("case", "hash_count", "expected_missing"),
+    [
+        pytest.param("empty_query", 0, 0, id="empty_query"),
+        pytest.param("unknown_hashes", 5, 5, id="unknown_hashes"),
+    ],
+)
+def test_query_prefetch_miss_contract(
+    case: str,
+    hash_count: int,
+    expected_missing: int,
+    engine_client,
+    registered_instance: str,
+    block_hashes: list[bytes],
+):
+    """A fresh server query returns a concrete miss contract, not only connectivity."""
+    requested_hashes = block_hashes[:hash_count]
 
-    def test_query_empty_hashes(self, engine_client, registered_instance: str):
-        """Query with empty hashes should succeed."""
-        result = engine_client.query_prefetch(registered_instance, [], req_id="test")
+    result = engine_client.query_prefetch(
+        registered_instance,
+        requested_hashes,
+        req_id=f"query-contract-{case}",
+    )
 
-        assert isinstance(result, dict)
-        assert "hit_blocks" in result or "ok" in result
-
-    def test_query_unknown_hashes(
-        self, engine_client, registered_instance: str, block_hashes: list[bytes]
-    ):
-        """Query for unknown hashes should return zero hits (miss)."""
-        result = engine_client.query_prefetch(registered_instance, block_hashes[:5], req_id="test")
-
-        assert isinstance(result, dict)
-        hit_blocks = result.get("hit_blocks", 0)
-        assert hit_blocks == 0, "Unknown hashes should have zero hits"
+    assert result == {
+        "ok": True,
+        "message": "",
+        "hit_blocks": 0,
+        "prefetch_state": "done",
+        "loading_blocks": 0,
+        "missing_blocks": expected_missing,
+    }


### PR DESCRIPTION
## Summary
- remove stale runbook text from `python/tests/__init__.py`; keep it as a package marker only
- replace weak engine-client connectivity checks with a concrete `query_prefetch` miss response contract
- keep scope limited to task #14 quick cleanup; stress profile and test file naming remain separate tasks

## Verification
- `cd python && uv run --extra dev ruff format --check tests/__init__.py tests/test_engine_client.py`
- `cd python && uv run --extra dev ruff check tests/__init__.py tests/test_engine_client.py`
- `cd python && uv run --extra test pytest -q` => 31 passed / 6 deselected
- `cd python && uv run --extra test pytest --collect-only -q` => 37 collected / 31 selected / 6 deselected
- `cd python && uv run --extra test pytest -m integration --collect-only -q` => 3 selected
- `PYTHONPATH=/data/slock_agents/KV-Dev/pegaflow-python-tests-quick/python /data/pegadev/pegaflow/.venv/bin/python -m pytest -m integration -q -rs python/tests/test_engine_client.py python/tests/test_session_watcher.py` => 3 passed
- `typos python/tests/__init__.py python/tests/test_engine_client.py`
- `git diff --check`
