### PR TITLE
chore: tune transfer duration buckets

### DIFF
--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -113,23 +113,29 @@ fn rdma_fetch_duration_boundaries() -> Vec<f64> {
     ]
 }
 
-/// Custom histogram boundaries for duration in seconds (1ms to 5s)
-/// Optimized for local IPC workloads where most operations are 10-100ms
+/// Tail-focused transfer duration boundaries in seconds.
+///
+/// Load/save debugging cares more about sustained tail regressions than small
+/// sub-10ms jitter, so buckets stay coarse at the low end and distinguish
+/// transfer stalls up to one minute.
 fn duration_seconds_boundaries() -> Vec<f64> {
     vec![
-        0.001, // 1ms
-        0.005, // 5ms
         0.01,  // 10ms
         0.025, // 25ms
         0.05,  // 50ms
         0.1,   // 100ms
-        0.2,   // 200ms
-        0.3,   // 300ms
-        0.4,   // 400ms
+        0.25,  // 250ms
         0.5,   // 500ms
         1.0,   // 1s
+        1.5,   // 1.5s
         2.0,   // 2s
+        3.0,   // 3s
         5.0,   // 5s
+        7.5,   // 7.5s
+        10.0,  // 10s
+        15.0,  // 15s
+        30.0,  // 30s
+        60.0,  // 60s
     ]
 }
 

--- a/python/pegaflow/connector/connector_metrics.py
+++ b/python/pegaflow/connector/connector_metrics.py
@@ -15,6 +15,25 @@ from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
+TRANSFER_DURATION_BUCKETS_SECONDS = [
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    5.0,
+    7.5,
+    10.0,
+    15.0,
+    30.0,
+    60.0,
+]
+
 try:
     from vllm.v1.metrics.utils import create_metric_per_engine
 except ImportError:
@@ -309,14 +328,12 @@ class PegaPromMetrics(KVConnectorPromMetrics):
         )
         self.histogram_prefetch_blocks = _bind_metric_per_engine(self, histogram_prefetch_blocks)
 
-        # Histogram for load operations (worker-side)
-        # Optimized for fast SSD: typical range 1-50ms
-        # Buckets: 1, 2, 3, 5, 7.5, 10, 15, 20, 30, 50, 100 ms
-        duration_buckets = [0.001, 0.002, 0.003, 0.005, 0.0075, 0.01, 0.015, 0.02, 0.03, 0.05, 0.1]
+        # Histogram for load/save operations (worker-side), tuned for tail
+        # visibility over sub-10ms jitter. Buckets: 10ms to 60s.
         histogram_load_duration = self._histogram_cls(
             name="vllm:pega_load_duration_seconds",
             documentation="Histogram of KV cache load duration in seconds.",
-            buckets=duration_buckets,
+            buckets=TRANSFER_DURATION_BUCKETS_SECONDS,
             labelnames=labelnames,
         )
         self.histogram_load_duration = _bind_metric_per_engine(self, histogram_load_duration)
@@ -347,7 +364,7 @@ class PegaPromMetrics(KVConnectorPromMetrics):
         histogram_save_duration = self._histogram_cls(
             name="vllm:pega_save_duration_seconds",
             documentation="Histogram of KV cache save duration in seconds.",
-            buckets=duration_buckets,
+            buckets=TRANSFER_DURATION_BUCKETS_SECONDS,
             labelnames=labelnames,
         )
         self.histogram_save_duration = _bind_metric_per_engine(self, histogram_save_duration)


### PR DESCRIPTION
## Summary
- tune core load/save duration histogram buckets toward transfer tail visibility
- align vLLM connector load/save duration buckets with the core transfer buckets
- keep sub-10ms jitter coarse and add explicit 3s / 7.5s / 10s / 15s / 30s / 60s buckets for long-tail stalls

## Tests
- `git diff --check`
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Review/target-pr281 cargo fmt --check -p pegaflow-core`
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Review/target-pr281 cargo check -p pegaflow-core`
- `cd python && uv run --extra test python -m py_compile pegaflow/connector/connector_metrics.py`
- `cd python && uv run --extra test ruff check pegaflow/connector/connector_metrics.py && uv run --extra test ruff format --check pegaflow/connector/connector_metrics.py`
- `prek run --files pegaflow-core/src/metrics.rs python/pegaflow/connector/connector_metrics.py`
