### PR TITLE
fix(connector): preserve non-MLA kv layout registration

### DIFF
--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -82,23 +82,40 @@ def _infer_kv_cache_registration(
     if logical_block_size <= 0:
         raise ValueError(f"logical block size must be > 0, got {logical_block_size}")
 
-    if not is_mla and len(shape) >= 2 and shape[0] == 2:
-        layout = "KV-first"
-        physical_num_blocks = shape[1]
-        physical_block_size = shape[2] if len(shape) >= 3 else logical_block_size
-        physical_bytes_per_block = stride[1] * element_size
-        kv_stride_bytes = stride[0] * element_size
-        segments = 2
-    else:
-        layout = "blocks-first"
-        physical_num_blocks = shape[0]
-        if len(shape) >= 3 and shape[1] == 2:
-            physical_block_size = shape[2]
+    if not is_mla:
+        if len(shape) >= 2 and shape[0] == 2:
+            layout = "KV-first"
+            num_blocks = shape[1]
+            bytes_per_block = stride[1] * element_size
+            kv_stride_bytes = stride[0] * element_size
+            segments = 2
         else:
-            physical_block_size = shape[1] if len(shape) >= 2 else logical_block_size
-        physical_bytes_per_block = stride[0] * element_size
-        kv_stride_bytes = 0
-        segments = 1
+            layout = "blocks-first"
+            num_blocks = shape[0]
+            bytes_per_block = stride[0] * element_size
+            kv_stride_bytes = 0
+            segments = 1
+
+        if num_blocks <= 0:
+            raise ValueError(f"physical block count must be > 0, got {num_blocks}")
+        if bytes_per_block == 0:
+            raise ValueError(f"Invalid bytes_per_block: shape={shape} stride={stride}")
+
+        return _KVCacheRegistrationInfo(
+            layout=layout,
+            num_blocks=num_blocks,
+            bytes_per_block=bytes_per_block,
+            kv_stride_bytes=kv_stride_bytes,
+            segments=segments,
+            physical_blocks_per_logical_block=1,
+        )
+
+    layout = "blocks-first"
+    physical_num_blocks = shape[0]
+    physical_block_size = shape[1] if len(shape) >= 2 else logical_block_size
+    physical_bytes_per_block = stride[0] * element_size
+    kv_stride_bytes = 0
+    segments = 1
 
     if physical_num_blocks <= 0:
         raise ValueError(

--- a/python/tests/test_worker_kv_layout.py
+++ b/python/tests/test_worker_kv_layout.py
@@ -24,7 +24,7 @@ class FakeTensor:
         return self._element_size
 
 
-def test_blocks_first_flashmla_physical_rows_are_grouped_into_logical_blocks():
+def test_mla_blocks_first_physical_rows_are_grouped_into_logical_blocks():
     info = _infer_kv_cache_registration(
         FakeTensor(
             shape=(6, 64, 576),
@@ -32,6 +32,7 @@ def test_blocks_first_flashmla_physical_rows_are_grouped_into_logical_blocks():
             element_size=2,
         ),
         logical_block_size=128,
+        is_mla=True,
     )
 
     assert info.layout == "blocks-first"
@@ -42,7 +43,7 @@ def test_blocks_first_flashmla_physical_rows_are_grouped_into_logical_blocks():
     assert info.physical_blocks_per_logical_block == 2
 
 
-def test_kv_first_physical_rows_are_grouped_per_kv_segment():
+def test_non_mla_kv_first_uses_legacy_block_stride():
     info = _infer_kv_cache_registration(
         FakeTensor(
             shape=(2, 6, 64, 4, 8),
@@ -53,11 +54,11 @@ def test_kv_first_physical_rows_are_grouped_per_kv_segment():
     )
 
     assert info.layout == "KV-first"
-    assert info.num_blocks == 3
-    assert info.bytes_per_block == 2 * 64 * 4 * 8 * 2
+    assert info.num_blocks == 6
+    assert info.bytes_per_block == 64 * 4 * 8 * 2
     assert info.kv_stride_bytes == 6 * 64 * 4 * 8 * 2
     assert info.segments == 2
-    assert info.physical_blocks_per_logical_block == 2
+    assert info.physical_blocks_per_logical_block == 1
 
 
 def test_mla_prefers_blocks_first_when_first_dimension_is_two():
@@ -79,7 +80,7 @@ def test_mla_prefers_blocks_first_when_first_dimension_is_two():
     assert info.physical_blocks_per_logical_block == 2
 
 
-def test_equal_physical_and_logical_block_size_is_unchanged():
+def test_mla_equal_physical_and_logical_block_size_is_unchanged():
     info = _infer_kv_cache_registration(
         FakeTensor(
             shape=(3, 128, 576),
@@ -87,6 +88,7 @@ def test_equal_physical_and_logical_block_size_is_unchanged():
             element_size=2,
         ),
         logical_block_size=128,
+        is_mla=True,
     )
 
     assert info.num_blocks == 3
@@ -94,20 +96,27 @@ def test_equal_physical_and_logical_block_size_is_unchanged():
     assert info.physical_blocks_per_logical_block == 1
 
 
-def test_blocks_first_standard_attention_uses_third_dim_as_physical_block_size():
+def test_non_mla_cross_layer_layout_uses_legacy_block_stride():
     info = _infer_kv_cache_registration(
         FakeTensor(
-            shape=(6, 2, 64, 4, 8),
-            stride=(2 * 64 * 4 * 8, 64 * 4 * 8, 4 * 8, 8, 1),
+            shape=(6, 93, 2, 64, 1, 128),
+            stride=(
+                93 * 2 * 64 * 1 * 128,
+                2 * 64 * 1 * 128,
+                64 * 1 * 128,
+                1 * 128,
+                128,
+                1,
+            ),
             element_size=2,
         ),
         logical_block_size=128,
     )
 
     assert info.layout == "blocks-first"
-    assert info.num_blocks == 3
-    assert info.bytes_per_block == 2 * 2 * 64 * 4 * 8 * 2
-    assert info.physical_blocks_per_logical_block == 2
+    assert info.num_blocks == 6
+    assert info.bytes_per_block == 93 * 2 * 64 * 1 * 128 * 2
+    assert info.physical_blocks_per_logical_block == 1
 
 
 def test_logical_block_size_must_be_multiple_of_physical_block_size():
@@ -119,6 +128,7 @@ def test_logical_block_size_must_be_multiple_of_physical_block_size():
                 element_size=2,
             ),
             logical_block_size=128,
+            is_mla=True,
         )
 
 
@@ -131,6 +141,7 @@ def test_logical_block_size_must_be_positive():
                 element_size=2,
             ),
             logical_block_size=0,
