### PR TITLE
fix(connector): handle split physical kv blocks

### DIFF
--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -8,7 +8,7 @@ import threading
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import torch
 
@@ -45,6 +45,94 @@ if _LOAD_TIMEOUT_RAW < _LOAD_TIMEOUT_FLOOR_SECONDS:
 class SaveTask:
     metadata: PegaConnectorMetadata
     request_ids: list[str]
+
+
+_KVCacheLayout = Literal["KV-first", "blocks-first"]
+
+
+@dataclass(frozen=True)
+class _KVCacheRegistrationInfo:
+    layout: _KVCacheLayout
+    num_blocks: int
+    bytes_per_block: int
+    kv_stride_bytes: int
+    segments: int
+    physical_blocks_per_logical_block: int
+
+
+def _infer_kv_cache_registration(
+    kv_cache: torch.Tensor,
+    logical_block_size: int,
+    *,
+    is_mla: bool = False,
+) -> _KVCacheRegistrationInfo:
+    """Infer the PegaFlow registration from a vLLM KV cache tensor.
+
+    vLLM may split one scheduler/manager block into multiple kernel KV rows
+    when the attention backend only supports a smaller kernel block size. For
+    example, FlashMLA supports 64-token kernel blocks while the manager can use
+    128-token blocks. PegaFlow stores hashes at scheduler-block granularity, so
+    each registered PegaFlow block must cover all physical rows for that logical
+    block.
+    """
+    shape = tuple(kv_cache.shape)
+    stride = tuple(kv_cache.stride())
+    element_size = kv_cache.element_size()
+
+    if logical_block_size <= 0:
+        raise ValueError(f"logical block size must be > 0, got {logical_block_size}")
+
+    if not is_mla and len(shape) >= 2 and shape[0] == 2:
+        layout = "KV-first"
+        physical_num_blocks = shape[1]
+        physical_block_size = shape[2] if len(shape) >= 3 else logical_block_size
+        physical_bytes_per_block = stride[1] * element_size
+        kv_stride_bytes = stride[0] * element_size
+        segments = 2
+    else:
+        layout = "blocks-first"
+        physical_num_blocks = shape[0]
+        if len(shape) >= 3 and shape[1] == 2:
+            physical_block_size = shape[2]
+        else:
+            physical_block_size = shape[1] if len(shape) >= 2 else logical_block_size
+        physical_bytes_per_block = stride[0] * element_size
+        kv_stride_bytes = 0
+        segments = 1
+
+    if physical_num_blocks <= 0:
+        raise ValueError(
+            f"physical block count must be > 0, got {physical_num_blocks}"
+        )
+    if physical_block_size <= 0:
+        raise ValueError(
+            f"physical block size must be > 0, got {physical_block_size}"
+        )
+    if logical_block_size % physical_block_size != 0:
+        raise ValueError(
+            "logical block size must be a multiple of physical block size "
+            f"(logical={logical_block_size}, physical={physical_block_size})"
+        )
+
+    physical_blocks_per_logical_block = logical_block_size // physical_block_size
+    if physical_num_blocks % physical_blocks_per_logical_block != 0:
+        raise ValueError(
+            "physical block count must be divisible by physical/logical split ratio "
+            f"(physical_blocks={physical_num_blocks}, ratio={physical_blocks_per_logical_block})"
+        )
+
+    bytes_per_block = physical_bytes_per_block * physical_blocks_per_logical_block
+    if bytes_per_block == 0:
+        raise ValueError(f"Invalid bytes_per_block: shape={shape} stride={stride}")
+
+    return _KVCacheRegistrationInfo(
+        layout=layout,
+        num_blocks=physical_num_blocks // physical_blocks_per_logical_block,
+        bytes_per_block=bytes_per_block,
+        kv_stride_bytes=kv_stride_bytes,
+        segments=segments,
+        physical_blocks_per_logical_block=physical_blocks_per_logical_block,
+    )
 
 
 class WorkerConnector:
@@ -141,6 +229,9 @@ class WorkerConnector:
         layer_bytes_per_block = []
         layer_kv_stride_bytes = []
         layer_segments = []
