### PR TITLE
feat(metaserver): add node lifecycle fencing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tonic",
  "uuid",
 ]
@@ -2184,6 +2185,7 @@ version = "0.22.3"
 dependencies = [
  "axum",
  "clap",
+ "criterion",
  "dashmap",
  "log",
  "opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tonic",
+ "uuid",
 ]
 
 [[package]]

--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -44,6 +44,7 @@ mea = "0.6.3"
 criterion.workspace = true
 cudarc.workspace = true
 tokio.workspace = true
+tokio-stream = { workspace = true, features = ["net"] }
 tempfile = "3"
 
 [[bench]]

--- a/pegaflow-core/src/internode/README.md
+++ b/pegaflow-core/src/internode/README.md
@@ -40,7 +40,7 @@ internode/
 |                  | client.rs                          | registrar.rs                        |
 |------------------|------------------------------------|-------------------------------------|
 | Talks to         | Remote **pegaflow-server**         | Central **pegaflow-metaserver**     |
-| RPC service      | `Engine` (Query, Health)           | `MetaServer` (RegisterNode, HeartbeatNode, InsertBlockHashes) |
+| RPC service      | `Engine` (Query, Health)           | `MetaServer` (HeartbeatNode, InsertBlockHashes, RemoveBlockHashes) |
 | Direction        | Read path — query remote cache     | Write path — register sealed blocks |
 | Call pattern     | Request-response (caller awaits)   | Fire-and-forget (`try_send`)        |
 | Connection mgmt  | Pool of connections (multi-node)   | Single lazy connection + node session heartbeat |
@@ -61,11 +61,11 @@ insert_worker_loop (sync thread)
 
 Both use the same pattern: `tokio::sync::mpsc::try_send()` from the sync insert thread,
 with an async tokio task draining the channel on the other end. The background
-task registers this server's advertise address first, keeps the returned
-`node_id`, sends heartbeats, and attaches `{node, node_id}` to insert/remove
-RPCs. If the MetaServer restarts or rejects a stale session, the task
-re-registers and continues with future queued updates. It does not backfill
-resident cache keys that were registered before the MetaServer lost state.
+task generates a local `node_id`, announces it with `HeartbeatNode`, and attaches
+`{node, node_id}` to insert/remove RPCs. If the MetaServer restarts or rejects a
+missing session, the task sends heartbeat again and continues with future queued
+updates. It does not backfill resident cache keys that were registered before
+the MetaServer lost state.
 
 ## Configuration
 

--- a/pegaflow-core/src/internode/README.md
+++ b/pegaflow-core/src/internode/README.md
@@ -40,10 +40,10 @@ internode/
 |                  | client.rs                          | registrar.rs                        |
 |------------------|------------------------------------|-------------------------------------|
 | Talks to         | Remote **pegaflow-server**         | Central **pegaflow-metaserver**     |
-| RPC service      | `Engine` (Query, Health)           | `MetaServer` (InsertBlockHashes)    |
+| RPC service      | `Engine` (Query, Health)           | `MetaServer` (RegisterNode, HeartbeatNode, InsertBlockHashes) |
 | Direction        | Read path — query remote cache     | Write path — register sealed blocks |
 | Call pattern     | Request-response (caller awaits)   | Fire-and-forget (`try_send`)        |
-| Connection mgmt  | Pool of connections (multi-node)   | Single lazy connection              |
+| Connection mgmt  | Pool of connections (multi-node)   | Single lazy connection + node session heartbeat |
 | Failure mode     | Returns error to caller            | Log + metric, drop on queue full    |
 | Used by          | P/D router, cross-node queries     | Write pipeline (after block seal)   |
 
