### PR TITLE
feat(rdma): per-peer N QPs with WQE-level round-robin

### DIFF
--- a/pegaflow-core/src/backing/rdma.rs
+++ b/pegaflow-core/src/backing/rdma.rs
@@ -29,9 +29,13 @@ impl RdmaTransport {
     }
 
     /// Create a new RDMA transport and register all pinned memory regions.
-    fn new(nic_names: &[String], allocator: &PinnedAllocator) -> Result<Self, String> {
+    fn new(
+        nic_names: &[String],
+        allocator: &PinnedAllocator,
+        qps_per_peer: usize,
+    ) -> Result<Self, String> {
         let t0 = Instant::now();
-        let engine = TransferEngine::new(nic_names).map_err(|e| e.to_string())?;
+        let engine = TransferEngine::new(nic_names, qps_per_peer).map_err(|e| e.to_string())?;
 
         let regions: Vec<(NonNull<u8>, usize)> = allocator.memory_regions();
         let mr_descs: Vec<MemoryRegion> = regions
@@ -73,8 +77,9 @@ impl Drop for RdmaTransport {
 pub(crate) fn new_rdma(
     nic_names: &[String],
     allocator: &PinnedAllocator,
+    qps_per_peer: usize,
 ) -> Result<Arc<RdmaTransport>, String> {
-    RdmaTransport::new(nic_names, allocator)
+    RdmaTransport::new(nic_names, allocator, qps_per_peer)
         .map(Arc::new)
         .map_err(|e| format!("Failed to initialise RDMA transport (nics={nic_names:?}): {e}"))
 }

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -42,7 +42,7 @@ pub use pegaflow_common::NumaNode;
 use pegaflow_common::NumaTopology;
 pub use pinned_pool::PinnedAllocation;
 pub use seal_offload::SlotMeta;
-pub use storage::{MemoryCacheCleanupStats, StorageConfig};
+pub use storage::{DEFAULT_RDMA_QPS_PER_PEER, MemoryCacheCleanupStats, StorageConfig};
 pub use sync_state::{LoadState, LoadStateError};
 pub use trace::{set_trace_sample_rate, should_sample};
 

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -27,6 +27,7 @@ use read_cache::ReadCache;
 use write_path::{InsertDeps, WritePipeline};
 
 const RECLAIM_BATCH_SIZE: usize = 64;
+pub const DEFAULT_RDMA_QPS_PER_PEER: usize = 2;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct MemoryCacheCleanupStats {
@@ -47,9 +48,7 @@ pub struct StorageConfig {
     pub ssd_cache_config: Option<SsdCacheConfig>,
     /// Optional RDMA NIC names for inter-node transfer (e.g. `["mlx5_0", "mlx5_1"]`).
     pub rdma_nic_names: Option<Vec<String>>,
-    /// Number of RC QPs per (local NIC, remote NIC) pair. Used to spread WQE
-    /// pressure across QPs — small-msg workloads need 4–8 to hit the NIC PPS
-    /// ceiling. See `docs/resources/rdma-qp-count-impact.md`.
+    /// Number of RC QPs per (local NIC, remote NIC) pair.
     pub rdma_qps_per_peer: usize,
     /// Enable NUMA-aware memory allocation.
     pub enable_numa_affinity: bool,
@@ -77,7 +76,7 @@ impl Default for StorageConfig {
             max_prefetch_blocks: DEFAULT_MAX_PREFETCH_BLOCKS,
             ssd_cache_config: None,
             rdma_nic_names: None,
-            rdma_qps_per_peer: 2,
+            rdma_qps_per_peer: DEFAULT_RDMA_QPS_PER_PEER,
             enable_numa_affinity: true,
             blockwise_alloc: false,
             transfer_lock_timeout: Duration::from_secs(120),

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -47,6 +47,10 @@ pub struct StorageConfig {
     pub ssd_cache_config: Option<SsdCacheConfig>,
     /// Optional RDMA NIC names for inter-node transfer (e.g. `["mlx5_0", "mlx5_1"]`).
     pub rdma_nic_names: Option<Vec<String>>,
+    /// Number of RC QPs per (local NIC, remote NIC) pair. Used to spread WQE
+    /// pressure across QPs — small-msg workloads need 4–8 to hit the NIC PPS
+    /// ceiling. See `docs/resources/rdma-qp-count-impact.md`.
+    pub rdma_qps_per_peer: usize,
     /// Enable NUMA-aware memory allocation.
     pub enable_numa_affinity: bool,
     /// Allocate each block separately instead of contiguous batch allocation.
@@ -73,6 +77,7 @@ impl Default for StorageConfig {
             max_prefetch_blocks: DEFAULT_MAX_PREFETCH_BLOCKS,
             ssd_cache_config: None,
             rdma_nic_names: None,
+            rdma_qps_per_peer: 2,
             enable_numa_affinity: true,
             blockwise_alloc: false,
             transfer_lock_timeout: Duration::from_secs(120),
@@ -108,6 +113,7 @@ impl StorageEngine {
         let max_prefetch_blocks = config.max_prefetch_blocks;
         let ssd_cache_config = config.ssd_cache_config;
         let rdma_nic_names = config.rdma_nic_names;
+        let rdma_qps_per_peer = config.rdma_qps_per_peer;
         let blockwise_alloc = config.blockwise_alloc;
         let transfer_lock_timeout = config.transfer_lock_timeout;
 
@@ -171,7 +177,11 @@ impl StorageEngine {
         // RDMA transport must be created after the allocator so it can
         // register the pinned memory regions with the RDMA NICs.
         let rdma_transport = match rdma_nic_names.as_deref().filter(|nics| !nics.is_empty()) {
-            Some(nics) => Some(crate::backing::new_rdma(nics, &allocator)?),
+            Some(nics) => Some(crate::backing::new_rdma(
+                nics,
+                &allocator,
+                rdma_qps_per_peer,
+            )?),
             None => None,
         };
 

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -148,6 +148,11 @@ pub struct Cli {
     #[arg(long, value_delimiter = ',', value_parser = parse_nic_name, num_args = 1..)]
     pub nics: Option<Vec<String>>,
 
+    /// Number of RC QPs per (local NIC, remote NIC) pair. Spreads WQE pressure
+    /// across N QPs; see `docs/resources/rdma-qp-count-impact.md`. Range [1, 16].
+    #[arg(long, default_value_t = 2)]
+    pub qps_per_peer: usize,
+
     /// MetaServer address for cross-node block hash registration (e.g. http://127.0.0.1:50056).
     /// When set, sealed block hashes are automatically registered with the MetaServer.
     #[arg(long)]
@@ -524,6 +529,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         max_prefetch_blocks: cli.max_prefetch_blocks,
         ssd_cache_config,
         rdma_nic_names: cli.nics.clone(),
+        rdma_qps_per_peer: cli.qps_per_peer,
         enable_numa_affinity: !cli.disable_numa_affinity,
         blockwise_alloc: cli.blockwise_alloc,
         transfer_lock_timeout: Duration::from_secs(cli.transfer_lock_timeout_secs),

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -148,9 +148,8 @@ pub struct Cli {
     #[arg(long, value_delimiter = ',', value_parser = parse_nic_name, num_args = 1..)]
     pub nics: Option<Vec<String>>,
 
-    /// Number of RC QPs per (local NIC, remote NIC) pair. Spreads WQE pressure
-    /// across N QPs; see `docs/resources/rdma-qp-count-impact.md`. Range [1, 16].
-    #[arg(long, default_value_t = 2)]
+    /// Number of RC QPs per (local NIC, remote NIC) pair.
+    #[arg(long, default_value_t = pegaflow_core::DEFAULT_RDMA_QPS_PER_PEER)]
     pub qps_per_peer: usize,
 
     /// MetaServer address for cross-node block hash registration (e.g. http://127.0.0.1:50056).

--- a/pegaflow-transfer/src/bin/cpu_bench.rs
+++ b/pegaflow-transfer/src/bin/cpu_bench.rs
@@ -77,9 +77,7 @@ struct Cli {
     #[arg(long)]
     numa: Option<u32>,
 
-    /// QPs per peer per NIC; spreads WQE pressure across N QPs.
-    /// See `docs/resources/rdma-qp-count-impact.md` — small-msg workloads need
-    /// 4–8 to hit the NIC PPS ceiling; large-msg saturates at 2.
+    /// QPs per peer per NIC.
     #[arg(long, default_value_t = 2)]
     qps_per_peer: usize,
 }

--- a/pegaflow-transfer/src/bin/cpu_bench.rs
+++ b/pegaflow-transfer/src/bin/cpu_bench.rs
@@ -76,6 +76,12 @@ struct Cli {
     /// Restrict to a single NUMA node (e.g. 0).
     #[arg(long)]
     numa: Option<u32>,
+
+    /// QPs per peer per NIC; spreads WQE pressure across N QPs.
+    /// See `docs/resources/rdma-qp-count-impact.md` — small-msg workloads need
+    /// 4–8 to hit the NIC PPS ceiling; large-msg saturates at 2.
+    #[arg(long, default_value_t = 2)]
+    qps_per_peer: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -511,13 +517,14 @@ fn create_engine_context(
     numa_node: u32,
     buf_size: usize,
     use_hugepages: bool,
+    qps_per_peer: usize,
 ) -> EngineContext {
     let server_buf = NumaBuffer::alloc(numa_node, buf_size, use_hugepages);
     let client_buf = NumaBuffer::alloc(numa_node, buf_size, use_hugepages);
     server_buf.fill(0xAA);
     client_buf.fill(0xBB);
 
-    let server = TransferEngine::new(nic_names).expect("server init failed");
+    let server = TransferEngine::new(nic_names, qps_per_peer).expect("server init failed");
     server
         .register_memory(&[MemoryRegion {
             ptr: server_buf.ptr,
@@ -525,7 +532,7 @@ fn create_engine_context(
         }])
         .expect("server register_memory failed");
 
-    let client = TransferEngine::new(nic_names).expect("client init failed");
+    let client = TransferEngine::new(nic_names, qps_per_peer).expect("client init failed");
     client
         .register_memory(&[MemoryRegion {
             ptr: client_buf.ptr,
@@ -728,6 +735,7 @@ fn main() {
                     group.node.0,
                     pool_size,
                     cli.use_hugepages,
+                    cli.qps_per_peer,
                 );
                 println!("  {} ready (handshake complete)", nic.name);
                 if op == TransferOp::Read {
@@ -755,6 +763,7 @@ fn main() {
                     group.node.0,
                     pool_size,
                     cli.use_hugepages,
+                    cli.qps_per_peer,
                 );
                 println!(
                     "  multi-NIC engine ready ({} NICs, handshake complete)",

--- a/pegaflow-transfer/src/engine.rs
+++ b/pegaflow-transfer/src/engine.rs
@@ -44,10 +44,13 @@ pub(crate) struct RegisteredMemoryRegion {
     pub(crate) rkey: u32,
 }
 
-/// Per-NIC handshake data: endpoint + memory region snapshot.
+/// Per-NIC handshake data: N endpoints (one per QP) + memory region snapshot.
+///
+/// The same NIC pair maintains N RC QPs so the caller can spread load across
+/// them. Both peers must agree on N (set via `qps_per_peer` at backend init).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct NicHandshake {
-    pub(crate) endpoint: RcEndpoint,
+    pub(crate) endpoints: Vec<RcEndpoint>,
     pub(crate) memory_regions: Vec<RegisteredMemoryRegion>,
 }
 
@@ -105,9 +108,9 @@ pub struct TransferEngine {
 }
 
 impl TransferEngine {
-    pub fn new(nic_names: &[String]) -> Result<Self> {
+    pub fn new(nic_names: &[String], qps_per_peer: usize) -> Result<Self> {
         Ok(Self {
-            backend: RcBackend::new(nic_names)?,
+            backend: RcBackend::new(nic_names, qps_per_peer)?,
         })
     }
 
@@ -195,12 +198,12 @@ mod tests {
     fn handshake_metadata_roundtrip() {
         let meta = HandshakeMetadata {
             nics: vec![NicHandshake {
-                endpoint: RcEndpoint {
+                endpoints: vec![RcEndpoint {
                     gid: [7u8; 16],
                     lid: 0,
                     qp_num: 200,
                     psn: 0x1111,
-                },
+                }],
                 memory_regions: vec![RegisteredMemoryRegion {
                     base_ptr: 0x1000,
                     len: 0x2000,
@@ -211,21 +214,29 @@ mod tests {
         let bytes = meta.to_bytes();
         let decoded = HandshakeMetadata::from_bytes(&bytes).expect("decode");
         assert_eq!(decoded.nics.len(), 1);
-        assert_eq!(decoded.nics[0].endpoint, meta.nics[0].endpoint);
+        assert_eq!(decoded.nics[0].endpoints, meta.nics[0].endpoints);
         assert_eq!(decoded.nics[0].memory_regions, meta.nics[0].memory_regions);
     }
 
     #[test]
-    fn handshake_metadata_multi_nic_roundtrip() {
+    fn handshake_metadata_multi_nic_multi_qp_roundtrip() {
         let meta = HandshakeMetadata {
             nics: vec![
                 NicHandshake {
-                    endpoint: RcEndpoint {
-                        gid: [1u8; 16],
-                        lid: 0,
-                        qp_num: 100,
-                        psn: 0x1000,
-                    },
+                    endpoints: vec![
+                        RcEndpoint {
+                            gid: [1u8; 16],
+                            lid: 0,
+                            qp_num: 100,
+                            psn: 0x1000,
+                        },
+                        RcEndpoint {
+                            gid: [1u8; 16],
+                            lid: 0,
+                            qp_num: 101,
+                            psn: 0x1001,
+                        },
+                    ],
                     memory_regions: vec![RegisteredMemoryRegion {
                         base_ptr: 0x1000,
                         len: 0x2000,
@@ -233,12 +244,20 @@ mod tests {
                     }],
                 },
                 NicHandshake {
-                    endpoint: RcEndpoint {
-                        gid: [2u8; 16],
-                        lid: 0,
-                        qp_num: 200,
-                        psn: 0x2000,
-                    },
+                    endpoints: vec![
+                        RcEndpoint {
+                            gid: [2u8; 16],
+                            lid: 0,
+                            qp_num: 200,
+                            psn: 0x2000,
+                        },
+                        RcEndpoint {
+                            gid: [2u8; 16],
+                            lid: 0,
+                            qp_num: 201,
+                            psn: 0x2001,
+                        },
+                    ],
                     memory_regions: vec![RegisteredMemoryRegion {
                         base_ptr: 0x1000,
                         len: 0x2000,
@@ -250,10 +269,11 @@ mod tests {
         let bytes = meta.to_bytes();
         let decoded = HandshakeMetadata::from_bytes(&bytes).expect("decode");
         assert_eq!(decoded.nics.len(), 2);
-        assert_eq!(decoded.nics[0].endpoint.qp_num, 100);
-        assert_eq!(decoded.nics[0].memory_regions[0].rkey, 10);
-        assert_eq!(decoded.nics[1].endpoint.qp_num, 200);
-        assert_eq!(decoded.nics[1].memory_regions[0].rkey, 20);
+        assert_eq!(decoded.nics[0].endpoints.len(), 2);
+        assert_eq!(decoded.nics[0].endpoints[0].qp_num, 100);
+        assert_eq!(decoded.nics[0].endpoints[1].qp_num, 101);
+        assert_eq!(decoded.nics[1].endpoints[0].qp_num, 200);
+        assert_eq!(decoded.nics[1].endpoints[1].qp_num, 201);
     }
 
     #[test]

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -461,8 +461,10 @@ impl RcBackend {
                     "no connection for remote addr {remote_addr}"
                 )))?;
 
-            // Prepare ops for each NIC that has work; pick one of the N sessions
-            // for that NIC via round-robin to spread WQE pressure across QPs.
+            // Spread ops across the N sessions per NIC. Round-robin at the WQE
+            // (per-op) level inside the batch — not per call — so a single
+            // batch can fill all N QPs. Per-call RR would leave the rest of the
+            // QPs idle while one QP works through the whole batch.
             for nic_idx in 0..nic_count {
                 let nic_descs = &per_nic[nic_idx];
                 if nic_descs.is_empty() {
@@ -474,11 +476,16 @@ impl RcBackend {
                     .sessions
                     .get(&remote_first_qpn)
                     .expect("session vec must exist for established connection");
-                let rr = conn.rr_counters[nic_idx].fetch_add(1, Ordering::Relaxed);
-                let session = Arc::clone(&sessions[rr % sessions.len()]);
+                let n = sessions.len();
+                // Rotate the starting bucket each call so small batches still
+                // hit different QPs across calls.
+                let rot = conn.rr_counters[nic_idx].fetch_add(1, Ordering::Relaxed);
 
-                let mut prepared = Vec::with_capacity(nic_descs.len());
-                for desc in nic_descs {
+                let per_bucket = nic_descs.len().div_ceil(n);
+                let mut buckets: Vec<Vec<RdmaOp>> =
+                    (0..n).map(|_| Vec::with_capacity(per_bucket)).collect();
+
+                for (i, desc) in nic_descs.iter().enumerate() {
                     let local_ptr = desc.local_ptr.as_ptr() as u64;
                     let remote_ptr = desc.remote_ptr.as_ptr() as u64;
                     let len = desc.len;
@@ -497,7 +504,8 @@ impl RcBackend {
                             "remote memory not found in handshake snapshot",
                         ))?;
 
-                    prepared.push(RdmaOp {
+                    let bucket = rot.wrapping_add(i) % n;
+                    buckets[bucket].push(RdmaOp {
                         local_mr,
                         local_ptr,
                         remote_ptr,
@@ -505,7 +513,13 @@ impl RcBackend {
                         remote_rkey,
                     });
                 }
-                nic_work.push((session, prepared));
+
+                for (q_idx, prepared) in buckets.into_iter().enumerate() {
+                    if prepared.is_empty() {
+                        continue;
+                    }
+                    nic_work.push((Arc::clone(&sessions[q_idx]), prepared));
+                }
             }
         }
         let lookup_dur = lookup_start.elapsed();

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -98,18 +98,29 @@ pub(crate) enum GetOrPrepareResult {
     NeedHandshake(Vec<NicHandshake>),
 }
 
+/// Hard upper bound for QPs per peer per NIC. Each session owns a worker thread
+/// + a CQ; going wild here burns RAM and CPU. The RDMA QP-count sweep on CX-7
+/// (`docs/resources/rdma-qp-count-impact.md`) showed no benefit beyond 8.
+const MAX_QPS_PER_PEER: usize = 16;
+
 pub(crate) struct RcBackend {
     runtimes: Vec<Arc<RcRuntime>>,
     state: Arc<Mutex<RcBackendState>>,
     psn_counter: AtomicU64,
     numa_rr: NumaRoundRobin,
+    qps_per_peer: usize,
 }
 
 impl RcBackend {
-    pub(crate) fn new(nic_names: &[String]) -> Result<Self> {
+    pub(crate) fn new(nic_names: &[String], qps_per_peer: usize) -> Result<Self> {
         crate::init_logging();
         if nic_names.is_empty() {
             return Err(TransferError::InvalidArgument("nic_names is empty"));
+        }
+        if qps_per_peer == 0 || qps_per_peer > MAX_QPS_PER_PEER {
+            return Err(TransferError::InvalidArgument(
+                "qps_per_peer must be in [1, 16]",
+            ));
         }
         let mut runtimes = Vec::with_capacity(nic_names.len());
         for name in nic_names {
@@ -121,11 +132,16 @@ impl RcBackend {
         }
         let nic_count = runtimes.len();
         let numa_rr = NumaRoundRobin::from_runtimes(&runtimes);
+        info!(
+            "RC backend init: nics={}, qps_per_peer={}",
+            nic_count, qps_per_peer
+        );
         Ok(Self {
             runtimes,
             state: Arc::new(Mutex::new(RcBackendState::new(nic_count))),
             psn_counter: AtomicU64::new(1),
             numa_rr,
+            qps_per_peer,
         })
     }
 
@@ -202,31 +218,36 @@ impl RcBackend {
             .collect()
     }
 
-    /// Create one RC QP per NIC in INIT state, push to per-NIC pending queues,
-    /// return per-NIC handshake data.
+    /// Create N RC QPs per NIC in INIT state, push to per-NIC pending queues,
+    /// return per-NIC handshake data (each NIC carries N endpoints).
     fn prepare_handshake(&self) -> Result<Vec<NicHandshake>> {
         let snapshots = self.snapshot_registered_memory();
         let mut nic_handshakes = Vec::with_capacity(self.nic_count());
 
-        // Create all QPs before locking state.
-        let mut sessions = Vec::with_capacity(self.nic_count());
-        for runtime in &self.runtimes {
-            let psn_seed = self.psn_counter.fetch_add(1, Ordering::Relaxed);
-            let session = RcSession::create(runtime, psn_seed).map_err(|e| {
-                TransferError::Backend(format!(
-                    "QP creation failed on nic={}: {e}",
-                    runtime.nic_name
-                ))
-            })?;
-            sessions.push(session);
+        // Create all NIC × N QPs before locking state.
+        let mut sessions_per_nic: Vec<Vec<Arc<RcSession>>> =
+            (0..self.nic_count()).map(|_| Vec::new()).collect();
+        for (nic_idx, runtime) in self.runtimes.iter().enumerate() {
+            for qp_idx in 0..self.qps_per_peer {
+                let psn_seed = self.psn_counter.fetch_add(1, Ordering::Relaxed);
+                let session = RcSession::create(runtime, psn_seed).map_err(|e| {
+                    TransferError::Backend(format!(
+                        "QP creation failed on nic={} qp_idx={qp_idx}: {e}",
+                        runtime.nic_name
+                    ))
+                })?;
+                sessions_per_nic[nic_idx].push(session);
+            }
         }
 
         let mut state = self.state.lock();
-        for (nic_idx, session) in sessions.into_iter().enumerate() {
-            let endpoint = session.local_endpoint;
-            state.nics[nic_idx].pending.push_back(session);
+        for (nic_idx, sessions) in sessions_per_nic.into_iter().enumerate() {
+            let endpoints: Vec<_> = sessions.iter().map(|s| s.local_endpoint).collect();
+            for s in sessions {
+                state.nics[nic_idx].pending.push_back(s);
+            }
             nic_handshakes.push(NicHandshake {
-                endpoint,
+                endpoints,
                 memory_regions: snapshots[nic_idx].clone(),
             });
         }
@@ -269,59 +290,88 @@ impl RcBackend {
                 "remote NIC count mismatch in handshake",
             ));
         }
+        for (nic_idx, nic) in remote_nics.iter().enumerate() {
+            if nic.endpoints.len() != self.qps_per_peer {
+                return Err(TransferError::Backend(format!(
+                    "remote qps_per_peer mismatch on nic={nic_idx}: local={}, remote={}",
+                    self.qps_per_peer,
+                    nic.endpoints.len()
+                )));
+            }
+        }
 
         // Pop pending sessions by matching QPN from local_nics (not blind FIFO).
         // Concurrent prepare/complete for different remote addrs could reorder the
         // queue, so we must find our own sessions by QPN.
-        let pending: Vec<Arc<RcSession>> = {
+        let pending: Vec<Vec<Arc<RcSession>>> = {
             let mut state = self.state.lock();
             // If already connected (concurrent request beat us), remove our pending sessions
             if state.addr_connections.contains_key(remote_addr) {
                 for (nic_idx, nic) in local_nics.iter().enumerate() {
-                    state.nics[nic_idx].remove_pending_by_qpn(nic.endpoint.qp_num);
+                    for ep in &nic.endpoints {
+                        state.nics[nic_idx].remove_pending_by_qpn(ep.qp_num);
+                    }
                 }
                 state.connecting.remove(remote_addr);
                 info!("handshake won by concurrent path: remote={remote_addr}");
                 return Ok(());
             }
-            let mut sessions = Vec::with_capacity(nic_count);
+            let mut sessions_per_nic: Vec<Vec<Arc<RcSession>>> =
+                (0..nic_count).map(|_| Vec::with_capacity(self.qps_per_peer)).collect();
             for (nic_idx, nic) in local_nics.iter().enumerate() {
-                let session = state.nics[nic_idx]
-                    .remove_pending_by_qpn(nic.endpoint.qp_num)
-                    .ok_or(TransferError::Backend(
-                        "no pending session to complete".to_string(),
-                    ))?;
-                sessions.push(session);
+                for ep in &nic.endpoints {
+                    let session = state.nics[nic_idx]
+                        .remove_pending_by_qpn(ep.qp_num)
+                        .ok_or(TransferError::Backend(
+                            "no pending session to complete".to_string(),
+                        ))?;
+                    sessions_per_nic[nic_idx].push(session);
+                }
             }
-            sessions
+            sessions_per_nic
         };
 
-        // Connect outside lock
-        for (nic_idx, session) in pending.iter().enumerate() {
-            session.connect(&self.runtimes[nic_idx], &remote_nics[nic_idx].endpoint)?;
+        // Connect outside lock — pair local QP i with remote QP i in handshake order.
+        for (nic_idx, sessions) in pending.iter().enumerate() {
+            let remote_eps = &remote_nics[nic_idx].endpoints;
+            for (qp_idx, session) in sessions.iter().enumerate() {
+                session.connect(&self.runtimes[nic_idx], &remote_eps[qp_idx])?;
+            }
         }
 
         // Store sessions + addr_connections
         let mut state = self.state.lock();
-        let mut remote_qpns = Vec::with_capacity(nic_count);
-        for (nic_idx, session) in pending.into_iter().enumerate() {
+        let mut remote_first_qpns = Vec::with_capacity(nic_count);
+        for (nic_idx, sessions) in pending.into_iter().enumerate() {
             let remote = &remote_nics[nic_idx];
-            let remote_qpn = remote.endpoint.qp_num;
-            state.nics[nic_idx].cache_remote_memory(remote_qpn, &remote.memory_regions)?;
-            state.nics[nic_idx].sessions.insert(remote_qpn, session);
-            remote_qpns.push(remote_qpn);
+            let remote_first_qpn = remote.endpoints[0].qp_num;
+            state.nics[nic_idx].cache_remote_memory(remote_first_qpn, &remote.memory_regions)?;
+            state.nics[nic_idx]
+                .sessions
+                .insert(remote_first_qpn, sessions);
+            remote_first_qpns.push(remote_first_qpn);
         }
         let removed = state.connecting.remove(remote_addr);
         debug_assert!(removed, "connecting set should contain {remote_addr}");
-        let local_qpns: Vec<u32> = local_nics.iter().map(|n| n.endpoint.qp_num).collect();
+        let local_qpns: Vec<Vec<u32>> = local_nics
+            .iter()
+            .map(|n| n.endpoints.iter().map(|e| e.qp_num).collect())
+            .collect();
+        let remote_qpns: Vec<Vec<u32>> = remote_nics
+            .iter()
+            .map(|n| n.endpoints.iter().map(|e| e.qp_num).collect())
+            .collect();
         info!(
-            "RDMA connection established: remote={remote_addr}, local_qpns={local_qpns:?}, remote_qpns={remote_qpns:?}"
+            "RDMA connection established: remote={remote_addr}, qps_per_peer={}, local_qpns={local_qpns:?}, remote_qpns={remote_qpns:?}",
+            self.qps_per_peer
         );
+        let rr_counters = (0..nic_count).map(|_| AtomicUsize::new(0)).collect();
         state.addr_connections.insert(
             remote_addr.to_string(),
             AddrConnection {
-                remote_qpns,
+                remote_first_qpns,
                 local_nics,
+                rr_counters,
             },
         );
         Ok(())
@@ -333,7 +383,9 @@ impl RcBackend {
         let removed = state.connecting.remove(remote_addr);
         debug_assert!(removed, "connecting set should contain {remote_addr}");
         for (nic_idx, nic) in local_nics.iter().enumerate() {
-            state.nics[nic_idx].remove_pending_by_qpn(nic.endpoint.qp_num);
+            for ep in &nic.endpoints {
+                state.nics[nic_idx].remove_pending_by_qpn(ep.qp_num);
+            }
         }
         warn!("handshake aborted: remote={remote_addr}");
     }
@@ -351,8 +403,8 @@ impl RcBackend {
     pub(crate) fn invalidate_connection(&self, remote_addr: &str) {
         let mut state = self.state.lock();
         if let Some(conn) = state.addr_connections.remove(remote_addr) {
-            for (nic_idx, &remote_qpn) in conn.remote_qpns.iter().enumerate() {
-                state.nics[nic_idx].cleanup_connection(remote_qpn);
+            for (nic_idx, &remote_first_qpn) in conn.remote_first_qpns.iter().enumerate() {
+                state.nics[nic_idx].cleanup_connection(remote_first_qpn);
             }
             info!("connection invalidated: remote={remote_addr}");
         }
@@ -408,22 +460,22 @@ impl RcBackend {
                 .ok_or(TransferError::Backend(format!(
                     "no connection for remote addr {remote_addr}"
                 )))?;
-            let remote_qpns = &conn.remote_qpns;
 
-            // Prepare ops for each NIC that has work.
+            // Prepare ops for each NIC that has work; pick one of the N sessions
+            // for that NIC via round-robin to spread WQE pressure across QPs.
             for nic_idx in 0..nic_count {
                 let nic_descs = &per_nic[nic_idx];
                 if nic_descs.is_empty() {
                     continue;
                 }
 
-                let remote_qpn = remote_qpns[nic_idx];
-                let session = Arc::clone(
-                    state.nics[nic_idx]
-                        .sessions
-                        .get(&remote_qpn)
-                        .expect("session must exist for established connection"),
-                );
+                let remote_first_qpn = conn.remote_first_qpns[nic_idx];
+                let sessions = state.nics[nic_idx]
+                    .sessions
+                    .get(&remote_first_qpn)
+                    .expect("session vec must exist for established connection");
+                let rr = conn.rr_counters[nic_idx].fetch_add(1, Ordering::Relaxed);
+                let session = Arc::clone(&sessions[rr % sessions.len()]);
 
                 let mut prepared = Vec::with_capacity(nic_descs.len());
                 for desc in nic_descs {
@@ -440,7 +492,7 @@ impl RcBackend {
                         .ok_or(TransferError::MemoryNotRegistered { ptr: local_ptr })?;
 
                     let remote_rkey = state.nics[nic_idx]
-                        .find_remote_rkey(remote_qpn, remote_ptr, len)
+                        .find_remote_rkey(remote_first_qpn, remote_ptr, len)
                         .ok_or(TransferError::InvalidArgument(
                             "remote memory not found in handshake snapshot",
                         ))?;

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -98,11 +98,6 @@ pub(crate) enum GetOrPrepareResult {
     NeedHandshake(Vec<NicHandshake>),
 }
 
-/// Hard upper bound for QPs per peer per NIC. Each session owns a worker thread
-/// + a CQ; going wild here burns RAM and CPU. The RDMA QP-count sweep on CX-7
-/// (`docs/resources/rdma-qp-count-impact.md`) showed no benefit beyond 8.
-const MAX_QPS_PER_PEER: usize = 16;
-
 pub(crate) struct RcBackend {
     runtimes: Vec<Arc<RcRuntime>>,
     state: Arc<Mutex<RcBackendState>>,
@@ -117,10 +112,8 @@ impl RcBackend {
         if nic_names.is_empty() {
             return Err(TransferError::InvalidArgument("nic_names is empty"));
         }
-        if qps_per_peer == 0 || qps_per_peer > MAX_QPS_PER_PEER {
-            return Err(TransferError::InvalidArgument(
-                "qps_per_peer must be in [1, 16]",
-            ));
+        if qps_per_peer == 0 {
+            return Err(TransferError::InvalidArgument("qps_per_peer must be > 0"));
         }
         let mut runtimes = Vec::with_capacity(nic_names.len());
         for name in nic_names {
@@ -316,15 +309,14 @@ impl RcBackend {
                 info!("handshake won by concurrent path: remote={remote_addr}");
                 return Ok(());
             }
-            let mut sessions_per_nic: Vec<Vec<Arc<RcSession>>> =
-                (0..nic_count).map(|_| Vec::with_capacity(self.qps_per_peer)).collect();
+            let mut sessions_per_nic: Vec<Vec<Arc<RcSession>>> = (0..nic_count)
+                .map(|_| Vec::with_capacity(self.qps_per_peer))
+                .collect();
             for (nic_idx, nic) in local_nics.iter().enumerate() {
                 for ep in &nic.endpoints {
-                    let session = state.nics[nic_idx]
-                        .remove_pending_by_qpn(ep.qp_num)
-                        .ok_or(TransferError::Backend(
-                            "no pending session to complete".to_string(),
-                        ))?;
+                    let session = state.nics[nic_idx].remove_pending_by_qpn(ep.qp_num).ok_or(
+                        TransferError::Backend("no pending session to complete".to_string()),
+                    )?;
                     sessions_per_nic[nic_idx].push(session);
                 }
             }
@@ -461,12 +453,9 @@ impl RcBackend {
                     "no connection for remote addr {remote_addr}"
                 )))?;
 
-            // Spread ops across the N sessions per NIC. Round-robin at the WQE
-            // (per-op) level inside the batch — not per call — so a single
-            // batch can fill all N QPs. Per-call RR would leave the rest of the
-            // QPs idle while one QP works through the whole batch.
-            for nic_idx in 0..nic_count {
-                let nic_descs = &per_nic[nic_idx];
+            // Per-WQE round-robin across the N sessions per NIC so a single
+            // batch can fill all N QPs (per-call RR would leave the rest idle).
+            for (nic_idx, nic_descs) in per_nic.iter().enumerate() {
                 if nic_descs.is_empty() {
                     continue;
                 }

--- a/pegaflow-transfer/src/rc_backend/state.rs
+++ b/pegaflow-transfer/src/rc_backend/state.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
 
 use sideway::ibverbs::memory_region::MemoryRegion;
 
@@ -22,27 +23,30 @@ struct RemoteMemoryEntry {
 }
 
 /// Per-NIC state: pending/connected sessions and remote memory cache.
+///
+/// With per-peer N QPs, `sessions` and `remote_memory` are keyed by the
+/// **first** remote QPN of that NIC pair — this is the stable connection id.
 #[derive(Default)]
 pub(super) struct PerNicState {
     /// Pre-connect sessions in FIFO order (first prepared, first connected).
     pub(super) pending: VecDeque<Arc<RcSession>>,
-    /// Connected sessions keyed by remote QP number.
-    pub(super) sessions: HashMap<u32, Arc<RcSession>>,
-    /// Remote memory cache keyed by remote QP number.
+    /// Connected session vectors keyed by first remote QPN; each Vec has N sessions.
+    pub(super) sessions: HashMap<u32, Vec<Arc<RcSession>>>,
+    /// Remote memory cache keyed by first remote QPN (shared across the N sessions).
     remote_memory: HashMap<u32, Vec<RemoteMemoryEntry>>,
 }
 
 impl PerNicState {
     /// Look up the remote rkey for `[remote_ptr, remote_ptr+len)` from the
-    /// handshake snapshot cached for `remote_qpn`.
+    /// handshake snapshot cached for `remote_first_qpn`.
     pub(super) fn find_remote_rkey(
         &self,
-        remote_qpn: u32,
+        remote_first_qpn: u32,
         remote_ptr: u64,
         len: usize,
     ) -> Option<u32> {
         let end = remote_ptr.checked_add(len as u64)?;
-        let entries = self.remote_memory.get(&remote_qpn)?;
+        let entries = self.remote_memory.get(&remote_first_qpn)?;
         let index = match entries.binary_search_by_key(&remote_ptr, |e| e.base_ptr) {
             Ok(i) => i,
             Err(0) => return None,
@@ -65,15 +69,15 @@ impl PerNicState {
         self.pending.remove(pos)
     }
 
-    pub(super) fn cleanup_connection(&mut self, remote_qpn: u32) {
-        self.sessions.remove(&remote_qpn);
-        self.remote_memory.remove(&remote_qpn);
+    pub(super) fn cleanup_connection(&mut self, remote_first_qpn: u32) {
+        self.sessions.remove(&remote_first_qpn);
+        self.remote_memory.remove(&remote_first_qpn);
     }
 
     /// Validate and cache the remote memory regions received during handshake.
     pub(super) fn cache_remote_memory(
         &mut self,
-        remote_qpn: u32,
+        remote_first_qpn: u32,
         remote_memory_regions: &[RegisteredMemoryRegion],
     ) -> Result<()> {
         let mut cached = Vec::with_capacity(remote_memory_regions.len());
@@ -102,14 +106,17 @@ impl PerNicState {
                 ));
             }
         }
-        self.remote_memory.insert(remote_qpn, cached);
+        self.remote_memory.insert(remote_first_qpn, cached);
         Ok(())
     }
 }
 
 pub(super) struct AddrConnection {
-    pub(super) remote_qpns: Vec<u32>,
+    /// First remote QPN per NIC — stable id used to key sessions/remote_memory.
+    pub(super) remote_first_qpns: Vec<u32>,
     pub(super) local_nics: Vec<NicHandshake>,
+    /// Round-robin counter per NIC for picking among the N sessions of that pair.
+    pub(super) rr_counters: Vec<AtomicUsize>,
 }
 
 pub(super) struct RcBackendState {


### PR DESCRIPTION
## Summary
- Expand each (local NIC, remote NIC) pair from 1 RC QP to N (default N=2). `qps_per_peer` is configured explicitly via `pegaflow-server --qps-per-peer` / `TransferEngine::new` / `pegaflow-cpu-bench --qps-per-peer`; the handshake validates that both sides agree on N.
- `batch_transfer_async` round-robins **at the WQE level** within a single batch across N sessions (not at the per-call level), so a single in-flight task can keep all N QPs busy. A rotating start avoids small batches always landing on the first QP.
- `pegaflow-cpu-bench` exposes `--qps-per-peer` for reproducing and validating the result.

## Background

`docs/resources/rdma-qp-count-impact.md` (perftest sweep) shows a single RC QP cannot saturate CX-7 on large messages: 4 MB WRITE 1-QP 365 Gbps vs 2-QP 392 Gbps; 4 MB READ 1-QP 320 vs 2-QP 390 (root cause for READ is the `max_rd_atomic=16` window).

h20-100 loopback validation with `pegaflow-cpu-bench` at 4 MB:

| QP/peer | WRITE 1-NIC | WRITE 2-NIC | READ 1-NIC | READ 2-NIC |
|---|---|---|---|---|
| 1 | 361 | 719 | 322 | 644 |
| 2 | **374** | **745** | **374** | **744** |
| 4 | 375 | 747 | 375 | 747 |
| 8 | 375 | 747 | 375 | 747 |

READ catches up to WRITE at the wire ceiling. Default 2 is sufficient; going beyond 2 brings no benefit (the extra worker threads are not worth it).

## Test plan
- [x] `cargo test -p pegaflow-transfer` (state.rs / engine.rs unit tests cover the handshake schema change and the remote memory snapshot)
- [x] h20-100 loopback `pegaflow-cpu-bench --exclude-nic mlx5_0 --qps-per-peer {1,2,4,8} --block-size 4mb` — numbers as above
- [ ] Real cross-node run (h20-100 <-> h20-99) — to be added before merge or by the reviewer
- [ ] vLLM connector path with default N=2 does not break e2e (relies on the server CLI pass-through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
