### PR TITLE
test(server): add mock vLLM RPC E2E coverage

### DIFF
--- a/pegaflow-core/src/lease.rs
+++ b/pegaflow-core/src/lease.rs
@@ -133,9 +133,9 @@ impl QueryLeaseManager {
             .blocks)
     }
 
-    pub(crate) fn release(&self, token: &QueryLeaseId) {
+    pub(crate) fn release(&self, token: &QueryLeaseId) -> bool {
         self.sweep_expired();
-        self.inner.remove(token);
+        self.inner.remove(token)
     }
 
     pub(crate) fn release_instance(&self, instance_id: &str) {
@@ -168,11 +168,12 @@ impl QueryLeaseInner {
             .insert(token, lease);
     }
 
-    fn remove(&self, token: &QueryLeaseId) {
+    fn remove(&self, token: &QueryLeaseId) -> bool {
         self.leases
             .lock()
             .expect("query leases lock poisoned")
-            .remove(token);
+            .remove(token)
+            .is_some()
     }
 
     fn sweep_expired(&self) {

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -422,9 +422,9 @@ impl PegaEngine {
             .create(instance_id, blocks, instance.world_size()))
     }
 
-    /// Release a query lease. Unknown leases are successful no-ops.
-    pub fn release_query_lease(&self, lease: &QueryLeaseId) {
-        self.query_leases.release(lease);
+    /// Release a query lease. Returns false when the lease is unknown or expired.
+    pub fn release_query_lease(&self, lease: &QueryLeaseId) -> bool {
+        self.query_leases.release(lease)
     }
 
     /// Evict all resident in-memory cache blocks while preserving backing-store data.

--- a/pegaflow-core/tests/common/harness.rs
+++ b/pegaflow-core/tests/common/harness.rs
@@ -338,7 +338,7 @@ impl TestEnv {
     }
 
     pub fn release(&self, lease: &QueryLeaseId) {
-        self.engine.release_query_lease(lease);
+        assert!(self.engine.release_query_lease(lease), "release lease");
     }
 
     /// Count cache hits, then release the lease (for probing without consuming).

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -57,6 +57,12 @@ impl CudaTensorRegistry {
         })
     }
 
+    pub fn empty() -> Self {
+        Self {
+            contexts: HashMap::new(),
+        }
+    }
+
     pub fn register_layer(
         &mut self,
         context_key: &str,

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -614,10 +614,11 @@ impl Engine for GrpcEngineService {
         let result: Result<Response<ReleaseResponse>, Status> = async {
             debug!("RPC [release]: lease_len={}", lease_len);
 
-            if !req.lease.is_empty() {
-                let lease =
-                    QueryLeaseId::from_bytes(&req.lease).map_err(Status::invalid_argument)?;
-                self.engine.release_query_lease(&lease);
+            let lease = QueryLeaseId::from_bytes(&req.lease).map_err(Status::invalid_argument)?;
+            if !self.engine.release_query_lease(&lease) {
+                return Err(Status::failed_precondition(
+                    "query lease is unknown or expired",
+                ));
             }
 
             Ok(Response::new(ReleaseResponse {}))

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -1,0 +1,657 @@
+use std::ffi::c_void;
+use std::net::{SocketAddr, TcpListener};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use cudarc::driver::CudaContext;
+use cudarc::driver::sys;
+use parking_lot::Mutex;
+use pegaflow_core::sync_state::{LOAD_STATE_ERROR, LOAD_STATE_SUCCESS};
+use pegaflow_core::{LoadState, PegaEngine, StorageConfig};
+use pegaflow_server::proto::engine::engine_client::EngineClient;
+use pegaflow_server::proto::engine::engine_server::EngineServer;
+use pegaflow_server::proto::engine::{
+    LeaseLoad, LoadRequest, LoadResponse, QueryRequest, QueryResponse, ReleaseRequest,
+    ReleaseResponse, SaveLayer, SaveRequest, SaveResponse, SessionEvent, SessionRequest,
+};
+use pegaflow_server::{CudaTensorRegistry, GrpcEngineService};
+use tokio::sync::Notify;
+use tonic::transport::{Channel, Server};
+use tonic::{Status, Streaming};
+
+pub(crate) const INSTANCE_ID: &str = "mock-vllm-rpc-e2e";
+pub(crate) const SECOND_INSTANCE_ID: &str = "mock-vllm-rpc-e2e-second";
+pub(crate) const NAMESPACE: &str = "mock-vllm";
+pub(crate) const LAYER_NAME: &str = "layer_0";
+pub(crate) const BLOCK_COUNT: usize = 4;
+pub(crate) const BYTES_PER_BLOCK: usize = 1024;
+
+const LOAD_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy)]
+pub(crate) struct WorkerRegistration {
+    pub(crate) device_id: i32,
+    pub(crate) tp_rank: u32,
+}
+
+pub(crate) struct MockVllmRpcHarness {
+    _ctxs: Vec<Arc<CudaContext>>,
+    _engine: Arc<PegaEngine>,
+    workers: Vec<WorkerRegistration>,
+    server: tokio::task::JoinHandle<()>,
+    pub(crate) gpus: Vec<TestGpuData>,
+    scheduler: EngineClient<Channel>,
+    worker: EngineClient<Channel>,
+    extra_gpus: Vec<TestGpuData>,
+}
+
+pub(crate) struct RpcExchange<Request, Response> {
+    pub(crate) request: Request,
+    pub(crate) response: Response,
+}
+
+pub(crate) struct RpcError<Request> {
+    pub(crate) request: Request,
+    pub(crate) status: Status,
+}
+
+pub(crate) struct SessionRpcExchange {
+    pub(crate) request: SessionRequest,
+    pub(crate) stream: Streaming<SessionEvent>,
+}
+
+pub(crate) struct LoadRpcExchange {
+    pub(crate) request: LoadRequest,
+    pub(crate) response: LoadResponse,
+    pub(crate) state: LoadState,
+}
+
+pub(crate) struct LoadRpcError {
+    pub(crate) request: LoadRequest,
+    pub(crate) status: Status,
+    pub(crate) state: LoadState,
+}
+
+pub(crate) struct ReleaseRpcError {
+    pub(crate) request: ReleaseRequest,
+    pub(crate) status: Status,
+}
+
+impl MockVllmRpcHarness {
+    pub(crate) async fn new() -> Self {
+        Self::with_workers(
+            1,
+            1,
+            vec![WorkerRegistration {
+                device_id: 0,
+                tp_rank: 0,
+            }],
+        )
+        .await
+    }
+
+    pub(crate) async fn naive_tp2() -> Self {
+        Self::with_workers(
+            2,
+            2,
+            vec![
+                WorkerRegistration {
+                    device_id: 0,
+                    tp_rank: 0,
+                },
+                WorkerRegistration {
+                    device_id: 1,
+                    tp_rank: 1,
+                },
+            ],
+        )
+        .await
+    }
+
+    async fn with_workers(
+        tp_size: usize,
+        world_size: usize,
+        workers: Vec<WorkerRegistration>,
+    ) -> Self {
+        let mut ctxs = Vec::with_capacity(workers.len());
+        let mut gpus = Vec::with_capacity(workers.len());
+        for worker in &workers {
+            let ctx = CudaContext::new(worker.device_id as usize).expect("CUDA init");
+            let gpu = TestGpuData::new(Arc::clone(&ctx), BLOCK_COUNT, BYTES_PER_BLOCK);
+            ctxs.push(ctx);
+            gpus.push(gpu);
+        }
+
+        let engine = Arc::new(test_engine());
+        register_test_layers(&engine, &workers, &gpus, tp_size, world_size);
+
+        let (scheduler, worker, server) = spawn_engine_server(Arc::clone(&engine)).await;
+
+        Self {
+            _ctxs: ctxs,
+            _engine: engine,
+            workers,
+            server,
+            gpus,
+            scheduler,
+            worker,
+            extra_gpus: Vec::new(),
+        }
+    }
+
+    pub(crate) fn register_second_instance(&mut self) {
+        let worker = self.workers[0];
+        let ctx = CudaContext::new(worker.device_id as usize).expect("CUDA init");
+        let gpu = TestGpuData::new(Arc::clone(&ctx), BLOCK_COUNT, BYTES_PER_BLOCK);
+        register_instance_layers(
+            &self._engine,
+            SECOND_INSTANCE_ID,
+            &[worker],
+            std::slice::from_ref(&gpu),
+            1,
+            1,
+        );
+        self._ctxs.push(ctx);
+        self.extra_gpus.push(gpu);
+    }
+
+    pub(crate) async fn save_blocks(
+        &mut self,
+        hashes: &[Vec<u8>],
+    ) -> RpcExchange<SaveRequest, SaveResponse> {
+        self.save_blocks_for_worker(0, hashes).await
+    }
+
+    pub(crate) async fn save_blocks_for_worker(
+        &mut self,
+        worker_index: usize,
+        hashes: &[Vec<u8>],
+    ) -> RpcExchange<SaveRequest, SaveResponse> {
+        match self.try_save_blocks_for_worker(worker_index, hashes).await {
+            Ok(exchange) => exchange,
+            Err(err) => panic!("save rpc failed unexpectedly: {}", err.status),
+        }
+    }
+
+    pub(crate) async fn try_save_blocks_for_worker(
+        &mut self,
+        worker_index: usize,
+        hashes: &[Vec<u8>],
+    ) -> Result<RpcExchange<SaveRequest, SaveResponse>, RpcError<SaveRequest>> {
+        let worker = self.workers[worker_index];
+        let request = SaveRequest {
+            instance_id: INSTANCE_ID.to_string(),
+            tp_rank: worker.tp_rank,
+            device_id: worker.device_id,
+            saves: vec![SaveLayer {
+                layer_name: LAYER_NAME.to_string(),
+                block_ids: (0..hashes.len() as i32).collect(),
+                block_hashes: hashes.to_vec(),
+            }],
+            pp_rank: 0,
+        };
+        match self.worker.save(request.clone()).await {
+            Ok(response) => Ok(RpcExchange {
+                request,
+                response: response.into_inner(),
+            }),
+            Err(status) => Err(RpcError { request, status }),
+        }
+    }
+
+    pub(crate) async fn query_prefetch(
+        &mut self,
+        req_id: &str,
+        hashes: &[Vec<u8>],
+    ) -> RpcExchange<QueryRequest, QueryResponse> {
+        self.query_prefetch_for_instance(INSTANCE_ID, req_id, hashes)
+            .await
+    }
+
+    pub(crate) async fn query_prefetch_for_instance(
+        &mut self,
+        instance_id: &str,
+        req_id: &str,
+        hashes: &[Vec<u8>],
+    ) -> RpcExchange<QueryRequest, QueryResponse> {
+        match self
+            .try_query_prefetch_for_instance(instance_id, req_id, hashes)
+            .await
+        {
+            Ok(exchange) => exchange,
+            Err(err) => panic!("query_prefetch rpc failed unexpectedly: {}", err.status),
+        }
+    }
+
+    pub(crate) async fn try_query_prefetch(
+        &mut self,
+        req_id: &str,
+        hashes: &[Vec<u8>],
+    ) -> Result<RpcExchange<QueryRequest, QueryResponse>, RpcError<QueryRequest>> {
+        self.try_query_prefetch_for_instance(INSTANCE_ID, req_id, hashes)
+            .await
+    }
+
+    pub(crate) async fn try_query_prefetch_for_instance(
+        &mut self,
+        instance_id: &str,
+        req_id: &str,
+        hashes: &[Vec<u8>],
+    ) -> Result<RpcExchange<QueryRequest, QueryResponse>, RpcError<QueryRequest>> {
+        let request = QueryRequest {
+            instance_id: instance_id.to_string(),
+            block_hashes: hashes.to_vec(),
+            req_id: req_id.to_string(),
+        };
+        match self.scheduler.query_prefetch(request.clone()).await {
+            Ok(response) => Ok(RpcExchange {
+                request,
+                response: response.into_inner(),
+            }),
+            Err(status) => Err(RpcError { request, status }),
+        }
+    }
+
+    pub(crate) async fn open_session(&mut self) -> SessionRpcExchange {
+        let request = SessionRequest {
+            instance_id: INSTANCE_ID.to_string(),
+            namespace: NAMESPACE.to_string(),
+            tp_size: self.workers.len() as u32,
+            world_size: self.workers.len() as u32,
+        };
+        let stream = self
+            .scheduler
+            .session(request.clone())
+            .await
+            .expect("session rpc")
+            .into_inner();
+        SessionRpcExchange { request, stream }
+    }
+
+    pub(crate) async fn wait_for_instance_cleanup(
+        &mut self,
+        hashes: &[Vec<u8>],
+    ) -> RpcError<QueryRequest> {
+        let deadline = Instant::now() + LOAD_WAIT_TIMEOUT;
+        loop {
+            match self
+                .try_query_prefetch("mock-vllm-session-cleanup-probe", hashes)
+                .await
+            {
+                Ok(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Ok(_) => panic!("timed out waiting for session cleanup"),
+                Err(err)
+                    if err.status.code() == tonic::Code::FailedPrecondition
+                        && err.status.message().contains("instance") =>
+                {
+                    return err;
+                }
+                Err(err) => panic!("unexpected cleanup probe error: {}", err.status),
+            }
+        }
+    }
+
+    pub(crate) async fn try_release_lease(
+        &mut self,
+        lease: Vec<u8>,
+    ) -> Result<RpcExchange<ReleaseRequest, ReleaseResponse>, ReleaseRpcError> {
+        let request = ReleaseRequest { lease };
+        match self.scheduler.release(request.clone()).await {
+            Ok(response) => Ok(RpcExchange {
+                request,
+                response: response.into_inner(),
+            }),
+            Err(status) => Err(ReleaseRpcError { request, status }),
+        }
+    }
+
+    pub(crate) async fn submit_load(
+        &mut self,
+        lease: Vec<u8>,
+        block_count: usize,
+    ) -> LoadRpcExchange {
+        self.submit_load_for_worker(0, lease, block_count).await
+    }
+
+    pub(crate) async fn submit_load_for_worker(
+        &mut self,
+        worker_index: usize,
+        lease: Vec<u8>,
+        block_count: usize,
+    ) -> LoadRpcExchange {
+        match self
+            .try_submit_load_for_worker(worker_index, lease, block_count)
+            .await
+        {
+            Ok(exchange) => exchange,
+            Err(err) => panic!("load rpc failed unexpectedly: {}", err.status),
+        }
+    }
+
+    pub(crate) async fn try_submit_load_for_worker(
+        &mut self,
+        worker_index: usize,
+        lease: Vec<u8>,
+        block_count: usize,
+    ) -> Result<LoadRpcExchange, LoadRpcError> {
+        self.try_submit_load_for_instance_worker(INSTANCE_ID, worker_index, lease, block_count)
+            .await
+    }
+
+    pub(crate) async fn try_submit_load_for_instance_worker(
+        &mut self,
+        instance_id: &str,
+        worker_index: usize,
+        lease: Vec<u8>,
+        block_count: usize,
+    ) -> Result<LoadRpcExchange, LoadRpcError> {
+        let worker = self.workers[worker_index];
+        let state = LoadState::new().expect("create LoadState");
+        let request = LoadRequest {
+            instance_id: instance_id.to_string(),
+            tp_rank: worker.tp_rank,
+            device_id: worker.device_id,
+            load_state_shm: state.shm_name().to_string(),
+            layer_names: vec![LAYER_NAME.to_string()],
+            loads: vec![LeaseLoad {
+                lease,
+                block_ids: (0..block_count as i32).collect(),
+            }],
+        };
+        match self.worker.load(request.clone()).await {
+            Ok(response) => Ok(LoadRpcExchange {
+                request,
+                response: response.into_inner(),
+                state,
+            }),
+            Err(status) => Err(LoadRpcError {
+                request,
+                status,
+                state,
+            }),
+        }
+    }
+
+    pub(crate) async fn wait_for_load(&self, load_state: &LoadState) {
+        wait_for_load(load_state).await;
+    }
+}
+
+impl Drop for MockVllmRpcHarness {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+async fn spawn_engine_server(
+    engine: Arc<PegaEngine>,
+) -> (
+    EngineClient<Channel>,
+    EngineClient<Channel>,
+    tokio::task::JoinHandle<()>,
+) {
+    let port = unused_local_port();
+    let addr: SocketAddr = ([127, 0, 0, 1], port).into();
+    let registry = Arc::new(Mutex::new(CudaTensorRegistry::empty()));
+    let shutdown = Arc::new(Notify::new());
+    let hll_tracker = Arc::new(std::sync::Mutex::new(
+        pegaflow_common::hll::MultiWindowHllTracker::new(
+            vec![("24h".into(), Duration::from_secs(86400))],
+            14,
+        ),
+    ));
+    let service = GrpcEngineService::new(engine, registry, shutdown, hll_tracker);
+
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(EngineServer::new(service))
+            .serve(addr)
+            .await
+            .expect("Engine gRPC serve");
+    });
+
+    let endpoint = format!("http://127.0.0.1:{port}");
+    let scheduler = connect_client(&endpoint).await;
+    let worker = connect_client(&endpoint).await;
+    (scheduler, worker, handle)
+}
+
+async fn connect_client(endpoint: &str) -> EngineClient<Channel> {
+    let deadline = Instant::now() + LOAD_WAIT_TIMEOUT;
+    loop {
+        match EngineClient::connect(endpoint.to_string()).await {
+            Ok(client) => return client,
+            Err(err) if Instant::now() < deadline => {
+                let _ = err;
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            Err(err) => panic!("timed out connecting to test server: {err}"),
+        }
+    }
+}
+
+async fn wait_for_load(load_state: &LoadState) {
+    let deadline = Instant::now() + LOAD_WAIT_TIMEOUT;
+    loop {
+        let state = load_state.get();
+        if state == LOAD_STATE_SUCCESS {
+            return;
+        }
+        assert!(state != LOAD_STATE_ERROR, "load reported ERROR");
+        assert!(Instant::now() < deadline, "timed out waiting for load");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+fn test_engine() -> PegaEngine {
+    PegaEngine::new_with_config(
+        16 << 20,
+        false,
+        StorageConfig {
+            enable_lfu_admission: false,
+            ..StorageConfig::default()
+        },
+    )
+    .expect("test engine should start")
+}
+
+fn register_test_layers(
+    engine: &PegaEngine,
+    workers: &[WorkerRegistration],
+    gpus: &[TestGpuData],
+    tp_size: usize,
+    world_size: usize,
+) {
+    register_instance_layers(engine, INSTANCE_ID, workers, gpus, tp_size, world_size);
+}
+
+fn register_instance_layers(
+    engine: &PegaEngine,
+    instance_id: &str,
+    workers: &[WorkerRegistration],
+    gpus: &[TestGpuData],
+    tp_size: usize,
+    world_size: usize,
+) {
+    for (worker, gpu) in workers.iter().zip(gpus.iter()) {
+        engine
+            .register_context_layer_batch(
+                instance_id,
+                NAMESPACE,
+                worker.device_id,
+                worker.tp_rank as usize,
+                0,
+                tp_size,
+                world_size,
+                1,
+                &[LAYER_NAME.to_string()],
+                &[gpu.ptr()],
+                &[gpu.total_size()],
+                &[BLOCK_COUNT],
+                &[BYTES_PER_BLOCK],
+                &[0],
+                &[1],
+            )
+            .expect("register_context_layer_batch");
+    }
+}
+
+fn unused_local_port() -> u16 {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind ephemeral port");
+    listener.local_addr().expect("local addr").port()
+}
+
+pub(crate) fn make_block_hashes(num_blocks: usize, salt: u8) -> Vec<Vec<u8>> {
+    (0..num_blocks)
+        .map(|idx| {
+            let mut hash = Vec::with_capacity(5);
+            hash.push(salt);
+            hash.extend_from_slice(&(idx as u32).to_le_bytes());
+            hash
+        })
+        .collect()
+}
+
+pub(crate) fn cuda_device_count() -> usize {
+    let mut count = 0;
+    check_cuda(unsafe { sys::cuInit(0) }, "cuInit");
+    check_cuda(
+        unsafe { sys::cuDeviceGetCount(&raw mut count) },
+        "cuDeviceGetCount",
+    );
+    count as usize
+}
+
+pub(crate) struct TestGpuData {
+    gpu: GpuBuffer,
+    ctx: Arc<CudaContext>,
+    expected: Vec<u8>,
+    block_size: usize,
+}
+
+impl TestGpuData {
+    fn new(ctx: Arc<CudaContext>, num_blocks: usize, block_size: usize) -> Self {
+        ctx.bind_to_thread().expect("bind CUDA context");
+        let total = num_blocks * block_size;
+        let gpu = GpuBuffer::alloc(total);
+        let mut expected = vec![0u8; total];
+        fill_test_pattern(&mut expected, block_size);
+        gpu.copy_from_host(&expected);
+        Self {
+            gpu,
+            ctx,
+            expected,
+            block_size,
+        }
+    }
+
+    fn ptr(&self) -> u64 {
+        self.gpu.as_u64()
+    }
+
+    fn total_size(&self) -> usize {
+        self.expected.len()
+    }
+
+    pub(crate) fn zero(&self) {
+        self.ctx.bind_to_thread().expect("bind CUDA context");
+        self.gpu.zero();
+    }
+
+    pub(crate) fn assert_matches_expected(&self) {
+        self.ctx.bind_to_thread().expect("bind CUDA context");
+        assert_eq!(self.gpu.copy_to_host(), self.expected, "GPU data mismatch");
+    }
+
+    pub(crate) fn assert_prefix_loaded_and_suffix_zero(&self, loaded_blocks: usize) {
+        self.ctx.bind_to_thread().expect("bind CUDA context");
+        let actual = self.gpu.copy_to_host();
+        let loaded_bytes = loaded_blocks * self.block_size;
+        assert_eq!(&actual[..loaded_bytes], &self.expected[..loaded_bytes]);
+        assert!(
+            actual[loaded_bytes..].iter().all(|byte| *byte == 0),
+            "GPU suffix after loaded prefix should stay zero"
+        );
+    }
+}
+
+impl Drop for TestGpuData {
+    fn drop(&mut self) {
+        let _ = self.ctx.bind_to_thread();
+    }
+}
+
+fn fill_test_pattern(host_data: &mut [u8], block_size: usize) {
+    assert_eq!(
+        host_data.len() % block_size,
+        0,
+        "host_data must contain full blocks"
+    );
+    for (i, block) in host_data.chunks_exact_mut(block_size).enumerate() {
+        let fill = ((i % 251) + 1) as u8;
+        block.fill(fill);
+    }
+}
+
+struct GpuBuffer {
+    ptr: sys::CUdeviceptr,
+    len: usize,
+}
+
+impl GpuBuffer {
+    fn alloc(len: usize) -> Self {
+        assert!(len > 0, "GpuBuffer::alloc: len must be > 0");
+        let mut ptr: sys::CUdeviceptr = 0;
+        check_cuda(
+            unsafe { sys::cuMemAlloc_v2(&raw mut ptr, len) },
+            "cuMemAlloc_v2",
+        );
+        Self { ptr, len }
+    }
+
+    fn as_u64(&self) -> u64 {
+        self.ptr
+    }
+
+    fn copy_from_host(&self, data: &[u8]) {
+        assert_eq!(data.len(), self.len);
+        check_cuda(
+            unsafe { sys::cuMemcpyHtoD_v2(self.ptr, data.as_ptr() as *const c_void, self.len) },
+            "cuMemcpyHtoD_v2",
+        );
+    }
+
+    fn copy_to_host(&self) -> Vec<u8> {
+        let mut output = vec![0u8; self.len];
+        check_cuda(
+            unsafe { sys::cuMemcpyDtoH_v2(output.as_mut_ptr() as *mut c_void, self.ptr, self.len) },
+            "cuMemcpyDtoH_v2",
+        );
+        output
+    }
+
+    fn zero(&self) {
+        check_cuda(
+            unsafe { sys::cuMemsetD8_v2(self.ptr, 0, self.len) },
+            "cuMemsetD8_v2",
+        );
+    }
+}
+
+impl Drop for GpuBuffer {
+    fn drop(&mut self) {
+        if self.ptr != 0 {
+            check_cuda(unsafe { sys::cuMemFree_v2(self.ptr) }, "cuMemFree_v2");
+            self.ptr = 0;
+        }
+    }
+}
+
+fn check_cuda(result: sys::CUresult, op: &str) {
+    assert!(
+        result == sys::CUresult::CUDA_SUCCESS,
+        "{op} failed with {result:?}"
+    );
+}

--- a/pegaflow-server/tests/mock_vllm_rpc_e2e.rs
+++ b/pegaflow-server/tests/mock_vllm_rpc_e2e.rs
@@ -1,0 +1,392 @@
+//! Mock vLLM RPC E2E test.
+//!
+//! This keeps the real GPU/engine boundary, but replaces vLLM with a thin
+//! Rust client that calls the same gRPC methods used by the connector.
+
+mod common;
+
+use common::{
+    BLOCK_COUNT, INSTANCE_ID, LAYER_NAME, MockVllmRpcHarness, SECOND_INSTANCE_ID,
+    cuda_device_count, make_block_hashes,
+};
+use pegaflow_server::proto::engine::{QueryReady, query_response};
+
+#[tokio::test]
+async fn mock_vllm_save_query_load_roundtrip_over_rpc() {
+    let mut harness = MockVllmRpcHarness::new().await;
+    let hashes = make_block_hashes(BLOCK_COUNT, 17);
+
+    let cold_query = harness
+        .query_prefetch("mock-vllm-cold-query", &hashes)
+        .await;
+    assert_eq!(cold_query.request.instance_id, INSTANCE_ID);
+    assert_eq!(cold_query.request.block_hashes, hashes);
+    assert_eq!(cold_query.request.req_id, "mock-vllm-cold-query");
+    let cold_ready = expect_query_ready(cold_query.response.outcome, "cold query");
+    assert_eq!(cold_ready.num_hit_blocks, 0);
+    assert!(cold_ready.lease.is_empty());
+
+    let save = harness.save_blocks(&hashes).await;
+    assert_eq!(save.request.instance_id, INSTANCE_ID);
+    assert_eq!(save.request.tp_rank, 0);
+    assert_eq!(save.request.device_id, 0);
+    assert_eq!(save.request.pp_rank, 0);
+    assert_eq!(save.request.saves[0].layer_name, LAYER_NAME);
+    assert_eq!(save.request.saves[0].block_ids, vec![0, 1, 2, 3]);
+    assert_eq!(save.request.saves[0].block_hashes, hashes);
+    assert_response_ok(save.response.status.as_ref(), "save");
+
+    let hit_query = harness.query_prefetch("mock-vllm-hit-query", &hashes).await;
+    assert_eq!(hit_query.request.instance_id, INSTANCE_ID);
+    assert_eq!(hit_query.request.block_hashes, hashes);
+    assert_eq!(hit_query.request.req_id, "mock-vllm-hit-query");
+    let hit_ready = expect_query_ready(hit_query.response.outcome, "hit query");
+    assert_eq!(hit_ready.num_hit_blocks as usize, hashes.len());
+    assert!(!hit_ready.lease.is_empty());
+
+    harness.gpus[0].zero();
+    let load = harness.submit_load(hit_ready.lease, hashes.len()).await;
+    assert_eq!(load.request.instance_id, INSTANCE_ID);
+    assert_eq!(load.request.tp_rank, 0);
+    assert_eq!(load.request.device_id, 0);
+    assert!(!load.request.load_state_shm.is_empty());
+    assert_eq!(load.request.layer_names, vec![LAYER_NAME.to_string()]);
+    assert_eq!(load.request.loads[0].block_ids, vec![0, 1, 2, 3]);
+    assert_response_ok(load.response.status.as_ref(), "load");
+
+    harness.wait_for_load(&load.state).await;
+    harness.gpus[0].assert_matches_expected();
+}
+
+#[tokio::test]
+async fn mock_vllm_empty_req_id_query_returns_zero_hit_ready() {
+    let mut harness = MockVllmRpcHarness::new().await;
+    let hashes = make_block_hashes(BLOCK_COUNT, 31);
+
+    let save = harness.save_blocks(&hashes).await;
+    assert_response_ok(save.response.status.as_ref(), "save");
+
+    let query = harness.query_prefetch("", &hashes).await;
+    assert_eq!(query.request.instance_id, INSTANCE_ID);
+    assert_eq!(query.request.block_hashes, hashes);
+    assert_eq!(query.request.req_id, "");
+    let ready = expect_query_ready(query.response.outcome, "empty req_id query");
+    assert_eq!(ready.num_hit_blocks, 0);
+    assert!(ready.lease.is_empty());
+}
+
+#[tokio::test]
+async fn mock_vllm_query_lease_is_bound_to_instance_id() {
+    let mut harness = MockVllmRpcHarness::new().await;
+    let hashes = make_block_hashes(BLOCK_COUNT, 37);
+
+    let save = harness.save_blocks(&hashes).await;
+    assert_response_ok(save.response.status.as_ref(), "save");
+
+    let query = harness
+        .query_prefetch("mock-vllm-instance-bound", &hashes)
+        .await;
+    let ready = expect_query_ready(query.response.outcome, "instance-bound query");
+    assert_eq!(ready.num_hit_blocks as usize, hashes.len());
+    assert!(!ready.lease.is_empty());
+
+    harness.register_second_instance();
+    let wrong_instance_load = match harness
+        .try_submit_load_for_instance_worker(SECOND_INSTANCE_ID, 0, ready.lease, hashes.len())
+        .await
+    {
+        Ok(_) => panic!("load with lease from another instance should fail"),
+        Err(err) => err,
+    };
+    assert_eq!(wrong_instance_load.request.instance_id, SECOND_INSTANCE_ID);
+    assert!(
+        wrong_instance_load
+            .status
+            .message()
+            .contains("query lease belongs to instance"),
+        "unexpected error: {}",
+        wrong_instance_load.status
+    );
+    assert!(wrong_instance_load.state.get() < 0);
+}
+
+#[tokio::test]
+async fn mock_vllm_release_unknown_lease_returns_error() {
+    let mut harness = MockVllmRpcHarness::new().await;
+    let hashes = make_block_hashes(BLOCK_COUNT, 39);
+
+    let save = harness.save_blocks(&hashes).await;
+    assert_response_ok(save.response.status.as_ref(), "save");
+
+    let query = harness
+        .query_prefetch("mock-vllm-release-once", &hashes)
+        .await;
+    let ready = expect_query_ready(query.response.outcome, "release once query");
+    assert_eq!(ready.num_hit_blocks as usize, hashes.len());
+    assert!(!ready.lease.is_empty());
+
+    let released = match harness.try_release_lease(ready.lease.clone()).await {
+        Ok(exchange) => exchange,
+        Err(err) => panic!("first release should succeed: {}", err.status),
+    };
+    assert_eq!(released.request.lease, ready.lease);
+
+    let duplicate_release = match harness.try_release_lease(ready.lease).await {
+        Ok(_) => panic!("second release should fail"),
+        Err(err) => err,
+    };
+    assert!(!duplicate_release.request.lease.is_empty());
+    assert_eq!(
+        duplicate_release.status.code(),
+        tonic::Code::FailedPrecondition
+    );
+    assert!(
+        duplicate_release
+            .status
+            .message()
+            .contains("query lease is unknown or expired"),
+        "unexpected error: {}",
+        duplicate_release.status
+    );
+}
+
+#[tokio::test]
+async fn mock_vllm_prefix_partial_query_returns_prefix_lease() {
+    let mut harness = MockVllmRpcHarness::new().await;
+    let hashes = make_block_hashes(BLOCK_COUNT, 41);
+    let prefix = &hashes[..2];
+
+    let save = harness.save_blocks(prefix).await;
+    assert_eq!(save.request.saves[0].block_ids, vec![0, 1]);
+    assert_eq!(save.request.saves[0].block_hashes, prefix);
+    assert_response_ok(save.response.status.as_ref(), "prefix save");
+
+    let query = harness
+        .query_prefetch("mock-vllm-prefix-partial", &hashes)
+        .await;
+    assert_eq!(query.request.block_hashes, hashes);
+    let ready = expect_query_ready(query.response.outcome, "prefix partial query");
+    assert_eq!(ready.num_hit_blocks, 2);
+    assert!(!ready.lease.is_empty());
+
+    harness.gpus[0].zero();
+    let load = harness.submit_load(ready.lease, 2).await;
+    assert_eq!(load.request.loads[0].block_ids, vec![0, 1]);
+    assert_response_ok(load.response.status.as_ref(), "prefix load");
+    harness.wait_for_load(&load.state).await;
+    harness.gpus[0].assert_prefix_loaded_and_suffix_zero(2);
+}
+
+#[tokio::test]
+async fn mock_vllm_load_rejects_lease_block_count_mismatch() {
+    let mut harness = MockVllmRpcHarness::new().await;
+    let hashes = make_block_hashes(BLOCK_COUNT, 43);
+    let prefix = &hashes[..2];
+
+    let save = harness.save_blocks(prefix).await;
+    assert_response_ok(save.response.status.as_ref(), "prefix save");
+
+    let query = harness
+        .query_prefetch("mock-vllm-load-count-mismatch", &hashes)
+        .await;
+    let ready = expect_query_ready(query.response.outcome, "load count mismatch query");
+    assert_eq!(ready.num_hit_blocks, 2);
+    assert!(!ready.lease.is_empty());
+
+    let mismatch = match harness
+        .try_submit_load_for_worker(0, ready.lease, hashes.len())
+        .await
+    {
+        Ok(_) => panic!("load block count mismatch should fail"),
+        Err(err) => err,
+    };
+    assert_eq!(mismatch.request.loads[0].block_ids, vec![0, 1, 2, 3]);
+    assert_eq!(mismatch.status.code(), tonic::Code::InvalidArgument);
+    assert!(
+        mismatch
+            .status
+            .message()
+            .contains("query lease block count 2 does not match destination block count 4"),
+        "unexpected error: {}",
+        mismatch.status
+    );
+    assert!(mismatch.state.get() < 0);
+}
+
+#[tokio::test]
+async fn mock_vllm_session_disconnect_cleans_instance() {
+    let mut harness = MockVllmRpcHarness::new().await;
+    let hashes = make_block_hashes(BLOCK_COUNT, 47);
+
+    let session = harness.open_session().await;
+    assert_eq!(session.request.instance_id, INSTANCE_ID);
+    assert_eq!(session.request.namespace, "mock-vllm");
+    assert_eq!(session.request.tp_size, 1);
+    assert_eq!(session.request.world_size, 1);
+
+    let save = harness.save_blocks(&hashes).await;
+    assert_response_ok(save.response.status.as_ref(), "save before session cleanup");
+
+    let query = harness
+        .query_prefetch("mock-vllm-session-cleanup-hit", &hashes)
+        .await;
+    let ready = expect_query_ready(query.response.outcome, "session cleanup hit query");
+    assert_eq!(ready.num_hit_blocks as usize, hashes.len());
+    assert!(!ready.lease.is_empty());
+
+    drop(session.stream);
+    let cleanup_probe = harness.wait_for_instance_cleanup(&hashes).await;
+    assert_eq!(cleanup_probe.request.instance_id, INSTANCE_ID);
+    assert_eq!(cleanup_probe.request.block_hashes, hashes);
+    assert_eq!(cleanup_probe.status.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        cleanup_probe
+            .status
+            .message()
+            .contains("instance mock-vllm-rpc-e2e not found"),
+        "unexpected error: {}",
+        cleanup_probe.status
+    );
+
+    let save_after_cleanup = match harness.try_save_blocks_for_worker(0, &hashes).await {
+        Ok(_) => panic!("save after session cleanup should fail"),
+        Err(err) => err,
+    };
+    assert_eq!(save_after_cleanup.request.instance_id, INSTANCE_ID);
+    assert_eq!(
+        save_after_cleanup.status.code(),
+        tonic::Code::FailedPrecondition
+    );
+    assert!(
+        save_after_cleanup
+            .status
+            .message()
+            .contains("instance mock-vllm-rpc-e2e not found"),
+        "unexpected error: {}",
+        save_after_cleanup.status
+    );
+
+    let load_after_cleanup = match harness
+        .try_submit_load_for_worker(0, ready.lease, hashes.len())
+        .await
+    {
+        Ok(_) => panic!("load with pre-cleanup lease should fail after session cleanup"),
+        Err(err) => err,
+    };
+    assert_eq!(load_after_cleanup.request.instance_id, INSTANCE_ID);
+    assert_eq!(
+        load_after_cleanup.status.code(),
+        tonic::Code::FailedPrecondition
+    );
+    assert!(
+        load_after_cleanup
+            .status
+            .message()
+            .contains("instance mock-vllm-rpc-e2e not found"),
+        "unexpected error: {}",
+        load_after_cleanup.status
+    );
+    assert!(load_after_cleanup.state.get() < 0);
+}
+
+#[tokio::test]
+async fn mock_vllm_naive_tp2_load_roundtrip_over_rpc() {
+    if cuda_device_count() < 2 {
+        eprintln!("skipping naive TP=2 RPC E2E: requires at least 2 CUDA devices");
+        return;
+    }
+
+    let mut harness = MockVllmRpcHarness::naive_tp2().await;
+    let hashes = make_block_hashes(BLOCK_COUNT, 23);
+
+    let save_tp0 = harness.save_blocks_for_worker(0, &hashes).await;
+    assert_eq!(save_tp0.request.tp_rank, 0);
+    assert_eq!(save_tp0.request.device_id, 0);
+    assert_eq!(save_tp0.request.saves[0].block_hashes, hashes);
+    assert_response_ok(save_tp0.response.status.as_ref(), "save tp0");
+
+    let partial_query = harness
+        .query_prefetch("mock-vllm-naive-tp2-before-all-slots", &hashes)
+        .await;
+    let partial_ready = expect_query_ready(
+        partial_query.response.outcome,
+        "naive tp2 query before all TP slots are saved",
+    );
+    assert_eq!(partial_ready.num_hit_blocks, 0);
+    assert!(partial_ready.lease.is_empty());
+
+    let save_tp1 = harness.save_blocks_for_worker(1, &hashes).await;
+    assert_eq!(save_tp1.request.tp_rank, 1);
+    assert_eq!(save_tp1.request.device_id, 1);
+    assert_eq!(save_tp1.request.saves[0].block_hashes, hashes);
+    assert_response_ok(save_tp1.response.status.as_ref(), "save tp1");
+
+    let hit_query = harness
+        .query_prefetch("mock-vllm-naive-tp2-hit", &hashes)
+        .await;
+    assert_eq!(hit_query.request.instance_id, INSTANCE_ID);
+    assert_eq!(hit_query.request.block_hashes, hashes);
+    assert_eq!(hit_query.request.req_id, "mock-vllm-naive-tp2-hit");
+    let hit_ready = expect_query_ready(hit_query.response.outcome, "naive tp2 hit query");
+    assert_eq!(hit_ready.num_hit_blocks as usize, hashes.len());
+    assert!(!hit_ready.lease.is_empty());
+
+    harness.gpus[0].zero();
+    harness.gpus[1].zero();
+
+    let load_tp0 = harness
+        .submit_load_for_worker(0, hit_ready.lease.clone(), hashes.len())
+        .await;
+    assert_eq!(load_tp0.request.tp_rank, 0);
+    assert_eq!(load_tp0.request.device_id, 0);
+    assert_eq!(load_tp0.request.loads[0].block_ids, vec![0, 1, 2, 3]);
+    assert_response_ok(load_tp0.response.status.as_ref(), "load tp0");
+
+    let load_tp1 = harness
+        .submit_load_for_worker(1, hit_ready.lease.clone(), hashes.len())
+        .await;
+    assert_eq!(load_tp1.request.tp_rank, 1);
+    assert_eq!(load_tp1.request.device_id, 1);
+    assert_eq!(load_tp1.request.loads[0].block_ids, vec![0, 1, 2, 3]);
+    assert_response_ok(load_tp1.response.status.as_ref(), "load tp1");
+
+    harness.wait_for_load(&load_tp0.state).await;
+    harness.wait_for_load(&load_tp1.state).await;
+    harness.gpus[0].assert_matches_expected();
+    harness.gpus[1].assert_matches_expected();
+
+    let over_consumed = match harness
+        .try_submit_load_for_worker(0, hit_ready.lease, hashes.len())
+        .await
+    {
+        Ok(_) => panic!("third TP load should exhaust query lease"),
+        Err(err) => err,
+    };
+    assert_eq!(over_consumed.request.tp_rank, 0);
+    assert_eq!(over_consumed.request.device_id, 0);
+    assert!(
+        over_consumed
+            .status
+            .message()
+            .contains("query lease is unknown or expired"),
+        "unexpected error: {}",
+        over_consumed.status
+    );
+    assert!(over_consumed.state.get() < 0);
+}
+
+fn expect_query_ready(outcome: Option<query_response::Outcome>, context: &str) -> QueryReady {
+    match outcome {
+        Some(query_response::Outcome::Ready(ready)) => ready,
+        Some(query_response::Outcome::Loading(_)) => {
+            panic!("{context}: memory-only query should not return Loading")
+        }
+        None => panic!("{context}: QueryResponse missing outcome"),
+    }
+}
+
+fn assert_response_ok(status: Option<&pegaflow_server::proto::engine::ResponseStatus>, rpc: &str) {
+    let status = status.unwrap_or_else(|| panic!("{rpc} response missing status"));
+    assert!(status.ok, "{rpc} failed: {}", status.message);
+    assert!(status.message.is_empty());
+}

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -458,7 +458,7 @@ impl EngineRpcClient {
         })
     }
 
-    /// Release a query lease. Unknown leases are successful no-ops.
+    /// Release a query lease.
     fn release(&self, py: Python<'_>, lease: PyQueryLease) -> PyResult<()> {
         self.call(py, "release", |mut c| async move {
             c.release(ReleaseRequest {


### PR DESCRIPTION
## Summary

- Add a Rust mock vLLM gRPC E2E harness under `pegaflow-server/tests` that keeps the real PegaEngine/GPU boundary but does not start vLLM.
- Cover save/query/load/release/session contracts through RPC transcripts, including prefix hit leases, lease instance binding, block-count mismatch, release-after-release errors, session disconnect cleanup, and a naive TP=2 lease consumption case.
- Change Release RPC contract so unknown/expired leases return `FailedPrecondition` instead of being silently accepted.

## Coverage Diff

Command used for both baseline and current branch:

```bash
cargo llvm-cov --workspace --summary-only --text -- --nocapture
cargo llvm-cov report --summary-only
```

Baseline: `/data/pegadev/pegaflow-master` at `3445884`.
Current: `feat/mock-vllm-rpc-e2e` at `8e7888b`.

| Scope | Baseline | Current | Diff |
| --- | ---: | ---: | ---: |
| Workspace total line coverage | 54.01% | 56.75% | +2.74pp |
| `pegaflow-server/src/service.rs` | 0.00% | 46.88% | +46.88pp |
| `pegaflow-core/src/lease.rs` | 84.15% | 96.36% | +12.21pp |

Test count diff:

| Branch | Passed | Ignored | Failed |
| --- | ---: | ---: | ---: |
| Baseline | 193 | 1 | 0 |
| Current | 194 | 1 | 0 |

Notes:

- `p2p_rdma_remote_fetch_roundtrip` remains ignored in default test runs.
- `mock_vllm_naive_tp2_load_roundtrip_over_rpc` passes on this single-GPU machine by exercising its explicit skip branch; actual TP=2 data movement needs a two-GPU machine.
- The test harness uses an empty CUDA tensor registry because it registers test contexts directly in the engine; `RegisterContextBatch` remains outside this PR's scope.

## Verification

- `cargo fmt --check`
- `cargo test -p pegaflow-server --test mock_vllm_rpc_e2e -- --nocapture`
- `cargo test --release -p pegaflow-server --test mock_vllm_rpc_e2e -- --nocapture`
- `cargo llvm-cov --workspace --summary-only --text -- --nocapture`
- Commit hook: `cargo fmt`, `cargo clippy`, `cargo test --release`, `typos`, commitizen
