### PR TITLE
feat: optimize cold-start pinned pool readiness

### DIFF
--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -48,6 +48,7 @@ use std::{
     collections::HashMap,
     fmt,
     sync::{Arc, RwLock},
+    time::Instant,
 };
 
 use log::{debug, info, warn};
@@ -129,8 +130,16 @@ impl PegaEngine {
         use_hugepages: bool,
         storage_config: storage::StorageConfig,
     ) -> Self {
+        let engine_start = Instant::now();
+        let topology_start = Instant::now();
         let topology = Arc::new(NumaTopology::detect());
+        let topology_elapsed = topology_start.elapsed();
         topology.log_summary();
+        debug!(
+            "NUMA topology detected: nodes={} elapsed_ms={:.2}",
+            topology.num_nodes(),
+            topology_elapsed.as_secs_f64() * 1000.0
+        );
 
         let config = storage_config;
         let numa_nodes: Vec<NumaNode> = if config.enable_numa_affinity && topology.is_multi_numa() {
@@ -143,13 +152,26 @@ impl PegaEngine {
             vec![]
         };
 
+        let storage_start = Instant::now();
         let storage = StorageEngine::new_with_config(pool_size, use_hugepages, config, &numa_nodes);
+        debug!(
+            "PegaEngine storage ready: elapsed_ms={:.2}",
+            storage_start.elapsed().as_secs_f64() * 1000.0
+        );
 
-        PegaEngine {
+        let engine = PegaEngine {
             instances: Arc::new(RwLock::new(HashMap::new())),
             storage,
             topology,
-        }
+        };
+        info!(
+            "PegaEngine initialized: pool_size={} hugepages={} numa_nodes={} elapsed_ms={:.2}",
+            pool_size,
+            use_hugepages,
+            numa_nodes.len(),
+            engine_start.elapsed().as_secs_f64() * 1000.0
+        );
+        engine
     }
 
     /// Get or create an instance with the specified topology.

--- a/pegaflow-core/src/pinned_mem.rs
+++ b/pegaflow-core/src/pinned_mem.rs
@@ -1,11 +1,16 @@
 //! Low-level pinned memory allocation for CUDA.
 //!
-//! This module provides two allocation strategies:
+//! This module provides pinned memory allocation strategies for different
+//! cold-start and data-path requirements:
 //!
 //! 1. **Write-combined** (`PinnedMemory::allocate_write_combined`): Uses `cudaHostAlloc` with write-combined flag.
 //!    Optimized for CPU-to-GPU transfers with better write performance.
 //!
-//! 2. **Huge pages** (`PinnedMemory::allocate_hugepages`): Uses `mmap(MAP_HUGETLB)` + `cudaHostRegister`.
+//! 2. **Registered mmap** (`PinnedMemory::allocate_registered_parallel`): Uses anonymous
+//!    `mmap`, parallel first-touch, then `cudaHostRegister`. Optimized for large
+//!    full-capacity startup where ordinary CPU backing is acceptable.
+//!
+//! 3. **Huge pages** (`PinnedMemory::allocate_hugepages`): Uses `mmap(MAP_HUGETLB)` + `cudaHostRegister`.
 //!    Much faster allocation for large buffers but requires pre-configured huge pages:
 //!    ```bash
 //!    # Reserve huge pages (size from /proc/meminfo, typically 2MB)
@@ -22,11 +27,16 @@
 use std::io;
 use std::ptr::NonNull;
 use std::sync::OnceLock;
+use std::thread;
+use std::time::Instant;
 
 use cudarc::runtime::sys as rt;
+use log::debug;
 
 /// Cached huge page size from /proc/meminfo
 static HUGE_PAGE_SIZE: OnceLock<Option<usize>> = OnceLock::new();
+
+const PARALLEL_REGISTER_MIN_BYTES: usize = 1024 * 1024 * 1024;
 
 /// Read the system's default huge page size from /proc/meminfo.
 /// Returns None if reading or parsing fails.
@@ -92,6 +102,9 @@ pub(crate) enum AllocStrategy {
     /// Write-combined via cudaHostAlloc.
     /// Fast for CPU→GPU (write-only) workloads, but CPU reads are extremely slow.
     WriteCombined,
+    /// Anonymous mmap, parallel page pre-touch, then cudaHostRegister.
+    /// Used for large write-mostly pools to reduce full-capacity startup latency.
+    RegisteredMmap,
     /// Huge pages (size from /proc/meminfo, requires system configuration)
     HugePages,
 }
@@ -142,6 +155,17 @@ impl PinnedMemory {
         Self::allocate_internal(size, AllocStrategy::WriteCombined)
     }
 
+    /// Allocate pinned memory with mmap + parallel pre-touch + cudaHostRegister.
+    ///
+    /// This keeps the backing ordinary CPU memory but pins it after parallel first-touch,
+    /// which is much faster for large pools than one monolithic cudaHostAlloc on some hosts.
+    pub(crate) fn allocate_registered_parallel(size: usize) -> Result<Self, PinnedMemError> {
+        if size < PARALLEL_REGISTER_MIN_BYTES {
+            return Self::allocate_write_combined(size);
+        }
+        Self::allocate_internal(size, AllocStrategy::RegisteredMmap)
+    }
+
     /// Allocate pinned memory using huge pages.
     ///
     /// Uses `mmap(MAP_HUGETLB)` for fast allocation, then registers with CUDA.
@@ -164,6 +188,7 @@ impl PinnedMemory {
             return Err(PinnedMemError::ZeroSize);
         }
 
+        let alloc_start = Instant::now();
         let (ptr, aligned_size) = match strategy {
             AllocStrategy::Regular => {
                 let mut ptr: *mut libc::c_void = std::ptr::null_mut();
@@ -182,6 +207,47 @@ impl PinnedMemory {
                 if result != rt::cudaError::cudaSuccess {
                     return Err(PinnedMemError::CudaAllocFailed(result));
                 }
+                (ptr, size)
+            }
+            AllocStrategy::RegisteredMmap => {
+                // SAFETY: null hint, anonymous private mapping, validated non-zero size.
+                let ptr = unsafe {
+                    libc::mmap(
+                        std::ptr::null_mut(),
+                        size,
+                        libc::PROT_READ | libc::PROT_WRITE,
+                        libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                        -1,
+                        0,
+                    )
+                };
+
+                if ptr == libc::MAP_FAILED {
+                    return Err(PinnedMemError::MmapFailed(std::io::Error::last_os_error()));
+                }
+
+                let touch_start = Instant::now();
+                parallel_touch_pages(ptr as *mut u8, size);
+                let touch_elapsed = touch_start.elapsed();
+
+                let register_start = Instant::now();
+                // SAFETY: ptr is a valid mmap'd region of `size` bytes.
+                let result =
+                    unsafe { rt::cudaHostRegister(ptr, size, rt::cudaHostRegisterDefault) };
+                let register_elapsed = register_start.elapsed();
+
+                if result != rt::cudaError::cudaSuccess {
+                    unsafe { libc::munmap(ptr, size) };
+                    return Err(PinnedMemError::CudaRegisterFailed(result));
+                }
+
+                debug!(
+                    "Pinned memory registered mmap ready: requested={} touch_ms={:.2} register_ms={:.2}",
+                    size,
+                    touch_elapsed.as_secs_f64() * 1000.0,
+                    register_elapsed.as_secs_f64() * 1000.0
+                );
+
                 (ptr, size)
             }
             AllocStrategy::HugePages => {
@@ -208,19 +274,42 @@ impl PinnedMemory {
                     return Err(PinnedMemError::MmapFailed(std::io::Error::last_os_error()));
                 }
 
+                let touch_start = Instant::now();
+                parallel_touch_pages(ptr as *mut u8, aligned);
+                let touch_elapsed = touch_start.elapsed();
+
                 // Register with CUDA for DMA
+                let register_start = Instant::now();
                 // SAFETY: ptr is a valid mmap'd region of `aligned` bytes (checked above).
                 let result =
                     unsafe { rt::cudaHostRegister(ptr, aligned, rt::cudaHostRegisterDefault) };
+                let register_elapsed = register_start.elapsed();
 
                 if result != rt::cudaError::cudaSuccess {
                     unsafe { libc::munmap(ptr, aligned) };
                     return Err(PinnedMemError::CudaRegisterFailed(result));
                 }
 
+                debug!(
+                    "Pinned memory hugepage backing ready: requested={} aligned={} touch_ms={:.2} register_ms={:.2}",
+                    size,
+                    aligned,
+                    touch_elapsed.as_secs_f64() * 1000.0,
+                    register_elapsed.as_secs_f64() * 1000.0
+                );
+
                 (ptr, aligned)
             }
         };
+
+        let elapsed = alloc_start.elapsed();
+        debug!(
+            "Pinned memory backing allocated: strategy={:?} requested={} aligned={} elapsed_ms={:.2}",
+            strategy,
+            size,
+            aligned_size,
+            elapsed.as_secs_f64() * 1000.0
+        );
 
         // SAFETY: allocation succeeded and returned non-null pointer
         let ptr = NonNull::new(ptr as *mut u8).expect("allocation returned null");
@@ -257,7 +346,7 @@ impl Drop for PinnedMemory {
                     eprintln!("Warning: cudaFreeHost failed: {:?}", result);
                 }
             }
-            AllocStrategy::HugePages => {
+            AllocStrategy::HugePages | AllocStrategy::RegisteredMmap => {
                 // SAFETY: ptr was registered with cudaHostRegister
                 unsafe {
                     let result = rt::cudaHostUnregister(self.ptr.as_ptr() as *mut libc::c_void);
@@ -275,6 +364,58 @@ impl Drop for PinnedMemory {
                 }
             }
         }
+    }
+}
+
+fn parallel_touch_pages(ptr: *mut u8, size: usize) {
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    let page_size = if page_size > 0 {
+        page_size as usize
+    } else {
+        4096
+    };
+    let hw_threads = thread::available_parallelism()
+        .map(|threads| threads.get())
+        .unwrap_or(1);
+    let touch_threads = if hw_threads > 64 {
+        16
+    } else {
+        hw_threads.min(8)
+    }
+    .max(1);
+    let chunk_size = size.div_ceil(touch_threads);
+
+    let base = ptr as usize;
+    let mut handles = Vec::with_capacity(touch_threads);
+    for thread_idx in 0..touch_threads {
+        let offset = thread_idx * chunk_size;
+        if offset >= size {
+            break;
+        }
+        let len = (size - offset).min(chunk_size);
+        handles.push(thread::spawn(move || {
+            touch_pages(base + offset, len, page_size);
+        }));
+    }
+
+    for handle in handles {
+        handle
+            .join()
+            .expect("pinned memory pre-touch thread panicked");
+    }
+}
+
+fn touch_pages(base: usize, len: usize, page_size: usize) {
+    let ptr = base as *mut u8;
+    let mut offset = 0usize;
+    while offset < len {
+        // SAFETY: caller passes a valid mmap range; offsets stay inside the chunk.
+        unsafe { ptr.add(offset).write_volatile(0u8) };
+        offset += page_size;
+    }
+    if len > 0 {
+        // SAFETY: last byte is inside the chunk and forces tail-page materialization.
+        unsafe { ptr.add(len - 1).write_volatile(0u8) };
     }
 }
 