+            is_mla=True,
         )
 
 
@@ -143,6 +154,7 @@ def test_physical_block_count_must_be_positive():
                 element_size=2,
             ),
             logical_block_size=128,
+            is_mla=True,
         )
 
 
@@ -155,6 +167,7 @@ def test_physical_block_size_must_be_positive():
                 element_size=2,
             ),
             logical_block_size=128,
+            is_mla=True,
         )
 
 
@@ -167,6 +180,7 @@ def test_physical_block_count_must_be_divisible_by_split_ratio():
                 element_size=2,
             ),
             logical_block_size=128,
+            is_mla=True,
         )
 
 
@@ -179,4 +193,5 @@ def test_bytes_per_block_must_be_nonzero():
                 element_size=2,
             ),
             logical_block_size=128,
+            is_mla=True,
         )


### PR DESCRIPTION
## Summary
- keep non-MLA KV registration on the legacy shape/stride path, so cross-layer layouts like GLM-4.7-FP8's `(blocks, layers, 2, block_size, ...)` are registered by block stride without parsing token-block dimensions
- limit logical/physical block splitting to MLA layouts, where FlashMLA can expose 64-token physical rows under a larger scheduler block size
- add regression coverage for non-MLA cross-layer layout registration and MLA split/equal-size registration

Closes #294

## Test Plan
- `python3 -m pytest python/tests/test_worker_kv_layout.py python/tests/test_combine_hashes.py` (32 passed)
- `python3 -m py_compile python/pegaflow/connector/worker.py python/tests/test_worker_kv_layout.py`
- `git diff --check`