### PR TITLE
fix: warn on split MLA KV block layout

### DIFF
--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -41,6 +41,39 @@ if _LOAD_TIMEOUT_RAW < _LOAD_TIMEOUT_FLOOR_SECONDS:
     _LOAD_TIMEOUT_RAW = _LOAD_TIMEOUT_FLOOR_SECONDS
 
 
+def _is_known_compressed_storage_shape(shape: tuple[int, ...]) -> bool:
+    # DeepSeek V4 compressed MLA stores one compressed storage page per manager
+    # block. Its small storage_block_size is not a manager->kernel page split.
+    return len(shape) == 3 and shape[-1] == 584
+
+
+def _infer_physical_block_size_tokens(shape: tuple[int, ...], layout: str) -> int | None:
+    if layout == "KV-first" and len(shape) >= 3:
+        return int(shape[2])
+    if layout == "blocks-first" and _is_known_compressed_storage_shape(shape):
+        return None
+    if layout == "blocks-first" and len(shape) >= 5 and shape[1] == 2:
+        return int(shape[2])
+    if layout == "blocks-first" and len(shape) == 3:
+        return int(shape[1])
+    return None
+
+
+def _detect_split_block_layout(
+    ctx: ConnectorContext,
+    shape: tuple[int, ...],
+    layout: str,
+) -> tuple[int, int] | None:
+    physical_block_size = _infer_physical_block_size_tokens(shape, layout)
+    if physical_block_size is None or physical_block_size >= ctx.block_size:
+        return None
+
+    if physical_block_size <= 0 or ctx.block_size % physical_block_size != 0:
+        return None
+
+    return physical_block_size, ctx.block_size // physical_block_size
+
+
 @dataclass
 class SaveTask:
     metadata: PegaConnectorMetadata
@@ -94,6 +127,7 @@ class WorkerConnector:
         self._cross_layer_key = _CROSS_LAYER_KEY
 
         self._finished_requests: set[str] = set()
+        self._reported_split_block_layout = False
 
         # Stats collection
         self._stats = PegaKVConnectorStats()
@@ -147,9 +181,6 @@ class WorkerConnector:
                 f"KV cache for {layer_name} must have zero storage offset"
             )
 
-            wrapper = CudaIPCWrapper(kv_cache)
-            wrapper_bytes = pickle.dumps(wrapper)
-
             shape = tuple(kv_cache.shape)
             stride = tuple(kv_cache.stride())
             element_size = kv_cache.element_size()
@@ -167,9 +198,35 @@ class WorkerConnector:
                 segments = 1
                 layout = "blocks-first"
 
+            split_layout = _detect_split_block_layout(self._ctx, shape, layout)
+            if split_layout is not None and not self._reported_split_block_layout:
+                physical_block_size, ratio = split_layout
+                logger.error(
+                    "[PegaKVConnector] detected split KV block layout: "
+                    "instance=%s layer=%s layout=%s shape=%s "
+                    "logical_block_size=%d physical_page_size=%d "
+                    "physical_pages_per_logical=%d. PegaFlow currently saves "
+                    "and loads one registered physical page per request block "
+                    "hash, so cache reuse can be incorrect for this layout. "
+                    "Use vLLM block_size=%d or disable PegaFlow KV cache until "
+                    "multi-page logical block support is implemented.",
+                    self._ctx.instance_id,
+                    layer_name,
+                    layout,
+                    shape,
+                    self._ctx.block_size,
+                    physical_block_size,
+                    ratio,
+                    physical_block_size,
+                )
+                self._reported_split_block_layout = True
+
             assert bytes_per_block != 0, (
                 f"Invalid bytes_per_block for {layer_name}: stride={stride}"
             )
+
+            wrapper = CudaIPCWrapper(kv_cache)
+            wrapper_bytes = pickle.dumps(wrapper)
 
             layer_names.append(layer_name)
             ipc_wrappers.append(wrapper_bytes)