--- a/pegaflow-core/src/pinned_pool.rs
+++ b/pegaflow-core/src/pinned_pool.rs
@@ -7,15 +7,19 @@ use std::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
+    thread,
+    time::Instant,
 };
 
 use bytesize::ByteSize;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 
 use crate::allocator::{Allocation, ScaledOffsetAllocator};
 use crate::metrics::core_metrics;
 use crate::pinned_mem::PinnedMemory;
 use pegaflow_common::{NumaNode, run_on_numa};
+
+const REGISTERED_MMAP_MIN_BYTES: usize = 1024 * 1024 * 1024;
 
 /// RAII guard for a pinned memory allocation.
 /// Automatically frees the allocation when dropped.
@@ -45,6 +49,37 @@ impl PinnedAllocation {
     /// Get the underlying NonNull pointer.
     pub(crate) fn as_non_null(&self) -> NonNull<u8> {
         self.ptr
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PoolBackingPlan {
+    HugePages,
+    Regular,
+    RegisteredMmap,
+    WriteCombined,
+}
+
+impl PoolBackingPlan {
+    fn for_request(pool_size: usize, use_hugepages: bool, ssd_enabled: bool) -> Self {
+        if use_hugepages {
+            PoolBackingPlan::HugePages
+        } else if pool_size >= REGISTERED_MMAP_MIN_BYTES {
+            PoolBackingPlan::RegisteredMmap
+        } else if ssd_enabled {
+            PoolBackingPlan::Regular
+        } else {
+            PoolBackingPlan::WriteCombined
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::HugePages => "hugepages",
+            Self::Regular => "regular",
+            Self::RegisteredMmap => "registered_mmap",
+            Self::WriteCombined => "write_combined",
+        }
     }
 }
 
@@ -82,8 +117,9 @@ impl PinnedMemoryPool {
     /// Allocate a new pinned memory pool of `pool_size` bytes.
     ///
     /// If `use_hugepages` is true, uses huge pages (requires system config).
-    /// If `ssd_enabled` is true, uses regular pinned memory instead of write-combined,
-    /// because SSD reads back data into CPU memory and write-combined has extremely slow CPU reads.
+    /// Large pools use registered mmap by default. For small SSD pools, uses
+    /// regular pinned memory instead of write-combined because SSD reads back
+    /// data into CPU memory and write-combined has extremely slow CPU reads.
     /// If `unit_size_hint` is provided, the allocator rounds allocations up to this size.
     fn new(
         pool_size: usize,
@@ -96,18 +132,19 @@ impl PinnedMemoryPool {
             "Pinned memory pool size must be greater than zero"
         );
 
-        let backing = if use_hugepages {
-            info!("Allocating pinned memory pool with huge pages");
-            PinnedMemory::allocate_hugepages(pool_size)
-                .expect("Failed to allocate pinned memory pool with huge pages")
-        } else if ssd_enabled {
-            info!("Allocating pinned memory pool with regular pages (SSD enabled)");
-            PinnedMemory::allocate_regular(pool_size)
-                .expect("Failed to allocate regular pinned memory pool")
-        } else {
-            info!("Allocating pinned memory pool with write-combined pages");
-            PinnedMemory::allocate_write_combined(pool_size)
-                .expect("Failed to allocate pinned memory pool")
+        let pool_start = Instant::now();
+        let plan = PoolBackingPlan::for_request(pool_size, use_hugepages, ssd_enabled);
+        let backing = match plan {
+            PoolBackingPlan::HugePages => PinnedMemory::allocate_hugepages(pool_size)
+                .expect("Failed to allocate pinned memory pool with huge pages"),
+            PoolBackingPlan::Regular => PinnedMemory::allocate_regular(pool_size)
+                .expect("Failed to allocate regular pinned memory pool"),
+            PoolBackingPlan::RegisteredMmap => {
+                PinnedMemory::allocate_registered_parallel(pool_size)
+                    .expect("Failed to allocate registered mmap pinned memory pool")
+            }
+            PoolBackingPlan::WriteCombined => PinnedMemory::allocate_write_combined(pool_size)
+                .expect("Failed to allocate pinned memory pool"),
         };
 
         let actual_size = backing.size() as u64;
@@ -115,12 +152,14 @@ impl PinnedMemoryPool {
         let max_units = actual_size / unit_size;
         let allocatable_bytes = max_units * unit_size;
 
-        info!(
-            "Pinned pool: backing_size={}, unit_size={}, max_units={}, allocatable_size={}",
+        debug!(
+            "Pinned pool shard backing ready: strategy={} backing_size={} unit_size={} max_units={} allocatable_size={} elapsed_ms={:.2}",
+            plan.as_str(),
             ByteSize(actual_size),
             ByteSize(unit_size),
             max_units,
-            ByteSize(allocatable_bytes)
+            ByteSize(allocatable_bytes),
+            pool_start.elapsed().as_secs_f64() * 1000.0
         );
 
         let metrics = core_metrics();
@@ -279,6 +318,31 @@ pub(crate) struct ShardedPinnedPool {
 }
 
 impl ShardedPinnedPool {
+    fn create_shard(
+        shard_idx: usize,
+        num_shards: usize,
+        per_shard: usize,
+        use_hugepages: bool,
+        ssd_enabled: bool,
+        unit_size_hint: Option<NonZeroU64>,
+    ) -> (usize, Arc<PinnedMemoryPool>) {
+        let shard_start = Instant::now();
+        let pool = Arc::new(PinnedMemoryPool::new(
+            per_shard,
+            use_hugepages,
+            ssd_enabled,
+            unit_size_hint,
+        ));
+        debug!(
+            "Pinned pool shard ready: shard={}/{} capacity={} elapsed_ms={:.2}",
+            shard_idx + 1,
+            num_shards,
+            ByteSize(per_shard as u64),
+            shard_start.elapsed().as_secs_f64() * 1000.0
+        );
+        (shard_idx, pool)
+    }
+
     /// Create a sharded pool by splitting `total_capacity` evenly across `num_shards` pools.
     ///
     /// When `num_shards <= 1`, a single pool is created (equivalent to the old behavior).
@@ -289,28 +353,60 @@ impl ShardedPinnedPool {
         ssd_enabled: bool,
         unit_size_hint: Option<NonZeroU64>,
     ) -> Self {
+        let total_start = Instant::now();
         let num_shards = num_shards.max(1);
         let per_shard = total_capacity / num_shards;
 
-        if num_shards > 1 {
-            info!(
-                "Creating sharded pinned pool: total={}, shards={}, per_shard={}",
-                ByteSize(total_capacity as u64),
+        let shards = if num_shards == 1 {
+            let (_, first_shard) = Self::create_shard(
+                0,
                 num_shards,
-                ByteSize(per_shard as u64)
+                per_shard,
+                use_hugepages,
+                ssd_enabled,
+                unit_size_hint,
             );
-        }
+            vec![first_shard]
+        } else {
+            let mut handles = Vec::with_capacity(num_shards);
+            for shard_idx in 0..num_shards {
+                let handle = thread::Builder::new()
+                    .name(format!("pinned-pool-shard-{shard_idx}"))
+                    .spawn(move || {
+                        Self::create_shard(
+                            shard_idx,
+                            num_shards,
+                            per_shard,
+                            use_hugepages,
+                            ssd_enabled,
+                            unit_size_hint,
+                        )
+                    })
+                    .expect("failed to spawn pinned pool shard init thread");
+                handles.push(handle);
+            }
 
-        let shards: Vec<Arc<PinnedMemoryPool>> = (0..num_shards)
-            .map(|_| {
-                Arc::new(PinnedMemoryPool::new(
-                    per_shard,
-                    use_hugepages,
-                    ssd_enabled,
-                    unit_size_hint,
-                ))
-            })
-            .collect();
+            let mut ordered = Vec::with_capacity(num_shards);
+            for handle in handles {
+                ordered.push(
+                    handle
+                        .join()
+                        .expect("pinned pool shard init thread panicked"),
+                );
+            }
+            ordered.sort_by_key(|(idx, _)| *idx);
+            ordered.into_iter().map(|(_, shard)| shard).collect()
+        };
+
+        let backing_plan = PoolBackingPlan::for_request(per_shard, use_hugepages, ssd_enabled);
+        info!(
+            "Pinned pool ready: total={} shards={} per_shard={} backing_strategy={} elapsed_ms={:.2}",
+            ByteSize(total_capacity as u64),
+            shards.len(),
+            ByteSize(per_shard as u64),
+            backing_plan.as_str(),
+            total_start.elapsed().as_secs_f64() * 1000.0
+        );
 
         Self {
             shards,
@@ -321,6 +417,9 @@ impl ShardedPinnedPool {
     /// Allocate from shards using round-robin with fallback to all shards.
     fn allocate(&self, size: NonZeroU64) -> Option<PinnedAllocation> {
         let n = self.shards.len();
+        if n == 0 {
+            return None;
+        }
         let start = self.cursor.fetch_add(1, Ordering::Relaxed) % n;
 
         for i in 0..n {
@@ -412,6 +511,7 @@ impl NumaAwarePinnedPools {
         ssd_enabled: bool,
         unit_size_hint: Option<NonZeroU64>,
     ) -> Self {
+        let total_start = Instant::now();
         let num_nodes = numa_nodes.len();
         if num_nodes == 0 {
             warn!("No NUMA nodes provided, creating empty NumaAwarePinnedPools");
@@ -440,6 +540,7 @@ impl NumaAwarePinnedPools {
             let hint = unit_size_hint;
 
             // Allocate sharded pool on a thread pinned to this NUMA node
+            let node_start = Instant::now();
             let result = run_on_numa(*node, move || {
                 ShardedPinnedPool::new(
                     per_node_capacity,
@@ -452,10 +553,12 @@ impl NumaAwarePinnedPools {
 
             match result {
                 Ok(pool) => {
+                    let elapsed = node_start.elapsed();
                     info!(
-                        "Created pinned pool on NUMA{}: capacity={}",
+                        "Created pinned pool on NUMA{}: capacity={} elapsed_ms={:.2}",
                         node_id,
-                        ByteSize(per_node_capacity as u64)
+                        ByteSize(per_node_capacity as u64),
+                        elapsed.as_secs_f64() * 1000.0
                     );
                     pools.insert(node_id, pool);
                 }
@@ -469,6 +572,14 @@ impl NumaAwarePinnedPools {
                 }
             }
         }
+
+        info!(
+            "NUMA-aware pinned pools ready: nodes={} configured_capacity={} usable_capacity={} elapsed_ms={:.2}",
+            pools.len(),
+            ByteSize(total_capacity as u64),
+            ByteSize((per_node_capacity * pools.len()) as u64),
+            total_start.elapsed().as_secs_f64() * 1000.0
+        );
 
         Self { pools }
     }
@@ -548,13 +659,26 @@ impl PinnedAllocator {
         ssd_enabled: bool,
         unit_hint: Option<NonZeroU64>,
     ) -> Self {
-        Self::Global(ShardedPinnedPool::new(
-            capacity,
+        let start = Instant::now();
+        info!(
+            "Pinned allocator global plan: capacity={} shards={} hugepages={} ssd_enabled={} unit_hint={}",
+            ByteSize(capacity as u64),
             num_shards,
             use_hugepages,
             ssd_enabled,
-            unit_hint,
-        ))
+            unit_hint
+                .map(|v| ByteSize(v.get()).to_string())
+                .unwrap_or_else(|| "none".to_string())
+        );
+        let pool =
+            ShardedPinnedPool::new(capacity, num_shards, use_hugepages, ssd_enabled, unit_hint);
+        info!(
+            "Pinned allocator global ready: capacity={} shards={} elapsed_ms={:.2}",
+            ByteSize(capacity as u64),
+            num_shards,
+            start.elapsed().as_secs_f64() * 1000.0
+        );
+        Self::Global(pool)
     }
 
     /// Create a new NUMA-aware allocator.
@@ -568,20 +692,29 @@ impl PinnedAllocator {
         ssd_enabled: bool,
         unit_hint: Option<NonZeroU64>,
     ) -> Self {
+        let start = Instant::now();
         if numa_nodes.is_empty() {
             warn!(
                 "NUMA allocator requested but no nodes provided, falling back to global allocator"
             );
             return Self::new_global(capacity, num_shards, use_hugepages, ssd_enabled, unit_hint);
         }
-        Self::Numa(NumaAwarePinnedPools::new(
+        let pools = NumaAwarePinnedPools::new(
             capacity,
             numa_nodes,
             num_shards,
             use_hugepages,
             ssd_enabled,
             unit_hint,
-        ))
+        );
+        info!(
+            "Pinned allocator NUMA ready: capacity={} nodes={} shards_per_node={} elapsed_ms={:.2}",
+            ByteSize(capacity as u64),
+            numa_nodes.len(),
+            num_shards,
+            start.elapsed().as_secs_f64() * 1000.0
+        );
+        Self::Numa(pools)
     }
 
     /// Allocate pinned memory.

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -9,7 +9,7 @@ use log::{debug, info};
 use std::collections::HashSet;
 use std::num::NonZeroU64;
 use std::sync::{Arc, Weak};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::backing::{
     AllocateFn, DEFAULT_MAX_PREFETCH_BLOCKS, RdmaFetchStore, RdmaTransport, SsdBackingStore,
@@ -103,6 +103,7 @@ impl StorageEngine {
         config: StorageConfig,
         numa_nodes: &[NumaNode],
     ) -> Arc<Self> {
+        let storage_start = Instant::now();
         let value_size_hint = config.hint_value_size_bytes.filter(|size| *size > 0);
         let unit_hint = value_size_hint.and_then(|size| NonZeroU64::new(size as u64));
         let max_prefetch_blocks = config.max_prefetch_blocks;
@@ -134,6 +135,7 @@ impl StorageEngine {
         let pool_shards = config.pool_shards;
 
         // Create unified allocator based on NUMA configuration
+        let allocator_start = Instant::now();
         let allocator = if !numa_nodes.is_empty() {
             info!(
                 "Creating NUMA-aware pinned pools for {} nodes",
@@ -157,6 +159,21 @@ impl StorageEngine {
                 unit_hint,
             ))
         };
+        let allocator_elapsed = allocator_start.elapsed();
+        let (_, usable_capacity) = allocator.usage();
+        let allocator_mode = if allocator.is_numa() {
+            "numa"
+        } else {
+            "global"
+        };
+        info!(
+            "Pinned allocator initialized: mode={} configured_capacity={} usable_capacity={} pool_shards={} elapsed_ms={:.2}",
+            allocator_mode,
+            ByteSize(capacity_bytes as u64),
+            ByteSize(usable_capacity),
+            pool_shards,
+            allocator_elapsed.as_secs_f64() * 1000.0
+        );
 
         // Sub-components
         let read_cache = Arc::new(ReadCache::new(
@@ -173,7 +190,18 @@ impl StorageEngine {
         let rdma_transport = rdma_nic_names
             .as_deref()
             .filter(|nics| !nics.is_empty())
-            .and_then(|nics| crate::backing::new_rdma(nics, &allocator));
+            .and_then(|nics| {
+                let rdma_start = Instant::now();
+                let transport = crate::backing::new_rdma(nics, &allocator);
+                let elapsed = rdma_start.elapsed();
+                info!(
+                    "RDMA startup phase completed: configured_nics={} enabled={} elapsed_ms={:.2}",
+                    nics.len(),
+                    transport.is_some(),
+                    elapsed.as_secs_f64() * 1000.0
+                );
+                transport
+            });
 
         if let Some(ref rdma) = rdma_transport {
             crate::metrics::register_rdma_gauges(rdma);
@@ -245,6 +273,18 @@ impl StorageEngine {
                 })
                 .expect("failed to spawn insert worker thread");
         }
+
+        let storage_elapsed = storage_start.elapsed();
+        info!(
+            "StorageEngine initialized: configured_capacity={} usable_capacity={} numa={} ssd={} rdma={} blockwise_alloc={} elapsed_ms={:.2}",
+            ByteSize(capacity_bytes as u64),
+            ByteSize(usable_capacity),
+            engine.is_numa_enabled(),
+            engine.ssd_store.is_some(),
+            engine.rdma_transport.is_some(),
+            engine.blockwise_alloc,
+            storage_elapsed.as_secs_f64() * 1000.0
+        );
 
         engine
     }

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -18,7 +18,7 @@ pub use service::GrpcEngineService;
 
 use clap::Parser;
 use cudarc::driver::result as cuda_driver;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use opentelemetry::global;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
@@ -30,7 +30,7 @@ use pyo3::{PyErr, Python, types::PyAnyMethods};
 use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::Notify;
 use tonic::transport::Server;
 use utils::parse_memory_size;
@@ -133,10 +133,11 @@ pub struct Cli {
     #[arg(long, default_value_t = 1.0, value_parser = parse_sample_rate)]
     pub trace_sample_rate: f64,
 
-    /// Number of shards for the pinned memory pool (reduces allocator lock contention).
+    /// Number of shards for the pinned memory pool.
     /// The pool is split into this many independent sub-pools with round-robin allocation.
-    #[arg(long, default_value_t = 1)]
-    pub pool_shards: usize,
+    /// Defaults to 1. Use only when the workload benefits from smaller allocator shards.
+    #[arg(long)]
+    pub pool_shards: Option<usize>,
 
     /// Allocate each block separately instead of contiguous batch allocation.
     /// Reduces memory fragmentation when blocks are freed in different order.
@@ -412,16 +413,23 @@ fn init_metrics(
 
 /// Main entry point for pegaflow-server
 pub fn run() -> Result<(), Box<dyn Error>> {
+    let process_start = Instant::now();
     let cli = Cli::parse();
     pegaflow_common::logging::init_stdout_colored(&cli.log_level);
     info!("Starting pega-engine-server v{}", env!("CARGO_PKG_VERSION"));
     trace::init();
     pegaflow_core::set_trace_sample_rate(cli.trace_sample_rate);
 
-    // Initialize CUDA in the main thread before starting Tokio runtime
+    // Initialize CUDA in the main thread before starting Tokio runtime.
+    let cuda_driver_start = Instant::now();
     init_cuda_driver()?;
+    debug!(
+        "CUDA driver initialized: elapsed_ms={:.2}",
+        cuda_driver_start.elapsed().as_secs_f64() * 1000.0
+    );
 
     // Determine which devices to initialize
+    let detect_devices_start = Instant::now();
     let devices = if cli.devices.is_empty() {
         // Auto-detect all available devices
         let detected = detect_cuda_devices()?;
@@ -435,23 +443,39 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         info!("Using specified CUDA device(s): {:?}", cli.devices);
         cli.devices.clone()
     };
+    debug!(
+        "CUDA devices selected: device_count={} elapsed_ms={:.2}",
+        devices.len(),
+        detect_devices_start.elapsed().as_secs_f64() * 1000.0
+    );
 
     if devices.is_empty() {
         return Err("No CUDA devices available".into());
     }
 
+    let python_cuda_start = Instant::now();
     init_python_cuda(&devices)?;
     info!(
         "CUDA runtime initialized for {} device(s): {:?}",
         devices.len(),
         devices
     );
+    debug!(
+        "Python CUDA runtime initialized: device_count={} elapsed_ms={:.2}",
+        devices.len(),
+        python_cuda_start.elapsed().as_secs_f64() * 1000.0
+    );
 
+    let registry_start = Instant::now();
     let registry = CudaTensorRegistry::new().map_err(|err| {
         let msg = format_py_err(err);
         std::io::Error::other(format!("failed to initialize torch CUDA context: {msg}"))
     })?;
     let registry = Arc::new(Mutex::new(registry));
+    debug!(
+        "CUDA tensor registry initialized: elapsed_ms={:.2}",
+        registry_start.elapsed().as_secs_f64() * 1000.0
+    );
 
     if let Some(hint_value_size) = cli.hint_value_size {
         if hint_value_size == 0 {
@@ -510,6 +534,8 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         None
     };
 
+    let pool_shards = cli.pool_shards.unwrap_or(1);
+
     let storage_config = pegaflow_core::StorageConfig {
         enable_lfu_admission: cli.enable_lfu_admission,
         hint_value_size_bytes: cli.hint_value_size,
@@ -522,13 +548,13 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         metaserver_addr: cli.metaserver_addr.clone(),
         advertise_addr,
         metaserver_queue_depth: cli.metaserver_queue_depth,
-        pool_shards: cli.pool_shards,
+        pool_shards,
     };
 
-    if cli.pool_shards > 1 {
+    if pool_shards > 1 {
         info!(
             "Pinned memory pool sharding enabled: {} shards",
-            cli.pool_shards
+            pool_shards
         );
     }
     if cli.enable_lfu_admission {
@@ -538,13 +564,14 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         info!("NUMA-aware memory allocation disabled");
     }
 
-    // Create Tokio runtime early - needed for OTLP metrics gRPC exporter
+    // Create Tokio runtime early - needed for OTLP metrics gRPC exporter.
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
 
     // Initialize OTEL metrics BEFORE creating PegaEngine, so that core metrics
     // (pool, cache, save/load) use the real meter provider instead of noop.
+    let metrics_start = Instant::now();
     let metrics_state = runtime.block_on(async {
         init_metrics(
             cli.enable_prometheus,
@@ -552,6 +579,12 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             cli.metrics_period_secs,
         )
     })?;
+    debug!(
+        "Metrics initialized: prometheus={} otlp={} elapsed_ms={:.2}",
+        cli.enable_prometheus,
+        cli.metrics_otel_endpoint.is_some(),
+        metrics_start.elapsed().as_secs_f64() * 1000.0
+    );
 
     let hll_tracker = Arc::new(std::sync::Mutex::new(
         pegaflow_common::hll::MultiWindowHllTracker::new(
@@ -566,11 +599,16 @@ pub fn run() -> Result<(), Box<dyn Error>> {
 
     runtime.block_on(async move {
         // Create PegaEngine inside tokio runtime context (needed for SSD cache tokio::spawn)
+        let engine_start = Instant::now();
         let engine = Arc::new(PegaEngine::new_with_config(
             cli.pool_size,
             cli.use_hugepages,
             storage_config,
         ));
+        debug!(
+            "PegaEngine ready: elapsed_ms={:.2}",
+            engine_start.elapsed().as_secs_f64() * 1000.0
+        );
 
         let service = GrpcEngineService::new(
             Arc::clone(&engine),
@@ -643,8 +681,11 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             }
         };
 
-        info!("PegaEngine gRPC server listening on {}", cli.addr);
-
+        info!(
+            "PegaEngine gRPC server listening on {} (startup_elapsed_ms={:.2})",
+            cli.addr,
+            process_start.elapsed().as_secs_f64() * 1000.0
+        );
         const MAX_GRPC_MESSAGE_SIZE: usize = 64 * 1024 * 1024; // 64 MiB
 
         let grpc_service = EngineServer::new(service)


### PR DESCRIPTION
## Summary

- Replace the default large-pool backing with `mmap + parallel pre-touch + cudaHostRegister`.
- Keep `--pool-shards` explicit. The default remains one allocator shard; there is no hidden auto-shard threshold in `pegaflow-server`.
- Remove the background partial-ready shard initialization path. Server listen now means the full configured memory capacity is usable.
- Apply parallel pre-touch before `cudaHostRegister` on the explicit hugepage path.
- Keep startup observability as a small set of info logs; no `startup_phase_seconds` metric and no default fastrace integration in this PR.

This PR addresses #274. It does not include #273 restart recovery.

## Mooncake-style microbench evidence

After checking Mooncake's large-memory registration pattern, I ran the pre-touch/register idea as an isolated local microbench before changing PegaFlow. Environment constraints: non-H200 machine, one process at a time. Before/after memory stayed in the same range and swap did not materially grow.

| experiment | command shape | timing | memory / swap | conclusion |
|---|---|---:|---|---|
| current Pega backing baseline | `cudaHostAllocWriteCombined(30GiB)` | alloc 15.68s, free 8.52s | available 65GiB -> 65GiB; swap 1.4GiB -> 1.4GiB | current full-capacity backing allocation baseline |
| mmap/register, no pre-touch | `mmap + cudaHostRegister(30GiB)` | register 18.24s, total 18.24s | available 65GiB -> 65GiB; swap 1.4GiB -> 1.4GiB | worse than current baseline |
| mmap/register, single-thread pre-touch | `mmap + single-thread page touch + cudaHostRegister(30GiB)` | touch 17.14s, register 3.49s, total 20.63s | available 65GiB -> 66GiB; swap 1.4GiB -> 1.4GiB | worse overall; pre-touch only moves time out of registration |
| mmap/register, parallel pre-touch | `mmap + parallel page touch + cudaHostRegister(30GiB)` | touch 2.80s, register 3.54s, total 6.34s | available 66GiB -> 66GiB; swap 1.4GiB -> 1.4GiB | clear full-capacity direction; implemented as the default large-pool backing |
| hugepage/register, no pre-touch | `MAP_HUGETLB + cudaHostRegister(256MiB)` | register 531.38ms, total 531.41ms | available 66GiB -> 66GiB; swap stable | baseline for available hugepage capacity |
| hugepage/register, single-thread pre-touch | `MAP_HUGETLB + single-thread touch + cudaHostRegister(256MiB)` | touch 28.20ms, register 549.17ms, total 577.39ms | available 66GiB -> 66GiB; swap stable | worse than direct hugepage registration |
| hugepage/register, parallel pre-touch | `MAP_HUGETLB + parallel touch + cudaHostRegister(256MiB)` | touch 21.64ms, register 378.12ms, total 399.78ms | available 66GiB -> 66GiB; swap stable | improves this hugepage sample; implemented for the explicit hugepage path |

Hugepage note: the manual reservation only produced 179 x 2MiB pages (~358MiB), so the hugepage experiment uses 256MiB rather than 4GiB/30GiB. This proves the direction on the available hugepage capacity, not 30GiB hugepage behavior.

## 30GiB cold-start evidence

Ran one 30GiB server at a time and killed the process after collecting evidence. Latest final run memory: before 78GiB total / 63GiB available / swap 1.5GiB used; after exit 78GiB total / 63GiB available / swap 1.6GiB used. Swap was already active on the machine before these experiments.

| mode | command shape | usable at listen | allocator/storage ready | server ready-to-listen | full 30GiB capacity |
|---|---|---:|---:|---:|---:|
| before optimization | `--pool-size 30gb`, 1 shard, `cudaHostAllocWriteCombined` | 30.0 GiB | 15.23s | 17.15s | 15.23s before listen |
| intermediate partial-ready experiment | `--pool-size 30gb`, first shard sync + background shards | 7.5 GiB | 4.16s | 6.00s | 10.97s after initial ready |
| final PR | `--pool-size 30gb`, 1 shard, registered mmap + parallel pre-touch | 30.0 GiB | 6.58s | 8.43s | 6.58s before listen |

The final PR no longer uses partial-ready/background expansion. It keeps the simple ready contract: once the server listens, full configured memory capacity is available. The cold-start win comes from making full-capacity backing allocation fast enough.

## Final log shape

Default 4GiB smoke after log cleanup:

```text
Pinned allocator global plan: capacity=4.0 GiB shards=1 hugepages=false ssd_enabled=false unit_hint=none
Pinned pool ready: total=4.0 GiB shards=1 per_shard=4.0 GiB backing_strategy=registered_mmap elapsed_ms=953.13
StorageEngine initialized: configured_capacity=4.0 GiB usable_capacity=4.0 GiB numa=false ssd=false rdma=false blockwise_alloc=false elapsed_ms=953.40
PegaEngine gRPC server listening on 127.0.0.1:0 (startup_elapsed_ms=2923.21)
```

Hugepage 256MiB smoke after log cleanup:

```text
Pinned allocator global plan: capacity=256.0 MiB shards=1 hugepages=true ssd_enabled=false unit_hint=none
Pinned pool ready: total=256.0 MiB shards=1 per_shard=256.0 MiB backing_strategy=hugepages elapsed_ms=105.63
Pinned allocator initialized: mode=global configured_capacity=256.0 MiB usable_capacity=256.0 MiB pool_shards=1 elapsed_ms=105.74
StorageEngine initialized: configured_capacity=256.0 MiB usable_capacity=256.0 MiB numa=false ssd=false rdma=false blockwise_alloc=false elapsed_ms=105.84
PegaEngine gRPC server listening on 127.0.0.1:0 (startup_elapsed_ms=2042.04)
```

## Path checks

| Path | Evidence | Result |
|---|---|---|
| H2D/D2H transfer | 4GiB `cudaMemcpy` microbench: write-combined H2D 21.75 GiB/s, D2H 22.45 GiB/s; registered mmap H2D 21.85 GiB/s, D2H 23.06 GiB/s | no regression in this transfer microbench |
| SSD | `--ssd-cache-path ... --ssd-cache-capacity 1gb` reaches listen with `ssd_enabled=true`, `backing_strategy=registered_mmap`; `cargo test -p pegaflow-core` includes SSD write and prefetch roundtrip contracts passing | SSD is no longer excluded from the default large-pool backing |
| RDMA | `--nics mlx5_0` on a no-HCA machine reaches allocator init with `backing_strategy=registered_mmap`, then RDMA init reports `rdma device not found: mlx5_0` | RDMA is not guarded out of the default backing; this machine only proves existing fail-fast behavior, not RDMA transfer performance |
| Huge pages | `HugePages_Total=179`, `HugePages_Free=179`, `Hugepagesize=2MiB`; 256MiB server smoke logs `backing_strategy=hugepages`, `usable_capacity=256.0 MiB`, then listens | hugepage path stays explicit and gets parallel pre-touch; only 256MiB verified because available hugepages were limited |
| Drop/unregister | 30GiB final smoke exits and available memory returns to the same 63GiB range; hugepage microbench returns all 179 pages to `HugePages_Free` after each run | release paths work in these smokes |

After the hugepage experiment, I attempted to release the manually reserved hugepages with `echo 0 > /proc/sys/vm/nr_hugepages`, but this user does not have permission. `HugePages_Total` remains 179 and `HugePages_Free` remains 179; root should release them when finished.

## Verification

- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Dev/target-pr275 cargo check -p pegaflow-core -p pegaflow-server`
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Dev/target-pr275 cargo clippy -p pegaflow-core -p pegaflow-server --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Dev/target-pr275 cargo test -p pegaflow-core`
- `PYTHONHOME=... PYTHONPATH=... LD_LIBRARY_PATH=... CARGO_TARGET_DIR=/data/slock_agents/KV-Dev/target-pr275 cargo test -p pegaflow-server`
- `PYTHONHOME=... PYTHONPATH=... LD_LIBRARY_PATH=... CARGO_TARGET_DIR=/data/slock_agents/KV-Dev/target-pr275 cargo build -p pegaflow-server --release`
- `PYTHONHOME=... PYTHONPATH=... LD_LIBRARY_PATH=... /data/slock_agents/KV-Dev/target-pr275/release/pegaflow-server --pool-size 30gb --devices 0 --addr 127.0.0.1:0 --http-addr 127.0.0.1:0 --disable-numa-affinity`
- `PYTHONHOME=... PYTHONPATH=... LD_LIBRARY_PATH=... /data/slock_agents/KV-Dev/target-pr275/release/pegaflow-server --pool-size 4gb --devices 0 --addr 127.0.0.1:0 --http-addr 127.0.0.1:0 --disable-numa-affinity`
- `PYTHONHOME=... PYTHONPATH=... LD_LIBRARY_PATH=... /data/slock_agents/KV-Dev/target-pr275/release/pegaflow-server --pool-size 1gb --devices 0 --addr 127.0.0.1:0 --http-addr 127.0.0.1:0 --disable-numa-affinity --ssd-cache-path /tmp/pr275-ssd-cache.bin --ssd-cache-capacity 1gb`
- `PYTHONHOME=... PYTHONPATH=... LD_LIBRARY_PATH=... /data/slock_agents/KV-Dev/target-pr275/release/pegaflow-server --pool-size 1gb --devices 0 --addr 127.0.0.1:0 --http-addr 127.0.0.1:0 --disable-numa-affinity --nics mlx5_0`
- `/data/slock_agents/KV-Dev/microbench/bench_pinned_alloc hugepage-register none 256mib`
- `/data/slock_agents/KV-Dev/microbench/bench_pinned_alloc hugepage-register single 256mib`
- `/data/slock_agents/KV-Dev/microbench/bench_pinned_alloc hugepage-register parallel 256mib`
- `PYTHONHOME=... PYTHONPATH=... LD_LIBRARY_PATH=... /data/slock_agents/KV-Dev/target-pr275/release/pegaflow-server --pool-size 256mb --devices 0 --addr 127.0.0.1:0 --http-addr 127.0.0.1:0 --disable-numa-affinity --use-hugepages`
- `PYTHONHOME=... PYTHONPATH=... LD_LIBRARY_PATH=... CARGO_TARGET_DIR=/data/slock_agents/KV-Dev/target-pr275 prek run --files pegaflow-core/src/metrics.rs pegaflow-core/src/lib.rs pegaflow-core/src/pinned_mem.rs pegaflow-core/src/pinned_pool.rs pegaflow-core/src/storage/mod.rs pegaflow-core/src/backing/rdma_fetch.rs pegaflow-server/src/lib.rs`
