### PR TITLE
perf: add cpu path benchmarks and optimize long-block saves

### DIFF
--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -59,6 +59,10 @@ harness = false
 name = "uds_latency"
 harness = false
 
+[[bench]]
+name = "cpu_path"
+harness = false
+
 [[example]]
 name = "pinned_alloc"
 

--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -2,8 +2,9 @@
 //!
 //! This exercises the core engine API with the same save -> query -> load shape
 //! used by the mock vLLM RPC tests, while keeping tonic/prost out of CPU
-//! profiles. Use `perf record --call-graph dwarf -- cargo bench -p pegaflow-core
-//! --bench cpu_path -- --profile-time 30` for profile captures.
+//! profiles. The benchmark binds CUDA device 0 at runtime. Use
+//! `perf record --call-graph dwarf -- cargo bench -p pegaflow-core --bench
+//! cpu_path -- --profile-time 30` for profile captures.
 
 use std::ffi::c_void;
 use std::hint::black_box;
@@ -23,6 +24,8 @@ const NAMESPACE: &str = "cpu-path";
 const LAYER_NAME: &str = "layer_0";
 const DEVICE_ID: i32 = 0;
 const LOAD_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+// Unreachable by design: the MetaServer group measures client-side enqueue and
+// save-path overhead, not a successful MetaServer RPC round trip.
 const FAKE_METASERVER_ADDR: &str = "http://127.0.0.1:9";
 const ADVERTISE_ADDR: &str = "127.0.0.1:50055";
 

--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -28,6 +28,7 @@ const ADVERTISE_ADDR: &str = "127.0.0.1:50055";
 
 const BLOCK_CASES: &[usize] = &[128, 1024, 8192, 32768];
 const BYTES_PER_BLOCK: usize = 1024;
+const MULTI_LAYER_COUNT: usize = 61;
 
 struct BenchFixture {
     engine: PegaEngine,
@@ -161,6 +162,108 @@ impl BenchFixture {
     }
 }
 