--- a/python/tests/test_worker_split_layout_diagnostic.py
+++ b/python/tests/test_worker_split_layout_diagnostic.py
@@ -1,0 +1,179 @@
+from unittest.mock import MagicMock
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from pegaflow.connector.common import ConnectorContext  # noqa: E402
+from pegaflow.connector.worker import (  # noqa: E402
+    WorkerConnector,
+    _detect_split_block_layout,
+    _infer_physical_block_size_tokens,
+)
+
+
+def _ctx(*, block_size: int = 128, is_mla: bool = True) -> ConnectorContext:
+    return ConnectorContext(
+        instance_id="test-instance",
+        namespace="test-namespace",
+        block_size=block_size,
+        num_layers=1,
+        tp_size=1,
+        world_size=1,
+        tp_rank=0,
+        device_id=0,
+        engine_client=MagicMock(),
+        state_manager=MagicMock(),
+        is_mla=is_mla,
+    )
+
+
+def test_blocks_first_mla_split_layout_is_detected():
+    assert _detect_split_block_layout(
+        _ctx(block_size=128, is_mla=True),
+        (16, 64, 656),
+        "blocks-first",
+    ) == (64, 2)
+
+
+def test_kv_first_standard_split_layout_is_detected():
+    assert _detect_split_block_layout(
+        _ctx(block_size=128, is_mla=False),
+        (2, 16, 64, 8, 128),
+        "KV-first",
+    ) == (64, 2)
+
+
+def test_blocks_first_flashinfer_split_layout_is_detected():
+    assert _detect_split_block_layout(
+        _ctx(block_size=128, is_mla=False),
+        (16, 2, 64, 8, 128),
+        "blocks-first",
+    ) == (64, 2)
+
+
+def test_matching_physical_block_layout_is_supported():
+    assert (
+        _detect_split_block_layout(
+            _ctx(block_size=128, is_mla=True),
+            (16, 128, 656),
+            "blocks-first",
+        )
+        is None
+    )
+
+
+def test_non_divisible_layout_is_not_reported_as_split():
+    assert (
+        _detect_split_block_layout(
+            _ctx(block_size=128, is_mla=True),
+            (16, 96, 656),
+            "blocks-first",
+        )
+        is None
+    )
+
+
+def test_compressed_mla_storage_shape_is_not_reported_as_split():
+    assert (
+        _detect_split_block_layout(
+            _ctx(block_size=256, is_mla=True),
+            (16, 2, 584),
+            "blocks-first",
+        )
+        is None
+    )
+
+
+def test_physical_block_size_inference_covers_common_vllm_layouts():
+    assert _infer_physical_block_size_tokens((2, 16, 64, 8, 128), "KV-first") == 64
+    assert _infer_physical_block_size_tokens((16, 2, 64, 8, 128), "blocks-first") == 64
+    assert _infer_physical_block_size_tokens((16, 64, 656), "blocks-first") == 64
+    assert _infer_physical_block_size_tokens((16, 2, 584), "blocks-first") is None
+
+
+class FakeTensor:
+    def __init__(self, shape: tuple[int, ...]):
+        self.shape = shape
+        self.device = "cuda:0"
+
+    def storage_offset(self) -> int:
+        return 0
+
+    def stride(self) -> tuple[int, ...]:
+        if len(self.shape) == 3:
+            return (self.shape[1] * self.shape[2], self.shape[2], 1)
+        if len(self.shape) == 5 and self.shape[0] == 2:
+            return (
+                self.shape[1] * self.shape[2] * self.shape[3] * self.shape[4],
+                self.shape[2] * self.shape[3] * self.shape[4],
+                self.shape[3] * self.shape[4],
+                self.shape[4],
+                1,
+            )
+        if len(self.shape) == 5:
+            return (
+                self.shape[1] * self.shape[2] * self.shape[3] * self.shape[4],
+                self.shape[2] * self.shape[3] * self.shape[4],
+                self.shape[3] * self.shape[4],
+                self.shape[4],
+                1,
+            )
+        return tuple(reversed(range(1, len(self.shape) + 1)))
+
+    def element_size(self) -> int:
+        return 1
+
+
+def _connector_for_registration(ctx: ConnectorContext) -> WorkerConnector:
+    connector = WorkerConnector.__new__(WorkerConnector)
+    connector._ctx = ctx
+    connector._registered_layers = []
+    connector._torch_device = None
+    connector._layer_name_to_id = {}
+    connector._cross_layer_mode = False
+    connector._reported_split_block_layout = False
+    return connector
+
+
+def test_split_layout_registration_logs_once_and_continues(monkeypatch):
+    ctx = _ctx(block_size=128, is_mla=False)
+    connector = _connector_for_registration(ctx)
+    ctx.engine_client.register_context_batch.return_value = (True, "")
+
+    errors: list[str] = []
+    monkeypatch.setattr(
+        "pegaflow.connector.worker.logger.error", lambda msg, *args: errors.append(msg % args)
+    )
+    monkeypatch.setattr("pegaflow.connector.worker.CudaIPCWrapper", lambda _tensor: object())
+    monkeypatch.setattr("pegaflow.connector.worker.pickle.dumps", lambda _wrapper: b"wrapper")
+
+    connector.register_kv_caches(
+        {
+            "layer.0": FakeTensor((16, 2, 64, 8, 128)),
+            "layer.1": FakeTensor((16, 2, 64, 8, 128)),
+        }
+    )
+
+    assert len(errors) == 1
+    assert "logical_block_size=128" in errors[0]
+    assert "physical_page_size=64" in errors[0]
+    assert "physical_pages_per_logical=2" in errors[0]
+    assert "incorrect" in errors[0]
+    ctx.engine_client.register_context_batch.assert_called_once()
+
+
+def test_matching_layout_registration_does_not_log(monkeypatch):
+    ctx = _ctx(block_size=128, is_mla=True)
+    connector = _connector_for_registration(ctx)
+    ctx.engine_client.register_context_batch.return_value = (True, "")
+
+    error = MagicMock()
+    monkeypatch.setattr("pegaflow.connector.worker.logger.error", error)
+    monkeypatch.setattr("pegaflow.connector.worker.CudaIPCWrapper", lambda _tensor: object())
+    monkeypatch.setattr("pegaflow.connector.worker.pickle.dumps", lambda _wrapper: b"wrapper")
+
+    connector.register_kv_caches({"layer.0": FakeTensor((16, 128, 656))})
+
+    error.assert_not_called()
+    ctx.engine_client.register_context_batch.assert_called_once()