@@ -60,7 +60,12 @@ insert_worker_loop (sync thread)
 ```
 
 Both use the same pattern: `tokio::sync::mpsc::try_send()` from the sync insert thread,
-with an async tokio task draining the channel on the other end.
+with an async tokio task draining the channel on the other end. The background
+task registers this server's advertise address first, keeps the returned
+`node_id`, sends heartbeats, and attaches `{node, node_id}` to insert/remove
+RPCs. If the MetaServer restarts or rejects a stale session, the task
+re-registers and continues with future queued updates. It does not backfill
+resident cache keys that were registered before the MetaServer lost state.
 
 ## Configuration
 

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -338,7 +338,6 @@ async fn registration_loop(
         // Process inserts
         let insert_namespaces: Vec<(String, Vec<Vec<u8>>)> = inserts.into_iter().collect();
         let mut insert_failed_at = None;
-        let mut heartbeat_after_insert_failure = false;
 
         for (i, (namespace, hashes)) in insert_namespaces.iter().enumerate() {
             let count = hashes.len();
@@ -364,7 +363,7 @@ async fn registration_loop(
                     );
                     if e.code() == Code::FailedPrecondition {
                         core_metrics().metaserver_session_resets.add(1, &[]);
-                        heartbeat_after_insert_failure = true;
+                        node_registered = false;
                     }
                     insert_failed_at = Some(i);
                     break;
@@ -384,16 +383,12 @@ async fn registration_loop(
                     .add(remove_total as u64, &[]);
             }
             client = None;
-            if heartbeat_after_insert_failure {
-                node_registered = false;
-            }
             continue;
         }
 
         // Process removes
         let remove_namespaces: Vec<(String, Vec<Vec<u8>>)> = removes.into_iter().collect();
         let mut remove_failed_at = None;
-        let mut heartbeat_after_remove_failure = false;
 
         for (i, (namespace, hashes)) in remove_namespaces.iter().enumerate() {
             let count = hashes.len();
@@ -419,7 +414,7 @@ async fn registration_loop(
                     );
                     if e.code() == Code::FailedPrecondition {
                         core_metrics().metaserver_session_resets.add(1, &[]);
-                        heartbeat_after_remove_failure = true;
+                        node_registered = false;
                     }
                     remove_failed_at = Some(i);
                     break;
@@ -433,9 +428,6 @@ async fn registration_loop(
                 .metaserver_removal_failures
                 .add(dropped as u64, &[]);
             client = None;
-            if heartbeat_after_remove_failure {
-                node_registered = false;
-            }
         }
     }
 

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -7,6 +7,7 @@ use pegaflow_proto::proto::engine::{
     RemoveBlockHashesRequest, UnregisterNodeRequest,
 };
 use tokio::sync::{mpsc, oneshot};
+use tokio::time::{Duration, Instant};
 use tonic::Code;
 use tonic::transport::{Channel, Endpoint};
 use uuid::Uuid;
@@ -31,8 +32,26 @@ impl std::fmt::Display for ClientError {
 
 const INITIAL_BACKOFF_MS: u64 = 100;
 const MAX_BACKOFF_MS: u64 = 30_000;
-const HEARTBEAT_INTERVAL_SECS: u64 = 10;
+const MIN_HEARTBEAT_INTERVAL_SECS: u64 = 1;
 const UNREGISTER_TIMEOUT_SECS: u64 = 3;
+
+struct HeartbeatState {
+    node_registered: bool,
+    backoff_ms: u64,
+    period: Duration,
+    next_at: Instant,
+}
+
+impl HeartbeatState {
+    fn new() -> Self {
+        Self {
+            node_registered: false,
+            backoff_ms: INITIAL_BACKOFF_MS,
+            period: Duration::from_secs(MIN_HEARTBEAT_INTERVAL_SECS),
+            next_at: Instant::now(),
+        }
+    }
+}
 
 pub struct MetaServerClientConfig {
     pub metaserver_addr: String,
@@ -231,31 +250,31 @@ async fn registration_loop(
 ) {
     let mut client: Option<MetaServerGrpcClient<Channel>> = None;
     let node_id = Uuid::new_v4().to_string();
-    let mut node_registered = false;
-    let mut backoff_ms: u64 = INITIAL_BACKOFF_MS;
-    let heartbeat_period = tokio::time::Duration::from_secs(HEARTBEAT_INTERVAL_SECS);
-    let mut heartbeat = tokio::time::interval_at(
-        tokio::time::Instant::now() + heartbeat_period,
-        heartbeat_period,
-    );
-    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut heartbeat = HeartbeatState::new();
 
     loop {
+        let heartbeat_sleep = tokio::time::sleep_until(heartbeat.next_at);
+        tokio::pin!(heartbeat_sleep);
         let cmd = tokio::select! {
             cmd = rx.recv() => match cmd {
                 Some(cmd) => cmd,
                 None => break,
             },
-            _ = heartbeat.tick() => {
-                if send_heartbeat(
+            _ = &mut heartbeat_sleep => {
+                match send_heartbeat(
                     &mut client,
-                    &mut node_registered,
+                    &mut heartbeat,
                     &metaserver_addr,
                     &advertise_addr,
                     &node_id,
-                    &mut backoff_ms,
-                ).await.is_err() {
-                    continue;
+                ).await {
+                    Ok(next_period) => {
+                        heartbeat.period = next_period;
+                        heartbeat.next_at = Instant::now() + heartbeat.period;
+                    }
+                    Err(retry_after) => {
+                        heartbeat.next_at = Instant::now() + retry_after;
+                    }
                 }
                 continue;
             }
@@ -315,11 +334,10 @@ async fn registration_loop(
         let remove_total: usize = removes.values().map(|v| v.len()).sum();
         if ensure_heartbeat_registered(
             &mut client,
-            &mut node_registered,
             &metaserver_addr,
             &advertise_addr,
             &node_id,
-            &mut backoff_ms,
+            &mut heartbeat,
         )
         .await
         .is_err()
@@ -363,7 +381,7 @@ async fn registration_loop(
                     );
                     if e.code() == Code::FailedPrecondition {
                         core_metrics().metaserver_session_resets.add(1, &[]);
-                        node_registered = false;
+                        heartbeat.node_registered = false;
                     }
                     insert_failed_at = Some(i);
                     break;
@@ -414,7 +432,7 @@ async fn registration_loop(
                     );
                     if e.code() == Code::FailedPrecondition {
                         core_metrics().metaserver_session_resets.add(1, &[]);
-                        node_registered = false;
+                        heartbeat.node_registered = false;
                     }
                     remove_failed_at = Some(i);
                     break;
@@ -436,48 +454,50 @@ async fn registration_loop(
 
 async fn ensure_heartbeat_registered(
     client: &mut Option<MetaServerGrpcClient<Channel>>,
-    node_registered: &mut bool,
     metaserver_addr: &str,
     advertise_addr: &str,
     node_id: &str,
-    backoff_ms: &mut u64,
+    heartbeat: &mut HeartbeatState,
 ) -> Result<(), ()> {
-    if *node_registered {
+    if heartbeat.node_registered && client.is_some() {
         return Ok(());
     }
 
-    send_heartbeat(
-        client,
-        node_registered,
-        metaserver_addr,
-        advertise_addr,
-        node_id,
-        backoff_ms,
-    )
-    .await
+    if Instant::now() < heartbeat.next_at {
+        return Err(());
+    }
+
+    match send_heartbeat(client, heartbeat, metaserver_addr, advertise_addr, node_id).await {
+        Ok(next_period) => {
+            heartbeat.period = next_period;
+            heartbeat.next_at = Instant::now() + next_period;
+            Ok(())
+        }
+        Err(retry_after) => {
+            heartbeat.next_at = Instant::now() + retry_after;
+            Err(())
+        }
+    }
 }
 
 async fn send_heartbeat(
     client: &mut Option<MetaServerGrpcClient<Channel>>,
-    node_registered: &mut bool,
+    heartbeat: &mut HeartbeatState,
     metaserver_addr: &str,
     advertise_addr: &str,
     node_id: &str,
-    backoff_ms: &mut u64,
-) -> Result<(), ()> {
+) -> Result<Duration, Duration> {
     if client.is_none() {
         match MetaServerGrpcClient::connect(metaserver_addr.to_string()).await {
             Ok(c) => {
                 info!("Connected to MetaServer at {}", metaserver_addr);
                 *client = Some(c);
-                *backoff_ms = INITIAL_BACKOFF_MS;
+                heartbeat.backoff_ms = INITIAL_BACKOFF_MS;
             }
             Err(e) => {
                 error!("Failed to connect to MetaServer: {e}");
                 core_metrics().metaserver_heartbeat_failures.add(1, &[]);
-                tokio::time::sleep(tokio::time::Duration::from_millis(*backoff_ms)).await;
-                *backoff_ms = (*backoff_ms * 2).min(MAX_BACKOFF_MS);
-                return Err(());
+                return Err(heartbeat.advance_backoff());
             }
         }
     }
@@ -490,24 +510,39 @@ async fn send_heartbeat(
         })
         .await
     {
-        Ok(_) => {
-            debug!("Heartbeat accepted by MetaServer: node={advertise_addr} node_id={node_id}");
-            *node_registered = true;
-            *backoff_ms = INITIAL_BACKOFF_MS;
-            Ok(())
+        Ok(resp) => {
+            let heartbeat_period =
+                heartbeat_period_from_stale_after(resp.into_inner().stale_after_secs);
+            debug!(
+                "Heartbeat accepted by MetaServer: node={advertise_addr} node_id={node_id} next_in={:?}",
+                heartbeat_period
+            );
+            heartbeat.node_registered = true;
+            heartbeat.backoff_ms = INITIAL_BACKOFF_MS;
+            Ok(heartbeat_period)
         }
         Err(e) => {
             warn!("MetaServer heartbeat failed: {e}");
             core_metrics().metaserver_heartbeat_failures.add(1, &[]);
             if e.code() == Code::FailedPrecondition {
                 core_metrics().metaserver_session_resets.add(1, &[]);
-                *node_registered = false;
+                heartbeat.node_registered = false;
             }
             *client = None;
-            tokio::time::sleep(tokio::time::Duration::from_millis(*backoff_ms)).await;
-            *backoff_ms = (*backoff_ms * 2).min(MAX_BACKOFF_MS);
-            Err(())
+            Err(heartbeat.advance_backoff())
         }
+    }
+}
+
+fn heartbeat_period_from_stale_after(stale_after_secs: u64) -> Duration {
+    Duration::from_secs((stale_after_secs / 2).max(MIN_HEARTBEAT_INTERVAL_SECS))
+}
+
+impl HeartbeatState {
+    fn advance_backoff(&mut self) -> Duration {
+        let delay = Duration::from_millis(self.backoff_ms);
+        self.backoff_ms = (self.backoff_ms * 2).min(MAX_BACKOFF_MS);
+        delay
     }
 }
 
@@ -556,5 +591,180 @@ async fn unregister_current_session(
             warn!("MetaServer unregister_node timed out");
             core_metrics().metaserver_unregister_failures.add(1, &[]);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pegaflow_proto::proto::engine::meta_server_server::{MetaServer, MetaServerServer};
+    use pegaflow_proto::proto::engine::{
+        HeartbeatNodeResponse, InsertBlockHashesResponse, QueryPrefixBlocksResponse,
+        RemoveBlockHashesResponse, ResponseStatus, UnregisterNodeResponse,
+    };
+    use std::net::SocketAddr;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use tokio::net::TcpListener;
+    use tokio::sync::{Notify, oneshot};
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::{Request, Response, Status, async_trait};
+
+    #[derive(Default)]
+    struct FakeMetaServerState {
+        heartbeat_count: AtomicUsize,
+        insert_count: AtomicUsize,
+        unregister_count: AtomicUsize,
+        fail_insert_with_stale_session: AtomicUsize,
+        heartbeat_notify: Notify,
+        unregister_notify: Notify,
+    }
+
+    #[derive(Clone)]
+    struct FakeMetaServer {
+        state: Arc<FakeMetaServerState>,
+    }
+
+    #[async_trait]
+    impl MetaServer for FakeMetaServer {
+        async fn heartbeat_node(
+            &self,
+            _request: Request<HeartbeatNodeRequest>,
+        ) -> Result<Response<HeartbeatNodeResponse>, Status> {
+            self.state.heartbeat_count.fetch_add(1, Ordering::SeqCst);
+            self.state.heartbeat_notify.notify_waiters();
+            Ok(Response::new(HeartbeatNodeResponse {
+                status: Some(ResponseStatus {
+                    ok: true,
+                    message: String::new(),
+                }),
+                stale_after_secs: 2,
+            }))
+        }
+
+        async fn unregister_node(
+            &self,
+            _request: Request<UnregisterNodeRequest>,
+        ) -> Result<Response<UnregisterNodeResponse>, Status> {
+            self.state.unregister_count.fetch_add(1, Ordering::SeqCst);
+            self.state.unregister_notify.notify_waiters();
+            Ok(Response::new(UnregisterNodeResponse { removed_keys: 0 }))
+        }
+
+        async fn insert_block_hashes(
+            &self,
+            _request: Request<InsertBlockHashesRequest>,
+        ) -> Result<Response<InsertBlockHashesResponse>, Status> {
+            self.state.insert_count.fetch_add(1, Ordering::SeqCst);
+            if self
+                .state
+                .fail_insert_with_stale_session
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    (remaining > 0).then_some(remaining - 1)
+                })
+                .is_ok()
+            {
+                return Err(Status::failed_precondition("stale node session"));
+            }
+            Ok(Response::new(InsertBlockHashesResponse {
+                status: Some(ResponseStatus {
+                    ok: true,
+                    message: String::new(),
+                }),
+                inserted_count: 1,
+            }))
+        }
+
+        async fn remove_block_hashes(
+            &self,
+            _request: Request<RemoveBlockHashesRequest>,
+        ) -> Result<Response<RemoveBlockHashesResponse>, Status> {
+            Ok(Response::new(RemoveBlockHashesResponse {
+                status: Some(ResponseStatus {
+                    ok: true,
+                    message: String::new(),
+                }),
+                removed_count: 1,
+            }))
+        }
+
+        async fn query_prefix_blocks(
+            &self,
+            _request: Request<QueryPrefixBlocksRequest>,
+        ) -> Result<Response<QueryPrefixBlocksResponse>, Status> {
+            Ok(Response::new(QueryPrefixBlocksResponse { nodes: vec![] }))
+        }
+    }
+
+    async fn start_fake_metaserver() -> (String, Arc<FakeMetaServerState>, oneshot::Sender<()>) {
+        let state = Arc::new(FakeMetaServerState::default());
+        let service = FakeMetaServer {
+            state: Arc::clone(&state),
+        };
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let incoming = TcpListenerStream::new(listener);
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(MetaServerServer::new(service))
+                .serve_with_incoming_shutdown(incoming, async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        (format!("http://{addr}"), state, shutdown_tx)
+    }
+
+    async fn wait_for_count(notify: &Notify, count: &AtomicUsize, expected: usize) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+        loop {
+            if count.load(Ordering::SeqCst) >= expected {
+                return;
+            }
+            tokio::select! {
+                _ = notify.notified() => {}
+                _ = tokio::time::sleep_until(deadline) => {
+                    panic!("timed out waiting for count {expected}");
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn heartbeat_loop_sends_initial_heartbeat_and_unregisters_on_shutdown() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        let client = MetaServerClient::new(MetaServerClientConfig::new(
+            addr,
+            "node-a:50055".to_string(),
+        ));
+
+        wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
+        client.shutdown().await;
+        wait_for_count(&service.unregister_notify, &service.unregister_count, 1).await;
+
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn stale_session_write_error_triggers_new_heartbeat() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        service
+            .fail_insert_with_stale_session
+            .store(1, Ordering::SeqCst);
+        let client = MetaServerClient::new(MetaServerClientConfig::new(
+            addr,
+            "node-a:50055".to_string(),
+        ));
+
+        wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
+        client.try_register(vec![("ns".to_string(), vec![1])]);
+        wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 2).await;
+
+        client.shutdown().await;
+        let _ = shutdown_tx.send(());
     }
 }

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -474,6 +474,7 @@ async fn send_heartbeat(
             }
             Err(e) => {
                 error!("Failed to connect to MetaServer: {e}");
+                core_metrics().metaserver_heartbeat_failures.add(1, &[]);
                 tokio::time::sleep(tokio::time::Duration::from_millis(*backoff_ms)).await;
                 *backoff_ms = (*backoff_ms * 2).min(MAX_BACKOFF_MS);
                 return Err(());
@@ -490,7 +491,7 @@ async fn send_heartbeat(
         .await
     {
         Ok(_) => {
-            info!("Heartbeat accepted by MetaServer: node={advertise_addr} node_id={node_id}");
+            debug!("Heartbeat accepted by MetaServer: node={advertise_addr} node_id={node_id}");
             *node_registered = true;
             *backoff_ms = INITIAL_BACKOFF_MS;
             Ok(())

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -4,11 +4,12 @@ use log::{debug, error, info, warn};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
     HeartbeatNodeRequest, InsertBlockHashesRequest, NodePrefixResult, QueryPrefixBlocksRequest,
-    RegisterNodeRequest, RemoveBlockHashesRequest, UnregisterNodeRequest,
+    RemoveBlockHashesRequest, UnregisterNodeRequest,
 };
 use tokio::sync::{mpsc, oneshot};
 use tonic::Code;
 use tonic::transport::{Channel, Endpoint};
+use uuid::Uuid;
 
 use crate::metrics::core_metrics;
 
@@ -229,7 +230,8 @@ async fn registration_loop(
     advertise_addr: String,
 ) {
     let mut client: Option<MetaServerGrpcClient<Channel>> = None;
-    let mut node_id: Option<String> = None;
+    let node_id = Uuid::new_v4().to_string();
+    let mut node_registered = false;
     let mut backoff_ms: u64 = INITIAL_BACKOFF_MS;
     let heartbeat_period = tokio::time::Duration::from_secs(HEARTBEAT_INTERVAL_SECS);
     let mut heartbeat = tokio::time::interval_at(
@@ -245,28 +247,15 @@ async fn registration_loop(
                 None => break,
             },
             _ = heartbeat.tick() => {
-                if ensure_registered(
+                if send_heartbeat(
                     &mut client,
-                    &mut node_id,
+                    &mut node_registered,
                     &metaserver_addr,
                     &advertise_addr,
+                    &node_id,
                     &mut backoff_ms,
                 ).await.is_err() {
                     continue;
-                }
-                if let (Some(c), Some(id)) = (client.as_mut(), node_id.as_ref()) {
-                    if let Err(e) = c.heartbeat_node(HeartbeatNodeRequest {
-                        node: advertise_addr.clone(),
-                        node_id: id.clone(),
-                    }).await {
-                        warn!("MetaServer heartbeat failed: {e}");
-                        core_metrics().metaserver_heartbeat_failures.add(1, &[]);
-                        if e.code() == Code::FailedPrecondition {
-                            core_metrics().metaserver_session_resets.add(1, &[]);
-                            node_id = None;
-                        }
-                        client = None;
-                    }
                 }
                 continue;
             }
@@ -324,11 +313,12 @@ async fn registration_loop(
 
         let insert_total: usize = inserts.values().map(|v| v.len()).sum();
         let remove_total: usize = removes.values().map(|v| v.len()).sum();
-        if ensure_registered(
+        if ensure_heartbeat_registered(
             &mut client,
-            &mut node_id,
+            &mut node_registered,
             &metaserver_addr,
             &advertise_addr,
+            &node_id,
             &mut backoff_ms,
         )
         .await
@@ -344,15 +334,11 @@ async fn registration_loop(
         }
 
         let c = client.as_mut().expect("client is Some after lazy-connect");
-        let id = node_id
-            .as_ref()
-            .expect("node_id is Some after ensure_registered")
-            .clone();
 
         // Process inserts
         let insert_namespaces: Vec<(String, Vec<Vec<u8>>)> = inserts.into_iter().collect();
         let mut insert_failed_at = None;
-        let mut reset_session_after_insert_failure = false;
+        let mut heartbeat_after_insert_failure = false;
 
         for (i, (namespace, hashes)) in insert_namespaces.iter().enumerate() {
             let count = hashes.len();
@@ -360,7 +346,7 @@ async fn registration_loop(
                 namespace: namespace.clone(),
                 block_hashes: hashes.clone(),
                 node: advertise_addr.clone(),
-                node_id: id.clone(),
+                node_id: node_id.clone(),
             };
 
             match c.insert_block_hashes(request).await {
@@ -378,7 +364,7 @@ async fn registration_loop(
                     );
                     if e.code() == Code::FailedPrecondition {
                         core_metrics().metaserver_session_resets.add(1, &[]);
-                        reset_session_after_insert_failure = true;
+                        heartbeat_after_insert_failure = true;
                     }
                     insert_failed_at = Some(i);
                     break;
@@ -398,8 +384,8 @@ async fn registration_loop(
                     .add(remove_total as u64, &[]);
             }
             client = None;
-            if reset_session_after_insert_failure {
-                node_id = None;
+            if heartbeat_after_insert_failure {
+                node_registered = false;
             }
             continue;
         }
@@ -407,7 +393,7 @@ async fn registration_loop(
         // Process removes
         let remove_namespaces: Vec<(String, Vec<Vec<u8>>)> = removes.into_iter().collect();
         let mut remove_failed_at = None;
-        let mut reset_session_after_remove_failure = false;
+        let mut heartbeat_after_remove_failure = false;
 
         for (i, (namespace, hashes)) in remove_namespaces.iter().enumerate() {
             let count = hashes.len();
@@ -415,7 +401,7 @@ async fn registration_loop(
                 namespace: namespace.clone(),
                 block_hashes: hashes.clone(),
                 node: advertise_addr.clone(),
-                node_id: id.clone(),
+                node_id: node_id.clone(),
             };
 
             match c.remove_block_hashes(request).await {
@@ -433,7 +419,7 @@ async fn registration_loop(
                     );
                     if e.code() == Code::FailedPrecondition {
                         core_metrics().metaserver_session_resets.add(1, &[]);
-                        reset_session_after_remove_failure = true;
+                        heartbeat_after_remove_failure = true;
                     }
                     remove_failed_at = Some(i);
                     break;
@@ -447,8 +433,8 @@ async fn registration_loop(
                 .metaserver_removal_failures
                 .add(dropped as u64, &[]);
             client = None;
-            if reset_session_after_remove_failure {
-                node_id = None;
+            if heartbeat_after_remove_failure {
+                node_registered = false;
             }
         }
     }
@@ -456,11 +442,35 @@ async fn registration_loop(
     info!("MetaServer registration loop shutting down");
 }
 
-async fn ensure_registered(
+async fn ensure_heartbeat_registered(
     client: &mut Option<MetaServerGrpcClient<Channel>>,
-    node_id: &mut Option<String>,
+    node_registered: &mut bool,
     metaserver_addr: &str,
     advertise_addr: &str,
+    node_id: &str,
+    backoff_ms: &mut u64,
+) -> Result<(), ()> {
+    if *node_registered {
+        return Ok(());
+    }
+
+    send_heartbeat(
+        client,
+        node_registered,
+        metaserver_addr,
+        advertise_addr,
+        node_id,
+        backoff_ms,
+    )
+    .await
+}
+
+async fn send_heartbeat(
+    client: &mut Option<MetaServerGrpcClient<Channel>>,
+    node_registered: &mut bool,
+    metaserver_addr: &str,
+    advertise_addr: &str,
+    node_id: &str,
     backoff_ms: &mut u64,
 ) -> Result<(), ()> {
     if client.is_none() {
@@ -479,27 +489,27 @@ async fn ensure_registered(
         }
     }
 
-    if node_id.is_some() {
-        return Ok(());
-    }
-
     let c = client.as_mut().expect("client is connected");
     match c
-        .register_node(RegisterNodeRequest {
+        .heartbeat_node(HeartbeatNodeRequest {
             node: advertise_addr.to_string(),
+            node_id: node_id.to_string(),
         })
         .await
     {
-        Ok(resp) => {
-            let id = resp.into_inner().node_id;
-            info!("Registered MetaServer node session: node={advertise_addr} node_id={id}");
-            *node_id = Some(id);
+        Ok(_) => {
+            info!("Heartbeat accepted by MetaServer: node={advertise_addr} node_id={node_id}");
+            *node_registered = true;
             *backoff_ms = INITIAL_BACKOFF_MS;
             Ok(())
         }
         Err(e) => {
-            error!("MetaServer register_node failed: {e}");
-            core_metrics().metaserver_node_register_failures.add(1, &[]);
+            warn!("MetaServer heartbeat failed: {e}");
+            core_metrics().metaserver_heartbeat_failures.add(1, &[]);
+            if e.code() == Code::FailedPrecondition {
+                core_metrics().metaserver_session_resets.add(1, &[]);
+                *node_registered = false;
+            }
             *client = None;
             tokio::time::sleep(tokio::time::Duration::from_millis(*backoff_ms)).await;
             *backoff_ms = (*backoff_ms * 2).min(MAX_BACKOFF_MS);
@@ -512,12 +522,8 @@ async fn unregister_current_session(
     client: &mut Option<MetaServerGrpcClient<Channel>>,
     metaserver_addr: &str,
     advertise_addr: &str,
-    node_id: &Option<String>,
+    node_id: &str,
 ) {
-    let Some(id) = node_id.as_ref() else {
-        return;
-    };
-
     if client.is_none() {
         match MetaServerGrpcClient::connect(metaserver_addr.to_string()).await {
             Ok(c) => *client = Some(c),
@@ -534,7 +540,7 @@ async fn unregister_current_session(
     };
     let request = UnregisterNodeRequest {
         node: advertise_addr.to_string(),
-        node_id: id.clone(),
+        node_id: node_id.to_string(),
     };
     match tokio::time::timeout(
         tokio::time::Duration::from_secs(UNREGISTER_TIMEOUT_SECS),

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -3,9 +3,11 @@ use std::collections::HashMap;
 use log::{debug, error, info, warn};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
-    InsertBlockHashesRequest, NodePrefixResult, QueryPrefixBlocksRequest, RemoveBlockHashesRequest,
+    HeartbeatNodeRequest, InsertBlockHashesRequest, NodePrefixResult, QueryPrefixBlocksRequest,
+    RegisterNodeRequest, RemoveBlockHashesRequest, UnregisterNodeRequest,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
+use tonic::Code;
 use tonic::transport::{Channel, Endpoint};
 
 use crate::metrics::core_metrics;
@@ -28,6 +30,8 @@ impl std::fmt::Display for ClientError {
 
 const INITIAL_BACKOFF_MS: u64 = 100;
 const MAX_BACKOFF_MS: u64 = 30_000;
+const HEARTBEAT_INTERVAL_SECS: u64 = 10;
+const UNREGISTER_TIMEOUT_SECS: u64 = 3;
 
 pub struct MetaServerClientConfig {
     pub metaserver_addr: String,
@@ -59,6 +63,7 @@ struct BlockHashBatch {
 enum MetaServerCommand {
     Insert(BlockHashBatch),
     Remove(BlockHashBatch),
+    Shutdown(oneshot::Sender<()>),
 }
 
 /// Unified MetaServer client handling both insert (fire-and-forget) and query (direct RPC).
@@ -139,8 +144,8 @@ impl MetaServerClient {
     /// Fire-and-forget removal of block hashes.
     ///
     /// Called after LRU eviction to notify MetaServer that this node no longer
-    /// holds these blocks. Losing an occasional remove message is acceptable —
-    /// TTL still serves as the ultimate fallback for node failures.
+    /// holds these blocks. Losing an occasional remove message is acceptable;
+    /// the node lifecycle sweep is the fallback for node failures.
     pub(crate) fn try_unregister(&self, entries: Vec<(String, Vec<u8>)>) {
         if entries.is_empty() {
             return;
@@ -169,6 +174,22 @@ impl MetaServerClient {
                     .add(count as u64, &[]);
             }
         }
+    }
+
+    /// Best-effort graceful unregister of this server's MetaServer node session.
+    pub async fn shutdown(&self) {
+        let (done_tx, done_rx) = oneshot::channel();
+        let shutdown_timeout = tokio::time::Duration::from_secs(UNREGISTER_TIMEOUT_SECS + 1);
+        match tokio::time::timeout(
+            shutdown_timeout,
+            self.command_tx.send(MetaServerCommand::Shutdown(done_tx)),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(_)) | Err(_) => return,
+        }
+        let _ = tokio::time::timeout(shutdown_timeout, done_rx).await;
     }
 
     /// Query MetaServer for the longest prefix of blocks that exist remotely.
@@ -208,9 +229,60 @@ async fn registration_loop(
     advertise_addr: String,
 ) {
     let mut client: Option<MetaServerGrpcClient<Channel>> = None;
+    let mut node_id: Option<String> = None;
     let mut backoff_ms: u64 = INITIAL_BACKOFF_MS;
+    let heartbeat_period = tokio::time::Duration::from_secs(HEARTBEAT_INTERVAL_SECS);
+    let mut heartbeat = tokio::time::interval_at(
+        tokio::time::Instant::now() + heartbeat_period,
+        heartbeat_period,
+    );
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-    while let Some(cmd) = rx.recv().await {
+    loop {
+        let cmd = tokio::select! {
+            cmd = rx.recv() => match cmd {
+                Some(cmd) => cmd,
+                None => break,
+            },
+            _ = heartbeat.tick() => {
+                if ensure_registered(
+                    &mut client,
+                    &mut node_id,
+                    &metaserver_addr,
+                    &advertise_addr,
+                    &mut backoff_ms,
+                ).await.is_err() {
+                    continue;
+                }
+                let mut reset_session = false;
+                if let (Some(c), Some(id)) = (client.as_mut(), node_id.as_ref()) {
+                    if let Err(e) = c.heartbeat_node(HeartbeatNodeRequest {
+                        node: advertise_addr.clone(),
+                        node_id: id.clone(),
+                    }).await {
+                        warn!("MetaServer heartbeat failed: {e}");
+                        core_metrics().metaserver_heartbeat_failures.add(1, &[]);
+                        if e.code() == Code::FailedPrecondition {
+                            core_metrics().metaserver_session_resets.add(1, &[]);
+                        }
+                        reset_session = true;
+                    }
+                }
+                if reset_session {
+                    client = None;
+                    node_id = None;
+                }
+                continue;
+            }
+        };
+
+        if let MetaServerCommand::Shutdown(done) = cmd {
+            unregister_current_session(&mut client, &metaserver_addr, &advertise_addr, &node_id)
+                .await;
+            let _ = done.send(());
+            break;
+        }
+
         // Drain all pending commands. For each (namespace, hash), keep only the last
         // operation (last-write-wins), so [Remove(X), Insert(X)] correctly resolves
         // to Insert(X) rather than being reversed by separate-bucket processing.
@@ -228,6 +300,18 @@ async fn registration_loop(
                         net.insert((ns, hash), false);
                     }
                 }
+                MetaServerCommand::Shutdown(done) => {
+                    unregister_current_session(
+                        &mut client,
+                        &metaserver_addr,
+                        &advertise_addr,
+                        &node_id,
+                    )
+                    .await;
+                    let _ = done.send(());
+                    info!("MetaServer registration loop shutting down");
+                    return;
+                }
             }
         }
 
@@ -242,32 +326,32 @@ async fn registration_loop(
             }
         }
 
-        // Lazy-connect with exponential backoff
-        if client.is_none() {
-            match MetaServerGrpcClient::connect(metaserver_addr.clone()).await {
-                Ok(c) => {
-                    info!("Connected to MetaServer at {}", metaserver_addr);
-                    client = Some(c);
-                    backoff_ms = INITIAL_BACKOFF_MS;
-                }
-                Err(e) => {
-                    error!("Failed to connect to MetaServer: {e}");
-                    let insert_total: usize = inserts.values().map(|v| v.len()).sum();
-                    let remove_total: usize = removes.values().map(|v| v.len()).sum();
-                    core_metrics()
-                        .metaserver_registration_failures
-                        .add(insert_total as u64, &[]);
-                    core_metrics()
-                        .metaserver_removal_failures
-                        .add(remove_total as u64, &[]);
-                    tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
-                    backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);
-                    continue;
-                }
-            }
+        let insert_total: usize = inserts.values().map(|v| v.len()).sum();
+        let remove_total: usize = removes.values().map(|v| v.len()).sum();
+        if ensure_registered(
+            &mut client,
+            &mut node_id,
+            &metaserver_addr,
+            &advertise_addr,
+            &mut backoff_ms,
+        )
+        .await
+        .is_err()
+        {
+            core_metrics()
+                .metaserver_registration_failures
+                .add(insert_total as u64, &[]);
+            core_metrics()
+                .metaserver_removal_failures
+                .add(remove_total as u64, &[]);
+            continue;
         }
 
         let c = client.as_mut().expect("client is Some after lazy-connect");
+        let id = node_id
+            .as_ref()
+            .expect("node_id is Some after ensure_registered")
+            .clone();
 
         // Process inserts
         let insert_namespaces: Vec<(String, Vec<Vec<u8>>)> = inserts.into_iter().collect();
@@ -279,6 +363,7 @@ async fn registration_loop(
                 namespace: namespace.clone(),
                 block_hashes: hashes.clone(),
                 node: advertise_addr.clone(),
+                node_id: id.clone(),
             };
 
             match c.insert_block_hashes(request).await {
@@ -294,6 +379,9 @@ async fn registration_loop(
                         "MetaServer insert_block_hashes failed (namespace={}, count={}): {e}",
                         namespace, count
                     );
+                    if e.code() == Code::FailedPrecondition {
+                        core_metrics().metaserver_session_resets.add(1, &[]);
+                    }
                     insert_failed_at = Some(i);
                     break;
                 }
@@ -312,6 +400,7 @@ async fn registration_loop(
                     .add(remove_total as u64, &[]);
             }
             client = None;
+            node_id = None;
             continue;
         }
 
@@ -325,6 +414,7 @@ async fn registration_loop(
                 namespace: namespace.clone(),
                 block_hashes: hashes.clone(),
                 node: advertise_addr.clone(),
+                node_id: id.clone(),
             };
 
             match c.remove_block_hashes(request).await {
@@ -340,6 +430,9 @@ async fn registration_loop(
                         "MetaServer remove_block_hashes failed (namespace={}, count={}): {e}",
                         namespace, count
                     );
+                    if e.code() == Code::FailedPrecondition {
+                        core_metrics().metaserver_session_resets.add(1, &[]);
+                    }
                     remove_failed_at = Some(i);
                     break;
                 }
@@ -352,8 +445,113 @@ async fn registration_loop(
                 .metaserver_removal_failures
                 .add(dropped as u64, &[]);
             client = None;
+            node_id = None;
         }
     }
 
     info!("MetaServer registration loop shutting down");
+}
+
+async fn ensure_registered(
+    client: &mut Option<MetaServerGrpcClient<Channel>>,
+    node_id: &mut Option<String>,
+    metaserver_addr: &str,
+    advertise_addr: &str,
+    backoff_ms: &mut u64,
+) -> Result<(), ()> {
+    if client.is_none() {
+        match MetaServerGrpcClient::connect(metaserver_addr.to_string()).await {
+            Ok(c) => {
+                info!("Connected to MetaServer at {}", metaserver_addr);
+                *client = Some(c);
+                *backoff_ms = INITIAL_BACKOFF_MS;
+            }
+            Err(e) => {
+                error!("Failed to connect to MetaServer: {e}");
+                tokio::time::sleep(tokio::time::Duration::from_millis(*backoff_ms)).await;
+                *backoff_ms = (*backoff_ms * 2).min(MAX_BACKOFF_MS);
+                return Err(());
+            }
+        }
+    }
+
+    if node_id.is_some() {
+        return Ok(());
+    }
+
+    let c = client.as_mut().expect("client is connected");
+    match c
+        .register_node(RegisterNodeRequest {
+            node: advertise_addr.to_string(),
+        })
+        .await
+    {
+        Ok(resp) => {
+            let id = resp.into_inner().node_id;
+            info!("Registered MetaServer node session: node={advertise_addr} node_id={id}");
+            *node_id = Some(id);
+            *backoff_ms = INITIAL_BACKOFF_MS;
+            Ok(())
+        }
+        Err(e) => {
+            error!("MetaServer register_node failed: {e}");
+            core_metrics().metaserver_node_register_failures.add(1, &[]);
+            *client = None;
+            tokio::time::sleep(tokio::time::Duration::from_millis(*backoff_ms)).await;
+            *backoff_ms = (*backoff_ms * 2).min(MAX_BACKOFF_MS);
+            Err(())
+        }
+    }
+}
+
+async fn unregister_current_session(
+    client: &mut Option<MetaServerGrpcClient<Channel>>,
+    metaserver_addr: &str,
+    advertise_addr: &str,
+    node_id: &Option<String>,
+) {
+    let Some(id) = node_id.as_ref() else {
+        return;
+    };
+
+    if client.is_none() {
+        match MetaServerGrpcClient::connect(metaserver_addr.to_string()).await {
+            Ok(c) => *client = Some(c),
+            Err(e) => {
+                warn!("Failed to connect to MetaServer for unregister: {e}");
+                core_metrics().metaserver_unregister_failures.add(1, &[]);
+                return;
+            }
+        }
+    }
+
+    let Some(c) = client.as_mut() else {
+        return;
+    };
+    let request = UnregisterNodeRequest {
+        node: advertise_addr.to_string(),
+        node_id: id.clone(),
+    };
+    match tokio::time::timeout(
+        tokio::time::Duration::from_secs(UNREGISTER_TIMEOUT_SECS),
+        c.unregister_node(request),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => {
+            debug!(
+                "Unregistered MetaServer node session: node={} removed_keys={}",
+                advertise_addr,
+                resp.into_inner().removed_keys
+            );
+        }
+        Ok(Err(e)) => {
+            warn!("MetaServer unregister_node failed: {e}");
+            core_metrics().metaserver_unregister_failures.add(1, &[]);
+        }
+        Err(_) => {
+            warn!("MetaServer unregister_node timed out");
+            core_metrics().metaserver_unregister_failures.add(1, &[]);
+        }
+    }
 }

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -380,6 +380,10 @@ async fn registration_loop(
                         namespace, count
                     );
                     if e.code() == Code::FailedPrecondition {
+                        warn!(
+                            "MetaServer insert rejected current session; resetting node registration: node={} node_id={}",
+                            advertise_addr, node_id
+                        );
                         core_metrics().metaserver_session_resets.add(1, &[]);
                         heartbeat.node_registered = false;
                     }
@@ -431,6 +435,10 @@ async fn registration_loop(
                         namespace, count
                     );
                     if e.code() == Code::FailedPrecondition {
+                        warn!(
+                            "MetaServer remove rejected current session; resetting node registration: node={} node_id={}",
+                            advertise_addr, node_id
+                        );
                         core_metrics().metaserver_session_resets.add(1, &[]);
                         heartbeat.node_registered = false;
                     }
@@ -513,10 +521,17 @@ async fn send_heartbeat(
         Ok(resp) => {
             let heartbeat_period =
                 heartbeat_period_from_stale_after(resp.into_inner().stale_after_secs);
-            debug!(
-                "Heartbeat accepted by MetaServer: node={advertise_addr} node_id={node_id} next_in={:?}",
-                heartbeat_period
-            );
+            if !heartbeat.node_registered {
+                info!(
+                    "MetaServer heartbeat established: node={advertise_addr} node_id={node_id} next_in={:?}",
+                    heartbeat_period
+                );
+            } else {
+                debug!(
+                    "Heartbeat accepted by MetaServer: node={advertise_addr} node_id={node_id} next_in={:?}",
+                    heartbeat_period
+                );
+            }
             heartbeat.node_registered = true;
             heartbeat.backoff_ms = INITIAL_BACKOFF_MS;
             Ok(heartbeat_period)
@@ -525,6 +540,9 @@ async fn send_heartbeat(
             warn!("MetaServer heartbeat failed: {e}");
             core_metrics().metaserver_heartbeat_failures.add(1, &[]);
             if e.code() == Code::FailedPrecondition {
+                warn!(
+                    "MetaServer heartbeat rejected current session; resetting node registration: node={advertise_addr} node_id={node_id}"
+                );
                 core_metrics().metaserver_session_resets.add(1, &[]);
                 heartbeat.node_registered = false;
             }
@@ -578,9 +596,9 @@ async fn unregister_current_session(
     {
         Ok(Ok(resp)) => {
             debug!(
-                "Unregistered MetaServer node session: node={} removed_keys={}",
+                "Unregistered MetaServer node session: node={} removed_owners={}",
                 advertise_addr,
-                resp.into_inner().removed_keys
+                resp.into_inner().removed_owners
             );
         }
         Ok(Err(e)) => {
@@ -636,10 +654,6 @@ mod tests {
             self.state.heartbeat_count.fetch_add(1, Ordering::SeqCst);
             self.state.heartbeat_notify.notify_waiters();
             Ok(Response::new(HeartbeatNodeResponse {
-                status: Some(ResponseStatus {
-                    ok: true,
-                    message: String::new(),
-                }),
                 stale_after_secs: 2,
             }))
         }
@@ -650,7 +664,7 @@ mod tests {
         ) -> Result<Response<UnregisterNodeResponse>, Status> {
             self.state.unregister_count.fetch_add(1, Ordering::SeqCst);
             self.state.unregister_notify.notify_waiters();
-            Ok(Response::new(UnregisterNodeResponse { removed_keys: 0 }))
+            Ok(Response::new(UnregisterNodeResponse { removed_owners: 0 }))
         }
 
         async fn insert_block_hashes(

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -254,7 +254,6 @@ async fn registration_loop(
                 ).await.is_err() {
                     continue;
                 }
-                let mut reset_session = false;
                 if let (Some(c), Some(id)) = (client.as_mut(), node_id.as_ref()) {
                     if let Err(e) = c.heartbeat_node(HeartbeatNodeRequest {
                         node: advertise_addr.clone(),
@@ -264,13 +263,10 @@ async fn registration_loop(
                         core_metrics().metaserver_heartbeat_failures.add(1, &[]);
                         if e.code() == Code::FailedPrecondition {
                             core_metrics().metaserver_session_resets.add(1, &[]);
+                            node_id = None;
                         }
-                        reset_session = true;
+                        client = None;
                     }
-                }
-                if reset_session {
-                    client = None;
-                    node_id = None;
                 }
                 continue;
             }
@@ -356,6 +352,7 @@ async fn registration_loop(
         // Process inserts
         let insert_namespaces: Vec<(String, Vec<Vec<u8>>)> = inserts.into_iter().collect();
         let mut insert_failed_at = None;
+        let mut reset_session_after_insert_failure = false;
 
         for (i, (namespace, hashes)) in insert_namespaces.iter().enumerate() {
             let count = hashes.len();
@@ -381,6 +378,7 @@ async fn registration_loop(
                     );
                     if e.code() == Code::FailedPrecondition {
                         core_metrics().metaserver_session_resets.add(1, &[]);
+                        reset_session_after_insert_failure = true;
                     }
                     insert_failed_at = Some(i);
                     break;
@@ -400,13 +398,16 @@ async fn registration_loop(
                     .add(remove_total as u64, &[]);
             }
             client = None;
-            node_id = None;
+            if reset_session_after_insert_failure {
+                node_id = None;
+            }
             continue;
         }
 
         // Process removes
         let remove_namespaces: Vec<(String, Vec<Vec<u8>>)> = removes.into_iter().collect();
         let mut remove_failed_at = None;
+        let mut reset_session_after_remove_failure = false;
 
         for (i, (namespace, hashes)) in remove_namespaces.iter().enumerate() {
             let count = hashes.len();
@@ -432,6 +433,7 @@ async fn registration_loop(
                     );
                     if e.code() == Code::FailedPrecondition {
                         core_metrics().metaserver_session_resets.add(1, &[]);
+                        reset_session_after_remove_failure = true;
                     }
                     remove_failed_at = Some(i);
                     break;
@@ -445,7 +447,9 @@ async fn registration_loop(
                 .metaserver_removal_failures
                 .add(dropped as u64, &[]);
             client = None;
-            node_id = None;
+            if reset_session_after_remove_failure {
+                node_id = None;
+            }
         }
     }
 

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -433,6 +433,11 @@ impl PegaEngine {
         self.storage.cleanup_memory_cache()
     }
 
+    /// Best-effort graceful unregister from MetaServer, if configured.
+    pub async fn shutdown_metaserver_client(&self) {
+        self.storage.shutdown_metaserver_client().await;
+    }
+
     /// Batch load KV blocks for multiple layers asynchronously.
     ///
     /// Returns immediately after submitting the task to the GPU worker pool.

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -382,7 +382,7 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
                 .build(),
             metaserver_node_register_failures: meter
                 .u64_counter("pegaflow_metaserver_node_register_failures")
-                .with_description("MetaServer RegisterNode RPC failures")
+                .with_description("MetaServer node heartbeat registration failures")
                 .build(),
             metaserver_heartbeat_failures: meter
                 .u64_counter("pegaflow_metaserver_heartbeat_failures")

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -75,7 +75,6 @@ pub(crate) struct CoreMetrics {
     pub metaserver_removal_blocks: Counter<u64>,
     pub metaserver_removal_failures: Counter<u64>,
     pub metaserver_removal_queue_full: Counter<u64>,
-    pub metaserver_node_register_failures: Counter<u64>,
     pub metaserver_heartbeat_failures: Counter<u64>,
     pub metaserver_session_resets: Counter<u64>,
     pub metaserver_unregister_failures: Counter<u64>,
@@ -379,10 +378,6 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
             metaserver_removal_queue_full: meter
                 .u64_counter("pegaflow_metaserver_removal_queue_full")
                 .with_description("Block hashes dropped due to full removal queue")
-                .build(),
-            metaserver_node_register_failures: meter
-                .u64_counter("pegaflow_metaserver_node_register_failures")
-                .with_description("MetaServer node heartbeat registration failures")
                 .build(),
             metaserver_heartbeat_failures: meter
                 .u64_counter("pegaflow_metaserver_heartbeat_failures")

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -75,6 +75,10 @@ pub(crate) struct CoreMetrics {
     pub metaserver_removal_blocks: Counter<u64>,
     pub metaserver_removal_failures: Counter<u64>,
     pub metaserver_removal_queue_full: Counter<u64>,
+    pub metaserver_node_register_failures: Counter<u64>,
+    pub metaserver_heartbeat_failures: Counter<u64>,
+    pub metaserver_session_resets: Counter<u64>,
+    pub metaserver_unregister_failures: Counter<u64>,
 
     // Cross-node transfer lock (serving side)
     pub transfer_lock_active: UpDownCounter<i64>,
@@ -375,6 +379,22 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
             metaserver_removal_queue_full: meter
                 .u64_counter("pegaflow_metaserver_removal_queue_full")
                 .with_description("Block hashes dropped due to full removal queue")
+                .build(),
+            metaserver_node_register_failures: meter
+                .u64_counter("pegaflow_metaserver_node_register_failures")
+                .with_description("MetaServer RegisterNode RPC failures")
+                .build(),
+            metaserver_heartbeat_failures: meter
+                .u64_counter("pegaflow_metaserver_heartbeat_failures")
+                .with_description("MetaServer HeartbeatNode RPC failures")
+                .build(),
+            metaserver_session_resets: meter
+                .u64_counter("pegaflow_metaserver_session_resets")
+                .with_description("MetaServer node session resets after stale-session errors")
+                .build(),
+            metaserver_unregister_failures: meter
+                .u64_counter("pegaflow_metaserver_unregister_failures")
+                .with_description("MetaServer UnregisterNode RPC failures")
                 .build(),
 
             // Transfer lock

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -568,6 +568,12 @@ impl StorageEngine {
     pub(crate) fn rdma_transport(&self) -> Option<&Arc<RdmaTransport>> {
         self.rdma_transport.as_ref()
     }
+
+    pub(crate) async fn shutdown_metaserver_client(&self) {
+        if let Some(client) = &self.metaserver_client {
+            client.shutdown().await;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/pegaflow-metaserver/Cargo.toml
+++ b/pegaflow-metaserver/Cargo.toml
@@ -33,3 +33,10 @@ opentelemetry_sdk.workspace = true
 opentelemetry-prometheus.workspace = true
 prometheus.workspace = true
 axum.workspace = true
+
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "unregister_node"
+harness = false

--- a/pegaflow-metaserver/Cargo.toml
+++ b/pegaflow-metaserver/Cargo.toml
@@ -25,6 +25,7 @@ clap.workspace = true
 log.workspace = true
 parking_lot.workspace = true
 dashmap.workspace = true
+uuid.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 opentelemetry.workspace = true

--- a/pegaflow-metaserver/README.md
+++ b/pegaflow-metaserver/README.md
@@ -61,10 +61,10 @@ cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056
 cargo run -p pegaflow-metaserver -- --log-level debug
 
 # Custom node lifecycle timings
-cargo run -p pegaflow-metaserver -- --node-stale-secs 30 --node-purge-secs 90 --sweep-interval-secs 10
+cargo run -p pegaflow-metaserver -- --node-stale-secs 30 --ttl-minutes 120
 
 # All options combined
-cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056 --node-stale-secs 30 --node-purge-secs 90 --log-level info
+cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056 --node-stale-secs 30 --ttl-minutes 120 --log-level info
 
 # Show all options
 cargo run -p pegaflow-metaserver -- --help
@@ -75,8 +75,7 @@ cargo run -p pegaflow-metaserver -- --help
 - `--addr <ADDR>`: Bind address (default: `127.0.0.1:50056`)
 - `--log-level <LEVEL>`: Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`)
 - `--node-stale-secs <SECONDS>`: Hide nodes from query after this many seconds without heartbeat (default: `30`)
