### PR TITLE
fix(connector): allow query leases across workers

### DIFF
--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -478,6 +478,11 @@ impl InstanceContext {
         self.tp_size
     }
 
+    /// Total worker count registered for this instance.
+    pub(crate) fn world_size(&self) -> usize {
+        self.world_size
+    }
+
     /// Return unique valid NUMA nodes for registered shards in one save group.
     pub(crate) fn registered_numa_nodes_for_save_group(
         &self,

--- a/pegaflow-core/src/lease.rs
+++ b/pegaflow-core/src/lease.rs
@@ -43,6 +43,7 @@ impl fmt::Debug for QueryLeaseId {
 struct QueryLease {
     instance_id: String,
     blocks: Vec<Arc<SealedBlock>>,
+    remaining_consumers: usize,
     expires_at: Instant,
 }
 
@@ -81,7 +82,12 @@ impl QueryLeaseManager {
         Self { inner, sweeper }
     }
 
-    pub(crate) fn create(&self, instance_id: &str, blocks: Vec<Arc<SealedBlock>>) -> QueryLeaseId {
+    pub(crate) fn create(
+        &self,
+        instance_id: &str,
+        blocks: Vec<Arc<SealedBlock>>,
+        consumers: usize,
+    ) -> QueryLeaseId {
         self.sweep_expired();
         debug_assert!(!blocks.is_empty(), "query leases require ready blocks");
 
@@ -89,6 +95,7 @@ impl QueryLeaseManager {
         let lease = QueryLease {
             instance_id: instance_id.to_string(),
             blocks,
+            remaining_consumers: consumers.max(1),
             expires_at: Instant::now() + DEFAULT_LEASE_TTL,
         };
         self.inner.insert(token, lease);
@@ -107,7 +114,7 @@ impl QueryLeaseManager {
             .lock()
             .expect("query leases lock poisoned");
         let lease = leases
-            .get(token)
+            .get_mut(token)
             .ok_or_else(|| "query lease is unknown or expired".to_string())?;
         if lease.instance_id != instance_id {
             return Err(format!(
@@ -115,6 +122,11 @@ impl QueryLeaseManager {
                 lease.instance_id, instance_id
             ));
         }
+        if lease.remaining_consumers > 1 {
+            lease.remaining_consumers -= 1;
+            return Ok(lease.blocks.clone());
+        }
+
         Ok(leases
             .remove(token)
             .expect("query lease disappeared during consume")
@@ -190,6 +202,7 @@ mod tests {
                 QueryLease {
                     instance_id: "inst-a".to_string(),
                     blocks: Vec::new(),
+                    remaining_consumers: 1,
                     expires_at: Instant::now() + DEFAULT_LEASE_TTL,
                 },
             );
@@ -203,5 +216,21 @@ mod tests {
         manager
             .consume("inst-a", &lease_id)
             .expect("original instance can still consume lease");
+    }
+
+    #[test]
+    fn consume_allows_configured_number_of_consumers() {
+        let manager = QueryLeaseManager::default();
+        let blocks = vec![Arc::new(SealedBlock::from_slots(Vec::new()))];
+        let lease_id = manager.create("inst-a", blocks, 2);
+
+        assert_eq!(manager.consume("inst-a", &lease_id).unwrap().len(), 1);
+        assert_eq!(manager.consume("inst-a", &lease_id).unwrap().len(), 1);
+
+        let err = manager
+            .consume("inst-a", &lease_id)
+            .err()
+            .expect("lease should be exhausted");
+        assert!(err.contains("query lease is unknown or expired"));
     }
 }

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -411,13 +411,15 @@ impl PegaEngine {
         instance_id: &str,
         blocks: Vec<Arc<SealedBlock>>,
     ) -> Result<QueryLeaseId, EngineError> {
-        self.get_instance(instance_id)?;
+        let instance = self.get_instance(instance_id)?;
         if blocks.is_empty() {
             return Err(EngineError::InvalidArgument(
                 "query lease requires at least one block".to_string(),
             ));
         }
-        Ok(self.query_leases.create(instance_id, blocks))
+        Ok(self
+            .query_leases
+            .create(instance_id, blocks, instance.world_size()))
     }
 
     /// Release a query lease. Unknown leases are successful no-ops.

--- a/pegaflow-core/tests/prefetch_lease.rs
+++ b/pegaflow-core/tests/prefetch_lease.rs
@@ -1,7 +1,7 @@
 //! Query lease protocol tests.
 //!
 //! Verifies the scheduler->worker contract: query_prefetch returns an opaque
-//! lease that owns ready blocks, and load consumes that lease exactly once.
+//! lease that owns ready blocks, and load consumes one lease share per worker.
 
 mod common;
 
@@ -26,7 +26,7 @@ async fn load_requires_query_prefetch() {
     env.expect_load_error(released, hashes.len(), "query lease is unknown or expired");
 }
 
-/// One scheduler query lease is consumed by one load.
+/// One scheduler query lease is consumed once per registered world-size worker.
 #[tokio::test]
 async fn query_then_load_consumes_reservation_budget() {
     let env = TestEnvBuilder::new("test-query-lease", "test-ns")
@@ -37,6 +37,10 @@ async fn query_then_load_consumes_reservation_budget() {
 
     env.save_and_wait(&hashes).await;
     let lease = env.assert_all_hit_lease(&hashes).await;
+
+    env.data().zero_gpu();
+    env.load_to_gpu(lease, hashes.len()).await;
+    env.data().assert_gpu_matches_expected();
 
     env.data().zero_gpu();
     env.load_to_gpu(lease, hashes.len()).await;
@@ -55,7 +59,7 @@ async fn query_then_load_consumes_reservation_budget() {
             &layer_names,
             &[(lease, block_ids)],
         )
-        .expect_err("second load should fail");
+        .expect_err("third load should fail");
     assert!(
         err.to_string()
             .contains("query lease is unknown or expired")


### PR DESCRIPTION
## Summary
- keep query lease ownership in `QueryLeaseManager` while allowing a lease to be consumed once per registered worker
- size the lease consumer budget from the instance's registered GPU contexts
- add a focused unit test for counted lease consumption

## Context
PR #284 replaced query pinning with lease-backed query/load/release semantics. The old pin path reserved one ref per worker, but the initial lease implementation removed a lease on the first consume. In multi-worker loads, later workers then failed with `query lease is unknown or expired`.

This preserves the lease ownership model from #284 and restores the previous multi-worker consume contract inside core.

## Verification
- `cargo fmt --check`
- `git diff --check`

h20b validation for the same lease fix passed `cargo test -p pegaflow-core --test prefetch_lease` and removed the TP1..TP7 `query lease is unknown or expired` failures.