### PR TITLE
fix(server): fail on invalid rdma nics

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -45,7 +45,7 @@ pegaflow-server
 
 ### Cross-Node (Multi-Node Setup)
 
-- `--nics`: RDMA NIC names for inter-node transfer (e.g., `--nics mlx5_0 mlx5_1`). When set, pinned memory is registered for RDMA access on these NICs. Required for P2P KV cache sharing.
+- `--nics`: RDMA NIC names for inter-node transfer (e.g., `--nics mlx5_0,mlx5_1` or `--nics mlx5_0 mlx5_1`). When set, pinned memory is registered for RDMA access on these NICs. Required for P2P KV cache sharing.
 - `--metaserver-addr`: MetaServer gRPC address for cross-node block hash registry (e.g., `http://10.0.0.100:50056`). When set, saved block hashes are inserted to the metaserver for cross-node discovery. Requires `--addr` to be a routable IP (not `0.0.0.0` or `127.0.0.1`).
 - `--transfer-lock-timeout-secs`: Transfer lock timeout in seconds (default: `120`). Blocks held for cross-node RDMA transfer are locked for at most this duration before being force-released (crash recovery).
 - `--metaserver-queue-depth`: MetaServer registration queue depth, max pending registration batches

--- a/pegaflow-core/src/backing/rdma.rs
+++ b/pegaflow-core/src/backing/rdma.rs
@@ -69,16 +69,12 @@ impl Drop for RdmaTransport {
     }
 }
 
-/// Create an [`RdmaTransport`], returning `None` on failure (logs the error).
+/// Create an [`RdmaTransport`].
 pub(crate) fn new_rdma(
     nic_names: &[String],
     allocator: &PinnedAllocator,
-) -> Option<Arc<RdmaTransport>> {
-    match RdmaTransport::new(nic_names, allocator) {
-        Ok(t) => Some(Arc::new(t)),
-        Err(e) => {
-            error!("Failed to initialise RDMA transport (nics={nic_names:?}): {e}");
-            None
-        }
-    }
+) -> Result<Arc<RdmaTransport>, String> {
+    RdmaTransport::new(nic_names, allocator)
+        .map(Arc::new)
+        .map_err(|e| format!("Failed to initialise RDMA transport (nics={nic_names:?}): {e}"))
 }

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -128,7 +128,7 @@ impl PegaEngine {
         pool_size: usize,
         use_hugepages: bool,
         storage_config: storage::StorageConfig,
-    ) -> Self {
+    ) -> Result<Self, EngineError> {
         let topology = Arc::new(NumaTopology::detect());
         topology.log_summary();
 
@@ -143,13 +143,14 @@ impl PegaEngine {
             vec![]
         };
 
-        let storage = StorageEngine::new_with_config(pool_size, use_hugepages, config, &numa_nodes);
+        let storage = StorageEngine::new_with_config(pool_size, use_hugepages, config, &numa_nodes)
+            .map_err(EngineError::Storage)?;
 
-        PegaEngine {
+        Ok(PegaEngine {
             instances: Arc::new(RwLock::new(HashMap::new())),
             storage,
             topology,
-        }
+        })
     }
 
     /// Get or create an instance with the specified topology.