-- `--node-purge-secs <SECONDS>`: Purge nodes and ownership after this many seconds without heartbeat (default: `90`)
-- `--sweep-interval-secs <SECONDS>`: Background lifecycle sweep interval (default: `10`)
+- `--ttl-minutes <MINUTES>`: Purge ownership and node records after this many minutes; the sweep runs at this interval (default: `120`)
 
 ### Storage Configuration
 
@@ -85,7 +84,7 @@ The MetaServer uses a DashMap-based in-memory store with the following character
 - **Multi-owner**: A block hash can be registered by multiple nodes simultaneously
 - **Node lifecycle**: Servers call `RegisterNode`, heartbeat periodically, and include the returned `node_id` in insert/remove RPCs.
 - **Stale filtering**: Nodes stop appearing in query results after 30 seconds without heartbeat by default.
-- **Purge sweep**: A background task removes stale owners and nodes after 90 seconds without heartbeat by default.
+- **TTL sweep**: A background task removes expired owners and nodes after `--ttl-minutes`.
 - **Conditional removal**: `RemoveBlockHashes` only removes the requesting node's ownership; other nodes' entries are untouched.
 - **Memory**: Scales with unique blocks across all nodes. No hard capacity cap — memory is naturally bounded by the total number of blocks in the cluster.
 
@@ -217,7 +216,7 @@ Graceful shutdown trigger.
 - **Data structure**: `blocks: DashMap<BlockKey, HashMap<Arc<str>, OwnerRecord>>` and `nodes: DashMap<Arc<str>, NodeRecord>`
 - **BlockKey**: `{ namespace: String, hash: Vec<u8> }` — matches pegaflow-core's BlockKey
 - **Multi-owner**: Multiple nodes can register the same block hash (e.g., after replication or shared prefill)
-- **Lifecycle sweep**: Background task removes owners whose node record is missing or older than `--node-purge-secs`; superseded sessions are hidden from queries by `node_id` matching and purged by key registration age.
+- **Lifecycle sweep**: Background task removes owners whose node record is missing or whose ownership TTL expired; superseded sessions are hidden from queries by `node_id` matching and purged by TTL.
 - **Concurrency**: DashMap uses shard-level locking for high-throughput concurrent access
 - **Persistence**: In-memory only (restart clears state)
 

--- a/pegaflow-metaserver/README.md
+++ b/pegaflow-metaserver/README.md
@@ -82,7 +82,7 @@ cargo run -p pegaflow-metaserver -- --help
 The MetaServer uses a DashMap-based in-memory store with the following characteristics:
 
 - **Multi-owner**: A block hash can be registered by multiple nodes simultaneously
-- **Node lifecycle**: Servers call `RegisterNode`, heartbeat periodically, and include the returned `node_id` in insert/remove RPCs.
+- **Node lifecycle**: Servers generate a `node_id`, announce it with `HeartbeatNode`, heartbeat periodically, and include the same `node_id` in insert/remove RPCs.
 - **Stale filtering**: Nodes stop appearing in query results after 30 seconds without heartbeat by default.
 - **TTL sweep**: A background task removes expired owners and nodes after `--ttl-minutes`.
 - **Conditional removal**: `RemoveBlockHashes` only removes the requesting node's ownership; other nodes' entries are untouched.
@@ -92,24 +92,11 @@ The MetaServer uses a DashMap-based in-memory store with the following character
 
 The MetaServer provides the following gRPC endpoints:
 
-### 1. RegisterNode
+### 1. HeartbeatNode
 
-Register a pegaflow-server node URL and receive a session id.
-
-```protobuf
-message RegisterNodeRequest {
-  string node = 1;
-}
-
-message RegisterNodeResponse {
-  ResponseStatus status = 1;
-  string node_id = 2;
-}
-```
-
-### 2. HeartbeatNode
-
-Refresh node liveness for the current session.
+Register or refresh node liveness for the current session. A different
+`node_id` may take over the same node URL only after the current session is
+stale.
 
 ```protobuf
 message HeartbeatNodeRequest {
@@ -118,7 +105,7 @@ message HeartbeatNodeRequest {
 }
 ```
 
-### 3. UnregisterNode
+### 2. UnregisterNode
 
 Gracefully remove a node and its matching ownership records.
 
@@ -129,7 +116,7 @@ message UnregisterNodeRequest {
 }
 ```
 
-### 4. InsertBlockHashes
+### 3. InsertBlockHashes
 
 Register a list of block hashes. The request must include the current `node_id`.
 
@@ -139,7 +126,7 @@ message InsertBlockHashesRequest {
   string namespace = 1;         // Model namespace (part of BlockKey)
   repeated bytes block_hashes = 2;  // List of block hashes to insert (part of BlockKey)
   string node = 3;              // The pegaflow-server gRPC address that owns these blocks
-  string node_id = 4;           // Session id returned by RegisterNode
+  string node_id = 4;           // Server-generated session id announced by HeartbeatNode
 }
 ```
 
@@ -151,7 +138,7 @@ message InsertBlockHashesResponse {
 }
 ```
 
-### 5. RemoveBlockHashes
+### 4. RemoveBlockHashes
 
 Remove block hashes owned by a specific node (conditional delete).
 
@@ -173,7 +160,7 @@ message RemoveBlockHashesResponse {
 }
 ```
 
-### 6. QueryPrefixBlocks
+### 5. QueryPrefixBlocks
 
 Query the longest contiguous prefix of block hashes that exist, with per-node prefix lengths.
 