+struct MultiLayerBenchFixture {
+    engine: PegaEngine,
+    _ctx: Arc<CudaContext>,
+    _gpu: GpuBuffer,
+    layer_names: Vec<String>,
+    num_blocks: usize,
+}
+
+impl MultiLayerBenchFixture {
+    fn new(num_blocks: usize, bytes_per_block: usize) -> Self {
+        let ctx = CudaContext::new(DEVICE_ID as usize).expect("CUDA context");
+        ctx.bind_to_thread().expect("bind CUDA context");
+
+        let layer_bytes = num_blocks
+            .checked_mul(bytes_per_block)
+            .expect("registered GPU size overflow");
+        let gpu = GpuBuffer::new(Arc::clone(&ctx), layer_bytes);
+        let mut host = vec![0u8; layer_bytes];
+        fill_test_pattern(&mut host, bytes_per_block);
+        gpu.copy_from_host(&host);
+
+        let save_bytes = layer_bytes
+            .checked_mul(MULTI_LAYER_COUNT)
+            .expect("multi-layer save size overflow");
+        let pool_size = save_bytes
+            .checked_mul(4)
+            .and_then(|size| size.checked_add(64 << 20))
+            .expect("pool size overflow");
+        let engine = PegaEngine::new_with_config(
+            pool_size,
+            false,
+            StorageConfig {
+                enable_lfu_admission: false,
+                hint_value_size_bytes: Some(bytes_per_block),
+                enable_numa_affinity: false,
+                ..StorageConfig::default()
+            },
+        )
+        .expect("engine");
+
+        let layer_names: Vec<String> = (0..MULTI_LAYER_COUNT)
+            .map(|idx| format!("layer_{idx}"))
+            .collect();
+        let layer_ptrs = vec![gpu.as_u64(); MULTI_LAYER_COUNT];
+        let layer_sizes = vec![layer_bytes; MULTI_LAYER_COUNT];
+        let layer_blocks = vec![num_blocks; MULTI_LAYER_COUNT];
+        let block_sizes = vec![bytes_per_block; MULTI_LAYER_COUNT];
+        let strides = vec![0; MULTI_LAYER_COUNT];
+        let segments = vec![1; MULTI_LAYER_COUNT];
+
+        engine
+            .register_context_layer_batch(
+                INSTANCE_ID,
+                NAMESPACE,
+                DEVICE_ID,
+                0,
+                0,
+                1,
+                1,
+                1,
+                &layer_names,
+                &layer_ptrs,
+                &layer_sizes,
+                &layer_blocks,
+                &block_sizes,
+                &strides,
+                &segments,
+            )
+            .expect("register layers");
+
+        Self {
+            engine,
+            _ctx: ctx,
+            _gpu: gpu,
+            layer_names,
+            num_blocks,
+        }
+    }
+
+    async fn save_and_flush(&self, hashes: &[Vec<u8>]) {
+        let ids = block_ids(self.num_blocks);
+        let saves: Vec<LayerSave> = self
+            .layer_names
+            .iter()
+            .map(|layer_name| LayerSave {
+                layer_name: layer_name.clone(),
+                block_ids: ids.clone(),
+                block_hashes: hashes.to_vec(),
+            })
+            .collect();
+        self.engine
+            .batch_save_kv_blocks_from_ipc(INSTANCE_ID, 0, 0, DEVICE_ID, saves)
+            .await
+            .expect("save");
+        self.engine.flush_saves().await;
+    }
+
+    fn cleanup_cache(&self) {
+        black_box(self.engine.cleanup_memory_cache());
+    }
+}
+
 fn save_flush_benchmarks(c: &mut Criterion) {
     let rt = Runtime::new().expect("tokio runtime");
     let mut group = c.benchmark_group("cpu_path/save_flush_unique");
@@ -215,6 +318,39 @@ fn save_flush_metaserver_benchmarks(c: &mut Criterion) {
                         let hashes = make_block_hashes(num_blocks, iter + 1);
                         let start = Instant::now();
                         fixture.save_and_flush(hashes).await;
+                        measured += start.elapsed();
+                        fixture.cleanup_cache();
+                    }
+                    measured
+                })
+            });
+            drop(fixture);
+            std::thread::sleep(Duration::from_millis(50));
+        });
+    }
+
+    group.finish();
+}
+
+fn save_flush_multilayer_benchmarks(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("cpu_path/save_flush_unique_multilayer_61");
+    group.sample_size(10);
+
+    for &num_blocks in BLOCK_CASES {
+        group.throughput(Throughput::Bytes(bytes_per_iter(
+            num_blocks * MULTI_LAYER_COUNT,
+            BYTES_PER_BLOCK,
+        )));
+        group.bench_function(BenchmarkId::from_parameter(num_blocks), |b| {
+            let fixture = MultiLayerBenchFixture::new(num_blocks, BYTES_PER_BLOCK);
+            b.iter_custom(|iters| {
+                rt.block_on(async {
+                    let mut measured = Duration::ZERO;
+                    for iter in 0..iters {
+                        let hashes = make_block_hashes(num_blocks, iter + 1);
+                        let start = Instant::now();
+                        fixture.save_and_flush(&hashes).await;
                         measured += start.elapsed();
                         fixture.cleanup_cache();
                     }
@@ -390,6 +526,7 @@ criterion_group!(
     benches,
     save_flush_benchmarks,
     save_flush_metaserver_benchmarks,
+    save_flush_multilayer_benchmarks,
     query_benchmarks,
     load_benchmarks
 );

--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -27,7 +27,10 @@ const FAKE_METASERVER_ADDR: &str = "http://127.0.0.1:9";
 const ADVERTISE_ADDR: &str = "127.0.0.1:50055";
 
 const BLOCK_CASES: &[usize] = &[128, 1024, 8192, 32768];
+const DTOH_MULTILAYER_BLOCK_CASES: &[usize] = &[128, 1024, 8192];
+const CPU_STAGE_BLOCK_CASES: &[usize] = &[1024, 8192, 32768];
 const BYTES_PER_BLOCK: usize = 1024;
+const CPU_PATH_BYTES_PER_BLOCK: usize = 1;
 const MULTI_LAYER_COUNT: usize = 61;
 
 struct BenchFixture {
@@ -170,16 +173,28 @@ struct MultiLayerBenchFixture {
     num_blocks: usize,
 }
 
+#[derive(Clone, Copy)]
+enum MultiLayerGpuLayout {
+    SharedSource,
+    DistinctLayerSources,
+}
+
 impl MultiLayerBenchFixture {
-    fn new(num_blocks: usize, bytes_per_block: usize) -> Self {
+    fn new(num_blocks: usize, bytes_per_block: usize, layout: MultiLayerGpuLayout) -> Self {
         let ctx = CudaContext::new(DEVICE_ID as usize).expect("CUDA context");
         ctx.bind_to_thread().expect("bind CUDA context");
 
         let layer_bytes = num_blocks
             .checked_mul(bytes_per_block)
             .expect("registered GPU size overflow");
-        let gpu = GpuBuffer::new(Arc::clone(&ctx), layer_bytes);
-        let mut host = vec![0u8; layer_bytes];
+        let gpu_bytes = match layout {
+            MultiLayerGpuLayout::SharedSource => layer_bytes,
+            MultiLayerGpuLayout::DistinctLayerSources => layer_bytes
+                .checked_mul(MULTI_LAYER_COUNT)
+                .expect("multi-layer GPU size overflow"),
+        };
+        let gpu = GpuBuffer::new(Arc::clone(&ctx), gpu_bytes);
+        let mut host = vec![0u8; gpu_bytes];
         fill_test_pattern(&mut host, bytes_per_block);
         gpu.copy_from_host(&host);
 
@@ -205,7 +220,12 @@ impl MultiLayerBenchFixture {
         let layer_names: Vec<String> = (0..MULTI_LAYER_COUNT)
             .map(|idx| format!("layer_{idx}"))
             .collect();
-        let layer_ptrs = vec![gpu.as_u64(); MULTI_LAYER_COUNT];
+        let layer_ptrs: Vec<u64> = match layout {
+            MultiLayerGpuLayout::SharedSource => vec![gpu.as_u64(); MULTI_LAYER_COUNT],
+            MultiLayerGpuLayout::DistinctLayerSources => (0..MULTI_LAYER_COUNT)
+                .map(|idx| gpu.offset_u64(idx * layer_bytes))
+                .collect(),
+        };
         let layer_sizes = vec![layer_bytes; MULTI_LAYER_COUNT];
         let layer_blocks = vec![num_blocks; MULTI_LAYER_COUNT];
         let block_sizes = vec![bytes_per_block; MULTI_LAYER_COUNT];
@@ -261,6 +281,17 @@ impl MultiLayerBenchFixture {
         self.engine.flush_saves().await;
     }
 
+    async fn save_only(&self, saves: Vec<LayerSave>) {
+        self.engine
+            .batch_save_kv_blocks_from_ipc(INSTANCE_ID, 0, 0, DEVICE_ID, saves)
+            .await
+            .expect("save");
+    }
+
+    async fn flush_saves(&self) {
+        self.engine.flush_saves().await;
+    }
+
     fn cleanup_cache(&self) {
         black_box(self.engine.cleanup_memory_cache());
     }
@@ -301,7 +332,7 @@ fn save_flush_benchmarks(c: &mut Criterion) {
 
 fn save_flush_metaserver_benchmarks(c: &mut Criterion) {
     let rt = Runtime::new().expect("tokio runtime");
-    let mut group = c.benchmark_group("cpu_path/save_flush_unique_metaserver");
+    let mut group = c.benchmark_group("cpu_path/save_flush_unique_metaserver_enqueue");
     group.sample_size(10);
 
     for &num_blocks in BLOCK_CASES {
@@ -334,18 +365,135 @@ fn save_flush_metaserver_benchmarks(c: &mut Criterion) {
     group.finish();
 }
 
-fn save_flush_multilayer_benchmarks(c: &mut Criterion) {
+fn save_flush_multilayer_cpu_benchmarks(c: &mut Criterion) {
     let rt = Runtime::new().expect("tokio runtime");
-    let mut group = c.benchmark_group("cpu_path/save_flush_unique_multilayer_61");
+    let mut group = c.benchmark_group("cpu_path/save_flush_cpu_multilayer_61");
     group.sample_size(10);
 
     for &num_blocks in BLOCK_CASES {
+        group.throughput(Throughput::Elements(
+            (num_blocks * MULTI_LAYER_COUNT) as u64,
+        ));
+        group.bench_function(BenchmarkId::from_parameter(num_blocks), |b| {
+            let fixture = MultiLayerBenchFixture::new(
+                num_blocks,
+                CPU_PATH_BYTES_PER_BLOCK,
+                MultiLayerGpuLayout::SharedSource,
+            );
+            b.iter_custom(|iters| {
+                rt.block_on(async {
+                    let mut measured = Duration::ZERO;
+                    for iter in 0..iters {
+                        let hashes = make_block_hashes(num_blocks, iter + 1);
+                        let saves = fixture.make_saves(&hashes);
+                        let start = Instant::now();
+                        fixture.save_and_flush(saves).await;
+                        measured += start.elapsed();
+                        fixture.cleanup_cache();
+                    }
+                    measured
+                })
+            });
+            drop(fixture);
+            std::thread::sleep(Duration::from_millis(50));
+        });
+    }
+
+    group.finish();
+}
+
+fn save_submit_multilayer_cpu_benchmarks(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("cpu_path/save_submit_cpu_multilayer_61");
+    group.sample_size(10);
+
+    for &num_blocks in CPU_STAGE_BLOCK_CASES {
+        group.throughput(Throughput::Elements(
+            (num_blocks * MULTI_LAYER_COUNT) as u64,
+        ));
+        group.bench_function(BenchmarkId::from_parameter(num_blocks), |b| {
+            let fixture = MultiLayerBenchFixture::new(
+                num_blocks,
+                CPU_PATH_BYTES_PER_BLOCK,
+                MultiLayerGpuLayout::SharedSource,
+            );
+            b.iter_custom(|iters| {
+                rt.block_on(async {
+                    let mut measured = Duration::ZERO;
+                    for iter in 0..iters {
+                        let hashes = make_block_hashes(num_blocks, iter + 1);
+                        let saves = fixture.make_saves(&hashes);
+                        let start = Instant::now();
+                        fixture.save_only(saves).await;
+                        measured += start.elapsed();
+                        fixture.flush_saves().await;
+                        fixture.cleanup_cache();
+                    }
+                    measured
+                })
+            });
+            drop(fixture);
+            std::thread::sleep(Duration::from_millis(50));
+        });
+    }
+
+    group.finish();
+}
+
+fn save_insert_flush_multilayer_cpu_benchmarks(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("cpu_path/save_insert_flush_cpu_multilayer_61");
+    group.sample_size(10);
+
+    for &num_blocks in CPU_STAGE_BLOCK_CASES {
+        group.throughput(Throughput::Elements(
+            (num_blocks * MULTI_LAYER_COUNT) as u64,
+        ));
+        group.bench_function(BenchmarkId::from_parameter(num_blocks), |b| {
+            let fixture = MultiLayerBenchFixture::new(
+                num_blocks,
+                CPU_PATH_BYTES_PER_BLOCK,
+                MultiLayerGpuLayout::SharedSource,
+            );
+            b.iter_custom(|iters| {
+                rt.block_on(async {
+                    let mut measured = Duration::ZERO;
+                    for iter in 0..iters {
+                        let hashes = make_block_hashes(num_blocks, iter + 1);
+                        let saves = fixture.make_saves(&hashes);
+                        fixture.save_only(saves).await;
+                        let start = Instant::now();
+                        fixture.flush_saves().await;
+                        measured += start.elapsed();
+                        fixture.cleanup_cache();
+                    }
+                    measured
+                })
+            });
+            drop(fixture);
+            std::thread::sleep(Duration::from_millis(50));
+        });
+    }
+
+    group.finish();
+}
+
+fn save_flush_multilayer_dtoh_benchmarks(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("cpu_path/save_flush_dtoh_multilayer_61");
+    group.sample_size(10);
+
+    for &num_blocks in DTOH_MULTILAYER_BLOCK_CASES {
         group.throughput(Throughput::Bytes(bytes_per_iter(
             num_blocks * MULTI_LAYER_COUNT,
             BYTES_PER_BLOCK,
         )));
         group.bench_function(BenchmarkId::from_parameter(num_blocks), |b| {
-            let fixture = MultiLayerBenchFixture::new(num_blocks, BYTES_PER_BLOCK);
+            let fixture = MultiLayerBenchFixture::new(
+                num_blocks,
+                BYTES_PER_BLOCK,
+                MultiLayerGpuLayout::DistinctLayerSources,
+            );
             b.iter_custom(|iters| {
                 rt.block_on(async {
                     let mut measured = Duration::ZERO;
@@ -498,6 +646,13 @@ impl GpuBuffer {
         self.ptr
     }
 
+    fn offset_u64(&self, offset: usize) -> u64 {
+        assert!(offset <= self.len);
+        self.ptr
+            .checked_add(offset as u64)
+            .expect("GPU pointer offset overflow")
+    }
+
     fn copy_from_host(&self, data: &[u8]) {
         assert_eq!(data.len(), self.len);
         self.ctx.bind_to_thread().expect("bind CUDA context");
@@ -529,7 +684,10 @@ criterion_group!(
     benches,
     save_flush_benchmarks,
     save_flush_metaserver_benchmarks,
-    save_flush_multilayer_benchmarks,
+    save_flush_multilayer_cpu_benchmarks,
+    save_submit_multilayer_cpu_benchmarks,
+    save_insert_flush_multilayer_cpu_benchmarks,
+    save_flush_multilayer_dtoh_benchmarks,
     query_benchmarks,
     load_benchmarks
 );

--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -1,0 +1,352 @@
+//! CPU-path benchmark for long block lists.
+//!
+//! This exercises the core engine API with the same save -> query -> load shape
+//! used by the mock vLLM RPC tests, while keeping tonic/prost out of CPU
+//! profiles. Use `perf record --call-graph dwarf -- cargo bench -p pegaflow-core
+//! --bench cpu_path -- --profile-time 30` for profile captures.
+
+use std::ffi::c_void;
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use cudarc::driver::{CudaContext, sys};
+use pegaflow_core::sync_state::{LOAD_STATE_ERROR, LOAD_STATE_SUCCESS};
+use pegaflow_core::{
+    LayerSave, LoadState, PegaEngine, PrefetchStatus, QueryLeaseId, StorageConfig,
+};
+use tokio::runtime::Runtime;
+
+const INSTANCE_ID: &str = "cpu-path-bench";
+const NAMESPACE: &str = "cpu-path";
+const LAYER_NAME: &str = "layer_0";
+const DEVICE_ID: i32 = 0;
+const LOAD_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+const BLOCK_CASES: &[usize] = &[128, 1024, 8192, 32768];
+const BYTES_PER_BLOCK: usize = 1024;
+
+struct BenchFixture {
+    engine: PegaEngine,
+    _ctx: Arc<CudaContext>,
+    _gpu: GpuBuffer,
+    num_blocks: usize,
+}
+
+impl BenchFixture {
+    fn new(num_blocks: usize, bytes_per_block: usize) -> Self {
+        let ctx = CudaContext::new(DEVICE_ID as usize).expect("CUDA context");
+        ctx.bind_to_thread().expect("bind CUDA context");
+
+        let total_bytes = num_blocks
+            .checked_mul(bytes_per_block)
+            .expect("registered GPU size overflow");
+        let gpu = GpuBuffer::new(Arc::clone(&ctx), total_bytes);
+        let mut host = vec![0u8; total_bytes];
+        fill_test_pattern(&mut host, bytes_per_block);
+        gpu.copy_from_host(&host);
+
+        let pool_size = total_bytes
+            .checked_mul(4)
+            .and_then(|size| size.checked_add(64 << 20))
+            .expect("pool size overflow");
+        let engine = PegaEngine::new_with_config(
+            pool_size,
+            false,
+            StorageConfig {
+                enable_lfu_admission: false,
+                hint_value_size_bytes: Some(bytes_per_block),
+                enable_numa_affinity: false,
+                ..StorageConfig::default()
+            },
+        )
+        .expect("engine");
+
+        engine
+            .register_context_layer_batch(
+                INSTANCE_ID,
+                NAMESPACE,
+                DEVICE_ID,
+                0,
+                0,
+                1,
+                1,
+                1,
+                &[LAYER_NAME.to_string()],
+                &[gpu.as_u64()],
+                &[total_bytes],
+                &[num_blocks],
+                &[bytes_per_block],
+                &[0],
+                &[1],
+            )
+            .expect("register layer");
+
+        Self {
+            engine,
+            _ctx: ctx,
+            _gpu: gpu,
+            num_blocks,
+        }
+    }
+
+    async fn save_and_flush(&self, hashes: Vec<Vec<u8>>) {
+        self.engine
+            .batch_save_kv_blocks_from_ipc(
+                INSTANCE_ID,
+                0,
+                0,
+                DEVICE_ID,
+                vec![LayerSave {
+                    layer_name: LAYER_NAME.to_string(),
+                    block_ids: block_ids(self.num_blocks),
+                    block_hashes: hashes,
+                }],
+            )
+            .await
+            .expect("save");
+        self.engine.flush_saves().await;
+    }
+
+    async fn prime_cache(&self) -> Vec<Vec<u8>> {
+        let hashes = make_block_hashes(self.num_blocks, 0);
+        self.save_and_flush(hashes.clone()).await;
+        hashes
+    }
+
+    async fn query_lease(&self, req_id: &str, hashes: &[Vec<u8>]) -> QueryLeaseId {
+        match self
+            .engine
+            .count_prefix_hit_blocks_with_prefetch(INSTANCE_ID, req_id, hashes)
+            .await
+            .expect("query")
+        {
+            PrefetchStatus::Ready { blocks, missing } => {
+                assert_eq!(blocks.len(), hashes.len());
+                assert_eq!(missing, 0);
+                self.engine
+                    .create_query_lease(INSTANCE_ID, blocks)
+                    .expect("create query lease")
+            }
+            PrefetchStatus::Loading => panic!("memory-only bench should not return Loading"),
+        }
+    }
+
+    async fn load_and_wait(&self, lease: QueryLeaseId) {
+        let load_state = LoadState::new().expect("create LoadState");
+        self.engine
+            .batch_load_kv_blocks_multi_layer(
+                INSTANCE_ID,
+                0,
+                DEVICE_ID,
+                load_state.shm_name(),
+                &[LAYER_NAME],
+                &[(lease, block_ids(self.num_blocks))],
+            )
+            .expect("submit load");
+        wait_for_load(&load_state).await;
+    }
+
+    fn cleanup_cache(&self) {
+        black_box(self.engine.cleanup_memory_cache());
+    }
+}
+
+fn save_flush_benchmarks(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("cpu_path/save_flush_unique");
+    group.sample_size(10);
+
+    for &num_blocks in BLOCK_CASES {
+        group.throughput(Throughput::Bytes(bytes_per_iter(
+            num_blocks,
+            BYTES_PER_BLOCK,
+        )));
+        group.bench_function(BenchmarkId::from_parameter(num_blocks), |b| {
+            let fixture = BenchFixture::new(num_blocks, BYTES_PER_BLOCK);
+            b.iter_custom(|iters| {
+                rt.block_on(async {
+                    let mut measured = Duration::ZERO;
+                    for iter in 0..iters {
+                        let hashes = make_block_hashes(num_blocks, iter + 1);
+                        let start = Instant::now();
+                        fixture.save_and_flush(hashes).await;
+                        measured += start.elapsed();
+                        fixture.cleanup_cache();
+                    }
+                    measured
+                })
+            });
+            drop(fixture);
+            std::thread::sleep(Duration::from_millis(50));
+        });
+    }
+
+    group.finish();
+}
+
+fn query_benchmarks(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("cpu_path/query_prefetch_lease");
+    group.sample_size(10);
+
+    for &num_blocks in BLOCK_CASES {
+        group.throughput(Throughput::Elements(num_blocks as u64));
+        group.bench_function(BenchmarkId::from_parameter(num_blocks), |b| {
+            let fixture = BenchFixture::new(num_blocks, BYTES_PER_BLOCK);
+            let hashes = rt.block_on(fixture.prime_cache());
+            b.iter_custom(|iters| {
+                rt.block_on(async {
+                    let mut measured = Duration::ZERO;
+                    for iter in 0..iters {
+                        let req_id = format!("query-{iter}");
+                        let start = Instant::now();
+                        let lease = fixture.query_lease(&req_id, &hashes).await;
+                        measured += start.elapsed();
+                        assert!(fixture.engine.release_query_lease(&lease));
+                    }
+                    measured
+                })
+            });
+            drop(fixture);
+            std::thread::sleep(Duration::from_millis(50));
+        });
+    }
+
+    group.finish();
+}
+
+fn load_benchmarks(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("cpu_path/load_submit_wait");
+    group.sample_size(10);
+
+    for &num_blocks in BLOCK_CASES {
+        group.throughput(Throughput::Bytes(bytes_per_iter(
+            num_blocks,
+            BYTES_PER_BLOCK,
+        )));
+        group.bench_function(BenchmarkId::from_parameter(num_blocks), |b| {
+            let fixture = BenchFixture::new(num_blocks, BYTES_PER_BLOCK);
+            let hashes = rt.block_on(fixture.prime_cache());
+            b.iter_custom(|iters| {
+                rt.block_on(async {
+                    let mut measured = Duration::ZERO;
+                    for iter in 0..iters {
+                        let req_id = format!("load-{iter}");
+                        let lease = fixture.query_lease(&req_id, &hashes).await;
+                        let start = Instant::now();
+                        fixture.load_and_wait(lease).await;
+                        measured += start.elapsed();
+                    }
+                    measured
+                })
+            });
+            drop(fixture);
+            std::thread::sleep(Duration::from_millis(50));
+        });
+    }
+
+    group.finish();
+}
+
+fn block_ids(num_blocks: usize) -> Vec<i32> {
+    (0..num_blocks)
+        .map(|idx| i32::try_from(idx).expect("block index exceeds i32"))
+        .collect()
+}
+
+fn bytes_per_iter(num_blocks: usize, bytes_per_block: usize) -> u64 {
+    num_blocks
+        .checked_mul(bytes_per_block)
+        .expect("bytes per iter overflow") as u64
+}
+
+fn make_block_hashes(num_blocks: usize, salt: u64) -> Vec<Vec<u8>> {
+    (0..num_blocks)
+        .map(|idx| {
+            let mut hash = Vec::with_capacity(16);
+            hash.extend_from_slice(&salt.to_le_bytes());
+            hash.extend_from_slice(&(idx as u64).to_le_bytes());
+            hash
+        })
+        .collect()
+}
+
+async fn wait_for_load(load_state: &LoadState) {
+    let deadline = Instant::now() + LOAD_WAIT_TIMEOUT;
+    loop {
+        let state = load_state.get();
+        if state == LOAD_STATE_SUCCESS {
+            return;
+        }
+        assert!(state != LOAD_STATE_ERROR, "load reported ERROR");
+        assert!(Instant::now() < deadline, "timed out waiting for load");
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+}
+
+fn fill_test_pattern(host_data: &mut [u8], block_size: usize) {
+    assert_eq!(host_data.len() % block_size, 0);
+    for (idx, block) in host_data.chunks_exact_mut(block_size).enumerate() {
+        block.fill(((idx % 251) + 1) as u8);
+    }
+}
+
+struct GpuBuffer {
+    ctx: Arc<CudaContext>,
+    ptr: sys::CUdeviceptr,
+    len: usize,
+}
+
+impl GpuBuffer {
+    fn new(ctx: Arc<CudaContext>, len: usize) -> Self {
+        assert!(len > 0);
+        ctx.bind_to_thread().expect("bind CUDA context");
+        let mut ptr: sys::CUdeviceptr = 0;
+        check_cuda(
+            unsafe { sys::cuMemAlloc_v2(&raw mut ptr, len) },
+            "cuMemAlloc_v2",
+        );
+        Self { ctx, ptr, len }
+    }
+
+    fn as_u64(&self) -> u64 {
+        self.ptr
+    }
+
+    fn copy_from_host(&self, data: &[u8]) {
+        assert_eq!(data.len(), self.len);
+        self.ctx.bind_to_thread().expect("bind CUDA context");
+        check_cuda(
+            unsafe { sys::cuMemcpyHtoD_v2(self.ptr, data.as_ptr() as *const c_void, self.len) },
+            "cuMemcpyHtoD_v2",
+        );
+    }
+}
+
+impl Drop for GpuBuffer {
+    fn drop(&mut self) {
+        if self.ptr != 0 {
+            let _ = self.ctx.bind_to_thread();
+            check_cuda(unsafe { sys::cuMemFree_v2(self.ptr) }, "cuMemFree_v2");
+            self.ptr = 0;
+        }
+    }
+}
+
+fn check_cuda(result: sys::CUresult, op: &str) {
+    assert!(
+        result == sys::CUresult::CUDA_SUCCESS,
+        "{op} failed with {result:?}"
+    );
+}
+
+criterion_group!(
+    benches,
+    save_flush_benchmarks,
+    query_benchmarks,
+    load_benchmarks
+);
+criterion_main!(benches);

--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -241,17 +241,19 @@ impl MultiLayerBenchFixture {
         }
     }
 
-    async fn save_and_flush(&self, hashes: &[Vec<u8>]) {
+    fn make_saves(&self, hashes: &[Vec<u8>]) -> Vec<LayerSave> {
         let ids = block_ids(self.num_blocks);
-        let saves: Vec<LayerSave> = self
-            .layer_names
+        self.layer_names
             .iter()
             .map(|layer_name| LayerSave {
                 layer_name: layer_name.clone(),
                 block_ids: ids.clone(),
                 block_hashes: hashes.to_vec(),
             })
-            .collect();
+            .collect()
+    }
+
+    async fn save_and_flush(&self, saves: Vec<LayerSave>) {
         self.engine
             .batch_save_kv_blocks_from_ipc(INSTANCE_ID, 0, 0, DEVICE_ID, saves)
             .await
@@ -349,8 +351,9 @@ fn save_flush_multilayer_benchmarks(c: &mut Criterion) {
                     let mut measured = Duration::ZERO;
                     for iter in 0..iters {
                         let hashes = make_block_hashes(num_blocks, iter + 1);
+                        let saves = fixture.make_saves(&hashes);
                         let start = Instant::now();
-                        fixture.save_and_flush(&hashes).await;
+                        fixture.save_and_flush(saves).await;
                         measured += start.elapsed();
                         fixture.cleanup_cache();
                     }

--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -23,6 +23,8 @@ const NAMESPACE: &str = "cpu-path";
 const LAYER_NAME: &str = "layer_0";
 const DEVICE_ID: i32 = 0;
 const LOAD_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+const FAKE_METASERVER_ADDR: &str = "http://127.0.0.1:9";
+const ADVERTISE_ADDR: &str = "127.0.0.1:50055";
 
 const BLOCK_CASES: &[usize] = &[128, 1024, 8192, 32768];
 const BYTES_PER_BLOCK: usize = 1024;
@@ -36,6 +38,10 @@ struct BenchFixture {
 
 impl BenchFixture {
     fn new(num_blocks: usize, bytes_per_block: usize) -> Self {
+        Self::with_metaserver(num_blocks, bytes_per_block, false)
+    }
+
+    fn with_metaserver(num_blocks: usize, bytes_per_block: usize, enable_metaserver: bool) -> Self {
         let ctx = CudaContext::new(DEVICE_ID as usize).expect("CUDA context");
         ctx.bind_to_thread().expect("bind CUDA context");
 
@@ -58,6 +64,8 @@ impl BenchFixture {
                 enable_lfu_admission: false,
                 hint_value_size_bytes: Some(bytes_per_block),
                 enable_numa_affinity: false,
+                metaserver_addr: enable_metaserver.then(|| FAKE_METASERVER_ADDR.to_string()),
+                advertise_addr: enable_metaserver.then(|| ADVERTISE_ADDR.to_string()),
                 ..StorageConfig::default()
             },
         )
@@ -165,6 +173,41 @@ fn save_flush_benchmarks(c: &mut Criterion) {
         )));
         group.bench_function(BenchmarkId::from_parameter(num_blocks), |b| {
             let fixture = BenchFixture::new(num_blocks, BYTES_PER_BLOCK);
+            b.iter_custom(|iters| {
+                rt.block_on(async {
+                    let mut measured = Duration::ZERO;
+                    for iter in 0..iters {
+                        let hashes = make_block_hashes(num_blocks, iter + 1);
+                        let start = Instant::now();
+                        fixture.save_and_flush(hashes).await;
+                        measured += start.elapsed();
+                        fixture.cleanup_cache();
+                    }
+                    measured
+                })
+            });
+            drop(fixture);
+            std::thread::sleep(Duration::from_millis(50));
+        });
+    }
+
+    group.finish();
+}
+
+fn save_flush_metaserver_benchmarks(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("cpu_path/save_flush_unique_metaserver");
+    group.sample_size(10);
+
+    for &num_blocks in BLOCK_CASES {
+        group.throughput(Throughput::Bytes(bytes_per_iter(
+            num_blocks,
+            BYTES_PER_BLOCK,
+        )));
+        group.bench_function(BenchmarkId::from_parameter(num_blocks), |b| {
+            let _guard = rt.enter();
+            let fixture = BenchFixture::with_metaserver(num_blocks, BYTES_PER_BLOCK, true);
+            drop(_guard);
             b.iter_custom(|iters| {
                 rt.block_on(async {
                     let mut measured = Duration::ZERO;
@@ -346,6 +389,7 @@ fn check_cuda(result: sys::CUresult, op: &str) {
 criterion_group!(
     benches,
     save_flush_benchmarks,
+    save_flush_metaserver_benchmarks,
     query_benchmarks,
     load_benchmarks
 );

--- a/pegaflow-core/src/block.rs
+++ b/pegaflow-core/src/block.rs
@@ -86,9 +86,42 @@ unsafe impl Sync for Segment {}
 ///
 /// RawBlock automatically derives Send+Sync from Segment.
 pub struct RawBlock {
-    segments: Box<[Segment]>,
+    segments: BlockSegments,
     /// Total size across all segments (for footprint tracking).
     total_size: usize,
+}
+
+enum BlockSegments {
+    One(Segment),
+    Two([Segment; 2]),
+    Many(Box<[Segment]>),
+}
+
+impl BlockSegments {
+    fn from_vec(segments: Vec<Segment>) -> Self {
+        match segments.len() {
+            1 => {
+                let mut segments = segments.into_iter();
+                Self::One(segments.next().expect("length checked"))
+            }
+            2 => {
+                let mut segments = segments.into_iter();
+                Self::Two([
+                    segments.next().expect("length checked"),
+                    segments.next().expect("length checked"),
+                ])
+            }
+            _ => Self::Many(segments.into_boxed_slice()),
+        }
+    }
+
+    fn as_slice(&self) -> &[Segment] {
+        match self {
+            Self::One(segment) => std::slice::from_ref(segment),
+            Self::Two(segments) => segments,
+            Self::Many(segments) => segments,
+        }
+    }
 }
 
 impl RawBlock {
@@ -98,29 +131,45 @@ impl RawBlock {
         debug_assert!(!segments.is_empty(), "RawBlock requires at least 1 segment");
         let total_size = segments.iter().map(|s| s.size).sum();
         Self {
-            segments: segments.into_boxed_slice(),
+            segments: BlockSegments::from_vec(segments),
+            total_size,
+        }
+    }
+
+    pub(crate) fn single_segment(segment: Segment) -> Self {
+        let total_size = segment.size;
+        Self {
+            segments: BlockSegments::One(segment),
+            total_size,
+        }
+    }
+
+    pub(crate) fn two_segments(k_segment: Segment, v_segment: Segment) -> Self {
+        let total_size = k_segment.size + v_segment.size;
+        Self {
+            segments: BlockSegments::Two([k_segment, v_segment]),
             total_size,
         }
     }
 
     /// Number of segments.
     pub(crate) fn num_segments(&self) -> usize {
-        self.segments.len()
+        self.segments.as_slice().len()
     }
 
     /// Get segment pointer by index.
     pub(crate) fn segment_ptr(&self, index: usize) -> Option<NonNull<u8>> {
-        self.segments.get(index).map(|s| s.ptr)
+        self.segments.as_slice().get(index).map(|s| s.ptr)
     }
 
     /// Get segment size by index.
     pub(crate) fn segment_size(&self, index: usize) -> Option<usize> {
-        self.segments.get(index).map(|s| s.size)
+        self.segments.as_slice().get(index).map(|s| s.size)
     }
 
     /// Iterator over (NonNull<u8>, size) pairs -- used for SSD I/O.
     pub(crate) fn segment_iovecs(&self) -> impl Iterator<Item = (NonNull<u8>, usize)> + '_ {
-        self.segments.iter().map(|s| (s.ptr, s.size))
+        self.segments.as_slice().iter().map(|s| (s.ptr, s.size))
     }
 
     /// Total memory footprint.
@@ -231,6 +280,35 @@ impl SealedBlock {
             footprint,
             slot_numas,
         }
+    }
+
+    /// Create from a fully populated, slot-id ordered insert batch.
+    pub(crate) fn from_ordered_slot_inserts(
+        slots: Vec<(usize, Arc<RawBlock>)>,
+        total_slots: usize,
+        numa_node: NumaNode,
+    ) -> Result<Self, Vec<(usize, Arc<RawBlock>)>> {
+        if slots.len() != total_slots
+            || slots
+                .iter()
+                .enumerate()
+                .any(|(expected, (slot_id, _))| *slot_id != expected)
+        {
+            return Err(slots);
+        }
+
+        let mut footprint = 0u64;
+        let mut blocks = Vec::with_capacity(total_slots);
+        for (_, block) in slots {
+            footprint = footprint.saturating_add(block.memory_footprint());
+            blocks.push(block);
+        }
+
+        Ok(Self::from_slots_with_footprint(
+            blocks.into_boxed_slice(),
+            footprint,
+            vec![numa_node; total_slots],
+        ))
     }
 }
 

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -148,8 +148,8 @@ impl MetaServerClient {
 
     /// Fire-and-forget registration of block hashes.
     ///
-    /// Accepts a flat list of (namespace, block_hash) pairs. The background loop
-    /// groups by namespace before issuing gRPC calls.
+    /// Accepts one namespace and its block hashes so callers can preserve their
+    /// hot-path grouping and enqueue a single MetaServer command.
     pub(crate) fn try_register_namespace(&self, namespace: String, hashes: Vec<Vec<u8>>) {
         if hashes.is_empty() {
             return;
@@ -700,9 +700,10 @@ mod tests {
         HeartbeatNodeResponse, InsertBlockHashesResponse, QueryPrefixBlocksResponse,
         RemoveBlockHashesResponse, ResponseStatus, UnregisterNodeResponse,
     };
+    use std::collections::BTreeMap;
     use std::net::SocketAddr;
     use std::sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     };
     use tokio::net::TcpListener;
@@ -710,13 +711,21 @@ mod tests {
     use tokio_stream::wrappers::TcpListenerStream;
     use tonic::{Request, Response, Status, async_trait};
 
+    type RequestLog = Mutex<Vec<(String, Vec<Vec<u8>>)>>;
+    type RequestSet = BTreeMap<String, Vec<Vec<u8>>>;
+
     #[derive(Default)]
     struct FakeMetaServerState {
         heartbeat_count: AtomicUsize,
         insert_count: AtomicUsize,
+        remove_count: AtomicUsize,
         unregister_count: AtomicUsize,
         fail_insert_with_stale_session: AtomicUsize,
+        insert_requests: RequestLog,
+        remove_requests: RequestLog,
         heartbeat_notify: Notify,
+        insert_notify: Notify,
+        remove_notify: Notify,
         unregister_notify: Notify,
     }
 
@@ -749,38 +758,55 @@ mod tests {
 
         async fn insert_block_hashes(
             &self,
-            _request: Request<InsertBlockHashesRequest>,
+            request: Request<InsertBlockHashesRequest>,
         ) -> Result<Response<InsertBlockHashesResponse>, Status> {
+            let request = request.into_inner();
             self.state.insert_count.fetch_add(1, Ordering::SeqCst);
             if self
                 .state
                 .fail_insert_with_stale_session
                 .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
-                    (remaining > 0).then_some(remaining - 1)
+                    (remaining > 0).then(|| remaining - 1)
                 })
                 .is_ok()
             {
                 return Err(Status::failed_precondition("stale node session"));
             }
+            let inserted_count = request.block_hashes.len() as u64;
+            self.state
+                .insert_requests
+                .lock()
+                .unwrap()
+                .push((request.namespace, request.block_hashes));
+            self.state.insert_notify.notify_waiters();
             Ok(Response::new(InsertBlockHashesResponse {
                 status: Some(ResponseStatus {
                     ok: true,
                     message: String::new(),
                 }),
-                inserted_count: 1,
+                inserted_count,
             }))
         }
 
         async fn remove_block_hashes(
             &self,
-            _request: Request<RemoveBlockHashesRequest>,
+            request: Request<RemoveBlockHashesRequest>,
         ) -> Result<Response<RemoveBlockHashesResponse>, Status> {
+            let request = request.into_inner();
+            self.state.remove_count.fetch_add(1, Ordering::SeqCst);
+            let removed_count = request.block_hashes.len() as u64;
+            self.state
+                .remove_requests
+                .lock()
+                .unwrap()
+                .push((request.namespace, request.block_hashes));
+            self.state.remove_notify.notify_waiters();
             Ok(Response::new(RemoveBlockHashesResponse {
                 status: Some(ResponseStatus {
                     ok: true,
                     message: String::new(),
                 }),
-                removed_count: 1,
+                removed_count,
             }))
         }
 
@@ -811,6 +837,32 @@ mod tests {
                 .unwrap();
         });
         (format!("http://{addr}"), state, shutdown_tx)
+    }
+
+    fn collect_requests(requests: &RequestLog) -> RequestSet {
+        let mut grouped = BTreeMap::new();
+        for (namespace, hashes) in requests.lock().unwrap().iter() {
+            let namespace_hashes: &mut Vec<Vec<u8>> = grouped.entry(namespace.clone()).or_default();
+            namespace_hashes.extend(hashes.iter().cloned());
+        }
+        for hashes in grouped.values_mut() {
+            hashes.sort();
+        }
+        grouped
+    }
+
+    fn expected_requests(entries: &[(&str, Vec<u8>)]) -> RequestSet {
+        let mut grouped: RequestSet = BTreeMap::new();
+        for (namespace, hash) in entries {
+            grouped
+                .entry((*namespace).to_string())
+                .or_default()
+                .push(hash.clone());
+        }
+        for hashes in grouped.values_mut() {
+            hashes.sort();
+        }
+        grouped
     }
 
     async fn wait_for_count(notify: &Notify, count: &AtomicUsize, expected: usize) {
@@ -859,6 +911,67 @@ mod tests {
         wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 2).await;
 
         client.shutdown().await;
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn mixed_insert_remove_drain_preserves_last_write_per_namespace() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        let (tx, rx) = mpsc::channel(16);
+
+        let insert_then_remove = vec![0xa0];
+        let remove_then_insert = vec![0xb0];
+        let remove_only = vec![0xc0];
+        let insert_only = vec![0xd0];
+
+        tx.try_send(MetaServerCommand::Insert(BlockHashBatch::single_namespace(
+            "ns-first".to_string(),
+            vec![insert_then_remove.clone()],
+        )))
+        .unwrap();
+        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
+            vec![("ns-first".to_string(), insert_then_remove.clone())],
+        )))
+        .unwrap();
+        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
+            vec![
+                ("ns-second".to_string(), remove_then_insert.clone()),
+                ("ns-remove".to_string(), remove_only.clone()),
+            ],
+        )))
+        .unwrap();
+        tx.try_send(MetaServerCommand::Insert(BlockHashBatch::single_namespace(
+            "ns-second".to_string(),
+            vec![remove_then_insert.clone()],
+        )))
+        .unwrap();
+        tx.try_send(MetaServerCommand::Insert(BlockHashBatch::single_namespace(
+            "ns-insert".to_string(),
+            vec![insert_only.clone()],
+        )))
+        .unwrap();
+
+        let loop_task = tokio::spawn(registration_loop(rx, addr, "node-a:50055".to_string()));
+
+        wait_for_count(&service.insert_notify, &service.insert_count, 2).await;
+        wait_for_count(&service.remove_notify, &service.remove_count, 2).await;
+
+        assert_eq!(
+            collect_requests(&service.insert_requests),
+            expected_requests(&[
+                ("ns-second", remove_then_insert),
+                ("ns-insert", insert_only),
+            ])
+        );
+        assert_eq!(
+            collect_requests(&service.remove_requests),
+            expected_requests(&[("ns-first", insert_then_remove), ("ns-remove", remove_only)])
+        );
+
+        let (done_tx, done_rx) = oneshot::channel();
+        tx.send(MetaServerCommand::Shutdown(done_tx)).await.unwrap();
+        done_rx.await.unwrap();
+        loop_task.await.unwrap();
         let _ = shutdown_tx.send(());
     }
 }

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -74,9 +74,31 @@ impl MetaServerClientConfig {
     }
 }
 
-/// A batch of (namespace, block_hash) pairs for MetaServer operations.
+/// A batch of block hashes grouped by namespace for MetaServer operations.
 struct BlockHashBatch {
-    entries: Vec<(String, Vec<u8>)>,
+    groups: Vec<(String, Vec<Vec<u8>>)>,
+}
+
+impl BlockHashBatch {
+    fn from_entries(entries: Vec<(String, Vec<u8>)>) -> Self {
+        let mut groups: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+        for (namespace, hash) in entries {
+            groups.entry(namespace).or_default().push(hash);
+        }
+        Self {
+            groups: groups.into_iter().collect(),
+        }
+    }
+
+    fn single_namespace(namespace: String, hashes: Vec<Vec<u8>>) -> Self {
+        Self {
+            groups: vec![(namespace, hashes)],
+        }
+    }
+
+    fn count(&self) -> usize {
+        self.groups.iter().map(|(_, hashes)| hashes.len()).sum()
+    }
 }
 
 /// Command sent to the background MetaServer loop.
@@ -128,12 +150,15 @@ impl MetaServerClient {
     ///
     /// Accepts a flat list of (namespace, block_hash) pairs. The background loop
     /// groups by namespace before issuing gRPC calls.
-    pub(crate) fn try_register(&self, entries: Vec<(String, Vec<u8>)>) {
-        if entries.is_empty() {
+    pub(crate) fn try_register_namespace(&self, namespace: String, hashes: Vec<Vec<u8>>) {
+        if hashes.is_empty() {
             return;
         }
-        let count = entries.len();
-        let batch = BlockHashBatch { entries };
+        self.try_send_register_batch(BlockHashBatch::single_namespace(namespace, hashes));
+    }
+
+    fn try_send_register_batch(&self, batch: BlockHashBatch) {
+        let count = batch.count();
         match self.command_tx.try_send(MetaServerCommand::Insert(batch)) {
             Ok(()) => {
                 core_metrics()
@@ -170,8 +195,11 @@ impl MetaServerClient {
         if entries.is_empty() {
             return;
         }
-        let count = entries.len();
-        let batch = BlockHashBatch { entries };
+        self.try_send_unregister_batch(BlockHashBatch::from_entries(entries));
+    }
+
+    fn try_send_unregister_batch(&self, batch: BlockHashBatch) {
+        let count = batch.count();
         match self.command_tx.try_send(MetaServerCommand::Remove(batch)) {
             Ok(()) => {
                 core_metrics()
@@ -287,21 +315,36 @@ async fn registration_loop(
             break;
         }
 
-        // Drain all pending commands. For each (namespace, hash), keep only the last
-        // operation (last-write-wins), so [Remove(X), Insert(X)] correctly resolves
-        // to Insert(X) rather than being reversed by separate-bucket processing.
-        let mut net: HashMap<(String, Vec<u8>), bool> = HashMap::new(); // true=insert, false=remove
+        let mut inserts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+        let mut removes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+        let mut mixed_ops: Option<HashMap<(String, Vec<u8>), bool>> = None; // true=insert
+        let mut saw_insert = false;
+        let mut saw_remove = false;
 
+        // Drain all pending commands. Pure insert/remove batches stay grouped by
+        // namespace; mixed streams switch to last-write-wins netting.
         for cmd in std::iter::once(cmd).chain(std::iter::from_fn(|| rx.try_recv().ok())) {
             match cmd {
                 MetaServerCommand::Insert(batch) => {
-                    for (ns, hash) in batch.entries {
-                        net.insert((ns, hash), true);
+                    saw_insert = true;
+                    if saw_remove {
+                        let net = mixed_ops.get_or_insert_with(|| {
+                            build_net(std::mem::take(&mut inserts), std::mem::take(&mut removes))
+                        });
+                        insert_groups_into_net(net, batch.groups, true);
+                    } else {
+                        append_groups(&mut inserts, batch.groups);
                     }
                 }
                 MetaServerCommand::Remove(batch) => {
-                    for (ns, hash) in batch.entries {
-                        net.insert((ns, hash), false);
+                    saw_remove = true;
+                    if saw_insert {
+                        let net = mixed_ops.get_or_insert_with(|| {
+                            build_net(std::mem::take(&mut inserts), std::mem::take(&mut removes))
+                        });
+                        insert_groups_into_net(net, batch.groups, false);
+                    } else {
+                        append_groups(&mut removes, batch.groups);
                     }
                 }
                 MetaServerCommand::Shutdown(done) => {
@@ -319,14 +362,13 @@ async fn registration_loop(
             }
         }
 
-        let mut inserts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
-        let mut removes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
-
-        for ((ns, hash), is_insert) in net {
-            if is_insert {
-                inserts.entry(ns).or_default().push(hash);
-            } else {
-                removes.entry(ns).or_default().push(hash);
+        if let Some(net) = mixed_ops {
+            for ((namespace, hash), is_insert) in net {
+                if is_insert {
+                    inserts.entry(namespace).or_default().push(hash);
+                } else {
+                    removes.entry(namespace).or_default().push(hash);
+                }
             }
         }
 
@@ -458,6 +500,44 @@ async fn registration_loop(
     }
 
     info!("MetaServer registration loop shutting down");
+}
+
+fn append_groups(target: &mut HashMap<String, Vec<Vec<u8>>>, groups: Vec<(String, Vec<Vec<u8>>)>) {
+    for (namespace, mut hashes) in groups {
+        target.entry(namespace).or_default().append(&mut hashes);
+    }
+}
+
+fn build_net(
+    inserts: HashMap<String, Vec<Vec<u8>>>,
+    removes: HashMap<String, Vec<Vec<u8>>>,
+) -> HashMap<(String, Vec<u8>), bool> {
+    let mut net = HashMap::new();
+    insert_map_into_net(&mut net, inserts, true);
+    insert_map_into_net(&mut net, removes, false);
+    net
+}
+
+fn insert_map_into_net(
+    net: &mut HashMap<(String, Vec<u8>), bool>,
+    grouped: HashMap<String, Vec<Vec<u8>>>,
+    is_insert: bool,
+) {
+    for (namespace, hashes) in grouped {
+        insert_groups_into_net(net, vec![(namespace, hashes)], is_insert);
+    }
+}
+
+fn insert_groups_into_net(
+    net: &mut HashMap<(String, Vec<u8>), bool>,
+    groups: Vec<(String, Vec<Vec<u8>>)>,
+    is_insert: bool,
+) {
+    for (namespace, hashes) in groups {
+        for hash in hashes {
+            net.insert((namespace.clone(), hash), is_insert);
+        }
+    }
 }
 
 async fn ensure_heartbeat_registered(
@@ -775,7 +855,7 @@ mod tests {
         ));
 
         wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
-        client.try_register(vec![("ns".to_string(), vec![1])]);
+        client.try_register_namespace("ns".to_string(), vec![vec![1]]);
         wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 2).await;
 
         client.shutdown().await;

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -540,15 +540,19 @@ impl PegaEngine {
 
             let slot_id = instance.get_slot_index(layer_id, tp_rank)?;
 
-            let blocks: Vec<LoadBlock> = block_ids
-                .iter()
-                .zip(block_cache.iter())
-                .filter_map(|(block_id, block_entry)| {
-                    let block_idx = usize::try_from(*block_id).ok()?;
-                    let block = block_entry.get_slot(slot_id)?.clone();
-                    Some(LoadBlock { block_idx, block })
-                })
-                .collect();
+            let mut blocks = Vec::with_capacity(block_ids.len());
+            for (block_id, block_entry) in block_ids.iter().zip(block_cache.iter()) {
+                let Ok(block_idx) = usize::try_from(*block_id) else {
+                    continue;
+                };
+                let Some(block) = block_entry.get_slot(slot_id) else {
+                    continue;
+                };
+                blocks.push(LoadBlock {
+                    block_idx,
+                    block: Arc::clone(block),
+                });
+            }
 
             if !blocks.is_empty() {
                 layers.push(LayerLoadData {

--- a/pegaflow-core/src/offload.rs
+++ b/pegaflow-core/src/offload.rs
@@ -114,6 +114,27 @@ pub(crate) struct RawSaveBatch {
 pub(crate) fn build_insert_entries(batch: &RawSaveBatch) -> (InsertEntries, u64, usize) {
     use std::collections::HashMap;
 
+    if let [layer] = batch.layers.as_slice() {
+        let blockwise = layer.allocs.len() > 1;
+        let total_blocks = layer.block_hashes.len();
+        let total_bytes = (layer.padded_block_size as u64).saturating_mul(total_blocks as u64);
+        let entries = layer
+            .block_hashes
+            .iter()
+            .enumerate()
+            .map(|(i, hash)| {
+                let (alloc_idx, offset_in_alloc) = if blockwise { (i, 0) } else { (0, i) };
+                let block = layer.allocs[alloc_idx]
+                    .make_raw_block(offset_in_alloc, layer.padded_block_size);
+                (
+                    BlockKey::new(batch.namespace.clone(), hash.clone()),
+                    vec![(layer.slot_id, block)],
+                )
+            })
+            .collect();
+        return (entries, total_bytes, total_blocks);
+    }
+
     let mut hash_entries: HashMap<Vec<u8>, Vec<(usize, Arc<RawBlock>)>> = HashMap::new();
     let mut total_bytes: u64 = 0;
     let mut total_blocks: usize = 0;

--- a/pegaflow-core/src/offload.rs
+++ b/pegaflow-core/src/offload.rs
@@ -65,10 +65,10 @@ impl LayerAlloc {
                     std::ptr::NonNull::new(k_ptr).expect("split block K pointer must be non-null");
                 let v_ptr =
                     std::ptr::NonNull::new(v_ptr).expect("split block V pointer must be non-null");
-                Arc::new(RawBlock::new(vec![
+                Arc::new(RawBlock::two_segments(
                     Segment::new(k_ptr, half, Arc::clone(k_allocation)),
                     Segment::new(v_ptr, half, Arc::clone(v_allocation)),
-                ]))
+                ))
             }
             LayerAlloc::Contiguous {
                 allocation,
@@ -78,11 +78,11 @@ impl LayerAlloc {
                 // Safety: pointer is within pinned allocation, validated during allocation.
                 let ptr =
                     std::ptr::NonNull::new(ptr).expect("contiguous block pointer must be non-null");
-                Arc::new(RawBlock::new(vec![Segment::new(
+                Arc::new(RawBlock::single_segment(Segment::new(
                     ptr,
                     block_size,
                     Arc::clone(allocation),
-                )]))
+                )))
             }
         }
     }
@@ -114,25 +114,8 @@ pub(crate) struct RawSaveBatch {
 pub(crate) fn build_insert_entries(batch: &RawSaveBatch) -> (InsertEntries, u64, usize) {
     use std::collections::HashMap;
 
-    if let [layer] = batch.layers.as_slice() {
-        let blockwise = layer.allocs.len() > 1;
-        let total_blocks = layer.block_hashes.len();
-        let total_bytes = (layer.padded_block_size as u64).saturating_mul(total_blocks as u64);
-        let entries = layer
-            .block_hashes
-            .iter()
-            .enumerate()
-            .map(|(i, hash)| {
-                let (alloc_idx, offset_in_alloc) = if blockwise { (i, 0) } else { (0, i) };
-                let block = layer.allocs[alloc_idx]
-                    .make_raw_block(offset_in_alloc, layer.padded_block_size);
-                (
-                    BlockKey::new(batch.namespace.clone(), hash.clone()),
-                    vec![(layer.slot_id, block)],
-                )
-            })
-            .collect();
-        return (entries, total_bytes, total_blocks);
+    if let Some(entries) = build_ordered_insert_entries(batch) {
+        return entries;
     }
 
     let mut hash_entries: HashMap<Vec<u8>, Vec<(usize, Arc<RawBlock>)>> = HashMap::new();
@@ -165,6 +148,43 @@ pub(crate) fn build_insert_entries(batch: &RawSaveBatch) -> (InsertEntries, u64,
         .collect();
 
     (entries, total_bytes, total_blocks)
+}
+
+fn build_ordered_insert_entries(batch: &RawSaveBatch) -> Option<(InsertEntries, u64, usize)> {
+    let first_layer = batch.layers.first()?;
+    let num_entries = first_layer.block_hashes.len();
+    if batch.layers.iter().any(|layer| {
+        layer.block_hashes.len() != num_entries || layer.block_hashes != first_layer.block_hashes
+    }) {
+        return None;
+    }
+
+    let mut total_blocks = 0usize;
+    let mut total_bytes = 0u64;
+    for layer in &batch.layers {
+        total_blocks += layer.block_hashes.len();
+        total_bytes +=
+            (layer.padded_block_size as u64).saturating_mul(layer.block_hashes.len() as u64);
+    }
+
+    let mut entries = Vec::with_capacity(num_entries);
+    for (block_idx, hash) in first_layer.block_hashes.iter().enumerate() {
+        let mut slots = Vec::with_capacity(batch.layers.len());
+        for layer in &batch.layers {
+            let blockwise = layer.allocs.len() > 1;
+            let (alloc_idx, offset_in_alloc) = if blockwise {
+                (block_idx, 0)
+            } else {
+                (0, block_idx)
+            };
+            let block =
+                layer.allocs[alloc_idx].make_raw_block(offset_in_alloc, layer.padded_block_size);
+            slots.push((layer.slot_id, block));
+        }
+        entries.push((BlockKey::new(batch.namespace.clone(), hash.clone()), slots));
+    }
+
+    Some((entries, total_bytes, total_blocks))
 }
 
 // ============================================================================
@@ -319,9 +339,26 @@ impl PegaEngine {
 
         trace_scope!("save.hash_filter", _s);
 
-        // Collect union of all unique hashes across layers
+        let shared_hash_order = if let Some((first_layer, rest_layers)) = layers.split_first() {
+            rest_layers.iter().all(|layer| {
+                layer.blocks_to_save.len() == first_layer.blocks_to_save.len()
+                    && layer
+                        .blocks_to_save
+                        .iter()
+                        .zip(&first_layer.blocks_to_save)
+                        .all(|((_, hash), (_, first_hash))| hash == first_hash)
+            })
+        } else {
+            false
+        };
+
         let mut hashes_to_save: HashSet<Vec<u8>> = HashSet::new();
-        for layer in &layers {
+        let hash_source_layers = if shared_hash_order {
+            &layers[..1]
+        } else {
+            &layers[..]
+        };
+        for layer in hash_source_layers {
             for (_, hash) in &layer.blocks_to_save {
                 hashes_to_save.insert(hash.clone());
             }

--- a/pegaflow-core/src/storage/prefetch.rs
+++ b/pegaflow-core/src/storage/prefetch.rs
@@ -236,18 +236,16 @@ impl PrefetchScheduler {
         let remaining = &keys[hit..];
 
         let task_start = Instant::now();
-        let task_started = self.start_prefetch_task(PrefetchStart {
-            req_id: scan.req_id,
-            namespace: scan.namespace,
-            remaining,
-            prefix_blocks: prefix_blocks
-                .iter()
-                .map(|(_, block)| Arc::clone(block))
-                .collect(),
-            total: keys.len(),
-            hit,
-            emit_tier_metrics: scan.emit_tier_metrics,
-        });
+        let task_started = !remaining.is_empty()
+            && self.start_prefetch_task(PrefetchStart {
+                req_id: scan.req_id,
+                namespace: scan.namespace,
+                remaining,
+                prefix_blocks: prefix_blocks.clone(),
+                total: keys.len(),
+                hit,
+                emit_tier_metrics: scan.emit_tier_metrics,
+            });
         let task_schedule = task_start.elapsed();
 
         if task_started {
@@ -284,8 +282,10 @@ impl PrefetchScheduler {
                 task_schedule,
                 total_start.elapsed()
             );
-            let blocks = prefix_blocks.into_iter().map(|(_, block)| block).collect();
-            PrefetchStatus::Ready { blocks, missing }
+            PrefetchStatus::Ready {
+                blocks: prefix_blocks,
+                missing,
+            }
         }
     }
 

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -33,18 +33,15 @@ impl ReadCache {
     }
 
     /// Scan cache for a prefix of `keys`, stopping at the first miss.
-    pub(super) fn get_prefix_blocks(
-        &self,
-        keys: &[BlockKey],
-    ) -> (usize, Vec<(BlockKey, Arc<SealedBlock>)>) {
+    pub(super) fn get_prefix_blocks(&self, keys: &[BlockKey]) -> (usize, Vec<Arc<SealedBlock>>) {
         let mut hit = 0usize;
-        let mut blocks = Vec::new();
+        let mut blocks = Vec::with_capacity(keys.len());
         {
             let mut inner = self.inner.lock();
             for key in keys {
                 if let Some(block) = inner.cache.get(key) {
                     hit += 1;
-                    blocks.push((key.clone(), Arc::clone(&block)));
+                    blocks.push(block);
                 } else {
                     break;
                 }

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -53,18 +53,14 @@ impl ReadCache {
     pub(super) fn batch_insert(&self, blocks: Vec<(BlockKey, Arc<SealedBlock>)>) {
         let mut inner = self.inner.lock();
         for (key, block) in blocks {
-            let footprint_bytes = block.memory_footprint();
-            match inner.cache.insert(key, block) {
-                CacheInsertOutcome::InsertedNew => {
-                    let m = core_metrics();
-                    m.cache_block_insertions.add(1, &[]);
-                    m.cache_resident_bytes.add(footprint_bytes as i64, &[]);
-                }
-                CacheInsertOutcome::AlreadyExists => {}
-                CacheInsertOutcome::Rejected => {
-                    core_metrics().cache_block_admission_rejections.add(1, &[]);
-                }
-            }
+            insert_block(&mut inner, key, block);
+        }
+    }
+
+    pub(super) fn batch_insert_refs(&self, blocks: &[(BlockKey, Arc<SealedBlock>)]) {
+        let mut inner = self.inner.lock();
+        for (key, block) in blocks {
+            insert_block(&mut inner, key.clone(), Arc::clone(block));
         }
     }
 
@@ -90,6 +86,21 @@ impl ReadCache {
 
     pub(super) fn remove_all(&self) -> Vec<(BlockKey, Arc<SealedBlock>)> {
         self.inner.lock().cache.remove_all()
+    }
+}
+
+fn insert_block(inner: &mut ReadCacheInner, key: BlockKey, block: Arc<SealedBlock>) {
+    let footprint_bytes = block.memory_footprint();
+    match inner.cache.insert(key, block) {
+        CacheInsertOutcome::InsertedNew => {
+            let m = core_metrics();
+            m.cache_block_insertions.add(1, &[]);
+            m.cache_resident_bytes.add(footprint_bytes as i64, &[]);
+        }
+        CacheInsertOutcome::AlreadyExists => {}
+        CacheInsertOutcome::Rejected => {
+            core_metrics().cache_block_admission_rejections.add(1, &[]);
+        }
     }
 }
 

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -266,19 +266,18 @@ fn send_backing_batches(
     if deps.ssd_store.is_none() && deps.metaserver_client.is_none() {
         return;
     }
-  if let Some(ssd) = &deps.ssd_store {
-      let weak_blocks: Vec<(BlockKey, Weak<SealedBlock>)> = blocks
-          .iter()
-          .map(|(k, b)| (k.clone(), Arc::downgrade(b)))
-          .collect();
+    if let Some(ssd) = &deps.ssd_store {
+        let weak_blocks: Vec<(BlockKey, Weak<SealedBlock>)> = blocks
+            .iter()
+            .map(|(k, b)| (k.clone(), Arc::downgrade(b)))
+            .collect();
 
-      ssd.ingest_batch(weak_blocks);
-  }
+        ssd.ingest_batch(weak_blocks);
+    }
 
-  if let Some(client) = &deps.metaserver_client {
-      register_block_hashes(client, namespace, blocks);
-  }
-
+    if let Some(client) = &deps.metaserver_client {
+        register_block_hashes(client, namespace, blocks);
+    }
 }
 
 fn register_block_hashes(

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -266,16 +266,19 @@ fn send_backing_batches(
     if deps.ssd_store.is_none() && deps.metaserver_client.is_none() {
         return;
     }
-    let weak_blocks: Vec<(BlockKey, Weak<SealedBlock>)> = blocks
-        .iter()
-        .map(|(k, b)| (k.clone(), Arc::downgrade(b)))
-        .collect();
-    if let Some(ssd) = &deps.ssd_store {
-        ssd.ingest_batch(weak_blocks);
-    }
-    if let Some(client) = &deps.metaserver_client {
-        register_block_hashes(client, namespace, blocks);
-    }
+  if let Some(ssd) = &deps.ssd_store {
+      let weak_blocks: Vec<(BlockKey, Weak<SealedBlock>)> = blocks
+          .iter()
+          .map(|(k, b)| (k.clone(), Arc::downgrade(b)))
+          .collect();
+
+      ssd.ingest_batch(weak_blocks);
+  }
+
+  if let Some(client) = &deps.metaserver_client {
+      register_block_hashes(client, namespace, blocks);
+  }
+
 }
 
 fn register_block_hashes(

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -200,12 +200,19 @@ fn process_insert_batch(
     if !sealed_blocks.is_empty()
         && let Some(deps) = deps.upgrade()
     {
-        send_backing_batches(&deps, &sealed_blocks);
+        send_backing_batches(&deps, namespace, &sealed_blocks);
     }
 }
 
-fn send_backing_batches(deps: &InsertDeps, blocks: &[(BlockKey, Arc<SealedBlock>)]) {
+fn send_backing_batches(
+    deps: &InsertDeps,
+    namespace: &str,
+    blocks: &[(BlockKey, Arc<SealedBlock>)],
+) {
     if blocks.is_empty() {
+        return;
+    }
+    if deps.ssd_store.is_none() && deps.metaserver_client.is_none() {
         return;
     }
     let weak_blocks: Vec<(BlockKey, Weak<SealedBlock>)> = blocks
@@ -216,16 +223,17 @@ fn send_backing_batches(deps: &InsertDeps, blocks: &[(BlockKey, Arc<SealedBlock>
         ssd.ingest_batch(weak_blocks);
     }
     if let Some(client) = &deps.metaserver_client {
-        register_block_hashes(client, blocks);
+        register_block_hashes(client, namespace, blocks);
     }
 }
 
-fn register_block_hashes(client: &MetaServerClient, blocks: &[(BlockKey, Arc<SealedBlock>)]) {
-    let entries: Vec<(String, Vec<u8>)> = blocks
-        .iter()
-        .map(|(key, _)| (key.namespace.clone(), key.hash.clone()))
-        .collect();
-    client.try_register(entries);
+fn register_block_hashes(
+    client: &MetaServerClient,
+    namespace: &str,
+    blocks: &[(BlockKey, Arc<SealedBlock>)],
+) {
+    let hashes: Vec<Vec<u8>> = blocks.iter().map(|(key, _)| key.hash.clone()).collect();
+    client.try_register_namespace(namespace.to_string(), hashes);
 }
 
 fn gc_inflight(

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -131,15 +131,17 @@ fn process_insert_batch(
     total_slots: usize,
     numa_node: NumaNode,
     namespace: &str,
-) {
+) -> usize {
     let mut sealed_blocks: Vec<(BlockKey, Arc<SealedBlock>)> = Vec::new();
     let mut inflight_bytes_added: u64 = 0;
     let mut inflight_bytes_removed: u64 = 0;
+    let mut ordered_fast_path_seals = 0usize;
 
     for (key, slots) in entries {
         if !inflight.contains_key(&key) {
             match SealedBlock::from_ordered_slot_inserts(slots, total_slots, numa_node) {
                 Ok(sealed) => {
+                    ordered_fast_path_seals += 1;
                     sealed_blocks.push((key, Arc::new(sealed)));
                     continue;
                 }
@@ -190,6 +192,8 @@ fn process_insert_batch(
         deps.read_cache.batch_insert_refs(&sealed_blocks);
         send_backing_batches(&deps, namespace, &sealed_blocks);
     }
+
+    ordered_fast_path_seals
 }
 
 #[allow(
@@ -368,6 +372,41 @@ mod tests {
             engine.read_cache.contains_keys(std::slice::from_ref(&key))[0],
             "sealed block should be in cache"
         );
+    }
+
+    #[tokio::test]
+    async fn ordered_multi_slot_batch_seals_immediately() {
+        let engine =
+            StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]).unwrap();
+        let deps = make_deps(&engine);
+        let weak_deps = Arc::downgrade(&deps);
+
+        let key = BlockKey::new("ns".into(), vec![4, 5, 6]);
+        let block0 = make_raw_block(&engine, 64);
+        let block1 = make_raw_block(&engine, 96);
+        let block2 = make_raw_block(&engine, 128);
+        let expected_footprint =
+            block0.memory_footprint() + block1.memory_footprint() + block2.memory_footprint();
+
+        let entries: InsertEntries =
+            vec![(key.clone(), vec![(0, block0), (1, block1), (2, block2)])];
+        let mut inflight: HashMap<BlockKey, InflightBlock> = HashMap::new();
+
+        let ordered_fast_path_seals =
+            process_insert_batch(&mut inflight, &weak_deps, entries, 3, NumaNode(1), "ns");
+
+        assert_eq!(ordered_fast_path_seals, 1);
+        assert!(
+            inflight.is_empty(),
+            "ordered complete batch should skip inflight storage"
+        );
+        let cached = engine.read_cache.get_blocks(std::slice::from_ref(&key));
+        assert_eq!(cached.len(), 1, "sealed block should be in read cache");
+
+        let sealed = &cached[0].1;
+        assert_eq!(sealed.memory_footprint(), expected_footprint);
+        assert_eq!(sealed.slots().len(), 3);
+        assert_eq!(sealed.slot_numas(), &[NumaNode(1); 3]);
     }
 
     #[tokio::test]

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -137,53 +137,40 @@ fn process_insert_batch(
     let mut inflight_bytes_removed: u64 = 0;
 
     for (key, slots) in entries {
-        let inflight_block = match inflight.entry(key.clone()) {
-            Entry::Vacant(v) => v.insert(InflightBlock::new(total_slots)),
-            Entry::Occupied(o) => {
-                let ib = o.into_mut();
-                if ib.total_slots() != total_slots {
-                    error!(
-                        "insert worker: slot count mismatch: key namespace={} expected={} got={}",
+        if !inflight.contains_key(&key) {
+            match SealedBlock::from_ordered_slot_inserts(slots, total_slots, numa_node) {
+                Ok(sealed) => {
+                    sealed_blocks.push((key, Arc::new(sealed)));
+                    continue;
+                }
+                Err(slots) => {
+                    insert_partial_slots(
+                        inflight,
+                        key,
+                        slots,
+                        total_slots,
+                        numa_node,
                         namespace,
-                        ib.total_slots(),
-                        total_slots
+                        &mut sealed_blocks,
+                        &mut inflight_bytes_added,
+                        &mut inflight_bytes_removed,
                     );
                     continue;
                 }
-                ib
-            }
-        };
-
-        let mut completed = false;
-        for (slot_id, block) in slots {
-            match inflight_block.insert_slot(slot_id, block, numa_node) {
-                SlotInsertResult::Inserted {
-                    completed: c,
-                    footprint_added,
-                } => {
-                    inflight_bytes_added = inflight_bytes_added.saturating_add(footprint_added);
-                    completed = c;
-                    if completed {
-                        break;
-                    }
-                }
-                SlotInsertResult::Duplicate => {}
             }
         }
 
-        if completed {
-            let inflight_block = inflight.remove(&key).expect("just inserted");
-            let total_footprint = inflight_block.footprint();
-            inflight_bytes_removed = inflight_bytes_removed.saturating_add(total_footprint);
-            let sealed = Arc::new(inflight_block.seal());
-
-            if let Some(deps) = deps.upgrade() {
-                deps.read_cache
-                    .batch_insert(vec![(key.clone(), Arc::clone(&sealed))]);
-            }
-
-            sealed_blocks.push((key, sealed));
-        }
+        insert_partial_slots(
+            inflight,
+            key,
+            slots,
+            total_slots,
+            numa_node,
+            namespace,
+            &mut sealed_blocks,
+            &mut inflight_bytes_added,
+            &mut inflight_bytes_removed,
+        );
     }
 
     if inflight_bytes_added > 0 {
@@ -200,7 +187,67 @@ fn process_insert_batch(
     if !sealed_blocks.is_empty()
         && let Some(deps) = deps.upgrade()
     {
+        deps.read_cache.batch_insert_refs(&sealed_blocks);
         send_backing_batches(&deps, namespace, &sealed_blocks);
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "insert worker threads batch-local accounting through the fallback path"
+)]
+fn insert_partial_slots(
+    inflight: &mut HashMap<BlockKey, InflightBlock>,
+    key: BlockKey,
+    slots: Vec<(usize, Arc<crate::block::RawBlock>)>,
+    total_slots: usize,
+    numa_node: NumaNode,
+    namespace: &str,
+    sealed_blocks: &mut Vec<(BlockKey, Arc<SealedBlock>)>,
+    inflight_bytes_added: &mut u64,
+    inflight_bytes_removed: &mut u64,
+) {
+    let inflight_block = match inflight.entry(key.clone()) {
+        Entry::Vacant(v) => v.insert(InflightBlock::new(total_slots)),
+        Entry::Occupied(o) => {
+            let ib = o.into_mut();
+            if ib.total_slots() != total_slots {
+                error!(
+                    "insert worker: slot count mismatch: key namespace={} expected={} got={}",
+                    namespace,
+                    ib.total_slots(),
+                    total_slots
+                );
+                return;
+            }
+            ib
+        }
+    };
+
+    let mut completed = false;
+    for (slot_id, block) in slots {
+        match inflight_block.insert_slot(slot_id, block, numa_node) {
+            SlotInsertResult::Inserted {
+                completed: c,
+                footprint_added,
+            } => {
+                *inflight_bytes_added = inflight_bytes_added.saturating_add(footprint_added);
+                completed = c;
+                if completed {
+                    break;
+                }
+            }
+            SlotInsertResult::Duplicate => {}
+        }
+    }
+
+    if completed {
+        let inflight_block = inflight.remove(&key).expect("just inserted");
+        let total_footprint = inflight_block.footprint();
+        *inflight_bytes_removed = inflight_bytes_removed.saturating_add(total_footprint);
+        let sealed = Arc::new(inflight_block.seal());
+
+        sealed_blocks.push((key, sealed));
     }
 }
 

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -191,10 +191,13 @@ impl MockVllmRpcHarness {
             pp_rank: 0,
         };
         match self.worker.save(request.clone()).await {
-            Ok(response) => Ok(RpcExchange {
-                request,
-                response: response.into_inner(),
-            }),
+            Ok(response) => {
+                let response = response.into_inner();
+                if response.status.as_ref().is_some_and(|status| status.ok) {
+                    self._engine.flush_saves().await;
+                }
+                Ok(RpcExchange { request, response })
+            }
             Err(status) => Err(RpcError { request, status }),
         }
     }

--- a/pegaflow-server/tests/mock_vllm_rpc_e2e.rs
+++ b/pegaflow-server/tests/mock_vllm_rpc_e2e.rs
@@ -59,22 +59,22 @@ async fn mock_vllm_save_query_load_roundtrip_over_rpc() {
 }
 
 #[tokio::test]
-async fn mock_vllm_empty_req_id_query_is_rejected() {
+async fn mock_vllm_empty_req_id_query_returns_invalid_argument() {
     let mut harness = MockVllmRpcHarness::new().await;
     let hashes = make_block_hashes(BLOCK_COUNT, 31);
 
     let save = harness.save_blocks(&hashes).await;
     assert_response_ok(save.response.status.as_ref(), "save");
 
-    let query = match harness.try_query_prefetch("", &hashes).await {
-        Ok(_) => panic!("empty req_id query should be rejected"),
+    let err = match harness.try_query_prefetch("", &hashes).await {
+        Ok(_) => panic!("empty req_id query should fail validation"),
         Err(err) => err,
     };
-    assert_eq!(query.request.instance_id, INSTANCE_ID);
-    assert_eq!(query.request.block_hashes, hashes);
-    assert_eq!(query.request.req_id, "");
-    assert_eq!(query.status.code(), tonic::Code::InvalidArgument);
-    assert!(query.status.message().contains("req_id"));
+    assert_eq!(err.request.instance_id, INSTANCE_ID);
+    assert_eq!(err.request.block_hashes, hashes);
+    assert_eq!(err.request.req_id, "");
+    assert_eq!(err.status.code(), tonic::Code::InvalidArgument);
+    assert_eq!(err.status.message(), "req_id must not be empty");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add `pegaflow-core` CPU-path Criterion benchmarks for save/query/load, metaserver enqueue, 61-layer CPU overhead, and 61-layer DtoH save
- optimize long-block query/save paths by reducing prefix key cloning, ordered multi-layer save grouping, RawBlock segment allocation overhead, and insert/read-cache batching
- align mock RPC tests with current req_id validation and wait for save visibility in test helpers

## Before / After Performance
Measured locally on the same machine with `cargo bench -p pegaflow-core --bench cpu_path`; values are Criterion medians / local point estimates from the branch work.

| Path | Before | After | Notes |
| --- | ---: | ---: | --- |
| `cpu_path/query_prefetch_lease/32768` | ~12.3 ms | ~6.1 ms | Avoids cloning prefix cache keys and skips an extra remaining-prefix clone. |
| `cpu_path/save_flush_unique/8192` | ~21.3 ms | ~13.1 ms | RawBlock 1/2 segment inline storage and save/insert allocation reductions. |
| `cpu_path/save_flush_unique/32768` | ~78.4 ms | ~55 ms | Same single-layer save path, long-block case. |
| `cpu_path/save_flush_unique_metaserver/32768` | ~125 ms | ~66 ms | Original fake metaserver path; renamed to enqueue benchmark later to make scope explicit. |
| preliminary `cpu_path/save_flush_unique_multilayer_61/8192` | ~159 ms | superseded | Old 61-layer group mixed CPU overhead with 488 MiB DtoH and shared source pointers. |

## 61-Layer CPU Path Breakdown
The final 61-layer benchmark split separates CPU slot overhead from DtoH volume:

| Path | Current |
| --- | ---: |
| `cpu_path/save_flush_cpu_multilayer_61/8192` | ~130.3 ms for 499,712 slots |
| `cpu_path/save_submit_cpu_multilayer_61/8192` | ~53.7 ms |
| `cpu_path/save_insert_flush_cpu_multilayer_61/8192` | ~77.3 ms |
| `cpu_path/save_flush_dtoh_multilayer_61/8192` | ~133.5 ms with distinct per-layer GPU sources |

## Validation
- `cargo fmt --check`
- `cargo check -p pegaflow-core --benches`
- `cargo test -p pegaflow-core internode::metaserver_client`
- `cargo test -p pegaflow-core --test engine_basic --test save_validation --test prefix_semantics --test prefetch_lease`
- commit hooks passed `cargo clippy` and `cargo test --release`; after rebasing onto latest `origin/master`, conflict resolution was rechecked with the commands above