### PR TITLE
fix(connector): remove scheduler save limit

### DIFF
--- a/python/pegaflow/connector/connector_metrics.py
+++ b/python/pegaflow/connector/connector_metrics.py
@@ -128,7 +128,6 @@ class PegaKVConnectorStats(KVConnectorStats):
         - load_failure_count: failed load operations
         - save_success_count: successful save operations
         - save_failure_count: failed save operations
-        - save_dropped_count: save operations dropped due to queue limit
     """
 
     def __post_init__(self):
@@ -154,7 +153,6 @@ class PegaKVConnectorStats(KVConnectorStats):
             "load_failure_count": 0,
             "save_success_count": 0,
             "save_failure_count": 0,
-            "save_dropped_count": 0,
         }
 
     def record_load(self, duration_seconds: float, num_blocks: int, success: bool):
@@ -186,7 +184,6 @@ class PegaKVConnectorStats(KVConnectorStats):
             "load_failure_count",
             "save_success_count",
             "save_failure_count",
-            "save_dropped_count",
         ]:
             self.data[key] = self.data.get(key, 0) + other.data.get(key, 0)
 
@@ -248,7 +245,6 @@ class PegaKVConnectorStats(KVConnectorStats):
             result["avg_save_blocks"] = round(sum(save_blocks) / num_saves, 1)
         result["save_success_count"] = self.data.get("save_success_count", 0)
         result["save_failure_count"] = self.data.get("save_failure_count", 0)
-        result["save_dropped_count"] = self.data.get("save_dropped_count", 0)
 
         return result
 
@@ -263,7 +259,6 @@ class PegaKVConnectorStats(KVConnectorStats):
             and len(self.data.get("save_duration", [])) == 0
             and self.data.get("save_success_count", 0) == 0
             and self.data.get("save_failure_count", 0) == 0
-            and self.data.get("save_dropped_count", 0) == 0
         )
 
     def clone_and_reset(self) -> "PegaKVConnectorStats":
@@ -391,13 +386,6 @@ class PegaPromMetrics(KVConnectorPromMetrics):
         )
         self.counter_save_failure = _bind_metric_per_engine(self, counter_save_failure)
 
-        counter_save_dropped = self._counter_cls(
-            name="vllm:pega_save_dropped_total",
-            documentation="Number of save operations dropped due to queue limit.",
-            labelnames=labelnames,
-        )
-        self.counter_save_dropped = _bind_metric_per_engine(self, counter_save_dropped)
-
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
         """Record stats to Prometheus metrics."""
         # Gauge metrics (scheduler-side)
@@ -437,16 +425,13 @@ class PegaPromMetrics(KVConnectorPromMetrics):
         for blocks in transfer_stats_data.get("save_blocks", []):
             self.histogram_save_blocks[engine_idx].observe(blocks)
 
-        # Counter: save success/failure/dropped
+        # Counter: save success/failure
         save_success = transfer_stats_data.get("save_success_count", 0)
         if save_success > 0:
             self.counter_save_success[engine_idx].inc(save_success)
         save_failure = transfer_stats_data.get("save_failure_count", 0)
         if save_failure > 0:
             self.counter_save_failure[engine_idx].inc(save_failure)
-        save_dropped = transfer_stats_data.get("save_dropped_count", 0)
-        if save_dropped > 0:
-            self.counter_save_dropped[engine_idx].inc(save_dropped)
 
 
 __all__ = [

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -14,7 +14,6 @@ from pegaflow.connector.common import (
     PegaKVConnectorStats,
     SaveIntent,
     logger,
-    parse_env_int,
 )
 from pegaflow.connector.connector_metrics import PrefetchTracker
 from pegaflow.pegaflow import PegaFlowBusinessError, PegaFlowServiceError
@@ -40,11 +39,6 @@ class _PendingQueryProbe:
 
 class SchedulerConnector:
     """Holds scheduler-only state and behaviors."""
-
-    # Maximum number of requests that can have pending saves simultaneously.
-    # Default 0 means unlimited - drop strategy only activates when explicitly set.
-    # When this limit is reached, new save intents will be dropped (shorter first).
-    MAX_PENDING_SAVE_REQUESTS: int = parse_env_int("PEGA_MAX_PENDING_SAVE_REQUESTS", 0)
 
     def __init__(self, context: ConnectorContext):
         self._ctx = context
@@ -73,9 +67,6 @@ class SchedulerConnector:
         # Completion tracking
         self._pending_saves: set[str] = set()
         self._held_requests: set[str] = set()
-
-        # Save drop statistics (for metrics)
-        self._save_dropped_count: int = 0
 
     def get_num_new_matched_tokens(
         self,
@@ -236,7 +227,7 @@ class SchedulerConnector:
     def build_connector_meta(self, scheduler_output: "SchedulerOutput") -> PegaConnectorMetadata:
         self._drain_pending_query_probe_releases()
 
-        # Collect potential save intents first, then apply drop decision
+        # Collect all save intents that became available this scheduler step.
         potential_saves: dict[str, SaveIntent] = {}
 
         load_intents = self._pending_load_intents
@@ -285,61 +276,15 @@ class SchedulerConnector:
             if save_intent := self._consume_save_intent(req_id):
                 potential_saves[req_id] = save_intent
 
-        # Apply save limit: drop new save intents if pending saves exceed limit
-        # Priority: longer requests (more blocks) are kept, shorter ones are dropped
-        # When MAX_PENDING_SAVE_REQUESTS <= 0, no limit is applied (all saves allowed)
-        save_intents: dict[str, SaveIntent] = {}
-
-        if self.MAX_PENDING_SAVE_REQUESTS <= 0:
-            # No limit configured - save all requests
-            save_intents = potential_saves
-        else:
-            # Apply limit with length-based priority
-            current_pending = len(self._pending_saves)
-            available_slots = max(0, self.MAX_PENDING_SAVE_REQUESTS - current_pending)
-
-            # Separate continuing saves (already in pending) from new requests
-            continuing_saves: dict[str, SaveIntent] = {}
-            new_saves: list[tuple[str, SaveIntent, int]] = []  # (req_id, intent, block_count)
-
-            for req_id, intent in potential_saves.items():
-                if req_id in self._pending_saves:
-                    # Continuing saves are always allowed
-                    continuing_saves[req_id] = intent
-                else:
-                    # New request - record its total block count for sorting
-                    block_count = len(self._block_hashes.get(req_id, ()))
-                    new_saves.append((req_id, intent, block_count))
-
-            # Sort new requests by block count (descending) - longer requests first
-            new_saves.sort(key=lambda x: x[2], reverse=True)
-
-            # Add all continuing saves
-            save_intents.update(continuing_saves)
-
-            # Add new saves up to available slots, prioritizing longer requests
-            for req_id, intent, block_count in new_saves:
-                if len(save_intents) - len(continuing_saves) < available_slots:
-                    save_intents[req_id] = intent
-                else:
-                    # Drop this save intent due to limit (shorter requests dropped first)
-                    self._save_dropped_count += 1
-                    logger.warning(
-                        "[PegaKVConnector] Save limit reached (%d/%d), dropping req=%s (blocks=%d)",
-                        current_pending,
-                        self.MAX_PENDING_SAVE_REQUESTS,
-                        req_id,
-                        block_count,
-                    )
+        save_intents = potential_saves
 
         # Track requests with pending saves
         self._pending_saves.update(save_intents.keys())
 
         logger.debug(
-            "[PegaKVConnector] build_connector_meta: %d loads, %d saves (dropped %d)",
+            "[PegaKVConnector] build_connector_meta: %d loads, %d saves",
             len(load_intents),
             len(save_intents),
-            len(potential_saves) - len(save_intents),
         )
 
         return PegaConnectorMetadata(
@@ -479,20 +424,26 @@ class SchedulerConnector:
 
         # Handle new dict response format
         if isinstance(result, dict):
-            if not result.get("ok", False):
+            ok = result["ok"]
+            message = result["message"]
+            hit_blocks = result["hit_blocks"]
+            prefetch_state = result["prefetch_state"]
+            if prefetch_state not in {"done", "loading"}:
+                raise RuntimeError(
+                    "query_prefetch response field 'prefetch_state' must be "
+                    f"'done' or 'loading', got {prefetch_state!r}"
+                )
+
+            if not ok:
                 # Response-level errors are treated as business errors
-                error_msg = result.get("message", "unknown error")
                 logger.error(
                     "[PegaKVConnector] Query failed: %s, req_id=%s, instance_id=%s, num_blocks=%d",
-                    error_msg,
+                    message,
                     req_id,
                     self._ctx.instance_id,
                     len(block_hash_list),
                 )
-                raise RuntimeError(f"Query failed: {error_msg}")
-
-            prefetch_state = result.get("prefetch_state", "done")
-            hit_blocks = result.get("hit_blocks", 0)
+                raise RuntimeError(f"Query failed: {message}")
 
             if prefetch_state == "loading":
                 # Record first time we see loading state
@@ -525,7 +476,9 @@ class SchedulerConnector:
             return hit_blocks
 
         # Legacy tuple response format (ok, message, hit_blocks)
-        _, _, hit_blocks = result
+        ok, message, hit_blocks = result
+        if not ok:
+            raise RuntimeError(f"Query failed: {message}")
         return hit_blocks
 
     def get_stats(self) -> PegaKVConnectorStats | None:
@@ -540,11 +493,6 @@ class SchedulerConnector:
             "prefetch_duration": prefetch_stats["prefetch_duration"],
             "prefetch_blocks": prefetch_stats["prefetch_blocks"],
         }
-
-        # Add save_dropped_count if there were any drops
-        if self._save_dropped_count > 0:
-            data["save_dropped_count"] = self._save_dropped_count
-            self._save_dropped_count = 0
 
         stats = PegaKVConnectorStats(data=data)
         if stats.is_empty():

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -386,7 +386,11 @@ impl EngineRpcClient {
             let prefetch_state = match PrefetchState::try_from(r.prefetch_state) {
                 Ok(PrefetchState::PrefetchDone) => "done",
                 Ok(PrefetchState::PrefetchLoading) => "loading",
-                _ => "done", // Default to done for unknown states
+                Err(value) => {
+                    return Err(PyRuntimeError::new_err(format!(
+                        "query_prefetch returned unknown prefetch_state: {value}"
+                    )));
+                }
             };
 
             Python::attach(|py| {

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -274,6 +274,33 @@ class TestSchedulerQueryProbeReuse:
         engine_client.query_prefetch.assert_called_once()
         engine_client.unpin.assert_not_called()
 
+    def test_query_prefetch_dict_requires_contract_fields(self):
+        sc, engine_client = self._make_connector()
+        engine_client.query_prefetch.return_value = {
+            "ok": True,
+            "message": "ok",
+            "hit_blocks": 2,
+            "loading_blocks": 0,
+            "missing_blocks": 0,
+        }
+
+        with pytest.raises(KeyError, match="prefetch_state"):
+            sc._count_available_block_prefix([_hash(i) for i in range(4)], "r1")
+
+    def test_query_prefetch_dict_rejects_unknown_prefetch_state(self):
+        sc, engine_client = self._make_connector()
+        engine_client.query_prefetch.return_value = {
+            "ok": True,
+            "message": "ok",
+            "hit_blocks": 2,
+            "prefetch_state": "weird",
+            "loading_blocks": 0,
+            "missing_blocks": 0,
+        }
+
+        with pytest.raises(RuntimeError, match="prefetch_state"):
+            sc._count_available_block_prefix([_hash(i) for i in range(4)], "r1")
+
     def test_committed_probe_is_not_unpinned_on_cleanup(self):
         sc, engine_client = self._make_connector()
         req = _make_fake_request("r1", [_hash(i) for i in range(2)])


### PR DESCRIPTION
## Summary
- remove the unused scheduler pending-save request limit and save-drop accounting
- keep pending-save lifecycle tracking for request cleanup safety
- make query_prefetch response handling use required fields directly and reject unknown prefetch states with runtime errors instead of assert-only validation

## Tests
- `git diff --check`
- `cd python && uv run --extra test pytest tests/test_combine_hashes.py -q`
- `cd python && uv run --extra test pytest -q`
- `cd python && uv run --extra test python -m py_compile pegaflow/connector/scheduler.py pegaflow/connector/connector_metrics.py tests/test_combine_hashes.py`
- `cd python && uvx ruff check pegaflow/connector/scheduler.py pegaflow/connector/connector_metrics.py tests/test_combine_hashes.py && uvx ruff format --check pegaflow/connector/scheduler.py pegaflow/connector/connector_metrics.py tests/test_combine_hashes.py`
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Review/target-pr282 cargo fmt --check -p pegaflow-py`
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Review/target-pr282 cargo check -p pegaflow-py`
- `cargo test --release -p pegaflow-core --test engine_basic -- --nocapture`
- `prek run --files python/pegaflow/connector/scheduler.py python/pegaflow/connector/connector_metrics.py python/tests/test_combine_hashes.py python/src/lib.rs`
- `PYTHONPATH=/data/slock_agents/KV-Review/pegaflow-pr282/python /data/pegadev/pegaflow/.venv/bin/python -m pytest -m e2e tests/test_vllm_e2e_correctness.py --model /data/models/Qwen3-4B --tensor-parallel-size 1 --pipeline-parallel-size 1 --max-model-len 4096 -vv -s --tb=short`

E2E result: 2 passed in 170.38s; metrics saves=74 blocks / 174.6MB, hits=40 blocks / 94.4MB.