@@ -197,14 +184,14 @@ message QueryPrefixBlocksResponse {
 }
 ```
 
-### 7. Health
+### 6. Health
 
 Health check endpoint.
 
 **Request:** `HealthRequest {}`
 **Response:** `HealthResponse { status }`
 
-### 8. Shutdown
+### 7. Shutdown
 
 Graceful shutdown trigger.
 
@@ -222,8 +209,8 @@ Graceful shutdown trigger.
 
 ## Integration with PegaFlow Core
 
-1. **On server startup**: Call `RegisterNode` and retain the returned `node_id`
-2. **During server lifetime**: Call `HeartbeatNode` periodically
+1. **On server startup**: Generate a `node_id` and announce it with `HeartbeatNode`
+2. **During server lifetime**: Call `HeartbeatNode` periodically with the same `node_id`
 3. **On block save**: Call `InsertBlockHashes` with `{ node, node_id }`
 4. **On cache eviction**: Call `RemoveBlockHashes` with `{ node, node_id }`
 5. **On block query**: Call `QueryPrefixBlocks` to discover which live nodes hold a prefix

--- a/pegaflow-metaserver/README.md
+++ b/pegaflow-metaserver/README.md
@@ -61,10 +61,10 @@ cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056
 cargo run -p pegaflow-metaserver -- --log-level debug
 
 # Custom node lifecycle timings
-cargo run -p pegaflow-metaserver -- --node-stale-secs 30 --ttl-minutes 120
+cargo run -p pegaflow-metaserver -- --node-stale-secs 30 --ttl-minutes 120 --sweep-interval-secs 600
 
 # All options combined
-cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056 --node-stale-secs 30 --ttl-minutes 120 --log-level info
+cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056 --node-stale-secs 30 --ttl-minutes 120 --sweep-interval-secs 600 --log-level info
 
 # Show all options
 cargo run -p pegaflow-metaserver -- --help
@@ -75,7 +75,8 @@ cargo run -p pegaflow-metaserver -- --help
 - `--addr <ADDR>`: Bind address (default: `127.0.0.1:50056`)
 - `--log-level <LEVEL>`: Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`)
 - `--node-stale-secs <SECONDS>`: Hide nodes from query after this many seconds without heartbeat (default: `30`)
-- `--ttl-minutes <MINUTES>`: Purge ownership and node records after this many minutes; the sweep runs at this interval (default: `120`)
+- `--ttl-minutes <MINUTES>`: Purge ownership and node records after this many minutes (default: `120`)
+- `--sweep-interval-secs <SECONDS>`: Run the lifecycle sweep at this interval (default: `600`)
 
 ### Storage Configuration
 
@@ -84,7 +85,7 @@ The MetaServer uses a DashMap-based in-memory store with the following character
 - **Multi-owner**: A block hash can be registered by multiple nodes simultaneously
 - **Node lifecycle**: Servers generate a `node_id`, announce it with `HeartbeatNode`, heartbeat periodically, and include the same `node_id` in insert/remove RPCs.
 - **Stale filtering**: Nodes stop appearing in query results after 30 seconds without heartbeat by default.
-- **TTL sweep**: A background task removes expired owners and nodes after `--ttl-minutes`.
+- **TTL sweep**: A background task runs every `--sweep-interval-secs` and removes expired owners and nodes after `--ttl-minutes`.
 - **Conditional removal**: `RemoveBlockHashes` only removes the requesting node's ownership; other nodes' entries are untouched.
 - **Memory**: Scales with unique blocks across all nodes. No hard capacity cap — memory is naturally bounded by the total number of blocks in the cluster.
 
@@ -203,7 +204,7 @@ Graceful shutdown trigger.
 - **Data structure**: `blocks: DashMap<BlockKey, HashMap<Arc<str>, OwnerRecord>>` and `nodes: DashMap<Arc<str>, NodeRecord>`
 - **BlockKey**: `{ namespace: String, hash: Vec<u8> }` — matches pegaflow-core's BlockKey
 - **Multi-owner**: Multiple nodes can register the same block hash (e.g., after replication or shared prefill)
-- **Lifecycle sweep**: Background task removes owners whose node record is missing or whose ownership TTL expired; superseded sessions are hidden from queries by `node_id` matching and purged by TTL.
+- **Lifecycle sweep**: Background task runs periodically to remove owners whose node record is missing or whose ownership TTL expired; superseded sessions are hidden from queries by `node_id` matching and purged by TTL.
 - **Concurrency**: DashMap uses shard-level locking for high-throughput concurrent access
 - **Persistence**: In-memory only (restart clears state)
 

--- a/pegaflow-metaserver/README.md
+++ b/pegaflow-metaserver/README.md
@@ -60,11 +60,11 @@ cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056
 # With debug logging
 cargo run -p pegaflow-metaserver -- --log-level debug
 
-# Custom TTL (60 minutes)
-cargo run -p pegaflow-metaserver -- --ttl-minutes 60
+# Custom node lifecycle timings
+cargo run -p pegaflow-metaserver -- --node-stale-secs 30 --node-purge-secs 90 --sweep-interval-secs 10
 
 # All options combined
-cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056 --ttl-minutes 180 --log-level info
+cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056 --node-stale-secs 30 --node-purge-secs 90 --log-level info
 
 # Show all options
 cargo run -p pegaflow-metaserver -- --help
@@ -74,14 +74,18 @@ cargo run -p pegaflow-metaserver -- --help
 
 - `--addr <ADDR>`: Bind address (default: `127.0.0.1:50056`)
 - `--log-level <LEVEL>`: Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`)
-- `--ttl-minutes <MINUTES>`: Cache entry TTL in minutes (default: `120`)
+- `--node-stale-secs <SECONDS>`: Hide nodes from query after this many seconds without heartbeat (default: `30`)
+- `--node-purge-secs <SECONDS>`: Purge nodes and ownership after this many seconds without heartbeat (default: `90`)
+- `--sweep-interval-secs <SECONDS>`: Background lifecycle sweep interval (default: `10`)
 
 ### Storage Configuration
 
 The MetaServer uses a DashMap-based in-memory store with the following characteristics:
 
 - **Multi-owner**: A block hash can be registered by multiple nodes simultaneously
-- **TTL (Time-To-Live)**: 120 minutes default (configurable via `--ttl-minutes`). A background task sweeps expired entries every 10 minutes to prevent leaks from crashed nodes.
+- **Node lifecycle**: Servers call `RegisterNode`, heartbeat periodically, and include the returned `node_id` in insert/remove RPCs.
+- **Stale filtering**: Nodes stop appearing in query results after 30 seconds without heartbeat by default.
+- **Purge sweep**: A background task removes stale owners and nodes after 90 seconds without heartbeat by default.
 - **Conditional removal**: `RemoveBlockHashes` only removes the requesting node's ownership; other nodes' entries are untouched.
 - **Memory**: Scales with unique blocks across all nodes. No hard capacity cap — memory is naturally bounded by the total number of blocks in the cluster.
 
@@ -89,9 +93,46 @@ The MetaServer uses a DashMap-based in-memory store with the following character
 
 The MetaServer provides the following gRPC endpoints:
 
-### 1. InsertBlockHashes
+### 1. RegisterNode
 
-Register a list of block hashes. Re-inserting refreshes the TTL timestamp.
+Register a pegaflow-server node URL and receive a session id.
+
+```protobuf
+message RegisterNodeRequest {
+  string node = 1;
+}
+
+message RegisterNodeResponse {
+  ResponseStatus status = 1;
+  string node_id = 2;
+}
+```
+
+### 2. HeartbeatNode
+
+Refresh node liveness for the current session.
+
+```protobuf
+message HeartbeatNodeRequest {
+  string node = 1;
+  string node_id = 2;
+}
+```
+
+### 3. UnregisterNode
+
+Gracefully remove a node and its matching ownership records.
+
+```protobuf
+message UnregisterNodeRequest {
+  string node = 1;
+  string node_id = 2;
+}
+```
+
+### 4. InsertBlockHashes
+
+Register a list of block hashes. The request must include the current `node_id`.
 
 **Request:**
 ```protobuf
@@ -99,6 +140,7 @@ message InsertBlockHashesRequest {
   string namespace = 1;         // Model namespace (part of BlockKey)
   repeated bytes block_hashes = 2;  // List of block hashes to insert (part of BlockKey)
   string node = 3;              // The pegaflow-server gRPC address that owns these blocks
+  string node_id = 4;           // Session id returned by RegisterNode
 }
 ```
 
@@ -110,7 +152,7 @@ message InsertBlockHashesResponse {
 }
 ```
 
-### 2. RemoveBlockHashes
+### 5. RemoveBlockHashes
 
 Remove block hashes owned by a specific node (conditional delete).
 
@@ -120,6 +162,7 @@ message RemoveBlockHashesRequest {
   string namespace = 1;
   repeated bytes block_hashes = 2;
   string node = 3;              // Only this node's ownership is removed
+  string node_id = 4;           // Only matching ownership is removed
 }
 ```
 
@@ -131,7 +174,7 @@ message RemoveBlockHashesResponse {
 }
 ```
 
-### 3. QueryPrefixBlocks
+### 6. QueryPrefixBlocks
 
 Query the longest contiguous prefix of block hashes that exist, with per-node prefix lengths.
 
