### PR TITLE
fix(numa): allocate pinned pools on GPU-local NUMA nodes

### DIFF
--- a/pegaflow-common/src/numa.rs
+++ b/pegaflow-common/src/numa.rs
@@ -382,6 +382,19 @@ impl NumaTopology {
         &self.numa_nodes
     }
 
+    /// Get all valid NUMA nodes that have at least one GPU attached.
+    pub fn gpu_numa_nodes(&self) -> Vec<NumaNode> {
+        let mut nodes: Vec<NumaNode> = self
+            .gpu_numa_map
+            .values()
+            .copied()
+            .filter(NumaNode::is_valid)
+            .collect();
+        nodes.sort_unstable();
+        nodes.dedup();
+        nodes
+    }
+
     /// Get the number of NUMA nodes.
     pub fn num_nodes(&self) -> usize {
         self.numa_nodes.len()
@@ -542,6 +555,32 @@ mod tests {
     fn test_parse_cpulist_single_cpu() {
         let cpus = parse_cpulist("5").unwrap();
         assert_eq!(cpus, vec![5]);
+    }
+
+    #[test]
+    fn test_gpu_numa_nodes_are_valid_sorted_unique() {
+        let topology = NumaTopology {
+            gpu_numa_map: HashMap::from([
+                (0, NumaNode(3)),
+                (1, NumaNode(3)),
+                (2, NumaNode::UNKNOWN),
+                (3, NumaNode(0)),
+                (4, NumaNode(5)),
+            ]),
+            numa_nodes: vec![
+                NumaNode(0),
+                NumaNode(1),
+                NumaNode(2),
+                NumaNode(3),
+                NumaNode(4),
+                NumaNode(5),
+            ],
+        };
+
+        assert_eq!(
+            topology.gpu_numa_nodes(),
+            vec![NumaNode(0), NumaNode(3), NumaNode(5)]
+        );
     }
 
     #[test]

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -138,11 +138,21 @@ impl PegaEngine {
 
         let config = storage_config;
         let numa_nodes: Vec<NumaNode> = if config.enable_numa_affinity && topology.is_multi_numa() {
-            info!(
-                "Auto-enabling NUMA-aware memory allocation for {} nodes",
-                topology.num_nodes()
-            );
-            topology.numa_nodes().to_vec()
+            let gpu_numa_nodes = topology.gpu_numa_nodes();
+            if gpu_numa_nodes.is_empty() {
+                info!(
+                    "Auto-enabling NUMA-aware memory allocation for {} CPU NUMA nodes; no GPU NUMA affinity detected",
+                    topology.num_nodes()
+                );
+                topology.numa_nodes().to_vec()
+            } else {
+                info!(
+                    "Auto-enabling NUMA-aware memory allocation for {} GPU-local NUMA nodes ({} CPU NUMA nodes detected)",
+                    gpu_numa_nodes.len(),
+                    topology.num_nodes()
+                );
+                gpu_numa_nodes
+            }
         } else {
             vec![]
         };

--- a/pegaflow-server/tests/mock_vllm_rpc_e2e.rs
+++ b/pegaflow-server/tests/mock_vllm_rpc_e2e.rs
@@ -59,20 +59,22 @@ async fn mock_vllm_save_query_load_roundtrip_over_rpc() {
 }
 
 #[tokio::test]
-async fn mock_vllm_empty_req_id_query_returns_zero_hit_ready() {
+async fn mock_vllm_empty_req_id_query_is_rejected() {
     let mut harness = MockVllmRpcHarness::new().await;
     let hashes = make_block_hashes(BLOCK_COUNT, 31);
 
     let save = harness.save_blocks(&hashes).await;
     assert_response_ok(save.response.status.as_ref(), "save");
 
-    let query = harness.query_prefetch("", &hashes).await;
+    let query = match harness.try_query_prefetch("", &hashes).await {
+        Ok(_) => panic!("empty req_id query should be rejected"),
+        Err(err) => err,
+    };
     assert_eq!(query.request.instance_id, INSTANCE_ID);
     assert_eq!(query.request.block_hashes, hashes);
     assert_eq!(query.request.req_id, "");
-    let ready = expect_query_ready(query.response.outcome, "empty req_id query");
-    assert_eq!(ready.num_hit_blocks, 0);
-    assert!(ready.lease.is_empty());
+    assert_eq!(query.status.code(), tonic::Code::InvalidArgument);
+    assert!(query.status.message().contains("req_id"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add `NumaTopology::gpu_numa_nodes()` to derive the valid NUMA nodes that actually host GPUs
- allocate NUMA-aware pinned pools on GPU-local NUMA nodes instead of the full CPU NUMA set
- update stale mock vLLM RPC E2E coverage so empty `req_id` follows the current InvalidArgument contract

## Context
On guoji-b200, BIOS/SNC exposes 6 CPU NUMA nodes, but the 8 B200 GPUs are local only to NUMA0/2/3/5. The old startup path used the CPU NUMA set directly, so a 1.5 TiB pool was split across 6 nodes and wasted capacity on CPU-only NUMA1/4.

With this change, the same host should create pinned pools across the 4 GPU-local NUMA nodes. If GPU NUMA affinity cannot be detected, the code keeps the existing CPU NUMA fallback.

## Validation
- `cargo fmt`
- `cargo test -p pegaflow-common`
- `cargo test -p pegaflow-core --lib`
- `cargo test -p pegaflow-server --test mock_vllm_rpc_e2e mock_vllm_empty_req_id_query_is_rejected`
- pre-commit hook: `cargo clippy`, `cargo test --release`, `typos`
