### PR TITLE
perf(pinned-mem): NUMA-aware parallel pre-touch for pinned alloc

### DIFF
--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -60,3 +60,6 @@ harness = false
 
 [[example]]
 name = "pinned_alloc"
+
+[[example]]
+name = "pinned_alloc_parallel"

--- a/pegaflow-core/examples/pinned_alloc_parallel.rs
+++ b/pegaflow-core/examples/pinned_alloc_parallel.rs
@@ -1,0 +1,468 @@
+//! Cold-start cost of pinned memory allocation under different strategies.
+//! Motivates the `mmap + parallel_pre_touch + cudaHostRegister` path now used
+//! by `PinnedMemory::allocate_regular`/`allocate_hugepages`.
+//!
+//! Non-hugepage (size = BENCH_SIZE_GB):
+//!   A. cudaHostAlloc(flags=0)                       — old Regular path
+//!   B. mmap(MAP_POPULATE) + cudaHostRegister        — single-thread populate
+//!   C. mmap + parallel_pre_touch(N) + register      — current Regular path
+//!
+//! Hugepage (size = BENCH_HUGE_MB, requires reserved hugepages):
+//!   D. mmap(MAP_HUGETLB) + cudaHostRegister         — old HugePages path
+//!   E. mmap(MAP_HUGETLB) + parallel_touch(N) + register — current HugePages path
+//!
+//! ## Measured results
+//!
+//! ### 48-core single-socket (RTX 5070ti, EPYC 7402), 20 GB, median of 3
+//!
+//! | strategy     | total    | notes                         |
+//! |--------------|---------:|-------------------------------|
+//! | A            | 17.4 s   | old baseline                  |
+//! | B            | 13.5 s   |                               |
+//! | C[1]         | 14.0 s   | == B                          |
+//! | C[2]         |  8.9 s   |                               |
+//! | C[4]         |  5.8 s   |                               |
+//! | C[8]         |  4.4 s   |                               |
+//! | C[16]        |  3.9 s   | sweet spot                    |
+//! | C[32]        |  3.85 s  | plateaus                      |
+//!
+//! ### 240-core dual-socket (h20, 2× 120 hw-threads, 2 NUMA nodes), 500 GB, single rep
+//!
+//! Non-hugepage:
+//!
+//! | strategy     | total    | touch    | register | notes        |
+//! |--------------|---------:|---------:|---------:|--------------|
+//! | A            | 397.7 s  |          |          | old baseline |
+//! | B            | 121.2 s  |          |  20.1 s  |              |
+//! | C[1]         | 125.3 s  | 105.2 s  |  20.1 s  |              |
+//! | C[16]        |  27.3 s  |   7.9 s  |  19.4 s  |              |
+//! | C[64]        |  26.1 s  |   8.3 s  |  17.8 s  |              |
+//! | C[128]       |  21.3 s  |   4.3 s  |  17.0 s  | best         |
+//! | C[240]       |  24.4 s  |   6.0 s  |  18.4 s  | oversubscribed|
+//!
+//! Hugepage (the more dramatic win — cudaHostRegister hands its serial
+//! page-fault work to parallel pre-touch instead of doing it inline):
+//!
+//! | strategy     | total    | touch    | register | notes        |
+//! |--------------|---------:|---------:|---------:|--------------|
+//! | D            |  88.5 s  |          |  88.5 s  | old baseline |
+//! | E[1]         |  89.8 s  |  78.3 s  |  11.6 s  |              |
+//! | E[16]        |  17.7 s  |   6.4 s  |  11.4 s  |              |
+//! | E[64]        |  14.8 s  |   3.4 s  |  11.4 s  | best         |
+//! | E[128]       |  16.2 s  |   4.7 s  |  11.5 s  |              |
+//! | E[240]       |  18.0 s  |   6.6 s  |  11.4 s  | oversubscribed|
+//!
+//! ## NUMA-aware touch (verified separately on h20, 200 GB, 64 threads)
+//!
+//! Pre-touch threads must run on the target NUMA node so first-touch places
+//! every page locally. With explicit `pin_thread_to_numa_node`: 1000/1000
+//! sampled pages on the target node, no timing penalty vs unpinned. The
+//! production path now plumbs `NumaNode` through `allocate_regular` /
+//! `allocate_hugepages` so each pre-touch worker pins itself before faulting.
+//!
+//! ## Takeaways
+//!
+//! - cudaHostAlloc serializes page allocation + zero + pin → slowest.
+//! - `cudaHostRegister` on HUGETLB has ~12 s of "real" IOMMU pinning;
+//!   the rest of its cost on a cold mmap is serial fault-in we can offload.
+//! - Sweet spot scales with NUMA-local CPU count, not total HW threads.
+//!   Production uses `available_parallelism()` (affinity-aware) so a pinned
+//!   thread sees only its node's CPUs.
+//!
+//! ## Running
+//!
+//! ```bash
+//! cargo run --release --example pinned_alloc_parallel
+//! BENCH_SIZE_GB=500 BENCH_HUGE_MB=512000 BENCH_REPS=1 \
+//!   BENCH_THREADS=1,16,64,128,240 cargo run --release --example pinned_alloc_parallel
+//! ```
+//!
+//! Env:
+//!   BENCH_SIZE_GB  non-hugepage size, default 20
+//!   BENCH_HUGE_MB  hugepage size, default 256 (0 to skip)
+//!   BENCH_REPS     default 3
+//!   BENCH_THREADS  default "1,2,4,8,16,32"
+
+use std::ptr;
+use std::time::{Duration, Instant};
+
+use cudarc::driver::CudaContext;
+use cudarc::runtime::sys as rt;
+
+const GB: usize = 1024 * 1024 * 1024;
+
+fn main() {
+    let ctx = CudaContext::new(0).expect("CUDA context");
+    ctx.bind_to_thread().expect("bind CUDA context");
+
+    let size_gb: usize = env_parse("BENCH_SIZE_GB", 20);
+    let reps: usize = env_parse("BENCH_REPS", 3);
+    let thread_sweep: Vec<usize> = std::env::var("BENCH_THREADS")
+        .ok()
+        .map(|s| {
+            s.split(',')
+                .filter_map(|t| t.trim().parse().ok())
+                .collect::<Vec<usize>>()
+        })
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| vec![1, 2, 4, 8, 16, 32]);
+
+    let size = size_gb * GB;
+    println!(
+        "size = {} GB    reps = {}    page = {} B",
+        size_gb,
+        reps,
+        page_size()
+    );
+    println!();
+
+    println!("=== A: cudaHostAlloc(flags=0) ===");
+    let mut a_totals = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        let t = bench_cuda_host_alloc(size);
+        a_totals.push(t.total);
+        println!("  total: {:>9.2} ms", ms(t.total));
+    }
+    println!("  median total: {:>9.2} ms", ms(median(&mut a_totals)));
+    println!();
+
+    println!("=== B: mmap(MAP_POPULATE) + cudaHostRegister ===");
+    let mut b_totals = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        let t = bench_mmap_populate(size);
+        b_totals.push(t.total);
+        println!(
+            "  mmap: {:>9.2} ms   register: {:>9.2} ms   total: {:>9.2} ms",
+            ms(t.mmap),
+            ms(t.register),
+            ms(t.total)
+        );
+    }
+    println!("  median total: {:>9.2} ms", ms(median(&mut b_totals)));
+    println!();
+
+    for &n in &thread_sweep {
+        println!(
+            "=== C[{}]: mmap + parallel_touch(threads={}) + register ===",
+            n, n
+        );
+        let mut totals = Vec::with_capacity(reps);
+        for _ in 0..reps {
+            let t = bench_parallel_touch(size, n);
+            totals.push(t.total);
+            println!(
+                "  mmap: {:>7.2} ms   touch: {:>9.2} ms   register: {:>9.2} ms   total: {:>9.2} ms",
+                ms(t.mmap),
+                ms(t.touch),
+                ms(t.register),
+                ms(t.total),
+            );
+        }
+        println!("  median total: {:>9.2} ms", ms(median(&mut totals)));
+        println!();
+    }
+
+    let huge_mb: usize = env_parse("BENCH_HUGE_MB", 256);
+    if huge_mb == 0 {
+        return;
+    }
+    let huge_page = hugepage_size().unwrap_or(2 * 1024 * 1024);
+    let huge_size = ((huge_mb * 1024 * 1024) + huge_page - 1) & !(huge_page - 1);
+    println!(
+        "--- Hugepage bench: size = {} MB    hugepage = {} KB ---",
+        huge_size / (1024 * 1024),
+        huge_page / 1024,
+    );
+    println!();
+
+    println!("=== D: mmap(MAP_HUGETLB) + cudaHostRegister ===");
+    let mut d_totals = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        match bench_huge(huge_size, 0) {
+            Some(t) => {
+                d_totals.push(t.total);
+                println!(
+                    "  mmap: {:>6.2} ms   register: {:>9.2} ms   total: {:>9.2} ms",
+                    ms(t.mmap),
+                    ms(t.register),
+                    ms(t.total)
+                );
+            }
+            None => {
+                println!("  mmap(MAP_HUGETLB) FAILED — not enough reserved hugepages");
+                return;
+            }
+        }
+    }
+    println!("  median total: {:>9.2} ms", ms(median(&mut d_totals)));
+    println!();
+
+    for &n in &thread_sweep {
+        println!(
+            "=== E[{}]: mmap(MAP_HUGETLB) + parallel_touch(threads={}) + register ===",
+            n, n
+        );
+        let mut totals = Vec::with_capacity(reps);
+        for _ in 0..reps {
+            let Some(t) = bench_huge(huge_size, n) else {
+                println!("  mmap(MAP_HUGETLB) FAILED");
+                return;
+            };
+            totals.push(t.total);
+            println!(
+                "  mmap: {:>6.2} ms   touch: {:>7.2} ms   register: {:>9.2} ms   total: {:>9.2} ms",
+                ms(t.mmap),
+                ms(t.touch),
+                ms(t.register),
+                ms(t.total),
+            );
+        }
+        println!("  median total: {:>9.2} ms", ms(median(&mut totals)));
+        println!();
+    }
+}
+
+#[derive(Default)]
+struct Timing {
+    mmap: Duration,
+    touch: Duration,
+    register: Duration,
+    total: Duration,
+}
+
+fn bench_cuda_host_alloc(size: usize) -> Timing {
+    let mut ptr: *mut libc::c_void = ptr::null_mut();
+    let start = Instant::now();
+    // SAFETY: &mut ptr is a valid out-param; size validated > 0 by caller config.
+    let r = unsafe { rt::cudaHostAlloc(&mut ptr, size, 0) };
+    let total = start.elapsed();
+    assert_eq!(
+        r,
+        rt::cudaError::cudaSuccess,
+        "cudaHostAlloc failed: {:?}",
+        r
+    );
+    // SAFETY: ptr returned successfully by cudaHostAlloc above.
+    unsafe { rt::cudaFreeHost(ptr) };
+    Timing {
+        total,
+        ..Default::default()
+    }
+}
+
+fn bench_mmap_populate(size: usize) -> Timing {
+    let t0 = Instant::now();
+    // SAFETY: null hint + anon mapping with valid prot/flags; result checked vs MAP_FAILED.
+    let p = unsafe {
+        libc::mmap(
+            ptr::null_mut(),
+            size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_POPULATE,
+            -1,
+            0,
+        )
+    };
+    let mmap = t0.elapsed();
+    assert!(
+        p != libc::MAP_FAILED,
+        "mmap failed: {}",
+        std::io::Error::last_os_error()
+    );
+
+    let t1 = Instant::now();
+    // SAFETY: p points to a valid mapping of `size` bytes from mmap above.
+    let r = unsafe { rt::cudaHostRegister(p, size, rt::cudaHostRegisterDefault) };
+    let register = t1.elapsed();
+    assert_eq!(
+        r,
+        rt::cudaError::cudaSuccess,
+        "cudaHostRegister failed: {:?}",
+        r
+    );
+
+    // SAFETY: matched unregister/munmap for the pointer registered/mapped above.
+    unsafe { rt::cudaHostUnregister(p) };
+    // SAFETY: same.
+    unsafe { libc::munmap(p, size) };
+
+    Timing {
+        mmap,
+        register,
+        total: mmap + register,
+        touch: Duration::ZERO,
+    }
+}
+
+fn bench_parallel_touch(size: usize, threads: usize) -> Timing {
+    let t0 = Instant::now();
+    // SAFETY: null hint + anon mapping with valid prot/flags; result checked vs MAP_FAILED.
+    let p = unsafe {
+        libc::mmap(
+            ptr::null_mut(),
+            size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            0,
+        )
+    };
+    let mmap = t0.elapsed();
+    assert!(
+        p != libc::MAP_FAILED,
+        "mmap failed: {}",
+        std::io::Error::last_os_error()
+    );
+
+    let t1 = Instant::now();
+    parallel_pre_touch(p.cast::<u8>(), size, threads);
+    let touch = t1.elapsed();
+
+    let t2 = Instant::now();
+    // SAFETY: p points to a valid mapping of `size` bytes from mmap above.
+    let r = unsafe { rt::cudaHostRegister(p, size, rt::cudaHostRegisterDefault) };
+    let register = t2.elapsed();
+    assert_eq!(
+        r,
+        rt::cudaError::cudaSuccess,
+        "cudaHostRegister failed: {:?}",
+        r
+    );
+
+    // SAFETY: matched unregister/munmap for the pointer registered/mapped above.
+    unsafe { rt::cudaHostUnregister(p) };
+    // SAFETY: same.
+    unsafe { libc::munmap(p, size) };
+
+    Timing {
+        mmap,
+        touch,
+        register,
+        total: mmap + touch + register,
+    }
+}
+
+/// Fault in every page of [ptr, ptr+size) across N threads.
+/// Each thread owns a disjoint chunk; one byte per page + a tail byte per chunk
+/// forces the kernel to materialize all pages, including the last partial one.
+fn parallel_pre_touch(ptr: *mut u8, size: usize, threads: usize) {
+    let page = page_size();
+    let threads = threads.max(1);
+    let chunk = size.div_ceil(threads);
+    // *mut u8 is not Send; smuggle as usize and reconstruct inside the scope.
+    // Lifetimes are bounded by thread::scope.
+    let base = ptr as usize;
+
+    std::thread::scope(|s| {
+        for i in 0..threads {
+            let off = i * chunk;
+            if off >= size {
+                break;
+            }
+            let len = chunk.min(size - off);
+            s.spawn(move || touch_chunk(base + off, len, page));
+        }
+    });
+}
+
+fn touch_chunk(base: usize, len: usize, page: usize) {
+    let p = base as *mut u8;
+    let mut off = 0usize;
+    while off < len {
+        // SAFETY: caller guarantees [base, base+len) lies inside a valid mmap.
+        // Volatile keeps the compiler from elimating the write.
+        unsafe { p.add(off).write_volatile(0u8) };
+        off += page;
+    }
+    // Ensure the tail page (which `off += page` may overshoot past) is faulted.
+    // SAFETY: len > 0 is enforced by parallel_pre_touch's chunk bookkeeping.
+    unsafe { p.add(len - 1).write_volatile(0u8) };
+}
+
+/// Hugepage variant. If `touch_threads` > 0, pre-touches before register;
+/// otherwise relies on `cudaHostRegister` to materialize pages. Returns None
+/// if MAP_HUGETLB allocation fails (insufficient reserved hugepages).
+fn bench_huge(size: usize, touch_threads: usize) -> Option<Timing> {
+    let t0 = Instant::now();
+    // SAFETY: null hint + anon HUGETLB mapping; result checked vs MAP_FAILED.
+    let p = unsafe {
+        libc::mmap(
+            ptr::null_mut(),
+            size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_HUGETLB,
+            -1,
+            0,
+        )
+    };
+    let mmap = t0.elapsed();
+    if p == libc::MAP_FAILED {
+        return None;
+    }
+
+    let touch = if touch_threads > 0 {
+        let t1 = Instant::now();
+        parallel_pre_touch(p.cast::<u8>(), size, touch_threads);
+        t1.elapsed()
+    } else {
+        Duration::ZERO
+    };
+
+    let t2 = Instant::now();
+    // SAFETY: p points to a valid hugepage mapping of `size` bytes.
+    let r = unsafe { rt::cudaHostRegister(p, size, rt::cudaHostRegisterDefault) };
+    let register = t2.elapsed();
+    assert_eq!(
+        r,
+        rt::cudaError::cudaSuccess,
+        "cudaHostRegister failed: {:?}",
+        r
+    );
+
+    // SAFETY: matched unregister/munmap for the pointer registered/mapped above.
+    unsafe { rt::cudaHostUnregister(p) };
+    // SAFETY: same.
+    unsafe { libc::munmap(p, size) };
+
+    Some(Timing {
+        mmap,
+        touch,
+        register,
+        total: mmap + touch + register,
+    })
+}
+
+fn hugepage_size() -> Option<usize> {
+    let content = std::fs::read_to_string("/proc/meminfo").ok()?;
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("Hugepagesize:") {
+            let parts: Vec<&str> = rest.split_whitespace().collect();
+            if parts.len() == 2 && parts[1] == "kB" {
+                return parts[0].parse::<usize>().ok().map(|kb| kb * 1024);
+            }
+        }
+    }
+    None
+}
+
+fn page_size() -> usize {
+    // SAFETY: sysconf with a valid name; non-positive result is fallback-handled.
+    let v = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if v > 0 { v as usize } else { 4096 }
+}
+
+fn env_parse(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+fn median(v: &mut [Duration]) -> Duration {
+    v.sort();
+    v[v.len() / 2]
+}

--- a/pegaflow-core/src/pinned_mem.rs
+++ b/pegaflow-core/src/pinned_mem.rs
@@ -298,7 +298,7 @@ impl Drop for PinnedMemory {
 /// affinity (typically set by `run_on_numa` at the call site).
 fn parallel_pre_touch(ptr: *mut u8, size: usize, node: NumaNode) {
     let page = page_size();
-    let threads = touch_threads();
+    let threads = touch_threads(size);
     let chunk = size.div_ceil(threads);
     // *mut u8 is not Send; smuggle as usize and reconstruct inside the scope.
     // Lifetimes are bounded by thread::scope.
@@ -331,10 +331,19 @@ fn parallel_pre_touch(ptr: *mut u8, size: usize, node: NumaNode) {
     });
 }
 
-fn touch_threads() -> usize {
-    std::thread::available_parallelism()
+/// Pick worker count for pre-touch.
+///
+/// Spinning up many threads for a small allocation costs more than it saves —
+/// each thread must at least pay a NUMA pin + page-walk. Grant each worker a
+/// minimum chunk so tiny allocations stay single-threaded and large ones still
+/// scale up to the CPU count.
+fn touch_threads(size: usize) -> usize {
+    const MIN_BYTES_PER_THREAD: usize = 1 << 30; // 1 GiB
+    let by_size = size.div_ceil(MIN_BYTES_PER_THREAD).max(1);
+    let by_cpu = std::thread::available_parallelism()
         .map_or(8, |n| n.get())
-        .max(1)
+        .max(1);
+    by_size.min(by_cpu)
 }
 
 fn page_size() -> usize {

--- a/pegaflow-core/src/pinned_mem.rs
+++ b/pegaflow-core/src/pinned_mem.rs
@@ -1,16 +1,25 @@
 //! Low-level pinned memory allocation for CUDA.
 //!
-//! This module provides two allocation strategies:
+//! Three strategies, all returning DMA-pinned memory:
 //!
-//! 1. **Write-combined** (`PinnedMemory::allocate_write_combined`): Uses `cudaHostAlloc` with write-combined flag.
-//!    Optimized for CPU-to-GPU transfers with better write performance.
+//! 1. **Regular** (`allocate_regular`): lazy `mmap` + parallel page pre-touch +
+//!    `cudaHostRegister`. Each touch thread is pinned to the target NUMA node
+//!    so first-touch places every page on that node's local memory.
 //!
-//! 2. **Huge pages** (`PinnedMemory::allocate_hugepages`): Uses `mmap(MAP_HUGETLB)` + `cudaHostRegister`.
-//!    Much faster allocation for large buffers but requires pre-configured huge pages:
+//! 2. **HugePages** (`allocate_hugepages`): `mmap(MAP_HUGETLB)` + parallel
+//!    pre-touch + `cudaHostRegister`. Same NUMA-aware touch. Requires reserved
+//!    hugepages:
 //!    ```bash
-//!    # Reserve huge pages (size from /proc/meminfo, typically 2MB)
-//!    sudo sh -c 'echo 15360 > /proc/sys/vm/nr_hugepages'
+//!    sudo sh -c 'echo 15360 > /proc/sys/vm/nr_hugepages'  # 30GB at 2MB pages
 //!    ```
+//!
+//! 3. **WriteCombined** (`allocate_write_combined`): `cudaHostAlloc` with WC
+//!    flag. CPU reads are extremely slow — don't use when SSD offload is on.
+//!    NUMA placement follows the calling thread's affinity (caller is expected
+//!    to wrap with `run_on_numa`).
+//!
+//! See `examples/pinned_alloc_parallel.rs` for the benchmarks motivating the
+//! parallel pre-touch path.
 //!
 //! # Safety
 //!
@@ -24,6 +33,7 @@ use std::ptr::NonNull;
 use std::sync::OnceLock;
 
 use cudarc::runtime::sys as rt;
+use pegaflow_common::{NumaNode, pin_thread_to_numa_node};
 
 /// Cached huge page size from /proc/meminfo
 static HUGE_PAGE_SIZE: OnceLock<Option<usize>> = OnceLock::new();
@@ -86,13 +96,14 @@ impl std::error::Error for PinnedMemError {}
 /// Allocation strategy for pinned memory.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AllocStrategy {
-    /// Regular pinned memory via cudaHostAlloc (flags=0).
+    /// `mmap` + parallel pre-touch + `cudaHostRegister`.
     /// Safe for both CPU reads and writes; use when SSD offload is enabled.
     Regular,
-    /// Write-combined via cudaHostAlloc.
+    /// `cudaHostAlloc` with write-combined flag.
     /// Fast for CPU→GPU (write-only) workloads, but CPU reads are extremely slow.
     WriteCombined,
-    /// Huge pages (size from /proc/meminfo, requires system configuration)
+    /// `mmap(MAP_HUGETLB)` + parallel pre-touch + `cudaHostRegister`.
+    /// Requires reserved hugepages.
     HugePages,
 }
 
@@ -125,106 +136,108 @@ unsafe impl Send for PinnedMemory {}
 unsafe impl Sync for PinnedMemory {}
 
 impl PinnedMemory {
-    /// Allocate regular pinned memory (flags=0).
+    /// Allocate regular pinned memory via `mmap` + parallel pre-touch + register.
     ///
-    /// Safe for both CPU reads and writes. Use when SSD offload is enabled,
-    /// since write-combined memory has extremely slow CPU reads.
-    pub(crate) fn allocate_regular(size: usize) -> Result<Self, PinnedMemError> {
-        Self::allocate_internal(size, AllocStrategy::Regular)
+    /// All pages are first-touched by threads pinned to `node`, so the entire
+    /// region lands NUMA-local to that node. Pass `NumaNode::UNKNOWN` to skip
+    /// pinning and rely on the calling thread's existing affinity.
+    pub(crate) fn allocate_regular(size: usize, node: NumaNode) -> Result<Self, PinnedMemError> {
+        Self::allocate_mmap_register(size, AllocStrategy::Regular, node)
     }
 
-    /// Allocate pinned memory using write-combined mode.
+    /// Allocate write-combined pinned memory via `cudaHostAlloc`.
     ///
-    /// Uses `cudaHostAlloc` with `cudaHostAllocWriteCombined` flag.
     /// Fast for CPU→GPU transfers but CPU reads are extremely slow.
-    /// Do NOT use when SSD offload is enabled.
+    /// Do NOT use when SSD offload is enabled. NUMA placement follows the
+    /// calling thread's affinity at allocation time.
     pub(crate) fn allocate_write_combined(size: usize) -> Result<Self, PinnedMemError> {
-        Self::allocate_internal(size, AllocStrategy::WriteCombined)
+        if size == 0 {
+            return Err(PinnedMemError::ZeroSize);
+        }
+        let mut ptr: *mut libc::c_void = std::ptr::null_mut();
+        // SAFETY: ptr is a valid stack pointer; size is validated non-zero above.
+        let result = unsafe { rt::cudaHostAlloc(&mut ptr, size, rt::cudaHostAllocWriteCombined) };
+        if result != rt::cudaError::cudaSuccess {
+            return Err(PinnedMemError::CudaAllocFailed(result));
+        }
+        let ptr = NonNull::new(ptr as *mut u8).expect("cudaHostAlloc returned null");
+        Ok(Self {
+            ptr,
+            size,
+            strategy: AllocStrategy::WriteCombined,
+        })
     }
 
-    /// Allocate pinned memory using huge pages.
+    /// Allocate hugepage-backed pinned memory.
     ///
-    /// Uses `mmap(MAP_HUGETLB)` for fast allocation, then registers with CUDA.
-    /// Much faster than regular pages but requires system configuration:
+    /// Uses `mmap(MAP_HUGETLB)` + parallel pre-touch + `cudaHostRegister`.
+    /// Touch threads are pinned to `node` for NUMA-local first-touch.
     ///
+    /// Requires reserved hugepages:
     /// ```bash
-    /// # Reserve huge pages (size depends on system, typically 2MB)
-    /// sudo sh -c 'echo 15360 > /proc/sys/vm/nr_hugepages'  # for 30GB with 2MB pages
+    /// sudo sh -c 'echo 15360 > /proc/sys/vm/nr_hugepages'  # 30GB at 2MB pages
     /// ```
     ///
     /// # Errors
     ///
     /// Returns `MmapFailed` if huge pages are not configured or insufficient.
-    pub(crate) fn allocate_hugepages(size: usize) -> Result<Self, PinnedMemError> {
-        Self::allocate_internal(size, AllocStrategy::HugePages)
+    pub(crate) fn allocate_hugepages(size: usize, node: NumaNode) -> Result<Self, PinnedMemError> {
+        Self::allocate_mmap_register(size, AllocStrategy::HugePages, node)
     }
 
-    fn allocate_internal(size: usize, strategy: AllocStrategy) -> Result<Self, PinnedMemError> {
+    fn allocate_mmap_register(
+        size: usize,
+        strategy: AllocStrategy,
+        node: NumaNode,
+    ) -> Result<Self, PinnedMemError> {
         if size == 0 {
             return Err(PinnedMemError::ZeroSize);
         }
 
-        let (ptr, aligned_size) = match strategy {
-            AllocStrategy::Regular => {
-                let mut ptr: *mut libc::c_void = std::ptr::null_mut();
-                // SAFETY: ptr is a valid stack pointer; size is validated non-zero above.
-                let result = unsafe { rt::cudaHostAlloc(&mut ptr, size, 0) };
-                if result != rt::cudaError::cudaSuccess {
-                    return Err(PinnedMemError::CudaAllocFailed(result));
-                }
-                (ptr, size)
-            }
-            AllocStrategy::WriteCombined => {
-                let mut ptr: *mut libc::c_void = std::ptr::null_mut();
-                // SAFETY: ptr is a valid stack pointer; size is validated non-zero above.
-                let result =
-                    unsafe { rt::cudaHostAlloc(&mut ptr, size, rt::cudaHostAllocWriteCombined) };
-                if result != rt::cudaError::cudaSuccess {
-                    return Err(PinnedMemError::CudaAllocFailed(result));
-                }
-                (ptr, size)
-            }
+        let (flags, aligned_size) = match strategy {
             AllocStrategy::HugePages => {
                 let huge_page_size =
                     get_huge_page_size().ok_or(PinnedMemError::HugePageSizeUnavailable)?;
                 let aligned = (size + huge_page_size - 1) & !(huge_page_size - 1);
-                let flags = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_HUGETLB;
-
-                // SAFETY: All parameters are valid: null hint, aligned non-zero size,
-                // valid protection flags, MAP_ANONYMOUS with fd=-1. Return is checked
-                // against MAP_FAILED before use.
-                let ptr = unsafe {
-                    libc::mmap(
-                        std::ptr::null_mut(),
-                        aligned,
-                        libc::PROT_READ | libc::PROT_WRITE,
-                        flags,
-                        -1,
-                        0,
-                    )
-                };
-
-                if ptr == libc::MAP_FAILED {
-                    return Err(PinnedMemError::MmapFailed(std::io::Error::last_os_error()));
-                }
-
-                // Register with CUDA for DMA
-                // SAFETY: ptr is a valid mmap'd region of `aligned` bytes (checked above).
-                let result =
-                    unsafe { rt::cudaHostRegister(ptr, aligned, rt::cudaHostRegisterDefault) };
-
-                if result != rt::cudaError::cudaSuccess {
-                    unsafe { libc::munmap(ptr, aligned) };
-                    return Err(PinnedMemError::CudaRegisterFailed(result));
-                }
-
-                (ptr, aligned)
+                (
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_HUGETLB,
+                    aligned,
+                )
+            }
+            AllocStrategy::Regular => (libc::MAP_PRIVATE | libc::MAP_ANONYMOUS, size),
+            AllocStrategy::WriteCombined => {
+                unreachable!("WriteCombined does not use the mmap path")
             }
         };
 
-        // SAFETY: allocation succeeded and returned non-null pointer
-        let ptr = NonNull::new(ptr as *mut u8).expect("allocation returned null");
+        // SAFETY: null hint + anonymous mapping with valid prot/flags; the
+        // result is checked against MAP_FAILED before any use.
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                aligned_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                flags,
+                -1,
+                0,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            return Err(PinnedMemError::MmapFailed(io::Error::last_os_error()));
+        }
 
+        parallel_pre_touch(ptr.cast::<u8>(), aligned_size, node);
+
+        // SAFETY: ptr is a valid mapping of aligned_size bytes (checked above).
+        let result =
+            unsafe { rt::cudaHostRegister(ptr, aligned_size, rt::cudaHostRegisterDefault) };
+        if result != rt::cudaError::cudaSuccess {
+            // SAFETY: ptr was successfully mmap'd above.
+            unsafe { libc::munmap(ptr, aligned_size) };
+            return Err(PinnedMemError::CudaRegisterFailed(result));
+        }
+
+        let ptr = NonNull::new(ptr as *mut u8).expect("mmap returned null");
         Ok(Self {
             ptr,
             size: aligned_size,
@@ -250,32 +263,84 @@ impl PinnedMemory {
 impl Drop for PinnedMemory {
     fn drop(&mut self) {
         match self.strategy {
-            AllocStrategy::Regular | AllocStrategy::WriteCombined => {
-                // SAFETY: ptr was allocated with cudaHostAlloc
+            AllocStrategy::WriteCombined => {
+                // SAFETY: ptr was allocated with cudaHostAlloc.
                 let result = unsafe { rt::cudaFreeHost(self.ptr.as_ptr() as *mut libc::c_void) };
                 if result != rt::cudaError::cudaSuccess {
                     eprintln!("Warning: cudaFreeHost failed: {:?}", result);
                 }
             }
-            AllocStrategy::HugePages => {
-                // SAFETY: ptr was registered with cudaHostRegister
-                unsafe {
-                    let result = rt::cudaHostUnregister(self.ptr.as_ptr() as *mut libc::c_void);
-                    if result != rt::cudaError::cudaSuccess {
-                        eprintln!("Warning: cudaHostUnregister failed: {:?}", result);
-                    }
+            AllocStrategy::Regular | AllocStrategy::HugePages => {
+                // SAFETY: ptr was registered with cudaHostRegister.
+                let unreg =
+                    unsafe { rt::cudaHostUnregister(self.ptr.as_ptr() as *mut libc::c_void) };
+                if unreg != rt::cudaError::cudaSuccess {
+                    eprintln!("Warning: cudaHostUnregister failed: {:?}", unreg);
                 }
-
-                // SAFETY: ptr was allocated by mmap with the same size
-                unsafe {
-                    if libc::munmap(self.ptr.as_ptr() as *mut libc::c_void, self.size) == -1 {
-                        let err = std::io::Error::last_os_error();
-                        eprintln!("Warning: munmap failed: {}", err);
-                    }
+                // SAFETY: ptr was allocated by mmap with the same size.
+                let unmap =
+                    unsafe { libc::munmap(self.ptr.as_ptr() as *mut libc::c_void, self.size) };
+                if unmap == -1 {
+                    let err = io::Error::last_os_error();
+                    eprintln!("Warning: munmap failed: {}", err);
                 }
             }
         }
     }
+}
+
+/// Fault in every page of `[ptr, ptr+size)` across worker threads pinned to
+/// `node`. Each thread owns a disjoint chunk and writes one byte per page
+/// (plus a tail byte) to force materialization. First-touch on a pinned
+/// thread places each page on `node`'s local memory.
+///
+/// If `node.is_unknown()`, threads run with the calling thread's existing
+/// affinity (typically set by `run_on_numa` at the call site).
+fn parallel_pre_touch(ptr: *mut u8, size: usize, node: NumaNode) {
+    let page = page_size();
+    let threads = touch_threads();
+    let chunk = size.div_ceil(threads);
+    // *mut u8 is not Send; smuggle as usize and reconstruct inside the scope.
+    // Lifetimes are bounded by thread::scope.
+    let base = ptr as usize;
+
+    std::thread::scope(|s| {
+        for i in 0..threads {
+            let off = i * chunk;
+            if off >= size {
+                break;
+            }
+            let len = chunk.min(size - off);
+            s.spawn(move || {
+                if node.is_valid()
+                    && let Err(e) = pin_thread_to_numa_node(node)
+                {
+                    log::warn!("pre-touch NUMA pin to {} failed: {}", node, e);
+                }
+                let p = (base + off) as *mut u8;
+                let mut off = 0usize;
+                while off < len {
+                    // SAFETY: chunk is a disjoint sub-range of the caller's mapping.
+                    unsafe { p.add(off).write_volatile(0u8) };
+                    off += page;
+                }
+                // SAFETY: len > 0 is enforced by the chunk bookkeeping above.
+                unsafe { p.add(len - 1).write_volatile(0u8) };
+            });
+        }
+    });
+}
+
+fn touch_threads() -> usize {
+    std::thread::available_parallelism()
+        .map_or(8, |n| n.get())
+        .max(1)
+}
+
+fn page_size() -> usize {
+    // SAFETY: sysconf with a valid name; non-positive result is fallback-handled.
+    let v = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if v > 0 { v as usize } else { 4096 }
 }
 
 #[cfg(test)]
@@ -294,9 +359,25 @@ mod tests {
     }
 
     #[test]
+    fn test_allocate_regular() {
+        if cudarc::driver::CudaContext::new(0).is_err() {
+            return;
+        }
+
+        let mem = PinnedMemory::allocate_regular(4096, NumaNode::UNKNOWN).unwrap();
+        assert!(mem.size() >= 4096);
+    }
+
+    #[test]
     fn test_zero_size_fails() {
-        let result = PinnedMemory::allocate_write_combined(0);
-        assert!(matches!(result, Err(PinnedMemError::ZeroSize)));
+        assert!(matches!(
+            PinnedMemory::allocate_write_combined(0),
+            Err(PinnedMemError::ZeroSize)
+        ));
+        assert!(matches!(
+            PinnedMemory::allocate_regular(0, NumaNode::UNKNOWN),
+            Err(PinnedMemError::ZeroSize)
+        ));
     }
 
     #[test]

--- a/pegaflow-core/src/pinned_pool.rs
+++ b/pegaflow-core/src/pinned_pool.rs
@@ -81,6 +81,10 @@ impl PinnedMemoryPool {
 
     /// Allocate a new pinned memory pool of `pool_size` bytes.
     ///
+    /// `node` is the target NUMA node for first-touch placement of the backing
+    /// region (used by Regular and HugePages strategies). Pass
+    /// `NumaNode::UNKNOWN` for placement-agnostic allocation.
+    ///
     /// If `use_hugepages` is true, uses huge pages (requires system config).
     /// If `ssd_enabled` is true, uses regular pinned memory instead of write-combined,
     /// because SSD reads back data into CPU memory and write-combined has extremely slow CPU reads.
@@ -90,6 +94,7 @@ impl PinnedMemoryPool {
         use_hugepages: bool,
         ssd_enabled: bool,
         unit_size_hint: Option<NonZeroU64>,
+        node: NumaNode,
     ) -> Self {
         assert!(
             pool_size != 0,
@@ -97,12 +102,15 @@ impl PinnedMemoryPool {
         );
 
         let backing = if use_hugepages {
-            info!("Allocating pinned memory pool with huge pages");
-            PinnedMemory::allocate_hugepages(pool_size)
+            info!("Allocating pinned memory pool with huge pages on {}", node);
+            PinnedMemory::allocate_hugepages(pool_size, node)
                 .expect("Failed to allocate pinned memory pool with huge pages")
         } else if ssd_enabled {
-            info!("Allocating pinned memory pool with regular pages (SSD enabled)");
-            PinnedMemory::allocate_regular(pool_size)
+            info!(
+                "Allocating pinned memory pool with regular pages on {} (SSD enabled)",
+                node
+            );
+            PinnedMemory::allocate_regular(pool_size, node)
                 .expect("Failed to allocate regular pinned memory pool")
         } else {
             info!("Allocating pinned memory pool with write-combined pages");
@@ -281,6 +289,9 @@ pub(crate) struct ShardedPinnedPool {
 impl ShardedPinnedPool {
     /// Create a sharded pool by splitting `total_capacity` evenly across `num_shards` pools.
     ///
+    /// `node` is the NUMA node every shard is bound to. `NumaNode::UNKNOWN`
+    /// disables NUMA pinning (placement falls back to caller-thread affinity).
+    ///
     /// When `num_shards <= 1`, a single pool is created (equivalent to the old behavior).
     fn new(
         total_capacity: usize,
@@ -288,13 +299,15 @@ impl ShardedPinnedPool {
         use_hugepages: bool,
         ssd_enabled: bool,
         unit_size_hint: Option<NonZeroU64>,
+        node: NumaNode,
     ) -> Self {
         let num_shards = num_shards.max(1);
         let per_shard = total_capacity / num_shards;
 
         if num_shards > 1 {
             info!(
-                "Creating sharded pinned pool: total={}, shards={}, per_shard={}",
+                "Creating sharded pinned pool on {}: total={}, shards={}, per_shard={}",
+                node,
                 ByteSize(total_capacity as u64),
                 num_shards,
                 ByteSize(per_shard as u64)
@@ -308,6 +321,7 @@ impl ShardedPinnedPool {
                     use_hugepages,
                     ssd_enabled,
                     unit_size_hint,
+                    node,
                 ))
             })
             .collect();
@@ -438,15 +452,17 @@ impl NumaAwarePinnedPools {
 
             let node_id = node.0;
             let hint = unit_size_hint;
+            let target_node = *node;
 
             // Allocate sharded pool on a thread pinned to this NUMA node
-            let result = run_on_numa(*node, move || {
+            let result = run_on_numa(target_node, move || {
                 ShardedPinnedPool::new(
                     per_node_capacity,
                     num_shards,
                     use_hugepages,
                     ssd_enabled,
                     hint,
+                    target_node,
                 )
             });
 
@@ -554,6 +570,7 @@ impl PinnedAllocator {
             use_hugepages,
             ssd_enabled,
             unit_hint,
+            NumaNode::UNKNOWN,
         ))
     }
 
@@ -646,11 +663,25 @@ mod tests {
         let mut pools = HashMap::new();
         pools.insert(
             0,
-            ShardedPinnedPool::new(4096, 1, false, false, NonZeroU64::new(512)),
+            ShardedPinnedPool::new(
+                4096,
+                1,
+                false,
+                false,
+                NonZeroU64::new(512),
+                NumaNode::UNKNOWN,
+            ),
         );
         pools.insert(
             1,
-            ShardedPinnedPool::new(4096, 1, false, false, NonZeroU64::new(512)),
+            ShardedPinnedPool::new(
+                4096,
+                1,
+                false,
+                false,
+                NonZeroU64::new(512),
+                NumaNode::UNKNOWN,
+            ),
         );
         let allocator = PinnedAllocator::Numa(NumaAwarePinnedPools { pools });
 
@@ -680,7 +711,14 @@ mod tests {
         let mut pools = HashMap::new();
         pools.insert(
             0,
-            ShardedPinnedPool::new(4096, 1, false, false, NonZeroU64::new(512)),
+            ShardedPinnedPool::new(
+                4096,
+                1,
+                false,
+                false,
+                NonZeroU64::new(512),
+                NumaNode::UNKNOWN,
+            ),
         );
         let allocator = PinnedAllocator::Numa(NumaAwarePinnedPools { pools });
 


### PR DESCRIPTION
## Summary

- Replace `cudaHostAlloc` with `mmap + parallel_pre_touch + cudaHostRegister` for the Regular allocator path; add the same pre-touch step before register on the HugePages path.
- Each touch worker calls `pin_thread_to_numa_node(node)` so first-touch places every page on the target NUMA node.
- `PinnedMemoryPool::new` / `ShardedPinnedPool::new` now plumb `NumaNode` through to the allocator; `NumaAwarePinnedPools::new` passes the per-node id, `new_global` passes `NumaNode::UNKNOWN`.
- `Drop` splits: WriteCombined → `cudaFreeHost`; Regular / HugePages → `cudaHostUnregister + munmap`.

## Why

Cold-start of large pinned pools is the dominant init cost. Measurements show `cudaHostAlloc` (the old Regular path) and the serial fault-in inside `cudaHostRegister` for HUGETLB regions are both single-threaded. Parallel pre-touch parallelizes that work and pins placement.

500GB cold start on 240-core dual-socket (h20):
- non-hugepage: **397.7s → 21.3s** (18.7x)
- hugepage:      **88.5s → 14.8s** (5.98x)

20GB on 48-core single-socket: **17.4s → 3.9s** (4.4x).

NUMA-aware vs naive (200GB, 64 threads): explicit pinning gives 1000/1000 sampled pages on the target node at no timing cost; relying on scheduler luck is non-deterministic and unsafe under concurrent multi-pool init.

See top-of-file comment in `pegaflow-core/examples/pinned_alloc_parallel.rs` for the full measurement tables and methodology.

## Test plan

- [x] `cargo build --release -p pegaflow-core --examples`
- [x] `cargo clippy --release -p pegaflow-core --examples --tests -- -D warnings`
- [x] `cargo fmt -p pegaflow-core --check`
- [x] `cargo test --release -p pegaflow-core --lib pinned_mem` (4/4)
- [x] `cargo test --release -p pegaflow-core --lib pinned_pool` (2/2)
- [x] Bench example run on h20 (500GB, hugepage + non-hugepage sweeps)
- [x] NUMA placement verified via `move_pages(2)` (separate one-off bench, not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)