@@ -155,14 +198,14 @@ message QueryPrefixBlocksResponse {
 }
 ```
 
-### 4. Health
+### 7. Health
 
 Health check endpoint.
 
 **Request:** `HealthRequest {}`
 **Response:** `HealthResponse { status }`
 
-### 5. Shutdown
+### 8. Shutdown
 
 Graceful shutdown trigger.
 
@@ -171,19 +214,21 @@ Graceful shutdown trigger.
 
 ## Storage Implementation
 
-- **Data structure**: `DashMap<BlockKey, HashMap<Arc<str>, Instant>>` — each block key maps to a set of owning nodes with their registration timestamps
+- **Data structure**: `blocks: DashMap<BlockKey, HashMap<Arc<str>, OwnerRecord>>` and `nodes: DashMap<Arc<str>, NodeRecord>`
 - **BlockKey**: `{ namespace: String, hash: Vec<u8> }` — matches pegaflow-core's BlockKey
 - **Multi-owner**: Multiple nodes can register the same block hash (e.g., after replication or shared prefill)
-- **TTL sweep**: Background task runs every 10 minutes, removing per-node registrations older than the configured TTL
+- **Lifecycle sweep**: Background task removes owners whose node record is missing or older than `--node-purge-secs`; superseded sessions are hidden from queries by `node_id` matching and purged by key registration age.
 - **Concurrency**: DashMap uses shard-level locking for high-throughput concurrent access
 - **Persistence**: In-memory only (restart clears state)
 
 ## Integration with PegaFlow Core
 
-1. **On block save**: Call `InsertBlockHashes` to register new blocks
-2. **On cache eviction**: Call `RemoveBlockHashes` to deregister evicted blocks
-3. **On block query**: Call `QueryPrefixBlocks` to discover which nodes hold a prefix
-4. **On block load**: Query metaserver, then fetch from the best remote node via RDMA
+1. **On server startup**: Call `RegisterNode` and retain the returned `node_id`
+2. **During server lifetime**: Call `HeartbeatNode` periodically
+3. **On block save**: Call `InsertBlockHashes` with `{ node, node_id }`
+4. **On cache eviction**: Call `RemoveBlockHashes` with `{ node, node_id }`
+5. **On block query**: Call `QueryPrefixBlocks` to discover which live nodes hold a prefix
+6. **On block load**: Query metaserver, then fetch from the best remote node via RDMA
 
 ## Environment Variables
 

--- a/pegaflow-metaserver/benches/unregister_node.rs
+++ b/pegaflow-metaserver/benches/unregister_node.rs
@@ -1,0 +1,56 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use pegaflow_metaserver::store::{BlockHashStore, StoreConfig};
+use std::time::Duration;
+use uuid::Uuid;
+
+const TOTAL_KEYS: usize = 1_000_000;
+const TARGET_OWNED_KEYS: usize = 10_000;
+
+fn populate_store() -> (BlockHashStore, String, Uuid) {
+    let store = BlockHashStore::with_config(StoreConfig {
+        node_stale_after: Duration::from_secs(30),
+        ttl: Duration::from_secs(7_200),
+    });
+    let target_node = "target-node:50055".to_string();
+    let other_node = "other-node:50055".to_string();
+    let target_id = Uuid::new_v4();
+    let other_id = Uuid::new_v4();
+    store.heartbeat_node(&target_node, target_id).unwrap();
+    store.heartbeat_node(&other_node, other_id).unwrap();
+
+    for chunk_start in (0..TOTAL_KEYS).step_by(1_000) {
+        let chunk_end = (chunk_start + 1_000).min(TOTAL_KEYS);
+        let hashes: Vec<Vec<u8>> = (chunk_start..chunk_end)
+            .map(|i| (i as u64).to_le_bytes().to_vec())
+            .collect();
+        let (node, node_id) = if chunk_start < TARGET_OWNED_KEYS {
+            (target_node.as_str(), target_id)
+        } else {
+            (other_node.as_str(), other_id)
+        };
+        store
+            .insert_hashes("bench", &hashes, node, node_id)
+            .unwrap();
+    }
+
+    (store, target_node, target_id)
+}
+
+fn bench_unregister_node(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unregister_node");
+    group.sample_size(10);
+    group.bench_function("1m_keys_10k_owned", |b| {
+        b.iter_batched(
+            populate_store,
+            |(store, target_node, target_id)| {
+                let removed = store.unregister_node(&target_node, target_id).unwrap();
+                assert_eq!(removed, TARGET_OWNED_KEYS);
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_unregister_node);
+criterion_main!(benches);

--- a/pegaflow-metaserver/benches/unregister_node.rs
+++ b/pegaflow-metaserver/benches/unregister_node.rs
@@ -1,3 +1,15 @@
+//! Microbench for `unregister_node` synchronous owner cleanup.
+//!
+//! Reference numbers on h20:
+//!   cargo bench -p pegaflow-metaserver --bench unregister_node -- --sample-size 10
+//!   1m_keys_10k_owned: 315.95 / 320.52 / 326.10 ms
+//!
+//! `remove_node_owners` does a full `blocks.retain`, so cost is O(total_blocks),
+//! not O(owned). At roughly 3ms per 10k total blocks on h20, 10M total blocks
+//! would sit close to the 3s client-side unregister timeout. If that threshold
+//! becomes realistic, unregister should return after dropping the node record and
+//! leave owner cleanup to the lifecycle sweep.
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use pegaflow_metaserver::store::{BlockHashStore, StoreConfig};
 use std::time::Duration;

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -111,6 +111,9 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         .ttl_minutes
         .checked_mul(60)
         .ok_or("ttl-minutes is too large")?;
+    if cli.ttl_minutes == 0 {
+        return Err("ttl-minutes must be greater than 0".into());
+    }
     if ttl_secs < cli.node_stale_secs {
         return Err(format!(
             "ttl-minutes ({}) must be >= node-stale-secs ({})",

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -21,6 +21,8 @@ use tokio::signal;
 use tokio::sync::Notify;
 use tonic::transport::Server;
 
+const DEFAULT_SWEEP_INTERVAL_SECS: u64 = 600;
+
 #[derive(Parser, Debug)]
 #[command(
     name = "pegaflow-metaserver",
@@ -47,6 +49,10 @@ pub struct Cli {
     /// Minutes before block ownership records are purged by the lifecycle sweep.
     #[arg(long, default_value_t = store::DEFAULT_TTL_MINUTES)]
     pub ttl_minutes: u64,
+
+    /// Seconds between lifecycle sweeps.
+    #[arg(long, default_value_t = DEFAULT_SWEEP_INTERVAL_SECS)]
+    pub sweep_interval_secs: u64,
 }
 
 fn init_metrics() -> Result<(SdkMeterProvider, Registry), Box<dyn Error>> {
@@ -104,8 +110,8 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     info!("Starting PegaFlow MetaServer");
     info!("Binding to address: {}", cli.addr);
     info!(
-        "Node lifecycle: stale_after={}s ttl={}m",
-        cli.node_stale_secs, cli.ttl_minutes
+        "Node lifecycle: stale_after={}s ttl={}m sweep_interval={}s",
+        cli.node_stale_secs, cli.ttl_minutes, cli.sweep_interval_secs
     );
     let ttl_secs = cli
         .ttl_minutes
@@ -113,6 +119,9 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         .ok_or("ttl-minutes is too large")?;
     if cli.ttl_minutes == 0 {
         return Err("ttl-minutes must be greater than 0".into());
+    }
+    if cli.sweep_interval_secs == 0 {
+        return Err("sweep-interval-secs must be greater than 0".into());
     }
     if ttl_secs < cli.node_stale_secs {
         return Err(format!(
@@ -136,7 +145,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     // Spawn background node lifecycle sweep task.
     {
         let store = Arc::clone(&store);
-        let sweep_interval = Duration::from_secs(ttl_secs);
+        let sweep_interval = Duration::from_secs(cli.sweep_interval_secs);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(sweep_interval);
             loop {

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -44,13 +44,9 @@ pub struct Cli {
     #[arg(long, default_value_t = store::DEFAULT_NODE_STALE_SECS)]
     pub node_stale_secs: u64,
 
-    /// Seconds without heartbeat before a node and its block ownership are purged.
-    #[arg(long, default_value_t = store::DEFAULT_NODE_PURGE_SECS)]
-    pub node_purge_secs: u64,
-
-    /// Background sweep interval in seconds.
-    #[arg(long, default_value_t = 10)]
-    pub sweep_interval_secs: u64,
+    /// Minutes before block ownership records are purged by the lifecycle sweep.
+    #[arg(long, default_value_t = store::DEFAULT_TTL_MINUTES)]
+    pub ttl_minutes: u64,
 }
 
 fn init_metrics() -> Result<(SdkMeterProvider, Registry), Box<dyn Error>> {
@@ -108,13 +104,17 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     info!("Starting PegaFlow MetaServer");
     info!("Binding to address: {}", cli.addr);
     info!(
-        "Node lifecycle: stale_after={}s purge_after={}s sweep_interval={}s",
-        cli.node_stale_secs, cli.node_purge_secs, cli.sweep_interval_secs
+        "Node lifecycle: stale_after={}s ttl={}m",
+        cli.node_stale_secs, cli.ttl_minutes
     );
-    if cli.node_purge_secs < cli.node_stale_secs {
+    let ttl_secs = cli
+        .ttl_minutes
+        .checked_mul(60)
+        .ok_or("ttl-minutes is too large")?;
+    if ttl_secs < cli.node_stale_secs {
         return Err(format!(
-            "node-purge-secs ({}) must be >= node-stale-secs ({})",
-            cli.node_purge_secs, cli.node_stale_secs
+            "ttl-minutes ({}) must be >= node-stale-secs ({})",
+            cli.ttl_minutes, cli.node_stale_secs
         )
         .into());
     }
@@ -124,7 +124,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     let store = Arc::new(BlockHashStore::with_config(store::StoreConfig {
         node_stale_after: Duration::from_secs(cli.node_stale_secs),
-        node_purge_after: Duration::from_secs(cli.node_purge_secs),
+        ttl: Duration::from_secs(ttl_secs),
     }));
 
     // Register store observable gauges
@@ -133,7 +133,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     // Spawn background node lifecycle sweep task.
     {
         let store = Arc::clone(&store);
-        let sweep_interval = Duration::from_secs(cli.sweep_interval_secs);
+        let sweep_interval = Duration::from_secs(ttl_secs);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(sweep_interval);
             loop {

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -16,6 +16,7 @@ use prometheus::Registry;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::signal;
 use tokio::sync::Notify;
 use tonic::transport::Server;
@@ -39,9 +40,17 @@ pub struct Cli {
     #[arg(long, default_value = "info")]
     pub log_level: String,
 
-    /// Cache entry TTL in minutes
-    #[arg(long, default_value = "120")]
-    pub ttl_minutes: u64,
+    /// Seconds without heartbeat before a node is hidden from query results.
+    #[arg(long, default_value_t = store::DEFAULT_NODE_STALE_SECS)]
+    pub node_stale_secs: u64,
+
+    /// Seconds without heartbeat before a node and its block ownership are purged.
+    #[arg(long, default_value_t = store::DEFAULT_NODE_PURGE_SECS)]
+    pub node_purge_secs: u64,
+
+    /// Background sweep interval in seconds.
+    #[arg(long, default_value_t = 10)]
+    pub sweep_interval_secs: u64,
 }
 
 fn init_metrics() -> Result<(SdkMeterProvider, Registry), Box<dyn Error>> {
@@ -98,30 +107,45 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     info!("Starting PegaFlow MetaServer");
     info!("Binding to address: {}", cli.addr);
-    info!("Cache entry TTL: {} minutes", cli.ttl_minutes);
+    info!(
+        "Node lifecycle: stale_after={}s purge_after={}s sweep_interval={}s",
+        cli.node_stale_secs, cli.node_purge_secs, cli.sweep_interval_secs
+    );
+    if cli.node_purge_secs < cli.node_stale_secs {
+        return Err(format!(
+            "node-purge-secs ({}) must be >= node-stale-secs ({})",
+            cli.node_purge_secs, cli.node_stale_secs
+        )
+        .into());
+    }
 
     // Initialize metrics
     let (meter_provider, prometheus_registry) = init_metrics()?;
 
-    // Create the block hash store with TTL
-    let store = Arc::new(BlockHashStore::with_ttl(cli.ttl_minutes));
+    let store = Arc::new(BlockHashStore::with_config(store::StoreConfig {
+        node_stale_after: Duration::from_secs(cli.node_stale_secs),
+        node_purge_after: Duration::from_secs(cli.node_purge_secs),
+    }));
 
     // Register store observable gauges
     metric::register_store_gauges(&store);
 
-    // Spawn background TTL sweep task (every 10 minutes)
+    // Spawn background node lifecycle sweep task.
     {
         let store = Arc::clone(&store);
+        let sweep_interval = Duration::from_secs(cli.sweep_interval_secs);
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_secs(10 * 60));
+            let mut interval = tokio::time::interval(sweep_interval);
             loop {
                 interval.tick().await;
-                let removed = store.sweep_expired();
-                if removed > 0 {
-                    metric::record_ttl_sweep(removed as u64);
+                let stats = store.sweep_expired();
+                if !stats.is_empty() {
+                    metric::record_sweep(stats);
                     info!(
-                        "TTL sweep: removed {} stale block keys, {} remaining",
-                        removed,
+                        "Node sweep: removed keys={} owners={} nodes={}, {} keys remaining",
+                        stats.removed_keys,
+                        stats.removed_owners,
+                        stats.removed_nodes,
                         store.entry_count()
                     );
                 }

--- a/pegaflow-metaserver/src/metric.rs
+++ b/pegaflow-metaserver/src/metric.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, LazyLock, OnceLock};
 use std::time::Instant;
 use tonic::Status;
 
-use crate::store::BlockHashStore;
+use crate::store::{BlockHashStore, SweepStats};
 
 // ---------------------------------------------------------------------------
 // Store gauges
@@ -12,6 +12,8 @@ use crate::store::BlockHashStore;
 
 struct StoreGaugeHandles {
     _entries: ObservableGauge<u64>,
+    _owners: ObservableGauge<u64>,
+    _nodes: ObservableGauge<u64>,
 }
 
 static STORE_GAUGES: OnceLock<StoreGaugeHandles> = OnceLock::new();
@@ -21,37 +23,78 @@ pub fn register_store_gauges(store: &Arc<BlockHashStore>) {
     let s = Arc::clone(store);
     STORE_GAUGES.get_or_init(|| {
         let meter = global::meter("pegaflow_metaserver");
+        let entries_store = Arc::clone(&s);
         let entries = meter
             .u64_observable_gauge("pegaflow_metaserver_store_entries")
             .with_description("Number of unique block keys in the store")
             .with_callback(move |observer| {
-                observer.observe(s.entry_count(), &[]);
+                observer.observe(entries_store.entry_count(), &[]);
             })
             .build();
-        StoreGaugeHandles { _entries: entries }
+        let owners_store = Arc::clone(&s);
+        let owners = meter
+            .u64_observable_gauge("pegaflow_metaserver_block_owners")
+            .with_description("Number of node ownership records across all block keys")
+            .with_callback(move |observer| {
+                observer.observe(owners_store.owner_count(), &[]);
+            })
+            .build();
+        let nodes_store = Arc::clone(&s);
+        let nodes = meter
+            .u64_observable_gauge("pegaflow_metaserver_nodes")
+            .with_description("Number of registered nodes by liveness state")
+            .with_callback(move |observer| {
+                let (active, stale) = nodes_store.node_counts();
+                observer.observe(active, &[KeyValue::new("state", "active")]);
+                observer.observe(stale, &[KeyValue::new("state", "stale")]);
+            })
+            .build();
+        StoreGaugeHandles {
+            _entries: entries,
+            _owners: owners,
+            _nodes: nodes,
+        }
     });
 }
 
 // ---------------------------------------------------------------------------
-// TTL sweep counter
+// Node lifecycle sweep counters
 // ---------------------------------------------------------------------------
 
 struct SweepMetrics {
-    removed: Counter<u64>,
+    removed_owners: Counter<u64>,
+    removed_keys: Counter<u64>,
+    removed_nodes: Counter<u64>,
 }
 
 static SWEEP_METRICS: LazyLock<SweepMetrics> = LazyLock::new(|| {
     let meter = global::meter("pegaflow_metaserver");
     SweepMetrics {
-        removed: meter
-            .u64_counter("pegaflow_metaserver_ttl_sweep_removed")
-            .with_description("Total block keys removed by TTL sweep")
+        removed_owners: meter
+            .u64_counter("pegaflow_metaserver_sweep_removed_owners")
+            .with_description("Total node ownership records removed by lifecycle sweep")
+            .build(),
+        removed_keys: meter
+            .u64_counter("pegaflow_metaserver_sweep_removed_keys")
+            .with_description("Total block keys removed by lifecycle sweep")
+            .build(),
+        removed_nodes: meter
+            .u64_counter("pegaflow_metaserver_sweep_removed_nodes")
+            .with_description("Total node records removed by lifecycle sweep")
             .build(),
     }
 });
 
-pub fn record_ttl_sweep(removed: u64) {
-    SWEEP_METRICS.removed.add(removed, &[]);
+pub fn record_sweep(stats: SweepStats) {
+    SWEEP_METRICS
+        .removed_owners
+        .add(stats.removed_owners as u64, &[]);
+    SWEEP_METRICS
+        .removed_keys
+        .add(stats.removed_keys as u64, &[]);
+    SWEEP_METRICS
+        .removed_nodes
+        .add(stats.removed_nodes as u64, &[]);
 }
 
 // ---------------------------------------------------------------------------

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -55,6 +55,10 @@ impl MetaServer for GrpcMetaService {
     ) -> Result<Response<HeartbeatNodeResponse>, Status> {
         let start = Instant::now();
         let req = request.into_inner();
+        debug!(
+            "RPC [heartbeat_node]: node={} node_id={}",
+            req.node, req.node_id
+        );
         let result = async {
             let node_id = Self::parse_node_id(&req.node_id)?;
             self.store
@@ -75,6 +79,10 @@ impl MetaServer for GrpcMetaService {
     ) -> Result<Response<UnregisterNodeResponse>, Status> {
         let start = Instant::now();
         let req = request.into_inner();
+        debug!(
+            "RPC [unregister_node]: node={} node_id={}",
+            req.node, req.node_id
+        );
         let result = async {
             let node_id = Self::parse_node_id(&req.node_id)?;
             let removed = self
@@ -87,6 +95,14 @@ impl MetaServer for GrpcMetaService {
             }))
         }
         .await;
+        if let Ok(resp) = &result {
+            debug!(
+                "RPC [unregister_node]: node={} removed={} keys in {:?}",
+                req.node,
+                resp.get_ref().removed_keys,
+                start.elapsed()
+            );
+        }
         record_rpc_result("unregister_node", &result, start);
         result
     }

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -66,6 +66,7 @@ impl MetaServer for GrpcMetaService {
                 .map_err(Self::store_error_status)?;
             Ok(Response::new(HeartbeatNodeResponse {
                 status: Some(Self::ok_status()),
+                stale_after_secs: self.store.config().node_stale_after.as_secs(),
             }))
         }
         .await;
@@ -90,7 +91,6 @@ impl MetaServer for GrpcMetaService {
                 .unregister_node(&req.node, node_id)
                 .map_err(Self::store_error_status)?;
             Ok(Response::new(UnregisterNodeResponse {
-                status: Some(Self::ok_status()),
                 removed_keys: removed as u64,
             }))
         }
@@ -498,7 +498,6 @@ mod tests {
             .unwrap()
             .into_inner();
 
-        assert!(resp.status.unwrap().ok);
         assert_eq!(resp.removed_keys, 2);
 
         let query_resp = svc

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -3,8 +3,8 @@ use crate::proto::engine::meta_server_server::MetaServer;
 use crate::proto::engine::{
     HeartbeatNodeRequest, HeartbeatNodeResponse, InsertBlockHashesRequest,
     InsertBlockHashesResponse, NodePrefixResult, QueryPrefixBlocksRequest,
-    QueryPrefixBlocksResponse, RegisterNodeRequest, RegisterNodeResponse, RemoveBlockHashesRequest,
-    RemoveBlockHashesResponse, ResponseStatus, UnregisterNodeRequest, UnregisterNodeResponse,
+    QueryPrefixBlocksResponse, RemoveBlockHashesRequest, RemoveBlockHashesResponse, ResponseStatus,
+    UnregisterNodeRequest, UnregisterNodeResponse,
 };
 use crate::store::{BlockHashStore, StoreError};
 use log::debug;
@@ -49,27 +49,6 @@ impl GrpcMetaService {
 
 #[async_trait]
 impl MetaServer for GrpcMetaService {
-    async fn register_node(
-        &self,
-        request: Request<RegisterNodeRequest>,
-    ) -> Result<Response<RegisterNodeResponse>, Status> {
-        let start = Instant::now();
-        let req = request.into_inner();
-        if req.node.is_empty() {
-            let result = Err(Status::invalid_argument("node cannot be empty"));
-            record_rpc_result("register_node", &result, start);
-            return result;
-        }
-
-        let node_id = self.store.register_node(&req.node);
-        let result = Ok(Response::new(RegisterNodeResponse {
-            status: Some(Self::ok_status()),
-            node_id: node_id.to_string(),
-        }));
-        record_rpc_result("register_node", &result, start);
-        result
-    }
-
     async fn heartbeat_node(
         &self,
         request: Request<HeartbeatNodeRequest>,
@@ -307,18 +286,21 @@ mod tests {
         GrpcMetaService::new(Arc::new(BlockHashStore::new()))
     }
 
-    async fn register_node(svc: &GrpcMetaService, node: &str) -> String {
-        svc.register_node(Request::new(RegisterNodeRequest { node: node.into() }))
-            .await
-            .unwrap()
-            .into_inner()
-            .node_id
+    async fn heartbeat_node(svc: &GrpcMetaService, node: &str) -> String {
+        let node_id = Uuid::new_v4().to_string();
+        svc.heartbeat_node(Request::new(HeartbeatNodeRequest {
+            node: node.into(),
+            node_id: node_id.clone(),
+        }))
+        .await
+        .unwrap();
+        node_id
     }
 
     #[tokio::test]
     async fn test_remove_block_hashes_own_blocks() {
         let svc = make_service();
-        let node_id = register_node(&svc, "node-a").await;
+        let node_id = heartbeat_node(&svc, "node-a").await;
 
         // Insert
         svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
@@ -360,8 +342,8 @@ mod tests {
     #[tokio::test]
     async fn test_remove_block_hashes_wrong_owner_is_noop() {
         let svc = make_service();
-        let node_b_id = register_node(&svc, "node-b").await;
-        let node_a_id = register_node(&svc, "node-a").await;
+        let node_b_id = heartbeat_node(&svc, "node-b").await;
+        let node_a_id = heartbeat_node(&svc, "node-a").await;
 
         svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
             namespace: "ns".into(),
@@ -402,7 +384,7 @@ mod tests {
     #[tokio::test]
     async fn test_remove_block_hashes_empty_request_returns_error() {
         let svc = make_service();
-        let node_id = register_node(&svc, "node-a").await;
+        let node_id = heartbeat_node(&svc, "node-a").await;
 
         let resp = svc
             .remove_block_hashes(Request::new(RemoveBlockHashesRequest {
@@ -422,7 +404,7 @@ mod tests {
     #[tokio::test]
     async fn test_heartbeat_node_accepts_current_session() {
         let svc = make_service();
-        let node_id = register_node(&svc, "node-a").await;
+        let node_id = heartbeat_node(&svc, "node-a").await;
 
         let resp = svc
             .heartbeat_node(Request::new(HeartbeatNodeRequest {
@@ -437,10 +419,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_insert_with_old_session_is_rejected_after_reregister() {
+    async fn test_heartbeat_with_active_different_session_is_rejected() {
         let svc = make_service();
-        let old_id = register_node(&svc, "node-a").await;
-        let new_id = register_node(&svc, "node-a").await;
+        let old_id = heartbeat_node(&svc, "node-a").await;
+        let new_id = Uuid::new_v4().to_string();
+        assert_ne!(old_id, new_id);
+
+        let err = svc
+            .heartbeat_node(Request::new(HeartbeatNodeRequest {
+                node: "node-a".into(),
+                node_id: new_id,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    }
+
+    #[tokio::test]
+    async fn test_old_session_insert_is_rejected_after_stale_takeover() {
+        let store = Arc::new(BlockHashStore::with_config(crate::store::StoreConfig {
+            node_stale_after: std::time::Duration::ZERO,
+            ttl: std::time::Duration::from_secs(60),
+        }));
+        let svc = GrpcMetaService::new(store);
+        let old_id = heartbeat_node(&svc, "node-a").await;
+        let new_id = heartbeat_node(&svc, "node-a").await;
         assert_ne!(old_id, new_id);
 
         let err = svc
@@ -459,7 +462,7 @@ mod tests {
     #[tokio::test]
     async fn test_unregister_node_removes_matching_owners() {
         let svc = make_service();
-        let node_id = register_node(&svc, "node-a").await;
+        let node_id = heartbeat_node(&svc, "node-a").await;
 
         svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
             namespace: "ns".into(),
@@ -506,8 +509,8 @@ mod tests {
 
         let node_a = "node-a:50055";
         let node_b = "node-b:50055";
-        let node_a_id = register_node(&svc, node_a).await;
-        let node_b_id = register_node(&svc, node_b).await;
+        let node_a_id = heartbeat_node(&svc, node_a).await;
+        let node_b_id = heartbeat_node(&svc, node_b).await;
 
         svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
             namespace: namespace.into(),

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -1,15 +1,17 @@
 use crate::metric::record_rpc_result;
 use crate::proto::engine::meta_server_server::MetaServer;
 use crate::proto::engine::{
-    InsertBlockHashesRequest, InsertBlockHashesResponse, NodePrefixResult,
-    QueryPrefixBlocksRequest, QueryPrefixBlocksResponse, RemoveBlockHashesRequest,
-    RemoveBlockHashesResponse, ResponseStatus,
+    HeartbeatNodeRequest, HeartbeatNodeResponse, InsertBlockHashesRequest,
+    InsertBlockHashesResponse, NodePrefixResult, QueryPrefixBlocksRequest,
+    QueryPrefixBlocksResponse, RegisterNodeRequest, RegisterNodeResponse, RemoveBlockHashesRequest,
+    RemoveBlockHashesResponse, ResponseStatus, UnregisterNodeRequest, UnregisterNodeResponse,
 };
-use crate::store::BlockHashStore;
+use crate::store::{BlockHashStore, StoreError};
 use log::debug;
 use std::sync::Arc;
 use std::time::Instant;
 use tonic::{Request, Response, Status, async_trait};
+use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct GrpcMetaService {
@@ -31,10 +33,85 @@ impl GrpcMetaService {
     fn error_status(message: String) -> ResponseStatus {
         ResponseStatus { ok: false, message }
     }
+
+    fn parse_node_id(node_id: &str) -> Result<Uuid, Status> {
+        Uuid::parse_str(node_id)
+            .map_err(|e| Status::invalid_argument(format!("invalid node_id: {e}")))
+    }
+
+    fn store_error_status(err: StoreError) -> Status {
+        match err {
+            StoreError::UnknownNode => Status::failed_precondition("unknown node"),
+            StoreError::StaleSession => Status::failed_precondition("stale node session"),
+        }
+    }
 }
 
 #[async_trait]
 impl MetaServer for GrpcMetaService {
+    async fn register_node(
+        &self,
+        request: Request<RegisterNodeRequest>,
+    ) -> Result<Response<RegisterNodeResponse>, Status> {
+        let start = Instant::now();
+        let req = request.into_inner();
+        if req.node.is_empty() {
+            let result = Err(Status::invalid_argument("node cannot be empty"));
+            record_rpc_result("register_node", &result, start);
+            return result;
+        }
+
+        let node_id = self.store.register_node(&req.node);
+        let result = Ok(Response::new(RegisterNodeResponse {
+            status: Some(Self::ok_status()),
+            node_id: node_id.to_string(),
+        }));
+        record_rpc_result("register_node", &result, start);
+        result
+    }
+
+    async fn heartbeat_node(
+        &self,
+        request: Request<HeartbeatNodeRequest>,
+    ) -> Result<Response<HeartbeatNodeResponse>, Status> {
+        let start = Instant::now();
+        let req = request.into_inner();
+        let result = async {
+            let node_id = Self::parse_node_id(&req.node_id)?;
+            self.store
+                .heartbeat_node(&req.node, node_id)
+                .map_err(Self::store_error_status)?;
+            Ok(Response::new(HeartbeatNodeResponse {
+                status: Some(Self::ok_status()),
+            }))
+        }
+        .await;
+        record_rpc_result("heartbeat_node", &result, start);
+        result
+    }
+
+    async fn unregister_node(
+        &self,
+        request: Request<UnregisterNodeRequest>,
+    ) -> Result<Response<UnregisterNodeResponse>, Status> {
+        let start = Instant::now();
+        let req = request.into_inner();
+        let result = async {
+            let node_id = Self::parse_node_id(&req.node_id)?;
+            let removed = self
+                .store
+                .unregister_node(&req.node, node_id)
+                .map_err(Self::store_error_status)?;
+            Ok(Response::new(UnregisterNodeResponse {
+                status: Some(Self::ok_status()),
+                removed_keys: removed as u64,
+            }))
+        }
+        .await;
+        record_rpc_result("unregister_node", &result, start);
+        result
+    }
+
     async fn insert_block_hashes(
         &self,
         request: Request<InsertBlockHashesRequest>,
@@ -61,10 +138,27 @@ impl MetaServer for GrpcMetaService {
             return result;
         }
 
-        // Insert hashes with node ownership
-        let inserted = self
-            .store
-            .insert_hashes(&req.namespace, &req.block_hashes, &req.node);
+        let node_id = match Self::parse_node_id(&req.node_id) {
+            Ok(id) => id,
+            Err(status) => {
+                let result = Err(status);
+                record_rpc_result("insert_block_hashes", &result, start);
+                return result;
+            }
+        };
+
+        let inserted =
+            match self
+                .store
+                .insert_hashes(&req.namespace, &req.block_hashes, &req.node, node_id)
+            {
+                Ok(inserted) => inserted,
+                Err(err) => {
+                    let result = Err(Self::store_error_status(err));
+                    record_rpc_result("insert_block_hashes", &result, start);
+                    return result;
+                }
+            };
 
         let elapsed = start.elapsed();
         debug!(
@@ -105,9 +199,27 @@ impl MetaServer for GrpcMetaService {
             return result;
         }
 
-        let removed = self
-            .store
-            .remove_hashes(&req.namespace, &req.block_hashes, &req.node);
+        let node_id = match Self::parse_node_id(&req.node_id) {
+            Ok(id) => id,
+            Err(status) => {
+                let result = Err(status);
+                record_rpc_result("remove_block_hashes", &result, start);
+                return result;
+            }
+        };
+
+        let removed =
+            match self
+                .store
+                .remove_hashes(&req.namespace, &req.block_hashes, &req.node, node_id)
+            {
+                Ok(removed) => removed,
+                Err(err) => {
+                    let result = Err(Self::store_error_status(err));
+                    record_rpc_result("remove_block_hashes", &result, start);
+                    return result;
+                }
+            };
 
         let elapsed = start.elapsed();
         debug!(
@@ -195,15 +307,25 @@ mod tests {
         GrpcMetaService::new(Arc::new(BlockHashStore::new()))
     }
 
+    async fn register_node(svc: &GrpcMetaService, node: &str) -> String {
+        svc.register_node(Request::new(RegisterNodeRequest { node: node.into() }))
+            .await
+            .unwrap()
+            .into_inner()
+            .node_id
+    }
+
     #[tokio::test]
     async fn test_remove_block_hashes_own_blocks() {
         let svc = make_service();
+        let node_id = register_node(&svc, "node-a").await;
 
         // Insert
         svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
             namespace: "ns".into(),
             block_hashes: vec![vec![1, 2, 3]],
             node: "node-a".into(),
+            node_id: node_id.clone(),
         }))
         .await
         .unwrap();
@@ -214,6 +336,7 @@ mod tests {
                 namespace: "ns".into(),
                 block_hashes: vec![vec![1, 2, 3]],
                 node: "node-a".into(),
+                node_id,
             }))
             .await
             .unwrap()
@@ -237,11 +360,14 @@ mod tests {
     #[tokio::test]
     async fn test_remove_block_hashes_wrong_owner_is_noop() {
         let svc = make_service();
+        let node_b_id = register_node(&svc, "node-b").await;
+        let node_a_id = register_node(&svc, "node-a").await;
 
         svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
             namespace: "ns".into(),
             block_hashes: vec![vec![1, 2, 3]],
             node: "node-b".into(),
+            node_id: node_b_id,
         }))
         .await
         .unwrap();
@@ -252,6 +378,7 @@ mod tests {
                 namespace: "ns".into(),
                 block_hashes: vec![vec![1, 2, 3]],
                 node: "node-a".into(),
+                node_id: node_a_id,
             }))
             .await
             .unwrap()
@@ -275,12 +402,14 @@ mod tests {
     #[tokio::test]
     async fn test_remove_block_hashes_empty_request_returns_error() {
         let svc = make_service();
+        let node_id = register_node(&svc, "node-a").await;
 
         let resp = svc
             .remove_block_hashes(Request::new(RemoveBlockHashesRequest {
                 namespace: "ns".into(),
                 block_hashes: vec![],
                 node: "node-a".into(),
+                node_id,
             }))
             .await
             .unwrap()
@@ -288,6 +417,80 @@ mod tests {
 
         assert!(!resp.status.unwrap().ok);
         assert_eq!(resp.removed_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat_node_accepts_current_session() {
+        let svc = make_service();
+        let node_id = register_node(&svc, "node-a").await;
+
+        let resp = svc
+            .heartbeat_node(Request::new(HeartbeatNodeRequest {
+                node: "node-a".into(),
+                node_id,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(resp.status.unwrap().ok);
+    }
+
+    #[tokio::test]
+    async fn test_insert_with_old_session_is_rejected_after_reregister() {
+        let svc = make_service();
+        let old_id = register_node(&svc, "node-a").await;
+        let new_id = register_node(&svc, "node-a").await;
+        assert_ne!(old_id, new_id);
+
+        let err = svc
+            .insert_block_hashes(Request::new(InsertBlockHashesRequest {
+                namespace: "ns".into(),
+                block_hashes: vec![vec![1]],
+                node: "node-a".into(),
+                node_id: old_id,
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    }
+
+    #[tokio::test]
+    async fn test_unregister_node_removes_matching_owners() {
+        let svc = make_service();
+        let node_id = register_node(&svc, "node-a").await;
+
+        svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
+            namespace: "ns".into(),
+            block_hashes: vec![vec![1], vec![2]],
+            node: "node-a".into(),
+            node_id: node_id.clone(),
+        }))
+        .await
+        .unwrap();
+
+        let resp = svc
+            .unregister_node(Request::new(UnregisterNodeRequest {
+                node: "node-a".into(),
+                node_id,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(resp.status.unwrap().ok);
+        assert_eq!(resp.removed_keys, 2);
+
+        let query_resp = svc
+            .query_prefix_blocks(Request::new(QueryPrefixBlocksRequest {
+                namespace: "ns".into(),
+                block_hashes: vec![vec![1]],
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(query_resp.nodes.is_empty());
     }
 
     #[tokio::test]
@@ -303,11 +506,14 @@ mod tests {
 
         let node_a = "node-a:50055";
         let node_b = "node-b:50055";
+        let node_a_id = register_node(&svc, node_a).await;
+        let node_b_id = register_node(&svc, node_b).await;
 
         svc.insert_block_hashes(Request::new(InsertBlockHashesRequest {
             namespace: namespace.into(),
             block_hashes: vec![h1.clone(), h2.clone(), h3.clone(), h4.clone()],
             node: node_a.into(),
+            node_id: node_a_id,
         }))
         .await
         .unwrap();
@@ -316,6 +522,7 @@ mod tests {
             namespace: namespace.into(),
             block_hashes: vec![h1.clone(), h2.clone(), h3.clone(), h5],
             node: node_b.into(),
+            node_id: node_b_id,
         }))
         .await
         .unwrap();

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -65,7 +65,6 @@ impl MetaServer for GrpcMetaService {
                 .heartbeat_node(&req.node, node_id)
                 .map_err(Self::store_error_status)?;
             Ok(Response::new(HeartbeatNodeResponse {
-                status: Some(Self::ok_status()),
                 stale_after_secs: self.store.config().node_stale_after.as_secs(),
             }))
         }
@@ -91,15 +90,15 @@ impl MetaServer for GrpcMetaService {
                 .unregister_node(&req.node, node_id)
                 .map_err(Self::store_error_status)?;
             Ok(Response::new(UnregisterNodeResponse {
-                removed_keys: removed as u64,
+                removed_owners: removed as u64,
             }))
         }
         .await;
         if let Ok(resp) = &result {
             debug!(
-                "RPC [unregister_node]: node={} removed={} keys in {:?}",
+                "RPC [unregister_node]: node={} removed_owners={} in {:?}",
                 req.node,
-                resp.get_ref().removed_keys,
+                resp.get_ref().removed_owners,
                 start.elapsed()
             );
         }
@@ -431,7 +430,7 @@ mod tests {
             .unwrap()
             .into_inner();
 
-        assert!(resp.status.unwrap().ok);
+        assert_eq!(resp.stale_after_secs, 30);
     }
 
     #[tokio::test]
@@ -498,7 +497,7 @@ mod tests {
             .unwrap()
             .into_inner();
 
-        assert_eq!(resp.removed_keys, 2);
+        assert_eq!(resp.removed_owners, 2);
 
         let query_resp = svc
             .query_prefix_blocks(Request::new(QueryPrefixBlocksRequest {

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 pub const DEFAULT_NODE_STALE_SECS: u64 = 30;
-pub const DEFAULT_NODE_PURGE_SECS: u64 = 90;
+pub const DEFAULT_TTL_MINUTES: u64 = 120;
 
 /// A prefix query result: one block hash and all live nodes that own it.
 #[derive(Debug, Clone)]
@@ -18,14 +18,14 @@ pub struct PrefixEntry {
 #[derive(Debug, Clone, Copy)]
 pub struct StoreConfig {
     pub node_stale_after: Duration,
-    pub node_purge_after: Duration,
+    pub ttl: Duration,
 }
 
 impl Default for StoreConfig {
     fn default() -> Self {
         Self {
             node_stale_after: Duration::from_secs(DEFAULT_NODE_STALE_SECS),
-            node_purge_after: Duration::from_secs(DEFAULT_NODE_PURGE_SECS),
+            ttl: Duration::from_secs(DEFAULT_TTL_MINUTES * 60),
         }
     }
 }
@@ -82,6 +82,13 @@ impl BlockHashStore {
             nodes: DashMap::new(),
             config,
         }
+    }
+
+    pub fn with_ttl(ttl_minutes: u64) -> Self {
+        Self::with_config(StoreConfig {
+            node_stale_after: Duration::from_secs(DEFAULT_NODE_STALE_SECS),
+            ttl: Duration::from_secs(ttl_minutes * 60),
+        })
     }
 
     pub fn register_node(&self, node: &str) -> Uuid {
@@ -207,7 +214,7 @@ impl BlockHashStore {
         result
     }
 
-    /// Sweep owners whose node is missing or past purge age.
+    /// Sweep owners whose node is missing or whose ownership TTL has expired.
     pub fn sweep_expired(&self) -> SweepStats {
         let now = Instant::now();
         let mut stats = SweepStats::default();
@@ -225,9 +232,9 @@ impl BlockHashStore {
         });
 
         let node_before = self.nodes.len();
-        let purge_after = self.config.node_purge_after;
+        let ttl = self.config.ttl;
         self.nodes
-            .retain(|_, record| now.duration_since(record.last_seen) <= purge_after);
+            .retain(|_, record| now.duration_since(record.last_seen) <= ttl);
         stats.removed_nodes = node_before.saturating_sub(self.nodes.len());
 
         stats
@@ -252,7 +259,7 @@ impl BlockHashStore {
             let age = now.duration_since(node.last_seen);
             if age <= self.config.node_stale_after {
                 active += 1;
-            } else if age <= self.config.node_purge_after {
+            } else if age <= self.config.ttl {
                 stale += 1;
             }
         }
@@ -305,10 +312,8 @@ impl BlockHashStore {
         let Some(record) = self.nodes.get(node.as_ref()) else {
             return false;
         };
-        if record.node_id != owner.node_id {
-            return now.duration_since(owner.key_register_time) <= self.config.node_purge_after;
-        }
-        now.duration_since(record.last_seen) <= self.config.node_purge_after
+        now.duration_since(owner.key_register_time) <= self.config.ttl
+            && now.duration_since(record.last_seen) <= self.config.ttl
     }
 }
 
@@ -478,7 +483,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sweep_keeps_superseded_owner_until_node_purge() {
+    fn test_sweep_keeps_superseded_owner_until_ttl() {
         let store = BlockHashStore::new();
         let old_id = store.register_node("node-a");
         store
@@ -497,7 +502,7 @@ mod tests {
     fn test_sweep_removes_superseded_owner_after_key_purge_age() {
         let store = BlockHashStore::with_config(StoreConfig {
             node_stale_after: Duration::ZERO,
-            node_purge_after: Duration::ZERO,
+            ttl: Duration::ZERO,
         });
         let old_id = store.register_node("node-a");
         store
@@ -550,7 +555,7 @@ mod tests {
     fn test_query_filters_stale_node() {
         let store = BlockHashStore::with_config(StoreConfig {
             node_stale_after: Duration::ZERO,
-            node_purge_after: Duration::from_secs(60),
+            ttl: Duration::from_secs(60),
         });
         let node_id = store.register_node("node-a");
         store
@@ -567,7 +572,7 @@ mod tests {
     fn test_sweep_expired() {
         let store = BlockHashStore::with_config(StoreConfig {
             node_stale_after: Duration::ZERO,
-            node_purge_after: Duration::ZERO,
+            ttl: Duration::ZERO,
         });
         let node_id = store.register_node("node-a");
         store

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -1,4 +1,4 @@
-use dashmap::DashMap;
+use dashmap::{DashMap, mapref::entry::Entry};
 use pegaflow_common::BlockKey;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -91,20 +91,29 @@ impl BlockHashStore {
         })
     }
 
-    pub fn register_node(&self, node: &str) -> Uuid {
-        let node_id = Uuid::new_v4();
-        self.nodes.insert(
-            Arc::from(node),
-            NodeRecord {
-                node_id,
-                last_seen: Instant::now(),
-            },
-        );
-        node_id
-    }
-
     pub fn heartbeat_node(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
-        self.touch_node_session(node, node_id)
+        let now = Instant::now();
+        match self.nodes.entry(Arc::from(node)) {
+            Entry::Vacant(entry) => {
+                entry.insert(NodeRecord {
+                    node_id,
+                    last_seen: now,
+                });
+                Ok(())
+            }
+            Entry::Occupied(mut entry) => {
+                let record = entry.get_mut();
+                let same_session = record.node_id == node_id;
+                let stale_session =
+                    now.duration_since(record.last_seen) > self.config.node_stale_after;
+                if same_session || stale_session {
+                    record.node_id = node_id;
+                    record.last_seen = now;
+                    return Ok(());
+                }
+                Err(StoreError::StaleSession)
+            }
+        }
     }
 
     pub fn unregister_node(&self, node: &str, node_id: Uuid) -> Result<usize, StoreError> {
@@ -321,12 +330,18 @@ impl Default for BlockHashStore {
 mod tests {
     use super::*;
 
+    fn heartbeat_node(store: &BlockHashStore, node: &str) -> Uuid {
+        let node_id = Uuid::new_v4();
+        store.heartbeat_node(node, node_id).unwrap();
+        node_id
+    }
+
     #[test]
     fn test_register_insert_and_query() {
         let store = BlockHashStore::new();
         let namespace = "model-a";
         let node = "10.0.0.1:50055";
-        let node_id = store.register_node(node);
+        let node_id = heartbeat_node(&store, node);
 
         let hashes = vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12]];
 
@@ -357,8 +372,8 @@ mod tests {
         let hash = vec![1, 2, 3, 4];
         let node_a = "node-a:50055";
         let node_b = "node-b:50055";
-        let node_a_id = store.register_node(node_a);
-        let node_b_id = store.register_node(node_b);
+        let node_a_id = heartbeat_node(&store, node_a);
+        let node_b_id = heartbeat_node(&store, node_b);
 
         store
             .insert_hashes(namespace, std::slice::from_ref(&hash), node_a, node_a_id)
@@ -394,7 +409,7 @@ mod tests {
         let namespace = "model-a";
         let hash = vec![1, 2, 3, 4];
         let node = "node-a";
-        let node_id = store.register_node(node);
+        let node_id = heartbeat_node(&store, node);
 
         store
             .insert_hashes(namespace, std::slice::from_ref(&hash), node, node_id)
@@ -412,8 +427,8 @@ mod tests {
         let store = BlockHashStore::new();
         let namespace = "model-a";
         let hash = vec![1, 2, 3, 4];
-        let node_b_id = store.register_node("node-b");
-        let node_a_id = store.register_node("node-a");
+        let node_b_id = heartbeat_node(&store, "node-b");
+        let node_a_id = heartbeat_node(&store, "node-a");
 
         store
             .insert_hashes(namespace, std::slice::from_ref(&hash), "node-b", node_b_id)
@@ -430,8 +445,8 @@ mod tests {
     fn test_remove_one_owner_keeps_others() {
         let store = BlockHashStore::new();
         let hash = vec![1, 2, 3];
-        let node_a_id = store.register_node("node-a");
-        let node_b_id = store.register_node("node-b");
+        let node_a_id = heartbeat_node(&store, "node-a");
+        let node_b_id = heartbeat_node(&store, "node-b");
 
         store
             .insert_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a_id)
@@ -454,7 +469,7 @@ mod tests {
     #[test]
     fn test_remove_nonexistent_is_noop() {
         let store = BlockHashStore::new();
-        let node_id = store.register_node("node-a");
+        let node_id = heartbeat_node(&store, "node-a");
         let removed = store
             .remove_hashes("ns", &[vec![9, 9, 9]], "node-a", node_id)
             .unwrap();
@@ -462,13 +477,26 @@ mod tests {
     }
 
     #[test]
+    fn test_heartbeat_rejects_active_different_session() {
+        let store = BlockHashStore::new();
+        let old_id = heartbeat_node(&store, "node-a");
+        let new_id = Uuid::new_v4();
+        assert_ne!(old_id, new_id);
+
+        let err = store.heartbeat_node("node-a", new_id).unwrap_err();
+        assert_eq!(err, StoreError::StaleSession);
+    }
+
+    #[test]
     fn test_query_filters_superseded_node_session() {
         let store = BlockHashStore::new();
-        let old_id = store.register_node("node-a");
+        let old_id = heartbeat_node(&store, "node-a");
         store
             .insert_hashes("ns", &[vec![1]], "node-a", old_id)
             .unwrap();
-        let new_id = store.register_node("node-a");
+        store.nodes.get_mut("node-a").unwrap().last_seen =
+            Instant::now() - Duration::from_secs(DEFAULT_NODE_STALE_SECS + 1);
+        let new_id = heartbeat_node(&store, "node-a");
         assert_ne!(old_id, new_id);
 
         let existing = store.query_prefix("ns", &[vec![1]]);
@@ -479,11 +507,13 @@ mod tests {
     #[test]
     fn test_sweep_keeps_superseded_owner_until_ttl() {
         let store = BlockHashStore::new();
-        let old_id = store.register_node("node-a");
+        let old_id = heartbeat_node(&store, "node-a");
         store
             .insert_hashes("ns", &[vec![1]], "node-a", old_id)
             .unwrap();
-        let new_id = store.register_node("node-a");
+        store.nodes.get_mut("node-a").unwrap().last_seen =
+            Instant::now() - Duration::from_secs(DEFAULT_NODE_STALE_SECS + 1);
+        let new_id = heartbeat_node(&store, "node-a");
         assert_ne!(old_id, new_id);
 
         let removed = store.sweep_expired();
@@ -498,11 +528,12 @@ mod tests {
             node_stale_after: Duration::ZERO,
             ttl: Duration::ZERO,
         });
-        let old_id = store.register_node("node-a");
+        let old_id = heartbeat_node(&store, "node-a");
         store
             .insert_hashes("ns", &[vec![1]], "node-a", old_id)
             .unwrap();
-        let new_id = store.register_node("node-a");
+        store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(1);
+        let new_id = heartbeat_node(&store, "node-a");
         assert_ne!(old_id, new_id);
 
         let removed = store.sweep_expired();
@@ -520,8 +551,10 @@ mod tests {
     #[test]
     fn test_late_unregister_old_session_does_not_remove_current_node() {
         let store = BlockHashStore::new();
-        let old_id = store.register_node("node-a");
-        let new_id = store.register_node("node-a");
+        let old_id = heartbeat_node(&store, "node-a");
+        store.nodes.get_mut("node-a").unwrap().last_seen =
+            Instant::now() - Duration::from_secs(DEFAULT_NODE_STALE_SECS + 1);
+        let new_id = heartbeat_node(&store, "node-a");
         assert_ne!(old_id, new_id);
 
         store
@@ -551,7 +584,7 @@ mod tests {
             node_stale_after: Duration::ZERO,
             ttl: Duration::from_secs(60),
         });
-        let node_id = store.register_node("node-a");
+        let node_id = heartbeat_node(&store, "node-a");
         store
             .insert_hashes("ns", &[vec![1]], "node-a", node_id)
             .unwrap();
@@ -568,7 +601,7 @@ mod tests {
             node_stale_after: Duration::from_secs(60),
             ttl: Duration::from_secs(60),
         });
-        let node_id = store.register_node("node-a");
+        let node_id = heartbeat_node(&store, "node-a");
         store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(61);
 
         store
@@ -587,7 +620,7 @@ mod tests {
             node_stale_after: Duration::from_secs(60),
             ttl: Duration::from_secs(60),
         });
-        let node_id = store.register_node("node-a");
+        let node_id = heartbeat_node(&store, "node-a");
         store
             .insert_hashes("ns", &[vec![1]], "node-a", node_id)
             .unwrap();
@@ -606,7 +639,7 @@ mod tests {
             node_stale_after: Duration::ZERO,
             ttl: Duration::ZERO,
         });
-        let node_id = store.register_node("node-a");
+        let node_id = heartbeat_node(&store, "node-a");
         store
             .insert_hashes("ns", &[vec![1], vec![2]], "node-a", node_id)
             .unwrap();
@@ -630,7 +663,7 @@ mod tests {
     #[test]
     fn test_sweep_keeps_fresh_entries() {
         let store = BlockHashStore::new();
-        let node_id = store.register_node("node-a");
+        let node_id = heartbeat_node(&store, "node-a");
         store
             .insert_hashes("ns", &[vec![1], vec![2]], "node-a", node_id)
             .unwrap();
@@ -648,8 +681,8 @@ mod tests {
         let hash = vec![1, 2, 3, 4];
 
         for _ in 0..100 {
-            let node_a_id = store.register_node("node-a");
-            let node_b_id = store.register_node("node-b");
+            let node_a_id = heartbeat_node(&store, "node-a");
+            let node_b_id = heartbeat_node(&store, "node-b");
             store
                 .insert_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a_id)
                 .unwrap();
@@ -688,7 +721,7 @@ mod tests {
         let store = BlockHashStore::new();
         let namespace = "model-test";
         let node = "10.0.0.1:50055";
-        let node_id = store.register_node(node);
+        let node_id = heartbeat_node(&store, node);
 
         let hashes = vec![vec![1, 2, 3], vec![4, 5, 6]];
         store

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -91,6 +91,10 @@ impl BlockHashStore {
         })
     }
 
+    pub fn config(&self) -> StoreConfig {
+        self.config
+    }
+
     pub fn heartbeat_node(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
         let now = Instant::now();
         match self.nodes.entry(Arc::from(node)) {
@@ -581,13 +585,14 @@ mod tests {
     #[test]
     fn test_query_filters_stale_node() {
         let store = BlockHashStore::with_config(StoreConfig {
-            node_stale_after: Duration::ZERO,
+            node_stale_after: Duration::from_millis(1),
             ttl: Duration::from_secs(60),
         });
         let node_id = heartbeat_node(&store, "node-a");
         store
             .insert_hashes("ns", &[vec![1]], "node-a", node_id)
             .unwrap();
+        std::thread::sleep(Duration::from_millis(2));
 
         let existing = store.query_prefix("ns", &[vec![1]]);
         assert!(existing.is_empty());

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -1,4 +1,5 @@
 use dashmap::{DashMap, mapref::entry::Entry};
+use log::{info, warn};
 use pegaflow_common::BlockKey;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -49,12 +50,16 @@ pub enum StoreError {
     StaleSession,
 }
 
+/// Snapshot of the session that wrote this block ownership. Query compares it
+/// with the current `NodeRecord.node_id` to filter owners left by old sessions.
 #[derive(Debug, Clone)]
 struct OwnerRecord {
     node_id: Uuid,
     key_register_time: Instant,
 }
 
+/// Authoritative current session for a node URL. `last_seen` is bumped on
+/// heartbeat/insert/remove and gates query visibility.
 #[derive(Debug, Clone)]
 struct NodeRecord {
     node_id: Uuid,
@@ -99,6 +104,7 @@ impl BlockHashStore {
         let now = Instant::now();
         match self.nodes.entry(Arc::from(node)) {
             Entry::Vacant(entry) => {
+                info!("MetaServer node registered: node={node} node_id={node_id}");
                 entry.insert(NodeRecord {
                     node_id,
                     last_seen: now,
@@ -111,10 +117,20 @@ impl BlockHashStore {
                 let stale_session =
                     now.duration_since(record.last_seen) > self.config.node_stale_after;
                 if same_session || stale_session {
+                    if stale_session && !same_session {
+                        info!(
+                            "MetaServer node session takeover: node={} old_node_id={} new_node_id={}",
+                            node, record.node_id, node_id
+                        );
+                    }
                     record.node_id = node_id;
                     record.last_seen = now;
                     return Ok(());
                 }
+                warn!(
+                    "MetaServer heartbeat rejected stale session: node={} current_node_id={} rejected_node_id={}",
+                    node, record.node_id, node_id
+                );
                 Err(StoreError::StaleSession)
             }
         }
@@ -127,8 +143,16 @@ impl BlockHashStore {
             .is_none()
         {
             if self.nodes.contains_key(node) {
+                warn!(
+                    "MetaServer unregister rejected stale session: node={} rejected_node_id={}",
+                    node, node_id
+                );
                 return Err(StoreError::StaleSession);
             }
+            warn!(
+                "MetaServer unregister rejected unknown node: node={} node_id={}",
+                node, node_id
+            );
             return Err(StoreError::UnknownNode);
         }
         Ok(self.remove_node_owners(node, node_id))
@@ -239,8 +263,18 @@ impl BlockHashStore {
 
         let node_before = self.nodes.len();
         let ttl = self.config.ttl;
-        self.nodes
-            .retain(|_, record| now.duration_since(record.last_seen) <= ttl);
+        self.nodes.retain(|node, record| {
+            let keep = now.duration_since(record.last_seen) <= ttl;
+            if !keep {
+                info!(
+                    "MetaServer node swept: node={} node_id={} last_seen_age_secs={}",
+                    node,
+                    record.node_id,
+                    now.duration_since(record.last_seen).as_secs()
+                );
+            }
+            keep
+        });
         stats.removed_nodes = node_before.saturating_sub(self.nodes.len());
 
         stats
@@ -283,9 +317,17 @@ impl BlockHashStore {
 
     fn touch_node_session(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
         let Some(mut record) = self.nodes.get_mut(node) else {
+            warn!(
+                "MetaServer metadata write rejected unknown node: node={} node_id={}",
+                node, node_id
+            );
             return Err(StoreError::UnknownNode);
         };
         if record.node_id != node_id {
+            warn!(
+                "MetaServer metadata write rejected stale session: node={} current_node_id={} rejected_node_id={}",
+                node, record.node_id, node_id
+            );
             return Err(StoreError::StaleSession);
         }
         record.last_seen = Instant::now();

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -104,14 +104,7 @@ impl BlockHashStore {
     }
 
     pub fn heartbeat_node(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
-        let Some(mut record) = self.nodes.get_mut(node) else {
-            return Err(StoreError::UnknownNode);
-        };
-        if record.node_id != node_id {
-            return Err(StoreError::StaleSession);
-        }
-        record.last_seen = Instant::now();
-        Ok(())
+        self.touch_node_session(node, node_id)
     }
 
     pub fn unregister_node(&self, node: &str, node_id: Uuid) -> Result<usize, StoreError> {
@@ -135,7 +128,7 @@ impl BlockHashStore {
         node: &str,
         node_id: Uuid,
     ) -> Result<usize, StoreError> {
-        self.validate_node_session(node, node_id)?;
+        self.touch_node_session(node, node_id)?;
         let node: Arc<str> = Arc::from(node);
         let now = Instant::now();
         for hash in hashes {
@@ -158,7 +151,7 @@ impl BlockHashStore {
         node: &str,
         node_id: Uuid,
     ) -> Result<usize, StoreError> {
-        self.validate_node_session(node, node_id)?;
+        self.touch_node_session(node, node_id)?;
         let mut removed = 0;
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
@@ -275,13 +268,14 @@ impl BlockHashStore {
         self.nodes.clear();
     }
 
-    fn validate_node_session(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
-        let Some(record) = self.nodes.get(node) else {
+    fn touch_node_session(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
+        let Some(mut record) = self.nodes.get_mut(node) else {
             return Err(StoreError::UnknownNode);
         };
         if record.node_id != node_id {
             return Err(StoreError::StaleSession);
         }
+        record.last_seen = Instant::now();
         Ok(())
     }
 
@@ -566,6 +560,44 @@ mod tests {
         assert!(existing.is_empty());
         assert_eq!(store.entry_count(), 1);
         assert_eq!(store.owner_count(), 1);
+    }
+
+    #[test]
+    fn test_insert_refreshes_node_liveness() {
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::from_secs(60),
+            ttl: Duration::from_secs(60),
+        });
+        let node_id = store.register_node("node-a");
+        store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(61);
+
+        store
+            .insert_hashes("ns", &[vec![1]], "node-a", node_id)
+            .unwrap();
+
+        assert_eq!(store.node_counts(), (1, 0));
+        let existing = store.query_prefix("ns", &[vec![1]]);
+        assert_eq!(existing.len(), 1);
+        assert_eq!(existing[0].nodes[0].as_ref(), "node-a");
+    }
+
+    #[test]
+    fn test_remove_refreshes_node_liveness() {
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::from_secs(60),
+            ttl: Duration::from_secs(60),
+        });
+        let node_id = store.register_node("node-a");
+        store
+            .insert_hashes("ns", &[vec![1]], "node-a", node_id)
+            .unwrap();
+        store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(61);
+
+        store
+            .remove_hashes("ns", &[vec![2]], "node-a", node_id)
+            .unwrap();
+
+        assert_eq!(store.node_counts(), (1, 0));
     }
 
     #[test]

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -3,127 +3,312 @@ use pegaflow_common::BlockKey;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use uuid::Uuid;
 
-/// Default TTL for cache entries (120 minutes)
-pub const DEFAULT_TTL_MINUTES: u64 = 120;
+pub const DEFAULT_NODE_STALE_SECS: u64 = 30;
+pub const DEFAULT_NODE_PURGE_SECS: u64 = 90;
 
-/// A prefix query result: one block hash and all nodes that own it.
+/// A prefix query result: one block hash and all live nodes that own it.
 #[derive(Debug, Clone)]
 pub struct PrefixEntry {
     pub block_hash: Vec<u8>,
     pub nodes: Vec<Arc<str>>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct StoreConfig {
+    pub node_stale_after: Duration,
+    pub node_purge_after: Duration,
+}
+
+impl Default for StoreConfig {
+    fn default() -> Self {
+        Self {
+            node_stale_after: Duration::from_secs(DEFAULT_NODE_STALE_SECS),
+            node_purge_after: Duration::from_secs(DEFAULT_NODE_PURGE_SECS),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SweepStats {
+    pub removed_owners: usize,
+    pub removed_keys: usize,
+    pub removed_nodes: usize,
+}
+
+impl SweepStats {
+    pub fn is_empty(self) -> bool {
+        self.removed_owners == 0 && self.removed_keys == 0 && self.removed_nodes == 0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreError {
+    UnknownNode,
+    StaleSession,
+}
+
+#[derive(Debug, Clone)]
+struct OwnerRecord {
+    node_id: Uuid,
+    key_register_time: Instant,
+}
+
+#[derive(Debug, Clone)]
+struct NodeRecord {
+    node_id: Uuid,
+    last_seen: Instant,
+}
+
 /// Async thread-safe block hash storage using DashMap.
-/// Stores BlockKeys (namespace + hash) mapped to a set of owning node URLs with
-/// registration timestamps, enabling multi-owner tracking and periodic TTL sweep.
+///
+/// `blocks` maps each block key to node URL ownership records. `nodes` tracks
+/// the current MetaServer session and liveness for each node URL.
 pub struct BlockHashStore {
-    /// Key: BlockKey, Value: { node_url → registration_time }
-    map: DashMap<BlockKey, HashMap<Arc<str>, Instant>>,
-    ttl: Duration,
+    blocks: DashMap<BlockKey, HashMap<Arc<str>, OwnerRecord>>,
+    nodes: DashMap<Arc<str>, NodeRecord>,
+    config: StoreConfig,
 }
 
 impl BlockHashStore {
-    /// Create a new block hash store with default TTL (120 minutes)
     pub fn new() -> Self {
-        Self::with_ttl(DEFAULT_TTL_MINUTES)
+        Self::with_config(StoreConfig::default())
     }
 
-    /// Create a new block hash store with specified TTL in minutes
-    pub fn with_ttl(ttl_minutes: u64) -> Self {
+    pub fn with_config(config: StoreConfig) -> Self {
         Self {
-            map: DashMap::new(),
-            ttl: Duration::from_secs(ttl_minutes * 60),
+            blocks: DashMap::new(),
+            nodes: DashMap::new(),
+            config,
         }
     }
 
-    /// Insert a list of block hashes from a given node.
-    /// Re-inserting an existing (block, node) pair refreshes the TTL timestamp.
-    /// Returns the number of entries processed.
-    pub fn insert_hashes(&self, namespace: &str, hashes: &[Vec<u8>], node: &str) -> usize {
+    pub fn register_node(&self, node: &str) -> Uuid {
+        let node_id = Uuid::new_v4();
+        self.nodes.insert(
+            Arc::from(node),
+            NodeRecord {
+                node_id,
+                last_seen: Instant::now(),
+            },
+        );
+        node_id
+    }
+
+    pub fn heartbeat_node(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
+        let Some(mut record) = self.nodes.get_mut(node) else {
+            return Err(StoreError::UnknownNode);
+        };
+        if record.node_id != node_id {
+            return Err(StoreError::StaleSession);
+        }
+        record.last_seen = Instant::now();
+        Ok(())
+    }
+
+    pub fn unregister_node(&self, node: &str, node_id: Uuid) -> Result<usize, StoreError> {
+        if self
+            .nodes
+            .remove_if(node, |_, record| record.node_id == node_id)
+            .is_none()
+        {
+            if self.nodes.contains_key(node) {
+                return Err(StoreError::StaleSession);
+            }
+            return Err(StoreError::UnknownNode);
+        }
+        Ok(self.remove_node_owners(node, node_id))
+    }
+
+    pub fn insert_hashes(
+        &self,
+        namespace: &str,
+        hashes: &[Vec<u8>],
+        node: &str,
+        node_id: Uuid,
+    ) -> Result<usize, StoreError> {
+        self.validate_node_session(node, node_id)?;
         let node: Arc<str> = Arc::from(node);
         let now = Instant::now();
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
-            self.map
-                .entry(key)
-                .or_default()
-                .insert(Arc::clone(&node), now);
+            self.blocks.entry(key).or_default().insert(
+                Arc::clone(&node),
+                OwnerRecord {
+                    node_id,
+                    key_register_time: now,
+                },
+            );
         }
-        hashes.len()
+        Ok(hashes.len())
     }
 
-    /// Remove hashes owned by the given node (conditional delete).
-    /// Only removes the requesting node's ownership; other nodes' entries are untouched.
-    /// Returns the number of removed entries.
-    pub fn remove_hashes(&self, namespace: &str, hashes: &[Vec<u8>], node: &str) -> usize {
+    pub fn remove_hashes(
+        &self,
+        namespace: &str,
+        hashes: &[Vec<u8>],
+        node: &str,
+        node_id: Uuid,
+    ) -> Result<usize, StoreError> {
+        self.validate_node_session(node, node_id)?;
         let mut removed = 0;
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
-            let should_remove_key = if let Some(mut nodes) = self.map.get_mut(&key) {
-                if nodes.remove(node).is_some() {
+            let should_remove_key = if let Some(mut owners) = self.blocks.get_mut(&key) {
+                if owners
+                    .get(node)
+                    .is_some_and(|owner| owner.node_id == node_id)
+                {
+                    owners.remove(node);
                     removed += 1;
                 }
-                nodes.is_empty()
+                owners.is_empty()
             } else {
                 false
             };
             if should_remove_key {
-                // Only remove if still empty (another thread may have inserted)
-                self.map.remove_if(&key, |_, nodes| nodes.is_empty());
+                self.blocks.remove_if(&key, |_, owners| owners.is_empty());
             }
         }
-        removed
+        Ok(removed)
     }
 
-    /// Query the longest prefix of `hashes` that exists in the store.
-    /// Stops at the first hash not found on any node.
+    /// Query the longest prefix of `hashes` with at least one live owner.
     pub fn query_prefix(&self, namespace: &str, hashes: &[Vec<u8>]) -> Vec<PrefixEntry> {
+        let now = Instant::now();
         let mut result = Vec::new();
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
-            if let Some(nodes) = self.map.get(&key) {
-                if nodes.is_empty() {
-                    break;
-                }
-                result.push(PrefixEntry {
-                    block_hash: hash.clone(),
-                    nodes: nodes.keys().cloned().collect(),
-                });
-            } else {
+            let Some(owners) = self.blocks.get(&key) else {
+                break;
+            };
+
+            let live_nodes: Vec<Arc<str>> = owners
+                .iter()
+                .filter_map(|(node, owner)| {
+                    if self.is_owner_visible(node, owner, now) {
+                        Some(Arc::clone(node))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            if live_nodes.is_empty() {
                 break;
             }
+
+            result.push(PrefixEntry {
+                block_hash: hash.clone(),
+                nodes: live_nodes,
+            });
         }
         result
     }
 
-    /// Sweep expired entries. Removes per-node registrations older than TTL,
-    /// then drops block keys with no remaining owners.
-    /// Called periodically from a background task.
-    /// Returns the number of block keys fully removed.
-    pub fn sweep_expired(&self) -> usize {
+    /// Sweep owners whose node is missing or past purge age.
+    pub fn sweep_expired(&self) -> SweepStats {
         let now = Instant::now();
-        let ttl = self.ttl;
-        let before = self.map.len();
-        self.map.retain(|_, nodes| {
-            nodes.retain(|_, registered_at| now.duration_since(*registered_at) < ttl);
-            !nodes.is_empty()
+        let mut stats = SweepStats::default();
+
+        self.blocks.retain(|_, owners| {
+            let before = owners.len();
+            owners.retain(|node, owner| self.should_keep_owner(node, owner, now));
+            stats.removed_owners += before.saturating_sub(owners.len());
+            if owners.is_empty() {
+                stats.removed_keys += 1;
+                false
+            } else {
+                true
+            }
         });
-        before.saturating_sub(self.map.len())
+
+        let node_before = self.nodes.len();
+        let purge_after = self.config.node_purge_after;
+        self.nodes
+            .retain(|_, record| now.duration_since(record.last_seen) <= purge_after);
+        stats.removed_nodes = node_before.saturating_sub(self.nodes.len());
+
+        stats
     }
 
-    /// Get the number of unique block keys
     pub fn entry_count(&self) -> u64 {
-        self.map.len() as u64
+        self.blocks.len() as u64
     }
 
-    /// Clear all entries (for testing or maintenance)
+    pub fn owner_count(&self) -> u64 {
+        self.blocks
+            .iter()
+            .map(|entry| entry.value().len() as u64)
+            .sum()
+    }
+
+    pub fn node_counts(&self) -> (u64, u64) {
+        let now = Instant::now();
+        let mut active = 0;
+        let mut stale = 0;
+        for node in &self.nodes {
+            let age = now.duration_since(node.last_seen);
+            if age <= self.config.node_stale_after {
+                active += 1;
+            } else if age <= self.config.node_purge_after {
+                stale += 1;
+            }
+        }
+        (active, stale)
+    }
+
     #[allow(
         dead_code,
         reason = "maintenance API reserved for explicit store cleanup"
     )]
     pub fn invalidate_all(&self) {
-        self.map.clear();
+        self.blocks.clear();
+        self.nodes.clear();
+    }
+
+    fn validate_node_session(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
+        let Some(record) = self.nodes.get(node) else {
+            return Err(StoreError::UnknownNode);
+        };
+        if record.node_id != node_id {
+            return Err(StoreError::StaleSession);
+        }
+        Ok(())
+    }
+
+    fn remove_node_owners(&self, node: &str, node_id: Uuid) -> usize {
+        let mut removed = 0;
+        self.blocks.retain(|_, owners| {
+            if owners
+                .get(node)
+                .is_some_and(|owner| owner.node_id == node_id)
+            {
+                owners.remove(node);
+                removed += 1;
+            }
+            !owners.is_empty()
+        });
+        removed
+    }
+
+    fn is_owner_visible(&self, node: &Arc<str>, owner: &OwnerRecord, now: Instant) -> bool {
+        let Some(record) = self.nodes.get(node.as_ref()) else {
+            return false;
+        };
+        record.node_id == owner.node_id
+            && now.duration_since(record.last_seen) <= self.config.node_stale_after
+    }
+
+    fn should_keep_owner(&self, node: &Arc<str>, owner: &OwnerRecord, now: Instant) -> bool {
+        let Some(record) = self.nodes.get(node.as_ref()) else {
+            return false;
+        };
+        if record.node_id != owner.node_id {
+            return now.duration_since(owner.key_register_time) <= self.config.node_purge_after;
+        }
+        now.duration_since(record.last_seen) <= self.config.node_purge_after
     }
 }
 
@@ -138,18 +323,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_insert_and_query() {
+    fn test_register_insert_and_query() {
         let store = BlockHashStore::new();
         let namespace = "model-a";
         let node = "10.0.0.1:50055";
+        let node_id = store.register_node(node);
 
         let hashes = vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12]];
 
-        // Insert hashes
-        let inserted = store.insert_hashes(namespace, &hashes, node);
+        let inserted = store
+            .insert_hashes(namespace, &hashes, node, node_id)
+            .unwrap();
         assert_eq!(inserted, 3);
 
-        // Query existing hashes
         let existing = store.query_prefix(namespace, &hashes);
         assert_eq!(existing.len(), 3);
         for entry in &existing {
@@ -157,16 +343,10 @@ mod tests {
             assert_eq!(entry.nodes[0].as_ref(), node);
         }
 
-        // Query with gap — prefix stops at first miss
-        let mixed_hashes = vec![
-            vec![1, 2, 3, 4],     // exists
-            vec![99, 99, 99, 99], // doesn't exist — prefix stops here
-            vec![5, 6, 7, 8],     // exists but unreachable
-        ];
+        let mixed_hashes = vec![vec![1, 2, 3, 4], vec![99, 99, 99, 99], vec![5, 6, 7, 8]];
         let existing = store.query_prefix(namespace, &mixed_hashes);
         assert_eq!(existing.len(), 1);
 
-        // Query with different namespace
         let existing = store.query_prefix("other-namespace", &hashes);
         assert_eq!(existing.len(), 0);
     }
@@ -176,9 +356,17 @@ mod tests {
         let store = BlockHashStore::new();
         let namespace = "model-a";
         let hash = vec![1, 2, 3, 4];
+        let node_a = "node-a:50055";
+        let node_b = "node-b:50055";
+        let node_a_id = store.register_node(node_a);
+        let node_b_id = store.register_node(node_b);
 
-        store.insert_hashes(namespace, std::slice::from_ref(&hash), "node-a:50055");
-        store.insert_hashes(namespace, std::slice::from_ref(&hash), "node-b:50055");
+        store
+            .insert_hashes(namespace, std::slice::from_ref(&hash), node_a, node_a_id)
+            .unwrap();
+        store
+            .insert_hashes(namespace, std::slice::from_ref(&hash), node_b, node_b_id)
+            .unwrap();
 
         let existing = store.query_prefix(namespace, std::slice::from_ref(&hash));
         assert_eq!(existing.len(), 1);
@@ -193,6 +381,8 @@ mod tests {
     fn test_empty_store() {
         let store = BlockHashStore::new();
         assert_eq!(store.entry_count(), 0);
+        assert_eq!(store.owner_count(), 0);
+        assert_eq!(store.node_counts(), (0, 0));
 
         let hashes = vec![vec![1, 2, 3]];
         let existing = store.query_prefix("any-namespace", &hashes);
@@ -204,11 +394,16 @@ mod tests {
         let store = BlockHashStore::new();
         let namespace = "model-a";
         let hash = vec![1, 2, 3, 4];
+        let node = "node-a";
+        let node_id = store.register_node(node);
 
-        store.insert_hashes(namespace, std::slice::from_ref(&hash), "node-a");
+        store
+            .insert_hashes(namespace, std::slice::from_ref(&hash), node, node_id)
+            .unwrap();
 
-        // owner matches → should remove
-        let removed = store.remove_hashes(namespace, std::slice::from_ref(&hash), "node-a");
+        let removed = store
+            .remove_hashes(namespace, std::slice::from_ref(&hash), node, node_id)
+            .unwrap();
         assert_eq!(removed, 1);
         assert_eq!(store.query_prefix(namespace, &[hash]).len(), 0);
     }
@@ -218,11 +413,16 @@ mod tests {
         let store = BlockHashStore::new();
         let namespace = "model-a";
         let hash = vec![1, 2, 3, 4];
+        let node_b_id = store.register_node("node-b");
+        let node_a_id = store.register_node("node-a");
 
-        store.insert_hashes(namespace, std::slice::from_ref(&hash), "node-b");
+        store
+            .insert_hashes(namespace, std::slice::from_ref(&hash), "node-b", node_b_id)
+            .unwrap();
 
-        // owner does not match → should not remove
-        let removed = store.remove_hashes(namespace, std::slice::from_ref(&hash), "node-a");
+        let removed = store
+            .remove_hashes(namespace, std::slice::from_ref(&hash), "node-a", node_a_id)
+            .unwrap();
         assert_eq!(removed, 0);
         assert_eq!(store.query_prefix(namespace, &[hash]).len(), 1);
     }
@@ -231,11 +431,19 @@ mod tests {
     fn test_remove_one_owner_keeps_others() {
         let store = BlockHashStore::new();
         let hash = vec![1, 2, 3];
+        let node_a_id = store.register_node("node-a");
+        let node_b_id = store.register_node("node-b");
 
-        store.insert_hashes("ns", std::slice::from_ref(&hash), "node-a");
-        store.insert_hashes("ns", std::slice::from_ref(&hash), "node-b");
+        store
+            .insert_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a_id)
+            .unwrap();
+        store
+            .insert_hashes("ns", std::slice::from_ref(&hash), "node-b", node_b_id)
+            .unwrap();
 
-        let removed = store.remove_hashes("ns", std::slice::from_ref(&hash), "node-a");
+        let removed = store
+            .remove_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a_id)
+            .unwrap();
         assert_eq!(removed, 1);
 
         let existing = store.query_prefix("ns", std::slice::from_ref(&hash));
@@ -247,30 +455,151 @@ mod tests {
     #[test]
     fn test_remove_nonexistent_is_noop() {
         let store = BlockHashStore::new();
-        let removed = store.remove_hashes("ns", &[vec![9, 9, 9]], "node-a");
+        let node_id = store.register_node("node-a");
+        let removed = store
+            .remove_hashes("ns", &[vec![9, 9, 9]], "node-a", node_id)
+            .unwrap();
         assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn test_query_filters_superseded_node_session() {
+        let store = BlockHashStore::new();
+        let old_id = store.register_node("node-a");
+        store
+            .insert_hashes("ns", &[vec![1]], "node-a", old_id)
+            .unwrap();
+        let new_id = store.register_node("node-a");
+        assert_ne!(old_id, new_id);
+
+        let existing = store.query_prefix("ns", &[vec![1]]);
+        assert!(existing.is_empty());
+        assert_eq!(store.owner_count(), 1);
+    }
+
+    #[test]
+    fn test_sweep_keeps_superseded_owner_until_node_purge() {
+        let store = BlockHashStore::new();
+        let old_id = store.register_node("node-a");
+        store
+            .insert_hashes("ns", &[vec![1]], "node-a", old_id)
+            .unwrap();
+        let new_id = store.register_node("node-a");
+        assert_ne!(old_id, new_id);
+
+        let removed = store.sweep_expired();
+        assert_eq!(removed, SweepStats::default());
+        assert_eq!(store.owner_count(), 1);
+        assert!(store.query_prefix("ns", &[vec![1]]).is_empty());
+    }
+
+    #[test]
+    fn test_sweep_removes_superseded_owner_after_key_purge_age() {
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::ZERO,
+            node_purge_after: Duration::ZERO,
+        });
+        let old_id = store.register_node("node-a");
+        store
+            .insert_hashes("ns", &[vec![1]], "node-a", old_id)
+            .unwrap();
+        let new_id = store.register_node("node-a");
+        assert_ne!(old_id, new_id);
+
+        let removed = store.sweep_expired();
+        assert_eq!(
+            removed,
+            SweepStats {
+                removed_owners: 1,
+                removed_keys: 1,
+                removed_nodes: 1,
+            }
+        );
+        assert_eq!(store.owner_count(), 0);
+    }
+
+    #[test]
+    fn test_late_unregister_old_session_does_not_remove_current_node() {
+        let store = BlockHashStore::new();
+        let old_id = store.register_node("node-a");
+        let new_id = store.register_node("node-a");
+        assert_ne!(old_id, new_id);
+
+        store
+            .insert_hashes("ns", &[vec![1]], "node-a", new_id)
+            .unwrap();
+
+        let err = store.unregister_node("node-a", old_id).unwrap_err();
+        assert_eq!(err, StoreError::StaleSession);
+
+        let existing = store.query_prefix("ns", &[vec![1]]);
+        assert_eq!(existing.len(), 1);
+        assert_eq!(existing[0].nodes[0].as_ref(), "node-a");
+    }
+
+    #[test]
+    fn test_unregistered_insert_is_rejected() {
+        let store = BlockHashStore::new();
+        let err = store
+            .insert_hashes("ns", &[vec![1]], "node-a", Uuid::new_v4())
+            .unwrap_err();
+        assert_eq!(err, StoreError::UnknownNode);
+    }
+
+    #[test]
+    fn test_query_filters_stale_node() {
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::ZERO,
+            node_purge_after: Duration::from_secs(60),
+        });
+        let node_id = store.register_node("node-a");
+        store
+            .insert_hashes("ns", &[vec![1]], "node-a", node_id)
+            .unwrap();
+
+        let existing = store.query_prefix("ns", &[vec![1]]);
+        assert!(existing.is_empty());
+        assert_eq!(store.entry_count(), 1);
+        assert_eq!(store.owner_count(), 1);
     }
 
     #[test]
     fn test_sweep_expired() {
-        // TTL = 0 minutes → everything expires immediately
-        let store = BlockHashStore::with_ttl(0);
-        store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::ZERO,
+            node_purge_after: Duration::ZERO,
+        });
+        let node_id = store.register_node("node-a");
+        store
+            .insert_hashes("ns", &[vec![1], vec![2]], "node-a", node_id)
+            .unwrap();
         assert_eq!(store.entry_count(), 2);
+        assert_eq!(store.owner_count(), 2);
 
-        // Instant::now() is already past the zero-TTL deadline
         let removed = store.sweep_expired();
-        assert_eq!(removed, 2);
+        assert_eq!(
+            removed,
+            SweepStats {
+                removed_owners: 2,
+                removed_keys: 2,
+                removed_nodes: 1,
+            }
+        );
         assert_eq!(store.entry_count(), 0);
+        assert_eq!(store.owner_count(), 0);
+        assert_eq!(store.node_counts(), (0, 0));
     }
 
     #[test]
     fn test_sweep_keeps_fresh_entries() {
-        let store = BlockHashStore::with_ttl(120); // 120 min TTL
-        store.insert_hashes("ns", &[vec![1], vec![2]], "node-a");
+        let store = BlockHashStore::new();
+        let node_id = store.register_node("node-a");
+        store
+            .insert_hashes("ns", &[vec![1], vec![2]], "node-a", node_id)
+            .unwrap();
 
         let removed = store.sweep_expired();
-        assert_eq!(removed, 0);
+        assert_eq!(removed, SweepStats::default());
         assert_eq!(store.entry_count(), 2);
     }
 
@@ -281,11 +610,13 @@ mod tests {
         let store = Arc::new(BlockHashStore::new());
         let hash = vec![1, 2, 3, 4];
 
-        // Run a quick synchronous stress test
         for _ in 0..100 {
-            store.insert_hashes("ns", std::slice::from_ref(&hash), "node-a");
+            let node_a_id = store.register_node("node-a");
+            let node_b_id = store.register_node("node-b");
+            store
+                .insert_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a_id)
+                .unwrap();
 
-            // Simulate concurrent ops from different threads
             let store_a = Arc::clone(&store);
             let store_b = Arc::clone(&store);
             let hash_a = hash.clone();
@@ -293,15 +624,17 @@ mod tests {
 
             std::thread::scope(|s| {
                 s.spawn(|| {
-                    store_a.remove_hashes("ns", &[hash_a], "node-a");
+                    store_a
+                        .remove_hashes("ns", &[hash_a], "node-a", node_a_id)
+                        .unwrap();
                 });
                 s.spawn(|| {
-                    store_b.insert_hashes("ns", &[hash_b], "node-b");
+                    store_b
+                        .insert_hashes("ns", &[hash_b], "node-b", node_b_id)
+                        .unwrap();
                 });
             });
 
-            // node-b always inserts; node-a's remove only affects node-a's entry.
-            // So node-b must always be present.
             let existing = store.query_prefix("ns", std::slice::from_ref(&hash));
             assert_eq!(existing.len(), 1, "key must exist after concurrent ops");
             assert!(
@@ -309,7 +642,6 @@ mod tests {
                 "node-b must be present"
             );
 
-            // Clean up for next iteration
             store.invalidate_all();
         }
     }
@@ -319,20 +651,22 @@ mod tests {
         let store = BlockHashStore::new();
         let namespace = "model-test";
         let node = "10.0.0.1:50055";
+        let node_id = store.register_node(node);
 
         let hashes = vec![vec![1, 2, 3], vec![4, 5, 6]];
-        store.insert_hashes(namespace, &hashes, node);
+        store
+            .insert_hashes(namespace, &hashes, node, node_id)
+            .unwrap();
 
-        // Verify entries exist
         let existing = store.query_prefix(namespace, &hashes);
         assert_eq!(existing.len(), 2);
 
-        // Clear all
         store.invalidate_all();
 
-        // Verify entries are gone
         let existing = store.query_prefix(namespace, &hashes);
         assert_eq!(existing.len(), 0);
         assert_eq!(store.entry_count(), 0);
+        assert_eq!(store.owner_count(), 0);
+        assert_eq!(store.node_counts(), (0, 0));
     }
 }

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -203,7 +203,7 @@ message InsertBlockHashesRequest {
   repeated bytes block_hashes = 2;
   // The pegaflow-server address that owns these blocks, as ip:port (e.g., "10.0.0.1:50055")
   string node = 3;
-  // MetaServer-assigned session id returned by RegisterNode.
+  // Server-generated session id announced by HeartbeatNode.
   string node_id = 4;
 }
 
@@ -218,7 +218,7 @@ message RemoveBlockHashesRequest {
   // Only remove entries whose current owner matches this node address.
   // Prevents races where node A evicts but node B has since re-registered.
   string node = 3;
-  // MetaServer-assigned session id returned by RegisterNode.
+  // Server-generated session id announced by HeartbeatNode.
   string node_id = 4;
 }
 
@@ -241,17 +241,6 @@ message QueryPrefixBlocksResponse {
   repeated NodePrefixResult nodes = 1;
 }
 
-message RegisterNodeRequest {
-  // The pegaflow-server address that owns blocks, as ip:port.
-  string node = 1;
-}
-
-message RegisterNodeResponse {
-  ResponseStatus status = 1;
-  // MetaServer-generated UUID session id for this node URL.
-  string node_id = 2;
-}
-
 message HeartbeatNodeRequest {
   string node = 1;
   string node_id = 2;
@@ -272,7 +261,6 @@ message UnregisterNodeResponse {
 }
 
 service MetaServer {
-  rpc RegisterNode(RegisterNodeRequest) returns (RegisterNodeResponse);
   rpc HeartbeatNode(HeartbeatNodeRequest) returns (HeartbeatNodeResponse);
   rpc UnregisterNode(UnregisterNodeRequest) returns (UnregisterNodeResponse);
   rpc InsertBlockHashes(InsertBlockHashesRequest) returns (InsertBlockHashesResponse);

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -248,6 +248,7 @@ message HeartbeatNodeRequest {
 
 message HeartbeatNodeResponse {
   ResponseStatus status = 1;
+  uint64 stale_after_secs = 2;
 }
 
 message UnregisterNodeRequest {
@@ -256,8 +257,7 @@ message UnregisterNodeRequest {
 }
 
 message UnregisterNodeResponse {
-  ResponseStatus status = 1;
-  uint64 removed_keys = 2;
+  uint64 removed_keys = 1;
 }
 
 service MetaServer {

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -247,8 +247,7 @@ message HeartbeatNodeRequest {
 }
 
 message HeartbeatNodeResponse {
-  ResponseStatus status = 1;
-  uint64 stale_after_secs = 2;
+  uint64 stale_after_secs = 1;
 }
 
 message UnregisterNodeRequest {
@@ -257,7 +256,7 @@ message UnregisterNodeRequest {
 }
 
 message UnregisterNodeResponse {
-  uint64 removed_keys = 1;
+  uint64 removed_owners = 1;
 }
 
 service MetaServer {

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -203,6 +203,8 @@ message InsertBlockHashesRequest {
   repeated bytes block_hashes = 2;
   // The pegaflow-server address that owns these blocks, as ip:port (e.g., "10.0.0.1:50055")
   string node = 3;
+  // MetaServer-assigned session id returned by RegisterNode.
+  string node_id = 4;
 }
 
 message InsertBlockHashesResponse {
@@ -216,6 +218,8 @@ message RemoveBlockHashesRequest {
   // Only remove entries whose current owner matches this node address.
   // Prevents races where node A evicts but node B has since re-registered.
   string node = 3;
+  // MetaServer-assigned session id returned by RegisterNode.
+  string node_id = 4;
 }
 
 message RemoveBlockHashesResponse {
@@ -237,7 +241,40 @@ message QueryPrefixBlocksResponse {
   repeated NodePrefixResult nodes = 1;
 }
 
+message RegisterNodeRequest {
+  // The pegaflow-server address that owns blocks, as ip:port.
+  string node = 1;
+}
+
+message RegisterNodeResponse {
+  ResponseStatus status = 1;
+  // MetaServer-generated UUID session id for this node URL.
+  string node_id = 2;
+}
+
+message HeartbeatNodeRequest {
+  string node = 1;
+  string node_id = 2;
+}
+
+message HeartbeatNodeResponse {
+  ResponseStatus status = 1;
+}
+
+message UnregisterNodeRequest {
+  string node = 1;
+  string node_id = 2;
+}
+
+message UnregisterNodeResponse {
+  ResponseStatus status = 1;
+  uint64 removed_keys = 2;
+}
+
 service MetaServer {
+  rpc RegisterNode(RegisterNodeRequest) returns (RegisterNodeResponse);
+  rpc HeartbeatNode(HeartbeatNodeRequest) returns (HeartbeatNodeResponse);
+  rpc UnregisterNode(UnregisterNodeRequest) returns (UnregisterNodeResponse);
   rpc InsertBlockHashes(InsertBlockHashesRequest) returns (InsertBlockHashesResponse);
   rpc RemoveBlockHashes(RemoveBlockHashesRequest) returns (RemoveBlockHashesResponse);
   rpc QueryPrefixBlocks(QueryPrefixBlocksRequest) returns (QueryPrefixBlocksResponse);

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -674,6 +674,8 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         shutdown.notify_waiters();
         let _ = http_server_handle.await;
 
+        engine.shutdown_metaserver_client().await;
+
         // Flush metrics before exit
         if let Some(provider) = metrics_state.meter_provider
             && let Err(err) = provider.shutdown()


### PR DESCRIPTION
## Summary
- add heartbeat-based node lifecycle tracking with per-node UUID fencing
- fence metaserver insert/remove/unregister RPCs by node id and refresh last_seen on writes
- hide stale nodes from query results using --node-stale-secs while keeping TTL-based sweep cleanup
- update metaserver lifecycle metrics and tests

## Concurrency review
- reviewed pegaflow-metaserver/src/store.rs for DashMap lock ordering and cross-map visibility races
- store operations do not hold nodes guards while acquiring blocks guards on write paths; sweep/query only read nodes while holding a block entry/shard
- nodes/blocks updates are intentionally not a global transaction, and query visibility is fenced by matching node_id plus fresh last_seen

## Tests
- cargo check -p pegaflow-proto
- cargo check -p pegaflow-metaserver

Closes #222