@@ -701,5 +702,26 @@ impl PegaEngine {
             .map_err(|e| format!("complete_handshake failed: {e}"))?;
         info!("RDMA handshake accepted: client={client_addr}");
         Ok(server_meta.to_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rdma_initialization_failure_is_returned_to_caller() {
+        let config = storage::StorageConfig {
+            rdma_nic_names: Some(vec!["definitely-not-a-real-nic".to_string()]),
+            ..storage::StorageConfig::default()
+        };
+
+        let err = match PegaEngine::new_with_config(1 << 20, false, config) {
+            Ok(_) => panic!("engine startup must fail when RDMA NIC init fails"),
+            Err(err) => err.to_string(),
+        };
+
+        assert!(err.contains("Failed to initialise RDMA transport"), "{err}");
+        assert!(err.contains("definitely-not-a-real-nic"), "{err}");
     }
 }

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -102,7 +102,7 @@ impl StorageEngine {
         use_hugepages: bool,
         config: StorageConfig,
         numa_nodes: &[NumaNode],
-    ) -> Arc<Self> {
+    ) -> Result<Arc<Self>, String> {
         let value_size_hint = config.hint_value_size_bytes.filter(|size| *size > 0);
         let unit_hint = value_size_hint.and_then(|size| NonZeroU64::new(size as u64));
         let max_prefetch_blocks = config.max_prefetch_blocks;
@@ -170,10 +170,10 @@ impl StorageEngine {
 
         // RDMA transport must be created after the allocator so it can
         // register the pinned memory regions with the RDMA NICs.
-        let rdma_transport = rdma_nic_names
-            .as_deref()
-            .filter(|nics| !nics.is_empty())
-            .and_then(|nics| crate::backing::new_rdma(nics, &allocator));
+        let rdma_transport = match rdma_nic_names.as_deref().filter(|nics| !nics.is_empty()) {
+            Some(nics) => Some(crate::backing::new_rdma(nics, &allocator)?),
+            None => None,
+        };
 
         if let Some(ref rdma) = rdma_transport {
             crate::metrics::register_rdma_gauges(rdma);
@@ -246,7 +246,7 @@ impl StorageEngine {
                 .expect("failed to spawn insert worker thread");
         }
 
-        engine
+        Ok(engine)
     }
 
     pub(crate) fn is_ssd_enabled(&self) -> bool {
@@ -624,7 +624,7 @@ mod tests {
     use super::*;
 
     fn make_engine() -> Arc<StorageEngine> {
-        StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[])
+        StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]).unwrap()
     }
 
     #[tokio::test]
@@ -725,7 +725,8 @@ mod tests {
     async fn allocate_bounded_reclaim_terminates() {
         // With a tiny pool, allocation of a huge block should fail fast
         // (not loop forever) thanks to MAX_RECLAIM_ROUNDS.
-        let storage = StorageEngine::new_with_config(4096, false, StorageConfig::default(), &[]);
+        let storage =
+            StorageEngine::new_with_config(4096, false, StorageConfig::default(), &[]).unwrap();
 
         // Try to allocate more than the entire pool
         let result = storage.allocate(NonZeroU64::new(1 << 30).unwrap(), None);

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -288,7 +288,8 @@ mod tests {
 
     #[tokio::test]
     async fn single_slot_seals_immediately() {
-        let engine = StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]);
+        let engine =
+            StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]).unwrap();
         let deps = make_deps(&engine);
         let weak_deps = Arc::downgrade(&deps);
 
@@ -316,7 +317,8 @@ mod tests {
 
     #[tokio::test]
     async fn multi_slot_partial_then_complete() {
-        let engine = StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]);
+        let engine =
+            StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]).unwrap();
         let deps = make_deps(&engine);
         let weak_deps = Arc::downgrade(&deps);
 
@@ -367,7 +369,8 @@ mod tests {
 
     #[tokio::test]
     async fn duplicate_slot_is_idempotent() {
-        let engine = StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]);
+        let engine =
+            StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]).unwrap();
         let deps = make_deps(&engine);
         let weak_deps = Arc::downgrade(&deps);
 
@@ -394,7 +397,8 @@ mod tests {
 
     #[tokio::test]
     async fn slot_count_mismatch_skips_key() {
-        let engine = StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]);
+        let engine =
+            StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]).unwrap();
         let deps = make_deps(&engine);
         let weak_deps = Arc::downgrade(&deps);
 
@@ -445,7 +449,8 @@ mod tests {
 
     #[tokio::test]
     async fn send_backing_batches_no_stores_is_noop() {
-        let engine = StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]);
+        let engine =
+            StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]).unwrap();
         let deps = make_deps(&engine);
         let weak_deps = Arc::downgrade(&deps);
 

--- a/pegaflow-core/tests/common/helpers.rs
+++ b/pegaflow-core/tests/common/helpers.rs
@@ -9,7 +9,7 @@ pub const LOAD_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_TEST_POOL_SIZE: usize = 16 << 20;
 
 pub fn test_engine_with_pool(pool_size: usize, config: StorageConfig) -> PegaEngine {
-    PegaEngine::new_with_config(pool_size, false, config)
+    PegaEngine::new_with_config(pool_size, false, config).expect("test engine should start")
 }
 
 /// Layer registration info for batch registration.

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -143,9 +143,9 @@ pub struct Cli {
     #[arg(long, default_value_t = false)]
     pub blockwise_alloc: bool,
 
-    /// RDMA NIC names for inter-node transfer (e.g. --nics mlx5_0 mlx5_1).
+    /// RDMA NIC names for inter-node transfer (e.g. --nics mlx5_0,mlx5_1 or --nics mlx5_0 mlx5_1).
     /// When set, pinned memory is registered for RDMA access on these NICs.
-    #[arg(long, num_args = 1..)]
+    #[arg(long, value_delimiter = ',', value_parser = parse_nic_name, num_args = 1..)]
     pub nics: Option<Vec<String>>,
 
     /// MetaServer address for cross-node block hash registration (e.g. http://127.0.0.1:50056).
@@ -182,6 +182,14 @@ fn parse_hll_bucket_bits(s: &str) -> Result<u8, String> {
         ));
     }
     Ok(v)
