### PR TITLE
refactor(core): make prefetch task terminal

### DIFF
--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -1,7 +1,4 @@
-// RDMA remote block fetch: MetaServer query → gRPC QueryBlocksForTransfer → RDMA READ.
-//
-// Follows the same submit/oneshot pattern as SsdBackingStore::submit_prefix so that
-// PrefetchScheduler can treat remote fetch the same way it treats SSD prefetch.
+// RDMA remote block fetch: MetaServer query -> gRPC QueryBlocksForTransfer -> RDMA READ.
 
 use std::collections::HashMap;
 use std::ptr::NonNull;
@@ -10,7 +7,6 @@ use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use log::{debug, info, warn};
-use mea::oneshot;
 use mea::singleflight::Group;
 use pegaflow_proto::proto::engine::engine_client::EngineClient;
 use pegaflow_proto::proto::engine::{
@@ -112,43 +108,26 @@ impl RdmaFetchStore {
         Some((best.node.clone(), prefix_len))
     }
 
-    /// Start an RDMA fetch of `hashes` from `remote_addr`.
-    /// Returns a receiver that delivers the fetched blocks.
-    pub(crate) fn fetch_blocks(
+    /// Fetch `hashes` from `remote_addr`.
+    pub(crate) async fn fetch_blocks(
         &self,
         remote_addr: &str,
         req_id: &str,
         namespace: &str,
-        hashes: Vec<Vec<u8>>,
-    ) -> oneshot::Receiver<PrefetchResult> {
-        let (done_tx, done_rx) = oneshot::channel();
-
-        let rdma = Arc::clone(&self.rdma_transport);
-        let alloc_fn = Arc::clone(&self.allocate_fn);
-        let channels = Arc::clone(&self.grpc_channels);
-        let connect_group = Arc::clone(&self.connect_group);
-        let advertise = self.advertise_addr.clone();
-        let remote = remote_addr.to_string();
-        let req = req_id.to_string();
-        let ns = namespace.to_string();
-
-        tokio::spawn(async move {
-            let result = rdma_fetch_task(
-                &rdma,
-                &alloc_fn,
-                &channels,
-                &connect_group,
-                &remote,
-                &req,
-                &advertise,
-                &ns,
-                &hashes,
-            )
-            .await;
-            let _ = done_tx.send(result);
-        });
-
-        done_rx
+        hashes: &[Vec<u8>],
+    ) -> PrefetchResult {
+        rdma_fetch_task(
+            &self.rdma_transport,
+            &self.allocate_fn,
+            &self.grpc_channels,
+            &self.connect_group,
+            remote_addr,
+            req_id,
+            &self.advertise_addr,
+            namespace,
+            hashes,
+        )
+        .await
     }
 }
 

--- a/pegaflow-core/src/backing/ssd.rs
+++ b/pegaflow-core/src/backing/ssd.rs
@@ -187,13 +187,18 @@ impl SsdBackingStore {
         }
     }
 
+    /// Count consecutive SSD-resident keys from the start of `keys`.
+    pub(crate) fn prefix_len(&self, keys: &[BlockKey]) -> usize {
+        let inner = self.inner.lock();
+        keys.iter()
+            .map_while(|key| inner.ring.get(key).map(|_| ()))
+            .count()
+    }
+
     /// Submit prefix reads: scan `keys` in order, submit reads for consecutive hits, stop at first miss.
     ///
     /// Returns `(submitted, done_rx)` where `done_rx` delivers completed blocks.
-    pub(crate) fn submit_prefix(
-        &self,
-        keys: Vec<BlockKey>,
-    ) -> (usize, oneshot::Receiver<PrefetchResult>) {
+    fn submit_prefix(&self, keys: Vec<BlockKey>) -> (usize, oneshot::Receiver<PrefetchResult>) {
         let (done_tx, done_rx) = oneshot::channel();
 
         // Prefix-scan the ring buffer: stop at first miss.
@@ -226,6 +231,22 @@ impl SsdBackingStore {
         }
 
         (found, done_rx)
+    }
+
+    /// Prefetch prefix reads and await completion.
+    pub(crate) async fn prefetch_prefix(&self, keys: Vec<BlockKey>) -> (usize, PrefetchResult) {
+        let (found, done_rx) = self.submit_prefix(keys);
+        if found == 0 {
+            return (0, Vec::new());
+        }
+
+        match done_rx.await {
+            Ok(blocks) => (found, blocks),
+            Err(_) => {
+                warn!("SSD prefetch completion channel closed");
+                (found, Vec::new())
+            }
+        }
     }
 }
 