+        split_layer_count = 0
+        split_blocks_per_logical = 1
+        split_logical_blocks = 0
 
         for layer_name, kv_cache in kv_caches.items():
             assert kv_cache.storage_offset() == 0, (
@@ -150,33 +241,34 @@ class WorkerConnector:
             wrapper = CudaIPCWrapper(kv_cache)
             wrapper_bytes = pickle.dumps(wrapper)
 
-            shape = tuple(kv_cache.shape)
-            stride = tuple(kv_cache.stride())
-            element_size = kv_cache.element_size()
-
-            if len(shape) >= 2 and shape[0] == 2:
-                num_blocks = shape[1]
-                bytes_per_block = stride[1] * element_size
-                kv_stride_bytes = stride[0] * element_size
-                segments = 2
-                layout = "KV-first"
-            else:
-                num_blocks = shape[0]
-                bytes_per_block = stride[0] * element_size
-                kv_stride_bytes = 0
-                segments = 1
-                layout = "blocks-first"
-
-            assert bytes_per_block != 0, (
-                f"Invalid bytes_per_block for {layer_name}: stride={stride}"
+            registration = _infer_kv_cache_registration(
+                kv_cache,
+                self._ctx.block_size,
+                is_mla=self._ctx.is_mla,
             )
+            layout = registration.layout
 
             layer_names.append(layer_name)
             ipc_wrappers.append(wrapper_bytes)
-            layer_num_blocks.append(num_blocks)
-            layer_bytes_per_block.append(bytes_per_block)
-            layer_kv_stride_bytes.append(kv_stride_bytes)
-            layer_segments.append(segments)
+            layer_num_blocks.append(registration.num_blocks)
+            layer_bytes_per_block.append(registration.bytes_per_block)
+            layer_kv_stride_bytes.append(registration.kv_stride_bytes)
+            layer_segments.append(registration.segments)
+
+            if registration.physical_blocks_per_logical_block > 1:
+                split_layer_count += 1
+                split_blocks_per_logical = (
+                    registration.physical_blocks_per_logical_block
+                )
+                split_logical_blocks = registration.num_blocks
+                logger.debug(
+                    "[PegaKVConnector] Registered %s with virtual block split: "
+                    "logical_block_size=%d physical_blocks_per_logical=%d logical_blocks=%d",
+                    layer_name,
+                    self._ctx.block_size,
+                    registration.physical_blocks_per_logical_block,
+                    registration.num_blocks,
+                )
 
         ok, message = self._ctx.engine_client.register_context_batch(
             self._ctx.instance_id,
@@ -197,6 +289,18 @@ class WorkerConnector:
 
         if not ok:
             raise RuntimeError(f"Register context failed for {layer_name}: {message}")
+
+        if split_layer_count:
+            logger.info(
+                "[PegaKVConnector] Registered %d/%d KV cache layers with virtual "
+                "block split: logical_block_size=%d physical_blocks_per_logical=%d "
+                "logical_blocks=%d",
+                split_layer_count,
+                len(kv_caches),
+                self._ctx.block_size,
+                split_blocks_per_logical,
+                split_logical_blocks,
+            )
 
         logger.debug(
             "[PegaKVConnector] Registered %d KV cache layers (%s layout) instance=%s",

--- a/python/tests/test_worker_kv_layout.py
+++ b/python/tests/test_worker_kv_layout.py
@@ -1,0 +1,182 @@
+"""Unit tests for worker-side KV cache layout registration."""
+
+from __future__ import annotations
+
+import pytest
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from pegaflow.connector.worker import _infer_kv_cache_registration  # noqa: E402
+
+
+class FakeTensor:
+    def __init__(self, shape: tuple[int, ...], stride: tuple[int, ...], element_size: int = 2):
+        self.shape = shape
+        self._stride = stride
+        self._element_size = element_size
+
+    def stride(self) -> tuple[int, ...]:
+        return self._stride
+
+    def element_size(self) -> int:
+        return self._element_size
+
+
+def test_blocks_first_flashmla_physical_rows_are_grouped_into_logical_blocks():
+    info = _infer_kv_cache_registration(
+        FakeTensor(
+            shape=(6, 64, 576),
+            stride=(64 * 576, 576, 1),
+            element_size=2,
+        ),
+        logical_block_size=128,
+    )
+
+    assert info.layout == "blocks-first"
+    assert info.num_blocks == 3
+    assert info.bytes_per_block == 2 * 64 * 576 * 2
+    assert info.kv_stride_bytes == 0
+    assert info.segments == 1
+    assert info.physical_blocks_per_logical_block == 2
+
+
+def test_kv_first_physical_rows_are_grouped_per_kv_segment():
+    info = _infer_kv_cache_registration(
+        FakeTensor(
+            shape=(2, 6, 64, 4, 8),
+            stride=(6 * 64 * 4 * 8, 64 * 4 * 8, 4 * 8, 8, 1),
+            element_size=2,
+        ),
+        logical_block_size=128,
+    )
+
+    assert info.layout == "KV-first"
+    assert info.num_blocks == 3
+    assert info.bytes_per_block == 2 * 64 * 4 * 8 * 2
+    assert info.kv_stride_bytes == 6 * 64 * 4 * 8 * 2
+    assert info.segments == 2
+    assert info.physical_blocks_per_logical_block == 2
+
+
+def test_mla_prefers_blocks_first_when_first_dimension_is_two():
+    info = _infer_kv_cache_registration(
+        FakeTensor(
+            shape=(2, 64, 576),
+            stride=(64 * 576, 576, 1),
+            element_size=2,
+        ),
+        logical_block_size=128,
+        is_mla=True,
+    )
+
+    assert info.layout == "blocks-first"
+    assert info.num_blocks == 1
+    assert info.bytes_per_block == 2 * 64 * 576 * 2
+    assert info.kv_stride_bytes == 0
+    assert info.segments == 1
+    assert info.physical_blocks_per_logical_block == 2
+
+
+def test_equal_physical_and_logical_block_size_is_unchanged():
+    info = _infer_kv_cache_registration(
+        FakeTensor(
+            shape=(3, 128, 576),
+            stride=(128 * 576, 576, 1),
+            element_size=2,
+        ),
+        logical_block_size=128,
+    )
+
+    assert info.num_blocks == 3
+    assert info.bytes_per_block == 128 * 576 * 2
+    assert info.physical_blocks_per_logical_block == 1
+
+
+def test_blocks_first_standard_attention_uses_third_dim_as_physical_block_size():
+    info = _infer_kv_cache_registration(
+        FakeTensor(
+            shape=(6, 2, 64, 4, 8),
+            stride=(2 * 64 * 4 * 8, 64 * 4 * 8, 4 * 8, 8, 1),
+            element_size=2,
+        ),
+        logical_block_size=128,
+    )
+
+    assert info.layout == "blocks-first"
+    assert info.num_blocks == 3
+    assert info.bytes_per_block == 2 * 2 * 64 * 4 * 8 * 2
+    assert info.physical_blocks_per_logical_block == 2
+
+
+def test_logical_block_size_must_be_multiple_of_physical_block_size():
+    with pytest.raises(ValueError, match="logical block size"):
+        _infer_kv_cache_registration(
+            FakeTensor(
+                shape=(3, 96, 576),
+                stride=(96 * 576, 576, 1),
+                element_size=2,
+            ),
+            logical_block_size=128,
+        )
+
+
+def test_logical_block_size_must_be_positive():
+    with pytest.raises(ValueError, match="logical block size must be > 0"):
+        _infer_kv_cache_registration(
+            FakeTensor(
+                shape=(3, 128, 576),
+                stride=(128 * 576, 576, 1),
+                element_size=2,
+            ),
+            logical_block_size=0,
+        )
+
+
+def test_physical_block_count_must_be_positive():
+    with pytest.raises(ValueError, match="physical block count must be > 0"):
+        _infer_kv_cache_registration(
+            FakeTensor(
+                shape=(0, 128, 576),
+                stride=(128 * 576, 576, 1),
+                element_size=2,
+            ),
+            logical_block_size=128,
+        )
+
+
+def test_physical_block_size_must_be_positive():
+    with pytest.raises(ValueError, match="physical block size must be > 0"):
+        _infer_kv_cache_registration(
+            FakeTensor(
+                shape=(3, 0, 576),
+                stride=(0, 576, 1),
+                element_size=2,
+            ),
+            logical_block_size=128,
+        )
+
+
+def test_physical_block_count_must_be_divisible_by_split_ratio():
+    with pytest.raises(ValueError, match="physical block count"):
+        _infer_kv_cache_registration(
+            FakeTensor(
+                shape=(5, 64, 576),
+                stride=(64 * 576, 576, 1),
+                element_size=2,
+            ),
+            logical_block_size=128,
+        )
+
+
+def test_bytes_per_block_must_be_nonzero():
+    with pytest.raises(ValueError, match="Invalid bytes_per_block"):
+        _infer_kv_cache_registration(
+            FakeTensor(
+                shape=(3, 128, 576),
+                stride=(0, 576, 1),
+                element_size=2,
+            ),
+            logical_block_size=128,
+        )


### PR DESCRIPTION
## Summary
- infer the physical KV cache row layout from vLLM tensors and register PegaFlow blocks at scheduler logical-block granularity
- group split physical rows into one logical block when FlashMLA uses smaller physical blocks, e.g. physical 64 rows for logical block size 128
- keep MLA blocks-first inference while preserving the original KV-first path for non-MLA tensors
- add connector layout tests for KV-first, blocks-first, and split-physical layouts

## Test Plan
- `git diff --check`
- `cargo fmt --check`
- h20: `cd /root/kexi/pegaflow/python && maturin develop --release`
- h20: `python -m pytest tests/test_worker_kv_layout.py tests/test_combine_hashes.py` (27 passed)
- h20: `cargo test -p pegaflow-core --test prefetch_lease` (2 passed)
- h20 DeepSeek-V3.2 TP8 MLA correctness with 10GB pool:
  - command: `PEGAFLOW_POOL_SIZE=10gb bash scripts/bench/pegaflow-tp8-mla-deepseek/correctness.sh --run-id flashmla-blockfix-20260520-110956 --pool-size 10gb --num-prompts 4 --max-tokens 8 --prompt-tokens 384 --vllm-max-num-seqs 4`
  - run dir: `/root/kexi/pegaflow_bench_runs/tp8-mla/flashmla-blockfix-20260520-110956`
  - exact cold/warm outputs matched baseline; all non-partial comparisons passed
  - strict script reported one `prompt_0_partial` mismatch; treated as allowed chunk-prefill partial variance for this validation
  - external hits observed: 24 hit blocks, 64 successful load RPCs, 1.92GB loaded