### PR DESCRIPTION
## Summary
- detect KV layouts where the scheduler logical block size is larger than the registered physical KV page size
- cover common vLLM split shapes: KV-first `(2, blocks, block, ...)`, FlashMLA-style `(blocks, block, 656)`, and FlashInfer-style `(blocks, 2, block, heads, dim)`
- exclude known compressed storage shapes such as DeepSeek V4 `(blocks, storage_block_size, 584)`, because that is not a manager-block to multiple-physical-page split
- log one high-signal error per worker instance instead of failing registration

## Context
For DS V3.2 FlashMLA, vLLM can use logical `block_size=128` while the FlashMLA physical KV page is 64. Other vLLM attention backends can expose the same class when their kernel block size is smaller than the manager block size. PegaFlow currently saves/loads one registered physical page per request block hash, so this PR only adds diagnostic visibility. Multi-page logical block correctness belongs to task #20.

## Test Contract
`test_worker_split_layout_diagnostic.py` protects the diagnostic contract only: known split logical/physical layouts are observable at KV registration, matching layouts and compressed storage layouts are not misreported, registration still continues, and the log is emitted once per worker instance. It does not prove multi-page save/load correctness.

## Verification
- `cd python && env -u VIRTUAL_ENV uv run --extra dev ruff format --check pegaflow/connector/worker.py tests/test_worker_split_layout_diagnostic.py`
- `cd python && env -u VIRTUAL_ENV uv run --extra dev ruff check pegaflow/connector/worker.py tests/test_worker_split_layout_diagnostic.py`
- `cd python && env -u VIRTUAL_ENV uv run --extra test pytest tests/test_worker_split_layout_diagnostic.py -q` => 9 passed
- `cd python && env -u VIRTUAL_ENV uv run --extra test pytest -q` => 40 passed / 6 deselected
- `cd python && env -u VIRTUAL_ENV uv run --isolated --no-project --with pytest --with numpy --with 'requests>=2.26.0' pytest -q` => 40 passed / 6 deselected
- `LD_LIBRARY_PATH=/home/susun/.local/share/uv/python/cpython-3.13.5-linux-x86_64-gnu/lib:${LD_LIBRARY_PATH:-} prek run --files python/pegaflow/connector/worker.py python/tests/test_worker_split_layout_diagnostic.py`