+}
+
+fn parse_nic_name(s: &str) -> Result<String, String> {
+    let name = s.trim();
+    if name.is_empty() {
+        return Err("--nics contains an empty NIC name".into());
+    }
+    Ok(name.to_string())
 }
 
 fn parse_hll_windows_arg(s: &str) -> Result<String, String> {
@@ -570,7 +578,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             cli.pool_size,
             cli.use_hugepages,
             storage_config,
-        ));
+        )?);
 
         let service = GrpcEngineService::new(
             Arc::clone(&engine),
@@ -697,6 +705,58 @@ mod tests {
         assert_eq!(
             parse_hll_windows(&cli.metric_hll_windows).unwrap(),
             expected_hll_windows()
+        );
+    }
+
+    #[test]
+    fn cli_nics_accepts_comma_separated_values() {
+        let cli =
+            Cli::try_parse_from(["pegaflow-server", "--nics", "mlx5_0,mlx5_1,mlx5_2"]).unwrap();
+
+        assert_eq!(
+            cli.nics.unwrap(),
+            [
+                "mlx5_0".to_string(),
+                "mlx5_1".to_string(),
+                "mlx5_2".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn cli_nics_trims_comma_separated_values() {
+        let cli =
+            Cli::try_parse_from(["pegaflow-server", "--nics", "mlx5_0, mlx5_1, mlx5_2"]).unwrap();
+
+        assert_eq!(
+            cli.nics.unwrap(),
+            [
+                "mlx5_0".to_string(),
+                "mlx5_1".to_string(),
+                "mlx5_2".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn cli_nics_rejects_empty_comma_separated_values() {
+        let err = Cli::try_parse_from(["pegaflow-server", "--nics", "mlx5_0,,mlx5_1"]).unwrap_err();
+
+        assert!(err.to_string().contains("empty NIC name"), "{err}");
+    }
+
+    #[test]
+    fn cli_nics_accepts_repeated_values_after_flag() {
+        let cli = Cli::try_parse_from(["pegaflow-server", "--nics", "mlx5_0", "mlx5_1", "mlx5_2"])
+            .unwrap();
+
+        assert_eq!(
+            cli.nics.unwrap(),
+            [
+                "mlx5_0".to_string(),
+                "mlx5_1".to_string(),
+                "mlx5_2".to_string()
+            ]
         );
     }
 

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -287,7 +287,9 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
         rdma_nic_names: Some(vec!["mlx5_1".into()]),
         ..StorageConfig::default()
     };
-    let engine_a = Arc::new(PegaEngine::new_with_config(16 << 20, false, config_a));
+    let engine_a = Arc::new(
+        PegaEngine::new_with_config(16 << 20, false, config_a).expect("engine A should start"),
+    );
 
     // ── 3. Start Engine A gRPC server ──
     spawn_engine_server(Arc::clone(&engine_a), port_a).await;
@@ -364,7 +366,8 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
         rdma_nic_names: Some(vec!["mlx5_1".into()]),
         ..StorageConfig::default()
     };
-    let engine_b = PegaEngine::new_with_config(16 << 20, false, config_b);
+    let engine_b =
+        PegaEngine::new_with_config(16 << 20, false, config_b).expect("engine B should start");
 
     let gpu_b = GpuBuffer::alloc(TOTAL_SIZE);
     gpu_b.zero();


### PR DESCRIPTION
## Summary
- accept comma-separated and space-separated `pegaflow-server --nics` values, including quoted comma lists with spaces
- reject empty NIC names such as `--nics mlx5_0,,mlx5_1` instead of passing malformed values into RDMA init
- propagate RDMA transport initialization failures through engine/server startup instead of silently disabling P2P
- document both accepted `--nics` forms

Fixes #276

## Tests
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Review/target-pr283 cargo test -p pegaflow-server cli_nics --lib -- --nocapture`
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Review/target-pr283 cargo test -p pegaflow-server --lib -- --nocapture`
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Review/target-pr283 cargo test -p pegaflow-core rdma_initialization_failure_is_returned_to_caller --lib -- --nocapture`
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Review/target-pr283 cargo fmt --check -p pegaflow-server`
- `CARGO_TARGET_DIR=/data/slock_agents/KV-Review/target-pr283 cargo check -p pegaflow-server -p pegaflow-core`
- `prek run --files docs/server.md pegaflow-core/src/backing/rdma.rs pegaflow-core/src/lib.rs pegaflow-core/src/storage/mod.rs pegaflow-core/src/storage/write_path.rs pegaflow-core/tests/common/helpers.rs pegaflow-server/src/lib.rs pegaflow-server/tests/p2p_rdma.rs`
- GitHub CI green

## Notes
- `cargo test -p pegaflow-core` with default parallel integration tests hit an existing-looking `engine_basic::save_query_load_roundtrip_with_numa` flake twice (`0/4` then `2/4` hits). The same test passed alone and `engine_basic` passed with `--test-threads=1`.
