### PR TITLE
fix(connector): demote cache_lookup_reuse log to debug

### DIFF
--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -112,7 +112,7 @@ class SchedulerConnector:
             hit_blocks = pending_probe.hit_blocks
             self._external_matched_blocks[req_id] = computed_blocks + hit_blocks
             num_hit_tokens = hit_blocks * self._ctx.virtual_block_size
-            logger.info(
+            logger.debug(
                 "[PegaKVConnector] req=%s cache_lookup_reuse: hit_blocks=%d "
                 "computed_blocks=%d hit_tokens=%d num_tokens=%d total_query_hashes=%d",
                 req_id,


### PR DESCRIPTION
## Summary
- scheduler 在 KV cache 紧张时会反复轮询 `get_num_new_matched_tokens`，每次命中 pinned probe 都打 INFO 的 `cache_lookup_reuse`，刷屏严重
- 首次 lookup (`scheduler.py:152`) 的 INFO 日志已经覆盖同样的信息，reuse 路径降到 debug 即可

## Test plan
- [x] pre-commit / ruff / cargo test (本地通过)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)