--- a/pegaflow-core/src/backing/ssd_cache.rs
+++ b/pegaflow-core/src/backing/ssd_cache.rs
@@ -742,7 +742,8 @@ async fn dispatch_prefetch_batch(
     // 3. Build BatchContext + PrefetchTasks and enqueue
     let ctx = Arc::new(BatchContext::new(requests.len(), done_tx));
 
-    for (block_idx, req) in requests.into_iter().enumerate() {
+    let mut iter = requests.into_iter().enumerate();
+    while let Some((block_idx, req)) = iter.next() {
         let allocs: Vec<SlotAlloc> = slot_allocs[block_idx]
             .drain(..)
             .map(|opt| opt.expect("all slots must have allocations"))
@@ -755,8 +756,13 @@ async fn dispatch_prefetch_batch(
             ctx: Arc::clone(&ctx),
         };
 
-        if task_tx.send(task).await.is_err() {
+        if let Err(err) = task_tx.send(task).await {
             debug!("SSD prefetch dispatcher: worker channel closed");
+            let task = err.0;
+            ctx.complete_one(task.key, None);
+            for (_, req) in iter {
+                ctx.complete_one(req.key, None);
+            }
             return false;
         }
     }

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -52,7 +52,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use log::{debug, info, warn};
+use log::{debug, info};
 
 use crate::backing::SSD_ALIGNMENT;
 use crate::gpu_worker::{LayerLoadData, LoadBlock, LoadTask};
@@ -213,6 +213,13 @@ impl PegaEngine {
     ///
     /// This reduces gRPC round-trips from N to 1 and allows the engine to
     /// construct the GPU context with all layer registrations at once.
+    ///
+    /// Argument contract:
+    /// - `device_id` must be non-negative; RPC callers validate this in service.rs.
+    /// - `num_layers`, `tp_size`, and `world_size` must be non-zero.
+    /// - `tp_rank` must be less than `tp_size`.
+    /// - Layer metadata arrays must all have the same length as `layer_names`.
+    /// - Registration sizes and pointers must describe a valid KV cache layout.
     #[allow(
         clippy::too_many_arguments,
         reason = "public API mirrors one batched registration RPC payload"
@@ -235,12 +242,6 @@ impl PegaEngine {
         kv_stride_bytes_list: &[usize],
         segments_list: &[usize],
     ) -> Result<(), EngineError> {
-        if device_id < 0 {
-            return Err(EngineError::InvalidArgument(
-                "device_id must be >= 0".to_string(),
-            ));
-        }
-
         // Build all registrations
         let ssd_enabled = self.storage.is_ssd_enabled();
         let batch_size = layer_names.len();
@@ -361,6 +362,11 @@ impl PegaEngine {
 
     /// Count prefix hit blocks with SSD prefetch support.
     ///
+    /// Argument contract:
+    /// - `instance_id` must identify a registered instance.
+    /// - `req_id` must be non-empty; RPC callers validate this in service.rs.
+    /// - `block_hashes` may be empty.
+    ///
     /// Returns:
     /// - `Ready { blocks, missing: 0 }`: all blocks in memory cache
     /// - `Loading`: some blocks being fetched from backing storage
@@ -375,17 +381,8 @@ impl PegaEngine {
         req_id: &str,
         block_hashes: &[Vec<u8>],
     ) -> Result<PrefetchStatus, EngineError> {
-        if req_id.is_empty() {
-            warn!("count_prefix_hit_blocks_with_prefetch: empty req_id, returning 0 hits");
-            return Ok(PrefetchStatus::Ready {
-                blocks: Vec::new(),
-                missing: block_hashes.len(),
-            });
-        }
-
         let instance = self.get_instance(instance_id)?;
         let namespace = instance.namespace();
-        let metrics = core_metrics();
 
         let status = self
             .storage
@@ -394,6 +391,7 @@ impl PegaEngine {
 
         match &status {
             PrefetchStatus::Ready { blocks, missing } => {
+                let metrics = core_metrics();
                 metrics.cache_block_hits.add(blocks.len() as u64, &[]);
                 if *missing > 0 {
                     metrics.cache_block_misses.add(*missing as u64, &[]);

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -68,7 +68,7 @@ pub struct StorageConfig {
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
-            enable_lfu_admission: true,
+            enable_lfu_admission: false,
             hint_value_size_bytes: None,
             max_prefetch_blocks: DEFAULT_MAX_PREFETCH_BLOCKS,
             ssd_cache_config: None,
@@ -514,7 +514,12 @@ impl StorageEngine {
             .write_pipeline
             .gc_stale_inflight(inflight_max_age)
             .await;
-        let failed = self.prefetch.gc_failed_remote(failed_remote_max_age);
+        let (stale_prefetch, failed) = self
+            .prefetch
+            .gc_stale_entries(inflight_max_age, failed_remote_max_age);
+        if stale_prefetch > 0 {
+            log::debug!("gc: removed {stale_prefetch} stale prefetch entries");
+        }
         if failed > 0 {
             log::debug!("gc: cleared {failed} stale failed_remote entries");
         }

--- a/pegaflow-core/src/storage/prefetch.rs
+++ b/pegaflow-core/src/storage/prefetch.rs
@@ -6,11 +6,11 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use log::{info, warn};
-use mea::oneshot;
 use parking_lot::Mutex;
+use tokio::task::JoinHandle;
 
 use crate::backing::{PrefetchResult, RdmaFetchStore, SsdBackingStore};
-use crate::block::{BlockKey, PrefetchStatus};
+use crate::block::{BlockKey, PrefetchStatus, SealedBlock};
 use crate::metrics::core_metrics;
 
 use super::read_cache::ReadCache;
@@ -25,13 +25,6 @@ enum PrefetchSource {
 }
 
 impl PrefetchSource {
-    const fn as_str(self) -> &'static str {
-        match self {
-            Self::Ssd => "ssd",
-            Self::Rdma => "rdma",
-        }
-    }
-
     const fn as_attribution(self) -> AttributionSource {
         match self {
             Self::Ssd => AttributionSource::Ssd,
@@ -41,16 +34,16 @@ impl PrefetchSource {
 }
 
 struct PrefetchEntry {
-    blocks_rx: oneshot::Receiver<PrefetchResult>,
-    loading_count: usize,
-    source: PrefetchSource,
+    handle: JoinHandle<PrefetchTaskResult>,
+    started_at: Instant,
 }
 
-/// Result of a single load attempt (SSD or RDMA).
-struct LoadResult {
+struct PrefetchTaskResult {
+    source: Option<PrefetchSource>,
     found: usize,
-    rx: oneshot::Receiver<PrefetchResult>,
-    source: PrefetchSource,
+    cache_inserts: PrefetchResult,
+    ready_blocks: Vec<Arc<SealedBlock>>,
+    missing: usize,
 }
 
 struct PrefixScan<'a> {
@@ -60,10 +53,37 @@ struct PrefixScan<'a> {
     emit_tier_metrics: bool,
 }
 
+struct PrefetchStart<'a> {
+    req_id: &'a str,
+    namespace: &'a str,
+    remaining: &'a [BlockKey],
+    prefix_blocks: Vec<Arc<SealedBlock>>,
+    total: usize,
+    hit: usize,
+    emit_tier_metrics: bool,
+}
+
+struct PrefetchTaskDeps {
+    rdma_fetch: Option<Arc<RdmaFetchStore>>,
+    ssd_store: Option<Arc<SsdBackingStore>>,
+    prefetch_state: Arc<Mutex<PrefetchState>>,
+    max_prefetch_blocks: usize,
+}
+
+struct PrefetchTaskInput {
+    req_id: String,
+    namespace: String,
+    remaining_keys: Vec<BlockKey>,
+    prefix_blocks: Vec<Arc<SealedBlock>>,
+    total: usize,
+    hit: usize,
+    emit_tier_metrics: bool,
+}
+
 struct PrefetchState {
     active: HashMap<String, PrefetchEntry>,
-    /// Invariant: `inflight_count == active.values().map(|e| e.loading_count).sum()`
-    inflight_count: usize,
+    /// Reserved SSD prefetch budget for active background tasks.
+    reserved_ssd_prefetch_blocks: usize,
     /// req_ids where RDMA remote fetch returned zero blocks (remote evicted).
     /// Prevents re-triggering RDMA on every subsequent poll for the same request.
     failed_remote: HashMap<String, Instant>,
@@ -71,17 +91,26 @@ struct PrefetchState {
 
 impl PrefetchState {
     fn remove_entry(&mut self, req_id: &str) -> Option<PrefetchEntry> {
-        if let Some(entry) = self.active.remove(req_id) {
-            self.inflight_count = self.inflight_count.saturating_sub(entry.loading_count);
-            Some(entry)
-        } else {
-            None
-        }
+        self.active.remove(req_id)
+    }
+}
+
+struct SsdPrefetchReservation {
+    state: Arc<Mutex<PrefetchState>>,
+    blocks: usize,
+}
+
+impl Drop for SsdPrefetchReservation {
+    fn drop(&mut self) {
+        let mut state = self.state.lock();
+        state.reserved_ssd_prefetch_blocks = state
+            .reserved_ssd_prefetch_blocks
+            .saturating_sub(self.blocks);
     }
 }
 
 pub(super) struct PrefetchScheduler {
-    state: Mutex<PrefetchState>,
+    state: Arc<Mutex<PrefetchState>>,
     ssd_store: Option<Arc<SsdBackingStore>>,
     rdma_fetch: Option<Arc<RdmaFetchStore>>,
     max_prefetch_blocks: usize,
@@ -94,11 +123,11 @@ impl PrefetchScheduler {
         max_prefetch_blocks: usize,
     ) -> Self {
         Self {
-            state: Mutex::new(PrefetchState {
+            state: Arc::new(Mutex::new(PrefetchState {
                 active: HashMap::new(),
-                inflight_count: 0,
+                reserved_ssd_prefetch_blocks: 0,
                 failed_remote: HashMap::new(),
-            }),
+            })),
             ssd_store,
             rdma_fetch,
             max_prefetch_blocks,
@@ -113,20 +142,12 @@ impl PrefetchScheduler {
         hashes: &[Vec<u8>],
     ) -> PrefetchStatus {
         // Default: this call may be the first decision and should attribute.
-        let mut emit_tier_metrics = true;
-        if let Some(status) = self.poll_existing(read_cache, req_id) {
-            match status {
-                PollResult::StillLoading => {
-                    return PrefetchStatus::Loading;
-                }
-                PollResult::Completed => {
-                    // Backing has just written blocks into read_cache. The
-                    // fall-through scan will re-see them as RAM hits; we MUST
-                    // NOT attribute again, because we already attributed
-                    // them as `rdma`/`ssd` on the first decision.
-                    emit_tier_metrics = false;
-                }
+        match self.poll_existing(read_cache, req_id).await {
+            PollResult::NoActivePrefetch => {}
+            PollResult::StillLoading => {
+                return PrefetchStatus::Loading;
             }
+            PollResult::Ready(status) => return status,
         }
 
         self.full_prefix_scan(
@@ -135,51 +156,63 @@ impl PrefetchScheduler {
                 req_id,
                 namespace,
                 hashes,
-                emit_tier_metrics,
+                emit_tier_metrics: true,
             },
         )
         .await
     }
 
-    fn poll_existing(&self, read_cache: &ReadCache, req_id: &str) -> Option<PollResult> {
-        let mut state = self.state.lock();
-        let entry = state.active.get_mut(req_id)?;
+    async fn poll_existing(&self, read_cache: &ReadCache, req_id: &str) -> PollResult {
+        let entry = {
+            let mut state = self.state.lock();
+            let Some(entry) = state.active.get(req_id) else {
+                return PollResult::NoActivePrefetch;
+            };
+            if !entry.handle.is_finished() {
+                return PollResult::StillLoading;
+            }
+            state
+                .remove_entry(req_id)
+                .expect("active entry must exist after readiness check")
+        };
 
-        match entry.blocks_rx.try_recv() {
-            Err(oneshot::TryRecvError::Empty) => Some(PollResult::StillLoading),
-            Ok(prefetched_blocks) => {
-                let expected = entry.loading_count;
-                let source = entry.source;
-                state.remove_entry(req_id);
-                // RDMA remote node can return fewer blocks than MetaServer promised
-                // (likely evicted). Don't re-trigger RDMA on subsequent scans.
-                if source == PrefetchSource::Rdma
-                    && prefetched_blocks.len() < expected
-                    && expected > 0
-                {
-                    state
-                        .failed_remote
-                        .insert(req_id.to_string(), Instant::now());
-                    info!(
-                        "RDMA prefetch returned fewer blocks than expected: req_id={} returned={} expected={}",
-                        req_id,
-                        prefetched_blocks.len(),
-                        expected
-                    );
+        let result = match entry.handle.await {
+            Ok(result) => result,
+            Err(err) => {
+                warn!("Prefetch task failed for req_id={}: {}", req_id, err);
+                PrefetchTaskResult {
+                    source: None,
+                    found: 0,
+                    cache_inserts: Vec::new(),
+                    ready_blocks: Vec::new(),
+                    missing: 0,
                 }
-                drop(state);
-                read_cache.batch_insert(prefetched_blocks);
-                Some(PollResult::Completed)
             }
-            Err(oneshot::TryRecvError::Disconnected) => {
-                warn!(
-                    "Backing prefetch sender dropped for req_id={}, falling back to re-scan",
-                    req_id
-                );
-                state.remove_entry(req_id);
-                Some(PollResult::Completed)
-            }
+        };
+
+        // RDMA remote node can return fewer blocks than MetaServer promised
+        // (likely evicted). Don't re-trigger RDMA on subsequent scans.
+        if result.source == Some(PrefetchSource::Rdma)
+            && result.cache_inserts.len() < result.found
+            && result.found > 0
+        {
+            self.state
+                .lock()
+                .failed_remote
+                .insert(req_id.to_string(), Instant::now());
+            info!(
+                "RDMA prefetch returned fewer blocks than expected: req_id={} returned={} expected={}",
+                req_id,
+                result.cache_inserts.len(),
+                result.found
+            );
         }
+
+        read_cache.batch_insert(result.cache_inserts);
+        PollResult::Ready(PrefetchStatus::Ready {
+            blocks: result.ready_blocks,
+            missing: result.missing,
+        })
     }
 
     async fn full_prefix_scan(
@@ -202,43 +235,37 @@ impl PrefetchScheduler {
         let cache_scan = cache_scan_start.elapsed();
         let remaining = &keys[hit..];
 
-        let load_select_start = Instant::now();
-        let load = self.try_load(scan.req_id, scan.namespace, remaining).await;
-        let load_select = load_select_start.elapsed();
-        let loading = load.as_ref().map_or(0, |l| l.found);
-        let missing = keys.len() - hit - loading;
+        let task_start = Instant::now();
+        let task_started = self.start_prefetch_task(PrefetchStart {
+            req_id: scan.req_id,
+            namespace: scan.namespace,
+            remaining,
+            prefix_blocks: prefix_blocks
+                .iter()
+                .map(|(_, block)| Arc::clone(block))
+                .collect(),
+            total: keys.len(),
+            hit,
+            emit_tier_metrics: scan.emit_tier_metrics,
+        });
+        let task_schedule = task_start.elapsed();
 
-        if let Some(load) = load {
-            let source = load.source;
-            let register_start = Instant::now();
-            self.register_inflight(scan.req_id, load);
-            let register = register_start.elapsed();
-
-            self.maybe_record_tier_attribution(
-                keys.len(),
-                hit,
-                loading,
-                Some(source.as_attribution()),
-                scan.emit_tier_metrics,
-            );
-
+        if task_started {
             info!(
-                "Prefetch scheduling timing: req_id={} source={} total_keys={} hit={} loading={} missing={} key_build={:?} cache_scan={:?} load_select={:?} register_inflight={:?} total={:?}",
+                "Prefetch scheduling timing: req_id={} total_keys={} hit={} remaining={} key_build={:?} cache_scan={:?} task_schedule={:?} total={:?}",
                 scan.req_id,
-                source.as_str(),
                 keys.len(),
                 hit,
-                loading,
-                missing,
+                remaining.len(),
                 key_build,
                 cache_scan,
-                load_select,
-                register,
+                task_schedule,
                 total_start.elapsed()
             );
             PrefetchStatus::Loading
         } else {
-            self.maybe_record_tier_attribution(
+            let missing = keys.len() - hit;
+            record_tier_attribution(
                 keys.len(),
                 hit,
                 /* loading = */ 0,
@@ -247,14 +274,14 @@ impl PrefetchScheduler {
             );
 
             info!(
-                "Prefetch local-hit timing: req_id={} total_keys={} hit={} missing={} key_build={:?} cache_scan={:?} load_select={:?} total={:?}",
+                "Prefetch local-hit timing: req_id={} total_keys={} hit={} missing={} key_build={:?} cache_scan={:?} task_schedule={:?} total={:?}",
                 scan.req_id,
                 keys.len(),
                 hit,
                 missing,
                 key_build,
                 cache_scan,
-                load_select,
+                task_schedule,
                 total_start.elapsed()
             );
             let blocks = prefix_blocks.into_iter().map(|(_, block)| block).collect();
@@ -262,132 +289,221 @@ impl PrefetchScheduler {
         }
     }
 
-    /// Attribute this `query_prefetch` decision. Skips attribution when:
-    /// * `emit_tier_metrics == false` (e.g. post-completion fall-through);
-    /// * `keys` was empty (no decision to attribute).
-    fn maybe_record_tier_attribution(
-        &self,
-        total: usize,
-        hit: usize,
-        loading: usize,
-        loading_source: Option<AttributionSource>,
-        emit_tier_metrics: bool,
-    ) {
-        if !emit_tier_metrics || total == 0 {
-            return;
-        }
-        let attribution = TierAttribution::classify(total, hit, loading, loading_source);
-        record_cache_tier_block_requests(total, attribution);
-    }
-
-    /// Priority fallback: RDMA -> SSD. Returns `None` when neither source has blocks.
-    async fn try_load(
-        &self,
-        req_id: &str,
-        namespace: &str,
-        remaining: &[BlockKey],
-    ) -> Option<LoadResult> {
-        if remaining.is_empty() {
-            return None;
+    fn start_prefetch_task(&self, start: PrefetchStart<'_>) -> bool {
+        if start.remaining.is_empty() {
+            return false;
         }
 
-        if let Some(result) = self.try_rdma_load(req_id, namespace, remaining).await {
-            return Some(result);
+        let mut state = self.state.lock();
+        if state.active.contains_key(start.req_id) {
+            return true;
         }
 
-        self.try_ssd_load(remaining)
-    }
+        let rdma_fetch = self
+            .rdma_fetch
+            .as_ref()
+            .filter(|_| !state.failed_remote.contains_key(start.req_id))
+            .cloned();
 
-    fn try_ssd_load(&self, remaining: &[BlockKey]) -> Option<LoadResult> {
-        let ssd = self.ssd_store.as_ref()?;
-        let check_keys = self.limit_ssd_prefetch(remaining)?;
-
-        let (found, rx) = ssd.submit_prefix(check_keys);
-        if found == 0 {
-            return None;
+        if rdma_fetch.is_none() && self.ssd_store.is_none() {
+            return false;
         }
 
-        Some(LoadResult {
-            found,
-            rx,
-            source: PrefetchSource::Ssd,
-        })
-    }
-
-    async fn try_rdma_load(
-        &self,
-        req_id: &str,
-        namespace: &str,
-        remaining: &[BlockKey],
-    ) -> Option<LoadResult> {
-        let rdma = self.rdma_fetch.as_ref()?;
-
-        if self.state.lock().failed_remote.contains_key(req_id) {
-            return None;
-        }
-
-        let hashes: Vec<Vec<u8>> = remaining.iter().map(|k| k.hash.clone()).collect();
-        let (node, found) = rdma.query_prefix(namespace, &hashes).await?;
-
-        let rx = rdma.fetch_blocks(&node, req_id, namespace, hashes[..found].to_vec());
-
-        Some(LoadResult {
-            found,
-            rx,
-            source: PrefetchSource::Rdma,
-        })
-    }
-
-    /// Trim keys to fit inflight capacity, report skipped count to metrics.
-    fn limit_ssd_prefetch(&self, remaining: &[BlockKey]) -> Option<Vec<BlockKey>> {
-        let available = {
-            let state = self.state.lock();
-            self.max_prefetch_blocks
-                .saturating_sub(state.inflight_count)
+        let deps = PrefetchTaskDeps {
+            rdma_fetch,
+            ssd_store: self.ssd_store.clone(),
+            prefetch_state: Arc::clone(&self.state),
+            max_prefetch_blocks: self.max_prefetch_blocks,
+        };
+        let input = PrefetchTaskInput {
+            req_id: start.req_id.to_string(),
+            namespace: start.namespace.to_string(),
+            remaining_keys: start.remaining.to_vec(),
+            prefix_blocks: start.prefix_blocks,
+            total: start.total,
+            hit: start.hit,
+            emit_tier_metrics: start.emit_tier_metrics,
         };
 
-        if available == 0 {
-            core_metrics()
-                .ssd_prefetch_backpressure_blocks
-                .add(remaining.len() as u64, &[]);
-            return None;
-        }
+        let handle = tokio::spawn(async move { run_prefetch_task(deps, input).await });
 
-        let check_limit = remaining.len().min(available);
-        let skipped = remaining.len() - check_limit;
-        if skipped > 0 {
-            core_metrics()
-                .ssd_prefetch_backpressure_blocks
-                .add(skipped as u64, &[]);
-        }
-
-        Some(remaining[..check_limit].to_vec())
-    }
-
-    fn register_inflight(&self, req_id: &str, load: LoadResult) {
-        let mut state = self.state.lock();
-        state.inflight_count += load.found;
         state.active.insert(
-            req_id.to_string(),
+            start.req_id.to_string(),
             PrefetchEntry {
-                blocks_rx: load.rx,
-                loading_count: load.found,
-                source: load.source,
+                handle,
+                started_at: Instant::now(),
             },
         );
+        true
     }
 
-    /// Sweep `failed_remote` entries older than `max_age`.
-    /// Runs under the single `PrefetchState` mutex.
-    pub(super) fn gc_failed_remote(&self, max_age: std::time::Duration) -> usize {
+    /// Drop stale active entries and sweep old `failed_remote` entries.
+    ///
+    /// Dropping a `JoinHandle` detaches the task; it keeps running so RDMA
+    /// transfer locks can still be released by the normal completion path.
+    pub(super) fn gc_stale_entries(
+        &self,
+        active_max_age: std::time::Duration,
+        failed_remote_max_age: std::time::Duration,
+    ) -> (usize, usize) {
         let mut state = self.state.lock();
+        let active_before = state.active.len();
+        state
+            .active
+            .retain(|_, entry| entry.started_at.elapsed() < active_max_age);
+        let active_removed = active_before - state.active.len();
+
         let failed_before = state.failed_remote.len();
-        state.failed_remote.retain(|_, ts| ts.elapsed() < max_age);
-        failed_before - state.failed_remote.len()
+        state
+            .failed_remote
+            .retain(|_, ts| ts.elapsed() < failed_remote_max_age);
+        (active_removed, failed_before - state.failed_remote.len())
     }
 }
 
+/// Attribute this `query_prefetch` decision. Skips attribution when:
+/// * `emit_tier_metrics == false` (e.g. post-completion fall-through);
+/// * `total` is zero (no decision to attribute).
+fn record_tier_attribution(
+    total: usize,
+    hit: usize,
+    loading: usize,
+    loading_source: Option<AttributionSource>,
+    emit_tier_metrics: bool,
+) {
+    if !emit_tier_metrics || total == 0 {
+        return;
+    }
+    let attribution = TierAttribution::classify(total, hit, loading, loading_source);
+    record_cache_tier_block_requests(total, attribution);
+}
+
+fn reserve_ssd_prefetch_slots(
+    state: Arc<Mutex<PrefetchState>>,
+    max_prefetch_blocks: usize,
+    requested: usize,
+) -> Option<(usize, SsdPrefetchReservation)> {
+    let mut guard = state.lock();
+    let available = max_prefetch_blocks.saturating_sub(guard.reserved_ssd_prefetch_blocks);
+
+    if available == 0 {
+        core_metrics()
+            .ssd_prefetch_backpressure_blocks
+            .add(requested as u64, &[]);
+        return None;
+    }
+
+    let reserved = requested.min(available);
+    let skipped = requested - reserved;
+    if skipped > 0 {
+        core_metrics()
+            .ssd_prefetch_backpressure_blocks
+            .add(skipped as u64, &[]);
+    }
+
+    guard.reserved_ssd_prefetch_blocks += reserved;
+    drop(guard);
+
+    Some((
+        reserved,
+        SsdPrefetchReservation {
+            state,
+            blocks: reserved,
+        },
+    ))
+}
+
+fn build_ready_result(
+    prefix_blocks: Vec<Arc<SealedBlock>>,
+    total: usize,
+    source: Option<PrefetchSource>,
+    found: usize,
+    cache_inserts: PrefetchResult,
+) -> PrefetchTaskResult {
+    let mut ready_blocks = prefix_blocks;
+    ready_blocks.extend(cache_inserts.iter().map(|(_, block)| Arc::clone(block)));
+    let missing = total.saturating_sub(ready_blocks.len());
+    PrefetchTaskResult {
+        source,
+        found,
+        cache_inserts,
+        ready_blocks,
+        missing,
+    }
+}
+
+async fn run_prefetch_task(deps: PrefetchTaskDeps, input: PrefetchTaskInput) -> PrefetchTaskResult {
+    let PrefetchTaskInput {
+        req_id,
+        namespace,
+        remaining_keys,
+        prefix_blocks,
+        total,
+        hit,
+        emit_tier_metrics,
+    } = input;
+    let remaining_hashes: Vec<Vec<u8>> = remaining_keys.iter().map(|k| k.hash.clone()).collect();
+
+    if let Some(rdma) = deps.rdma_fetch
+        && let Some((node, found)) = rdma.query_prefix(&namespace, &remaining_hashes).await
+    {
+        let blocks = rdma
+            .fetch_blocks(&node, &req_id, &namespace, &remaining_hashes[..found])
+            .await;
+        record_tier_attribution(
+            total,
+            hit,
+            found,
+            Some(PrefetchSource::Rdma.as_attribution()),
+            emit_tier_metrics,
+        );
+        return build_ready_result(
+            prefix_blocks,
+            total,
+            Some(PrefetchSource::Rdma),
+            found,
+            blocks,
+        );
+    }
+
+    if let Some(ssd) = deps.ssd_store {
+        let found = ssd.prefix_len(&remaining_keys);
+        if found == 0 {
+            record_tier_attribution(total, hit, 0, None, emit_tier_metrics);
+            return build_ready_result(prefix_blocks, total, None, 0, Vec::new());
+        }
+        let Some((reserved, _reservation)) =
+            reserve_ssd_prefetch_slots(deps.prefetch_state, deps.max_prefetch_blocks, found)
+        else {
+            record_tier_attribution(total, hit, 0, None, emit_tier_metrics);
+            return build_ready_result(prefix_blocks, total, None, 0, Vec::new());
+        };
+        let keys = remaining_keys[..reserved].to_vec();
+        let (found, blocks) = ssd.prefetch_prefix(keys).await;
+        if found > 0 {
+            record_tier_attribution(
+                total,
+                hit,
+                found,
+                Some(PrefetchSource::Ssd.as_attribution()),
+                emit_tier_metrics,
+            );
+            return build_ready_result(
+                prefix_blocks,
+                total,
+                Some(PrefetchSource::Ssd),
+                found,
+                blocks,
+            );
+        }
+    }
+
+    record_tier_attribution(total, hit, 0, None, emit_tier_metrics);
+    build_ready_result(prefix_blocks, total, None, 0, Vec::new())
+}
+
 enum PollResult {
+    NoActivePrefetch,
     StillLoading,
-    Completed,
+    Ready(PrefetchStatus),
 }

--- a/pegaflow-core/tests/common/gpu_buffer.rs
+++ b/pegaflow-core/tests/common/gpu_buffer.rs
@@ -1,22 +1,25 @@
 use std::ffi::c_void;
+use std::sync::Arc;
 
-use cudarc::driver::sys;
+use cudarc::driver::{CudaContext, sys};
 
 pub struct GpuBuffer {
+    ctx: Arc<CudaContext>,
     ptr: sys::CUdeviceptr,
     len: usize,
 }
 
 impl GpuBuffer {
-    pub fn alloc(len: usize) -> Self {
+    pub fn alloc(ctx: Arc<CudaContext>, len: usize) -> Self {
         assert!(len > 0, "GpuBuffer::alloc: len must be > 0");
+        ctx.bind_to_thread().expect("bind CUDA context");
         let mut ptr: sys::CUdeviceptr = 0;
         // SAFETY: len > 0 (asserted above). ptr is a valid stack pointer.
         check_cuda(
             unsafe { sys::cuMemAlloc_v2(&raw mut ptr, len) },
             "cuMemAlloc_v2",
         );
-        Self { ptr, len }
+        Self { ctx, ptr, len }
     }
 
     pub fn as_u64(&self) -> u64 {
@@ -25,6 +28,7 @@ impl GpuBuffer {
 
     pub fn copy_from_host(&self, data: &[u8]) {
         assert_eq!(data.len(), self.len);
+        self.ctx.bind_to_thread().expect("bind CUDA context");
         // SAFETY: self.ptr is a valid device pointer from cuMemAlloc_v2.
         // data.len() matches the copy size.
         check_cuda(
@@ -34,6 +38,7 @@ impl GpuBuffer {
     }
 
     pub fn copy_to_host(&self) -> Vec<u8> {
+        self.ctx.bind_to_thread().expect("bind CUDA context");
         let mut output = vec![0u8; self.len];
         // SAFETY: self.ptr is valid, out has sufficient capacity (len bytes).
         check_cuda(
@@ -44,6 +49,7 @@ impl GpuBuffer {
     }
 
     pub fn zero(&self) {
+        self.ctx.bind_to_thread().expect("bind CUDA context");
         // SAFETY: self.ptr is a valid device pointer, self.len matches the allocation.
         check_cuda(
             unsafe { sys::cuMemsetD8_v2(self.ptr, 0, self.len) },
@@ -55,6 +61,7 @@ impl GpuBuffer {
 impl Drop for GpuBuffer {
     fn drop(&mut self) {
         if self.ptr != 0 {
+            self.ctx.bind_to_thread().expect("bind CUDA context");
             // SAFETY: self.ptr was allocated by cuMemAlloc_v2 and has not been freed.
             check_cuda(unsafe { sys::cuMemFree_v2(self.ptr) }, "cuMemFree_v2");
             self.ptr = 0;

--- a/pegaflow-core/tests/common/harness.rs
+++ b/pegaflow-core/tests/common/harness.rs
@@ -1,10 +1,18 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use cudarc::driver::CudaContext;
 use pegaflow_core::*;
 
 use super::gpu_buffer::GpuBuffer;
 use super::helpers::*;
+
+static CUDA_CONTEXT: OnceLock<Arc<CudaContext>> = OnceLock::new();
+
+fn test_cuda_context() -> Arc<CudaContext> {
+    let ctx = CUDA_CONTEXT.get_or_init(|| CudaContext::new(0).expect("CUDA init"));
+    ctx.bind_to_thread().expect("bind CUDA context");
+    Arc::clone(ctx)
+}
 
 // ---------------------------------------------------------------------------
 // TestGpuData: GPU buffer + expected content
@@ -17,9 +25,9 @@ pub struct TestGpuData {
 }
 
 impl TestGpuData {
-    pub fn new(num_blocks: usize, block_size: usize) -> Self {
+    pub fn new(ctx: Arc<CudaContext>, num_blocks: usize, block_size: usize) -> Self {
         let total = num_blocks * block_size;
-        let gpu = GpuBuffer::alloc(total);
+        let gpu = GpuBuffer::alloc(ctx, total);
         let mut expected = vec![0u8; total];
         fill_test_pattern(&mut expected, block_size);
         gpu.copy_from_host(&expected);
@@ -35,9 +43,14 @@ impl TestGpuData {
     /// `segment_size` is the size of one K or V segment.
     /// The GPU layout has K blocks at `[0..num_blocks*segment_size]` and
     /// V blocks at `[kv_stride..kv_stride+num_blocks*segment_size]`.
-    pub fn new_split(num_blocks: usize, segment_size: usize, kv_stride: usize) -> Self {
+    pub fn new_split(
+        ctx: Arc<CudaContext>,
+        num_blocks: usize,
+        segment_size: usize,
+        kv_stride: usize,
+    ) -> Self {
         let alloc_size = (num_blocks - 1) * segment_size + kv_stride + segment_size;
-        let gpu = GpuBuffer::alloc(alloc_size);
+        let gpu = GpuBuffer::alloc(ctx, alloc_size);
         let mut expected = vec![0u8; alloc_size];
 
         // Fill K region and V region with the same block pattern.
@@ -94,11 +107,11 @@ pub struct RegisteredLayer {
 }
 
 pub struct TestEnv {
-    pub _ctx: Arc<CudaContext>,
     pub engine: PegaEngine,
     pub instance_id: String,
     pub layers: Vec<RegisteredLayer>,
     pub world_size: usize,
+    pub _ctx: Arc<CudaContext>,
 }
 
 struct LayerSpec {
@@ -184,11 +197,8 @@ impl TestEnvBuilder {
     }
 
     pub fn build(self) -> TestEnv {
-        let ctx = CudaContext::new(0).expect("CUDA init");
-        let sc = self.storage_config.unwrap_or(StorageConfig {
-            enable_lfu_admission: false,
-            ..StorageConfig::default()
-        });
+        let ctx = test_cuda_context();
+        let sc = self.storage_config.unwrap_or_default();
         let engine = test_engine_with_pool(self.pool_size, sc);
 
         let layers: Vec<RegisteredLayer> = self
@@ -196,9 +206,14 @@ impl TestEnvBuilder {
             .iter()
             .map(|spec| {
                 let data = if spec.segments > 1 {
-                    TestGpuData::new_split(spec.num_blocks, spec.block_size, spec.kv_stride)
+                    TestGpuData::new_split(
+                        Arc::clone(&ctx),
+                        spec.num_blocks,
+                        spec.block_size,
+                        spec.kv_stride,
+                    )
                 } else {
-                    TestGpuData::new(spec.num_blocks, spec.block_size)
+                    TestGpuData::new(Arc::clone(&ctx), spec.num_blocks, spec.block_size)
                 };
                 RegisteredLayer {
                     name: spec.name.to_string(),
@@ -236,11 +251,11 @@ impl TestEnvBuilder {
         );
 
         TestEnv {
-            _ctx: ctx,
             engine,
             instance_id: self.instance_id.to_string(),
             layers,
             world_size: self.world_size,
+            _ctx: ctx,
         }
     }
 }

--- a/pegaflow-core/tests/prefix_semantics.rs
+++ b/pegaflow-core/tests/prefix_semantics.rs
@@ -83,6 +83,34 @@ async fn first_block_missing_yields_zero_prefix_hit() {
     // hit=0, no lease would be created by the server.
 }
 
+/// RAM-only queries are stateless with respect to req_id: a previous miss must
+/// not hide blocks that become resident later under the same req_id.
+#[tokio::test]
+async fn ram_miss_does_not_poison_later_same_req_id_hit() {
+    let env = TestEnvBuilder::new("test-ram-miss-then-hit", "test-ns")
+        .layer("layer_0", 4, 1024)
+        .build();
+
+    let hashes = env.hashes(40);
+    match env.query(&hashes).await {
+        PrefetchStatus::Ready { blocks, missing } => {
+            assert_eq!(blocks.len(), 0);
+            assert_eq!(missing, hashes.len());
+        }
+        other => panic!("expected Ready, got {other:?}"),
+    }
+
+    env.save_layer_and_flush(0, &hashes).await;
+
+    match env.query(&hashes).await {
+        PrefetchStatus::Ready { blocks, missing } => {
+            assert_eq!(blocks.len(), hashes.len());
+            assert_eq!(missing, 0);
+        }
+        other => panic!("expected Ready, got {other:?}"),
+    }
+}
+
 /// Empty hash list → zero hits, zero missing.
 #[tokio::test]
 async fn empty_query_returns_zero() {

--- a/pegaflow-core/tests/ssd_cache.rs
+++ b/pegaflow-core/tests/ssd_cache.rs
@@ -13,6 +13,7 @@ const NUM_BLOCKS: usize = 4;
 /// Pool fits one batch with headroom but not two — forces eviction.
 const POOL_SIZE: usize = NUM_BLOCKS * BLOCK_SIZE * 2;
 const SSD_CAPACITY: u64 = 64 * 1024 * 1024;
+const PREFETCH_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 fn ssd_env(instance_id: &'static str) -> (TestEnv, std::path::PathBuf, tempfile::TempDir) {
     let temp_dir = tempfile::tempdir().expect("create temp dir");
@@ -30,6 +31,52 @@ fn ssd_env(instance_id: &'static str) -> (TestEnv, std::path::PathBuf, tempfile:
         })
         .build();
     (env, cache_path, temp_dir)
+}
+
+fn ssd_split_env(instance_id: &'static str) -> (TestEnv, tempfile::TempDir) {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let cache_path = temp_dir.path().join("cache.bin");
+    let env = TestEnvBuilder::new(instance_id, "test-ns-ssd")
+        .split_layer(
+            "layer_0",
+            NUM_BLOCKS,
+            BLOCK_SIZE / 2,
+            BLOCK_SIZE * NUM_BLOCKS,
+        )
+        .pool_size(POOL_SIZE)
+        .storage(StorageConfig {
+            ssd_cache_config: Some(SsdCacheConfig {
+                cache_path,
+                capacity_bytes: SSD_CAPACITY,
+                ..SsdCacheConfig::default()
+            }),
+            ..StorageConfig::default()
+        })
+        .build();
+    (env, temp_dir)
+}
+
+async fn wait_query_ready(env: &TestEnv, hashes: &[Vec<u8>]) -> (usize, usize) {
+    let deadline = std::time::Instant::now() + PREFETCH_WAIT_TIMEOUT;
+    loop {
+        match env.query(hashes).await {
+            PrefetchStatus::Ready { blocks, missing } => return (blocks.len(), missing),
+            PrefetchStatus::Loading => {}
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for SSD prefetch to complete"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+fn cleanup_resident_memory(env: &TestEnv) {
+    let stats = env.engine.cleanup_memory_cache();
+    assert!(
+        stats.evicted_blocks > 0,
+        "cleanup_memory_cache should evict resident blocks"
+    );
 }
 
 /// Save blocks, flush to SSD, verify the cache file contains non-zero bytes.
@@ -69,32 +116,125 @@ async fn ssd_prefetch_roundtrip_after_eviction() {
     env.save_and_wait(&target).await;
     env.engine.flush_all().await;
 
-    // Phase 2: Evict target blocks from memory by saving filler that overflows the pool.
-    let filler = make_block_hashes(NUM_BLOCKS, 99);
-    env.save_layer(0, &filler).await;
-    env.engine.flush_saves().await;
+    // Phase 2: Evict target blocks from memory while preserving SSD data.
+    cleanup_resident_memory(&env);
 
     // Phase 3: Query the original hashes — should trigger SSD prefetch.
-    // First query may return Loading (SSD read in flight), poll until Done.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        let status = env.query(&target).await;
-        match status {
-            PrefetchStatus::Ready { blocks, .. } => {
-                if blocks.len() == target.len() {
-                    break;
-                }
-            }
-            PrefetchStatus::Loading => {}
-        }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "timed out waiting for SSD prefetch to complete"
-        );
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
+    // First query may return Loading (SSD read in flight), poll until Ready.
+    let (hit, missing) = wait_query_ready(&env, &target).await;
+    assert_eq!(hit, target.len());
+    assert_eq!(missing, 0);
 
     // Phase 4: Lease, load to GPU, and verify data integrity.
+    let lease = env.assert_all_hit_lease(&target).await;
+    env.data().zero_gpu();
+    env.load_to_gpu(lease, target.len()).await;
+    env.data().assert_gpu_matches_expected();
+}
+
+/// SSD prefetch preserves prefix semantics: if SSD only has the first part of
+/// the requested prefix, the query resolves to that partial hit plus miss suffix.
+#[tokio::test]
+async fn ssd_prefetch_reports_partial_prefix_after_cleanup() {
+    let (env, _cache_path, _temp_dir) = ssd_env("test-ssd-partial-prefix");
+
+    let all_hashes = env.hashes(7);
+    let saved_prefix = all_hashes[..2].to_vec();
+    env.save_and_wait(&saved_prefix).await;
+    env.engine.flush_all().await;
+    cleanup_resident_memory(&env);
+
+    let (hit, missing) = wait_query_ready(&env, &all_hashes).await;
+    assert_eq!(hit, saved_prefix.len());
+    assert_eq!(missing, all_hashes.len() - saved_prefix.len());
+}
+
+/// A complete SSD miss should resolve to Ready with the original miss count,
+/// not stay in Loading forever.
+#[tokio::test]
+async fn ssd_miss_resolves_to_ready_missing_after_cleanup() {
+    let (env, _cache_path, _temp_dir) = ssd_env("test-ssd-miss");
+
+    let persisted = env.hashes(11);
+    env.save_and_wait(&persisted).await;
+    env.engine.flush_all().await;
+    cleanup_resident_memory(&env);
+
+    let missing_hashes = make_block_hashes(NUM_BLOCKS, 222);
+    let (hit, missing) = wait_query_ready(&env, &missing_hashes).await;
+    assert_eq!(hit, 0);
+    assert_eq!(missing, missing_hashes.len());
+}
+
+/// A miss result for one req_id must not permanently suppress later backing
+/// lookups for the same req_id once the hashes become available in SSD.
+#[tokio::test]
+async fn ssd_miss_does_not_poison_later_same_req_id_hit() {
+    let (env, _cache_path, _temp_dir) = ssd_env("test-ssd-miss-then-hit");
+
+    let unrelated = env.hashes(12);
+    env.save_and_wait(&unrelated).await;
+    env.engine.flush_all().await;
+    cleanup_resident_memory(&env);
+
+    let later_available = make_block_hashes(NUM_BLOCKS, 55);
+    let (hit, missing) = wait_query_ready(&env, &later_available).await;
+    assert_eq!(hit, 0);
+    assert_eq!(missing, later_available.len());
+
+    env.save_and_wait(&later_available).await;
+    env.engine.flush_all().await;
+    cleanup_resident_memory(&env);
+
+    let (hit, missing) = wait_query_ready(&env, &later_available).await;
+    assert_eq!(hit, later_available.len());
+    assert_eq!(missing, 0);
+}
+
+/// When RAM already satisfies a prefix and SSD has the suffix, the async
+/// prefetch result is the complete query answer: RAM prefix plus SSD suffix.
+#[tokio::test]
+async fn ssd_prefetch_combines_ram_prefix_with_ssd_suffix() {
+    let (env, _cache_path, _temp_dir) = ssd_env("test-ssd-ram-prefix-ssd-suffix");
+
+    let target = env.hashes(77);
+    env.save_and_wait(&target).await;
+    env.engine.flush_all().await;
+    cleanup_resident_memory(&env);
+
+    let ram_prefix = target[..2].to_vec();
+    env.save_and_wait(&ram_prefix).await;
+
+    match env.query(&target).await {
+        PrefetchStatus::Loading => {}
+        other => panic!("expected SSD suffix prefetch to start, got {other:?}"),
+    }
+
+    let (hit, missing) = wait_query_ready(&env, &target).await;
+    assert_eq!(hit, target.len());
+    assert_eq!(missing, 0);
+
+    let lease = env.assert_all_hit_lease(&target).await;
+    env.data().zero_gpu();
+    env.load_to_gpu(lease, target.len()).await;
+    env.data().assert_gpu_matches_expected();
+}
+
+/// Split K/V storage should survive the same SSD persistence -> memory cleanup
+/// -> prefetch -> load round-trip as contiguous storage.
+#[tokio::test]
+async fn ssd_prefetch_split_storage_roundtrip_after_cleanup() {
+    let (env, _temp_dir) = ssd_split_env("test-ssd-split-prefetch");
+
+    let target = env.hashes(66);
+    env.save_and_wait(&target).await;
+    env.engine.flush_all().await;
+    cleanup_resident_memory(&env);
+
+    let (hit, missing) = wait_query_ready(&env, &target).await;
+    assert_eq!(hit, target.len());
+    assert_eq!(missing, 0);
+
     let lease = env.assert_all_hit_lease(&target).await;
     env.data().zero_gpu();
     env.load_to_gpu(lease, target.len()).await;

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -118,6 +118,56 @@ impl GrpcEngineService {
         })
     }
 
+    fn validate_device_id(device_id: i32) -> Result<(), Status> {
+        if device_id < 0 {
+            return Err(Status::invalid_argument(format!(
+                "device_id {device_id} must be >= 0"
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_register_context_request(req: &RegisterContextRequest) -> Result<(), Status> {
+        Self::validate_device_id(req.device_id)?;
+        if req.num_layers == 0 {
+            return Err(Status::invalid_argument("num_layers must be > 0"));
+        }
+        if req.tp_size == 0 {
+            return Err(Status::invalid_argument("tp_size must be > 0"));
+        }
+        if req.world_size == 0 {
+            return Err(Status::invalid_argument("world_size must be > 0"));
+        }
+        if req.tp_rank >= req.tp_size {
+            return Err(Status::invalid_argument(format!(
+                "tp_rank {} out of range (tp_size {})",
+                req.tp_rank, req.tp_size
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_save_layers(saves: &[crate::proto::engine::SaveLayer]) -> Result<(), Status> {
+        for layer in saves {
+            if layer.block_ids.len() != layer.block_hashes.len() {
+                return Err(Status::invalid_argument(format!(
+                    "block_ids length {} does not match block_hashes {} for layer {}",
+                    layer.block_ids.len(),
+                    layer.block_hashes.len(),
+                    layer.layer_name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_query_prefetch_request(req: &QueryRequest) -> Result<(), Status> {
+        if req.req_id.is_empty() {
+            return Err(Status::invalid_argument("req_id must not be empty"));
+        }
+        Ok(())
+    }
+
     fn build_register_context_response() -> RegisterContextResponse {
         RegisterContextResponse {
             status: Some(Self::ok_status()),
@@ -229,6 +279,7 @@ impl Engine for GrpcEngineService {
                 req.wrapper_bytes.iter().map(|b| b.len()).collect::<Vec<_>>()
             );
 
+            Self::validate_register_context_request(&req)?;
             let num_layers = Self::usize_from_u32(req.num_layers, "num_layers")?;
 
             // Validate array lengths are consistent with each other.
@@ -366,6 +417,8 @@ impl Engine for GrpcEngineService {
                 saves,
                 ..
             } = req;
+            Self::validate_device_id(device_id)?;
+            Self::validate_save_layers(&saves)?;
             let tp_rank = Self::usize_from_u32(tp_rank, "tp_rank")?;
             let pp_rank = Self::usize_from_u32(pp_rank, "pp_rank")?;
 
@@ -447,6 +500,7 @@ impl Engine for GrpcEngineService {
                 load_state_shm,
                 ..
             } = req;
+            Self::validate_device_id(device_id)?;
             let tp_rank = Self::usize_from_u32(tp_rank, "tp_rank")?;
             debug!(
                 "RPC [load]: instance_id={} tp_rank={} device_id={} layers={} loads={} blocks={} load_state_shm_len={}",
@@ -517,6 +571,7 @@ impl Engine for GrpcEngineService {
 
         let start = Instant::now();
         let fut = async {
+            Self::validate_query_prefetch_request(&req)?;
             debug!(
                 "RPC [query_prefetch]: instance_id={} block_hashes={}",
                 req.instance_id,
@@ -947,5 +1002,81 @@ impl Engine for GrpcEngineService {
         });
 
         Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::engine::SaveLayer;
+    use tonic::Code;
+
+    #[test]
+    fn validate_query_prefetch_rejects_empty_req_id() {
+        let err = GrpcEngineService::validate_query_prefetch_request(&QueryRequest {
+            instance_id: "instance".to_string(),
+            block_hashes: Vec::new(),
+            req_id: String::new(),
+        })
+        .expect_err("empty req_id must be rejected before engine lookup");
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("req_id"));
+    }
+
+    #[test]
+    fn validate_query_prefetch_allows_empty_hashes() {
+        GrpcEngineService::validate_query_prefetch_request(&QueryRequest {
+            instance_id: "instance".to_string(),
+            block_hashes: Vec::new(),
+            req_id: "request".to_string(),
+        })
+        .expect("empty block_hashes are a valid zero-hit query");
+    }
+
+    #[test]
+    fn validate_register_context_rejects_pure_argument_errors() {
+        let err = GrpcEngineService::validate_register_context_request(&RegisterContextRequest {
+            instance_id: "instance".to_string(),
+            namespace: "namespace".to_string(),
+            tp_rank: 1,
+            tp_size: 1,
+            world_size: 1,
+            device_id: 0,
+            num_layers: 1,
+            layer_names: Vec::new(),
+            wrapper_bytes: Vec::new(),
+            num_blocks: Vec::new(),
+            bytes_per_block: Vec::new(),
+            kv_stride_bytes: Vec::new(),
+            segments: Vec::new(),
+            pp_rank: 0,
+        })
+        .expect_err("tp_rank outside tp_size must be rejected at RPC boundary");
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("tp_rank"));
+    }
+
+    #[test]
+    fn validate_save_layers_rejects_mismatched_block_shapes() {
+        let err = GrpcEngineService::validate_save_layers(&[SaveLayer {
+            layer_name: "layer_0".to_string(),
+            block_ids: vec![0, 1],
+            block_hashes: vec![vec![1]],
+        }])
+        .expect_err("service must reject malformed save shape");
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("does not match"));
+    }
+
+    #[test]
+    fn validate_device_id_rejects_negative_values() {
+        let err = GrpcEngineService::validate_device_id(-1)
+            .expect_err("negative device_id must be rejected at RPC boundary");
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("device_id"));
     }
 }

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -79,6 +79,10 @@ class EngineRpcClient:
     ) -> tuple[bool, str]:
         """Register all KV cache layers on a GPU with a single RPC call.
 
+        Contract: device_id must be non-negative; num_layers, tp_size,
+        and world_size must be non-zero; tp_rank must be less than tp_size;
+        per-layer metadata lists must have the same non-zero length.
+
         Args:
             instance_id: Model instance ID.
             namespace: Namespace for model isolation.
@@ -114,6 +118,9 @@ class EngineRpcClient:
     ) -> tuple[bool, str]:
         """Save KV blocks to the engine.
 
+        Contract: device_id must be non-negative, and each save tuple must
+        have matching block_ids and block_hashes lengths.
+
         Args:
             instance_id: Model instance ID.
             tp_rank: Tensor parallel rank.
@@ -142,6 +149,10 @@ class EngineRpcClient:
     ) -> tuple[bool, str]:
         """Load KV blocks from the engine.
 
+        Contract: device_id must be non-negative; each lease must be returned
+        by query_prefetch; each lease's block count must match its destination
+        block_ids count.
+
         Args:
             instance_id: Model instance ID.
             tp_rank: Tensor parallel rank.
@@ -169,6 +180,9 @@ class EngineRpcClient:
 
         Checks memory cache and triggers SSD prefetch for missing blocks.
         Ready hits are owned by an opaque lease consumed by load or release.
+        Contract: instance_id must be registered, req_id must be non-empty
+        and stable across retries for the same request, and block_hashes may
+        be empty.
 
         Args:
             instance_id: Model instance ID.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -239,6 +239,12 @@ impl EngineRpcClient {
 
     /// Register all KV cache layers on a GPU with a single RPC call.
     ///
+    /// Argument contract:
+    /// - `device_id` must be non-negative.
+    /// - `num_layers`, `tp_size`, and `world_size` must be non-zero.
+    /// - `tp_rank` must be less than `tp_size`.
+    /// - Per-layer metadata lists must have the same non-zero length.
+    ///
     /// Args:
     ///     instance_id: Model instance ID
     ///     namespace: Namespace for block hash isolation
@@ -305,6 +311,10 @@ impl EngineRpcClient {
 
     /// Save KV blocks to the engine.
     ///
+    /// Argument contract:
+    /// - `device_id` must be non-negative.
+    /// - Each save tuple must have matching `block_ids` and `block_hashes` lengths.
+    ///
     /// Args:
     ///     instance_id: Model instance ID
     ///     tp_rank: Tensor parallel rank
@@ -347,6 +357,11 @@ impl EngineRpcClient {
     }
 
     /// Load KV blocks from the engine.
+    ///
+    /// Argument contract:
+    /// - `device_id` must be non-negative.
+    /// - Each lease must be a query lease returned by `query_prefetch`.
+    /// - Each lease's block count must match its destination block_ids count.
     ///
     /// Args:
     ///     instance_id: Model instance ID
@@ -396,12 +411,18 @@ impl EngineRpcClient {
     /// Checks memory cache and triggers backing-store prefetch for missing blocks.
     /// Ready blocks are owned by an opaque lease.
     ///
+    /// Argument contract:
+    /// - `instance_id` must identify a registered model instance.
+    /// - `req_id` must be non-empty and stable across retries for the same request.
+    /// - `block_hashes` may be empty; an empty list returns `QueryReady(0, empty lease)`.
+    ///
     /// Args:
     ///     instance_id: Model instance ID
     ///     block_hashes: List of block hashes to check
+    ///     req_id: Request ID for prefetch correlation
     ///
-    /// Returns: dict with keys:
-    ///     QueryLoading or QueryReady.
+    /// Returns:
+    ///     QueryLoading while backing fetch is in progress, otherwise QueryReady.
     fn query_prefetch(
         &self,
         py: Python<'_>,


### PR DESCRIPTION
## Summary
- move pure RPC argument validation into service layer and document core/Python API contracts
- run RDMA/SSD prefetch as Tokio tasks that return terminal Ready results including RAM prefix blocks
- strengthen SSD/RAM prefix IT coverage and make core IT harness stable under repeated runs
- default storage admission to no TinyLFU unless explicitly enabled

## Validation
- prek run
- cargo test -p pegaflow-core --tests --quiet x50
- cargo test -p pegaflow-server validate_ --lib
- cargo check -p pegaflow-core -p pegaflow-server
- cargo fmt --check
- git diff --check
