### PR TITLE
feat(connector): add save-only pegaflow mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The warm-start path achieves **~9x faster TTFT** compared to cold-start, demonst
 ## Documentation
 
 - [Server Configuration](./docs/server.md) — full CLI options, SSD cache, multi-node setup
+- [Python Package](./python/README.md) — Python bindings and vLLM connector configuration
 - [P2P KV Cache Sharing](./docs/p2p.md) — cross-node RDMA setup, tuning, and troubleshooting
 - [P/D Router](./docs/pd.md) — prefill/decode disaggregation
 - [vLLM I/O Patch](./docs/vllm-patch.md) — optional patch for better transfer throughput

--- a/python/README.md
+++ b/python/README.md
@@ -71,6 +71,44 @@ llm = LLM(
 )
 ```
 
+#### Connector Modes
+
+`PegaKVConnector` defaults to `read_write`: it queries PegaFlow for reusable KV
+blocks, loads matched blocks into vLLM, and saves newly computed full blocks
+back to PegaFlow.
+
+Set `pegaflow.mode` to `save_only` when another vLLM connector is responsible
+for reads and PegaFlow should only persist KV blocks for later reuse. This is
+intended for `MultiConnector` decode-side setups where an upstream connector
+owns the external hit/load path, while PegaFlow records the resulting KV cache.
+In `save_only` mode, PegaFlow does not query or load KV blocks.
+
+```bash
+vllm serve Qwen/Qwen3-0.6B \
+  --kv-transfer-config '{
+    "kv_connector": "MultiConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "connectors": [
+        {
+          "kv_connector": "<external-read-connector>",
+          "kv_role": "kv_both"
+        },
+        {
+          "kv_connector": "PegaKVConnector",
+          "kv_role": "kv_both",
+          "kv_connector_module_path": "pegaflow.connector",
+          "kv_connector_extra_config": {
+            "pegaflow.mode": "save_only"
+          }
+        }
+      ]
+    }
+  }'
+```
+
+Valid values are `read_write` and `save_only`.
+
 ## Development
 
 See the [examples](../examples/) directory for more usage examples.

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -18,6 +18,7 @@ from vllm.distributed.parallel_state import get_pp_group, get_tensor_model_paral
 from pegaflow.connector.common import (
     ConnectorContext,
     PegaConnectorMetadata,
+    PegaConnectorMode,
     PegaKVConnectorStats,
     PegaPromMetrics,
     derive_namespace,
@@ -96,6 +97,11 @@ class PegaKVConnector(KVConnectorBase_V1):
         server_port = os.environ.get(
             "PEGAFLOW_PORT"
         ) or vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.port", 50055)
+        mode = PegaConnectorMode.from_config(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "pegaflow.mode", PegaConnectorMode.READ_WRITE.value
+            )
+        )
         self._engine_endpoint = f"{server_host}:{server_port}"
         engine_client = EngineRpcClient(self._engine_endpoint)
         logger.debug("[PegaKVConnector] Connected to engine server at %s", self._engine_endpoint)
@@ -119,6 +125,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             dcp_rank=dcp_rank,
             pp_rank=pp_rank,
             pp_size=pp_size,
+            mode=mode,
         )
 
         self._scheduler: SchedulerConnector | None = None
@@ -136,7 +143,7 @@ class PegaKVConnector(KVConnectorBase_V1):
         logger.debug(
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
             "tp_rank=%s tp_size=%d pp_rank=%d pp_size=%d world_size=%d layers=%d namespace=%s "
-            "is_mla=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d",
+            "is_mla=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d mode=%s",
             role.name,
             instance_id,
             device_id if device_id is not None else "cpu",
@@ -151,6 +158,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             dcp_world_size,
             pcp_world_size,
             dcp_rank,
+            mode.value,
         )
 
     # ==============================

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import uuid
 from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
@@ -18,6 +19,25 @@ if TYPE_CHECKING:
     from pegaflow.connector.state_manager import ServiceStateManager
 
 logger = get_connector_logger()
+
+
+class PegaConnectorMode(str, Enum):
+    """Read/write behavior for the PegaFlow connector."""
+
+    READ_WRITE = "read_write"
+    SAVE_ONLY = "save_only"
+
+    @classmethod
+    def from_config(cls, value: object) -> "PegaConnectorMode":
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            for mode in cls:
+                if normalized == mode.value:
+                    return mode
+        allowed = ", ".join(mode.value for mode in cls)
+        raise ValueError(f"Unsupported pegaflow.mode {value!r}; expected one of: {allowed}")
 
 
 @dataclass(frozen=True)
@@ -40,6 +60,11 @@ class ConnectorContext:
     dcp_rank: int = 0
     pp_rank: int = 0
     pp_size: int = 1
+    mode: PegaConnectorMode = PegaConnectorMode.READ_WRITE
+
+    @property
+    def read_enabled(self) -> bool:
+        return self.mode is PegaConnectorMode.READ_WRITE
 
     @property
     def virtual_block_size(self) -> int:
@@ -213,6 +238,7 @@ def detect_mla(vllm_config) -> bool:
 __all__ = [
     "ConnectorContext",
     "LoadIntent",
+    "PegaConnectorMode",
     "PegaConnectorMetadata",
     "PegaKVConnectorStats",
     "PegaPromMetrics",

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -74,6 +74,14 @@ class SchedulerConnector:
     ) -> tuple[int | None, bool]:
         req_id = request.request_id
 
+        if not self._ctx.read_enabled:
+            logger.debug(
+                "[PegaKVConnector] req=%s cache_lookup_skipped: mode=%s",
+                req_id,
+                self._ctx.mode.value,
+            )
+            return (0, False)
+
         num_tokens = request.num_tokens
         block_hashes = request.block_hashes
 
@@ -255,7 +263,13 @@ class SchedulerConnector:
             if req.block_ids:
                 self._allocated_blocks[req_id] = list(req.block_ids[0])
 
-            self._scheduled_tokens[req_id] += num_tokens
+            if self._ctx.read_enabled:
+                self._scheduled_tokens[req_id] += num_tokens
+            else:
+                self._scheduled_tokens[req_id] = max(
+                    self._scheduled_tokens.get(req_id, 0),
+                    req.num_computed_tokens + num_tokens,
+                )
 
             if save_intent := self._consume_save_intent(req_id):
                 potential_saves[req_id] = save_intent
@@ -273,12 +287,22 @@ class SchedulerConnector:
                 self._block_hashes[req_id] = tuple(req.block_hashes)
 
             num_tokens = scheduler_output.num_scheduled_tokens.get(req_id, 0)
-            self._scheduled_tokens[req_id] += num_tokens
 
             # Append newly allocated blocks
             new_block_ids = cached_reqs.new_block_ids[idx]
-            if new_block_ids:
+            if req_id in cached_reqs.resumed_req_ids:
+                self._allocated_blocks[req_id] = list(new_block_ids[0]) if new_block_ids else []
+            elif new_block_ids:
                 self._allocated_blocks[req_id].extend(new_block_ids[0])
+
+            if self._ctx.read_enabled:
+                self._scheduled_tokens[req_id] += num_tokens
+            else:
+                prior_computed_tokens = cached_reqs.num_computed_tokens[idx]
+                self._scheduled_tokens[req_id] = max(
+                    self._scheduled_tokens.get(req_id, 0),
+                    prior_computed_tokens + num_tokens,
+                )
 
             if save_intent := self._consume_save_intent(req_id):
                 potential_saves[req_id] = save_intent

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -12,7 +12,7 @@ from .unit_stubs import install_connector_unit_stubs
 
 install_connector_unit_stubs()
 
-from pegaflow.connector.common import ConnectorContext  # noqa: E402
+from pegaflow.connector.common import ConnectorContext, PegaConnectorMode  # noqa: E402
 from pegaflow.connector.scheduler import SchedulerConnector  # noqa: E402
 from pegaflow.pegaflow import QueryLoading, QueryReady  # noqa: E402
 
@@ -239,6 +239,129 @@ class TestDecodeHashRefresh:
         assert intent.block_hashes == block_hashes[6:9]
         assert intent.block_ids == (200, 201, 202)
 
+    def test_save_only_mode_counts_precomputed_prefix_as_saveable(self):
+        """NIXL-loaded prefix should be saveable in Pega save-only mode."""
+        sc = SchedulerConnector(_make_ctx(mode=PegaConnectorMode.SAVE_ONLY))
+        block_hashes = [_hash(i) for i in range(4)]
+        req = _make_fake_request("r1", list(block_hashes))
+
+        # MultiConnector passes empty blocks and zero external tokens to
+        # non-owner children. In save-only mode, Pega must later rely on
+        # scheduler output rather than this allocation callback.
+        sc.update_state_after_alloc(req, _make_fake_blocks([]), num_external_tokens=0)
+
+        scheduler_output = SimpleNamespace(
+            scheduled_new_reqs=[
+                SimpleNamespace(
+                    req_id="r1",
+                    block_ids=([10, 11, 12, 13],),
+                    num_computed_tokens=48,
+                )
+            ],
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=[],
+                new_block_ids=[],
+                num_computed_tokens=[],
+            ),
+            num_scheduled_tokens={"r1": 1},
+            preempted_req_ids=set(),
+        )
+
+        metadata = sc.build_connector_meta(scheduler_output)
+
+        intent = metadata.save_intents["r1"]
+        assert intent.block_ids == (10, 11, 12)
+        assert intent.block_hashes == tuple(block_hashes[:3])
+
+    def test_save_only_mode_handles_full_prompt_hit_recompute_token(self):
+        """vLLM backs full prompt hits up by one token before scheduling."""
+        sc = SchedulerConnector(_make_ctx(mode=PegaConnectorMode.SAVE_ONLY))
+        block_hashes = [_hash(i) for i in range(4)]
+        req = _make_fake_request("r1", list(block_hashes))
+
+        sc.update_state_after_alloc(req, _make_fake_blocks([]), num_external_tokens=0)
+
+        scheduler_output = SimpleNamespace(
+            scheduled_new_reqs=[
+                SimpleNamespace(
+                    req_id="r1",
+                    block_ids=([10, 11, 12, 13],),
+                    num_computed_tokens=63,
+                )
+            ],
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=[],
+                new_block_ids=[],
+                num_computed_tokens=[],
+            ),
+            num_scheduled_tokens={"r1": 1},
+            preempted_req_ids=set(),
+        )
+
+        metadata = sc.build_connector_meta(scheduler_output)
+
+        intent = metadata.save_intents["r1"]
+        assert intent.block_ids == (10, 11, 12, 13)
+        assert intent.block_hashes == tuple(block_hashes)
+
+    def test_read_write_mode_does_not_save_unowned_precomputed_prefix(self):
+        """Default mode keeps old behavior for Pega-owned read/write paths."""
+        sc = self._make_connector(dcp_world_size=1)
+        block_hashes = [_hash(i) for i in range(4)]
+        req = _make_fake_request("r1", list(block_hashes))
+
+        sc.update_state_after_alloc(req, _make_fake_blocks([]), num_external_tokens=0)
+
+        scheduler_output = SimpleNamespace(
+            scheduled_new_reqs=[
+                SimpleNamespace(
+                    req_id="r1",
+                    block_ids=([10, 11, 12, 13],),
+                    num_computed_tokens=48,
+                )
+            ],
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=[],
+                new_block_ids=[],
+                num_computed_tokens=[],
+            ),
+            num_scheduled_tokens={"r1": 1},
+            preempted_req_ids=set(),
+        )
+
+        metadata = sc.build_connector_meta(scheduler_output)
+
+        assert "r1" not in metadata.save_intents
+
+    def test_resumed_cached_request_replaces_block_table(self):
+        """vLLM resumed reqs send the full block table, not append-only blocks."""
+        sc = SchedulerConnector(_make_ctx(mode=PegaConnectorMode.SAVE_ONLY))
+        block_hashes = [_hash(i) for i in range(4)]
+        req = _make_fake_request("r1", list(block_hashes))
+
+        sc.update_state_after_alloc(req, _make_fake_blocks([]), num_external_tokens=0)
+        sc._allocated_blocks["r1"] = [1, 2]
+        sc._next_stored_block_idx["r1"] = 2
+        sc._scheduled_tokens["r1"] = 32
+
+        scheduler_output = SimpleNamespace(
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=["r1"],
+                resumed_req_ids={"r1"},
+                new_block_ids=[([10, 11, 12, 13],)],
+                num_computed_tokens=[32],
+            ),
+            num_scheduled_tokens={"r1": 16},
+            preempted_req_ids=set(),
+        )
+
+        metadata = sc.build_connector_meta(scheduler_output)
+
+        intent = metadata.save_intents["r1"]
+        assert intent.block_hashes == tuple(block_hashes[2:3])
+        assert intent.block_ids == (12,)
+
 
 class TestSchedulerQueryProbeReuse:
     """Repeated scheduler probes should not repeat server-side query leases."""
@@ -271,6 +394,16 @@ class TestSchedulerQueryProbeReuse:
         engine_client.query_prefetch.return_value = QueryLoading()
 
         assert sc._count_available_block_prefix([_hash(i) for i in range(4)], "r1") is None
+
+    def test_save_only_mode_skips_query(self):
+        engine_client = MagicMock()
+        sc = SchedulerConnector(
+            _make_ctx(engine_client=engine_client, mode=PegaConnectorMode.SAVE_ONLY)
+        )
+        req = _make_fake_request("r1", [_hash(i) for i in range(4)])
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (0, False)
+        engine_client.query_prefetch.assert_not_called()
 
     def test_query_prefetch_rejects_unknown_outcome(self):
         sc, engine_client = self._make_connector()

--- a/python/tests/test_vllm_save_only_e2e.py
+++ b/python/tests/test_vllm_save_only_e2e.py
@@ -1,0 +1,252 @@
+"""E2E coverage for PegaFlow save_only behind an external full-hit connector.
+
+This test uses vLLM's DecodeBenchConnector as a deterministic stand-in for the
+decode-side connector that claims a full prompt hit. The expected ownership is:
+
+    MultiConnector child 0: DecodeBenchConnector -> load owner
+    MultiConnector child 1: PegaKVConnector(save_only) -> no read, save only
+
+Then a second vLLM instance with normal PegaKVConnector should load the blocks
+saved by the save_only instance.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from .vllm_helpers import (
+    PegaFlowServer,
+    VLLMServer,
+    call_openai_api,
+    fetch_pegaflow_metrics,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.gpu]
+
+SAVE_ONLY_BLOCK_SIZE = 16
+SAVE_ONLY_FULL_BLOCKS = 4
+SAVE_ONLY_PROMPT_TOKENS = SAVE_ONLY_BLOCK_SIZE * SAVE_ONLY_FULL_BLOCKS + 1
+SAVE_ONLY_MAX_TOKENS = 24
+SAVE_ONLY_MAX_MODEL_LEN = 160
+SAVE_ONLY_STARTUP_TIMEOUT = 600
+
+SAVE_ONLY_PROMPT = [100 + (idx % 200) for idx in range(SAVE_ONLY_PROMPT_TOKENS)]
+
+
+def _metric_delta(
+    before: dict[str, float],
+    after: dict[str, float],
+    key: str,
+) -> float:
+    return after.get(key, 0) - before.get(key, 0)
+
+
+def _wait_for_any_metric_delta(
+    metrics_port: int,
+    before: dict[str, float],
+    keys: tuple[str, ...],
+    *,
+    timeout_s: float = 30,
+) -> dict[str, float]:
+    deadline = time.time() + timeout_s
+    latest = before
+    while time.time() < deadline:
+        latest = fetch_pegaflow_metrics(metrics_port)
+        if any(_metric_delta(before, latest, key) > 0 for key in keys):
+            return latest
+        time.sleep(1)
+    return latest
+
+
+def _save_only_multi_config(pegaflow_port: int) -> dict[str, Any]:
+    return {
+        "kv_connector": "MultiConnector",
+        "kv_role": "kv_both",
+        "kv_connector_extra_config": {
+            "connectors": [
+                {
+                    "kv_connector": "DecodeBenchConnector",
+                    "kv_role": "kv_both",
+                    "kv_connector_extra_config": {
+                        "fill_mean": 0.015,
+                        "fill_std": 0.0,
+                    },
+                },
+                {
+                    "kv_connector": "PegaKVConnector",
+                    "kv_role": "kv_both",
+                    "kv_connector_module_path": "pegaflow.connector",
+                    "kv_connector_extra_config": {
+                        "pegaflow.port": pegaflow_port,
+                        "pegaflow.mode": "save_only",
+                    },
+                },
+            ],
+        },
+    }
+
+
+def _pegaflow_read_write_config(pegaflow_port: int) -> dict[str, Any]:
+    return {
+        "kv_connector": "PegaKVConnector",
+        "kv_role": "kv_both",
+        "kv_connector_module_path": "pegaflow.connector",
+        "kv_connector_extra_config": {
+            "pegaflow.port": pegaflow_port,
+        },
+    }
+
+
+def test_save_only_external_full_hit_is_saved_for_later_pegaflow_read(
+    model: str,
+    base_port: int,
+    tmp_path: Path,
+    max_model_len: int | None,
+):
+    """save_only must not query PegaFlow, but must save external-hit blocks."""
+
+    required_model_len = SAVE_ONLY_PROMPT_TOKENS + SAVE_ONLY_MAX_TOKENS
+    if max_model_len is not None and max_model_len < required_model_len:
+        pytest.skip(f"--max-model-len={max_model_len} is smaller than {required_model_len}")
+
+    prompt = SAVE_ONLY_PROMPT
+    assert len(prompt) == SAVE_ONLY_PROMPT_TOKENS
+    assert (len(prompt) - 1) % SAVE_ONLY_BLOCK_SIZE == 0
+
+    log_dir = tmp_path / "save_only_e2e_logs"
+    log_dir.mkdir()
+    server_log = log_dir / "pegaflow-server.log"
+    save_only_log = log_dir / "save-only-multi.log"
+    read_write_log = log_dir / "pegaflow-read-write.log"
+
+    vllm_extra_args = [
+        "--block-size",
+        str(SAVE_ONLY_BLOCK_SIZE),
+        "--max-num-seqs",
+        "2",
+        "--enforce-eager",
+    ]
+    vllm_env = {"VLLM_USE_FLASHINFER_SAMPLER": "0"}
+    server_max_model_len = max_model_len or SAVE_ONLY_MAX_MODEL_LEN
+
+    with PegaFlowServer(
+        log_file=server_log,
+        pool_size="1gb",
+        log_level="debug",
+    ) as pega_server:
+        save_port = base_port
+        read_port = base_port + 1
+
+        with VLLMServer(
+            model,
+            save_port,
+            pegaflow_port=pega_server.grpc_port,
+            log_file=save_only_log,
+            max_model_len=server_max_model_len,
+            extra_args=vllm_extra_args,
+            startup_timeout=SAVE_ONLY_STARTUP_TIMEOUT,
+            kv_transfer_config=_save_only_multi_config(pega_server.grpc_port),
+            server_label="SaveOnlyMulti",
+            env_overrides=vllm_env,
+        ):
+            save_metrics_before = fetch_pegaflow_metrics(pega_server.metrics_port)
+            save_only_result = call_openai_api(
+                save_port,
+                model,
+                prompt,
+                max_tokens=SAVE_ONLY_MAX_TOKENS,
+            )
+            save_metrics_after = _wait_for_any_metric_delta(
+                pega_server.metrics_port,
+                save_metrics_before,
+                (
+                    "pegaflow_save_bytes_total",
+                    "pegaflow_cache_block_insertions_total",
+                ),
+            )
+
+        with VLLMServer(
+            model,
+            read_port,
+            pegaflow_port=pega_server.grpc_port,
+            log_file=read_write_log,
+            max_model_len=server_max_model_len,
+            extra_args=vllm_extra_args,
+            startup_timeout=SAVE_ONLY_STARTUP_TIMEOUT,
+            kv_transfer_config=_pegaflow_read_write_config(pega_server.grpc_port),
+            server_label="PegaFlowReadWrite",
+            env_overrides=vllm_env,
+        ):
+            read_metrics_before = fetch_pegaflow_metrics(pega_server.metrics_port)
+            read_write_result = call_openai_api(
+                read_port,
+                model,
+                prompt,
+                max_tokens=SAVE_ONLY_MAX_TOKENS,
+            )
+            read_metrics_after = _wait_for_any_metric_delta(
+                pega_server.metrics_port,
+                read_metrics_before,
+                (
+                    "pegaflow_load_bytes_total",
+                    "pegaflow_cache_block_hits_total",
+                ),
+            )
+
+    assert save_only_result["text"] == read_write_result["text"]
+
+    save_bytes = _metric_delta(save_metrics_before, save_metrics_after, "pegaflow_save_bytes_total")
+    insertions = _metric_delta(
+        save_metrics_before,
+        save_metrics_after,
+        "pegaflow_cache_block_insertions_total",
+    )
+    assert save_bytes > 0 or insertions > 0, (
+        f"save_only phase produced no PegaFlow save activity: "
+        f"save_bytes={save_bytes}, insertions={insertions}; logs={log_dir}"
+    )
+
+    save_hits = _metric_delta(
+        save_metrics_before,
+        save_metrics_after,
+        "pegaflow_cache_block_hits_total",
+    )
+    save_load_bytes = _metric_delta(
+        save_metrics_before,
+        save_metrics_after,
+        "pegaflow_load_bytes_total",
+    )
+    assert save_hits == 0 and save_load_bytes == 0, (
+        f"save_only phase unexpectedly read from PegaFlow: "
+        f"hits={save_hits}, load_bytes={save_load_bytes}; logs={log_dir}"
+    )
+
+    read_hits = _metric_delta(
+        read_metrics_before,
+        read_metrics_after,
+        "pegaflow_cache_block_hits_total",
+    )
+    read_load_bytes = _metric_delta(
+        read_metrics_before,
+        read_metrics_after,
+        "pegaflow_load_bytes_total",
+    )
+    print(
+        "[save_only metrics] "
+        f"save_bytes={save_bytes:.0f} insertions={insertions:.0f} "
+        f"hits={save_hits:.0f} load_bytes={save_load_bytes:.0f}"
+    )
+    print(f"[read_write metrics] hits={read_hits:.0f} load_bytes={read_load_bytes:.0f}")
+    assert read_hits > 0 or read_load_bytes > 0, (
+        f"read_write phase did not load saved blocks: "
+        f"hits={read_hits}, load_bytes={read_load_bytes}; logs={log_dir}"
+    )
+
+    save_log_text = save_only_log.read_text(errors="replace")
+    read_log_text = read_write_log.read_text(errors="replace")
+    assert "cache_lookup:" not in save_log_text
+    assert "cache_lookup: hit_blocks=" in read_log_text

--- a/python/tests/vllm_helpers.py
+++ b/python/tests/vllm_helpers.py
@@ -17,6 +17,20 @@ import requests
 DEFAULT_VLLM_SEED = 42
 
 
+def _detect_pegaflow_cargo_features() -> list[str]:
+    try:
+        import torch
+    except ImportError:
+        return []
+
+    cuda_version = getattr(torch.version, "cuda", None)
+    if not cuda_version:
+        return []
+
+    major = cuda_version.split(".", maxsplit=1)[0]
+    return ["cuda-13"] if major == "13" else []
+
+
 class VLLMServer:
     """Context manager for vLLM server lifecycle."""
 
@@ -34,6 +48,9 @@ class VLLMServer:
         extra_args: list[str] | None = None,
         startup_timeout: int = 600,
         use_noop_connector: bool = False,
+        kv_transfer_config: dict[str, object] | None = None,
+        server_label: str | None = None,
+        env_overrides: dict[str, str] | None = None,
     ):
         self.model = model
         self.port = port
@@ -47,6 +64,9 @@ class VLLMServer:
         self.extra_args = extra_args or []
         self.startup_timeout = startup_timeout
         self.use_noop_connector = use_noop_connector
+        self.kv_transfer_config = kv_transfer_config
+        self.server_label = server_label
+        self.env_overrides = env_overrides or {}
         self.health_endpoints = ["/health", "/v1/models"]
         self.process: subprocess.Popen | None = None
         self.log_handle = None
@@ -65,8 +85,9 @@ class VLLMServer:
         env["PYTHONHASHSEED"] = "0"
         env["VLLM_BATCH_INVARIANT"] = "1"
 
-        if self.use_pegaflow and self.pegaflow_port is not None:
+        if self.pegaflow_port is not None:
             env["PEGAFLOW_PORT"] = str(self.pegaflow_port)
+        env.update(self.env_overrides)
 
         # Resolve vllm binary from the current Python environment's bin dir
         import sys
@@ -97,7 +118,9 @@ class VLLMServer:
         if self.max_model_len is not None:
             cmd.extend(["--max-model-len", str(self.max_model_len)])
 
-        if self.use_pegaflow or self.use_noop_connector:
+        if self.kv_transfer_config is not None:
+            cmd.extend(["--kv-transfer-config", json.dumps(self.kv_transfer_config)])
+        elif self.use_pegaflow or self.use_noop_connector:
             connector_name = "PegaKVConnector" if self.use_pegaflow else "NoopKVConnector"
             kv_config = {
                 "kv_connector": connector_name,
@@ -108,7 +131,9 @@ class VLLMServer:
 
         cmd.extend(self.extra_args)
 
-        server_label = "PegaFlow" if self.use_pegaflow else "Baseline"
+        server_label = self.server_label or (
+            "PegaFlow" if self.use_pegaflow or self.kv_transfer_config is not None else "Baseline"
+        )
         print(f"\n[{server_label}] Starting vLLM server on port {self.port}")
 
         if self.log_file:
@@ -136,7 +161,11 @@ class VLLMServer:
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Stop the vLLM server and all child processes."""
         if self.process:
-            server_label = "PegaFlow" if self.use_pegaflow else "Baseline"
+            server_label = self.server_label or (
+                "PegaFlow"
+                if self.use_pegaflow or self.kv_transfer_config is not None
+                else "Baseline"
+            )
             print(f"\n[{server_label}] Stopping vLLM server...")
             try:
                 os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
@@ -221,10 +250,20 @@ class PegaFlowServer:
     Picks random available ports for gRPC and HTTP endpoints.
     """
 
-    def __init__(self, log_file: Path | None = None, pool_size: str = "30gb"):
+    def __init__(
+        self,
+        log_file: Path | None = None,
+        pool_size: str = "30gb",
+        log_level: str | None = None,
+        cargo_features: list[str] | None = None,
+    ):
         self.grpc_port = find_available_port()
         self.http_port = find_available_port()
         self.pool_size = pool_size
+        self.log_level = log_level
+        self.cargo_features = (
+            cargo_features if cargo_features is not None else _detect_pegaflow_cargo_features()
+        )
         self.log_file = log_file
         self.process: subprocess.Popen | None = None
         self.log_handle = None
@@ -240,17 +279,26 @@ class PegaFlowServer:
             "cargo",
             "run",
             "-r",
-            "--bin",
-            "pegaflow-server",
-            "--",
-            "--addr",
-            f"127.0.0.1:{self.grpc_port}",
-            "--http-addr",
-            f"0.0.0.0:{self.http_port}",
-            "--pool-size",
-            self.pool_size,
-            "--enable-prometheus",
         ]
+        if self.cargo_features:
+            cmd.append("--no-default-features")
+            cmd.extend(["--features", ",".join(self.cargo_features)])
+        cmd.extend(
+            [
+                "--bin",
+                "pegaflow-server",
+                "--",
+                "--addr",
+                f"127.0.0.1:{self.grpc_port}",
+                "--http-addr",
+                f"0.0.0.0:{self.http_port}",
+                "--pool-size",
+                self.pool_size,
+                "--enable-prometheus",
+            ]
+        )
+        if self.log_level is not None:
+            cmd.extend(["--log-level", self.log_level])
 
         # pegaflow-server embeds Python via PyO3 (for CUDA device detection via torch)
         import sys
@@ -266,7 +314,11 @@ class PegaFlowServer:
         site_packages = next((p for p in sys.path if "site-packages" in p), None)
         env["PYTHONPATH"] = f"{python_dir}" + (f":{site_packages}" if site_packages else "")
 
-        print(f"\n[PegaFlow Server] cargo run -r on gRPC={self.grpc_port}, HTTP={self.http_port}")
+        feature_label = ",".join(self.cargo_features) or "default"
+        print(
+            f"\n[PegaFlow Server] cargo run -r features={feature_label} "
+            f"on gRPC={self.grpc_port}, HTTP={self.http_port}"
+        )
 
         if self.log_file:
             print(f"[PegaFlow Server] Logging to: {self.log_file}")
@@ -328,7 +380,7 @@ class PegaFlowServer:
 def call_openai_api(
     port: int,
     model: str,
-    prompt: str,
+    prompt: str | list[int],
     max_tokens: int = 50,
     temperature: float = 0.0,
     seed: int | None = None,


### PR DESCRIPTION
## Summary
- Add `pegaflow.mode` extra config with `read_write` default and `save_only` mode.
- Make save-only mode skip Pega query/load while still advancing save metadata from absolute computed-token watermarks.
- Add unit coverage for save-only scheduling/resume behavior and an E2E that combines full-hit DecodeBenchConnector + Pega save-only, then verifies a read-write Pega instance can load the saved KV.

## E2E evidence
- Save-only phase metrics: `save_bytes=9175040 insertions=5 hits=0 load_bytes=0`.
- Read-write phase metrics: `hits=4 load_bytes=7340032`.
- Save-only server log contains no `cache_lookup`, `query_prefetch`, or `load`; read-write phase logs `cache_lookup: hit_blocks=4`.

## Tests
- `uv run --extra dev ruff check python/pegaflow/connector/__init__.py python/pegaflow/connector/common.py python/pegaflow/connector/scheduler.py python/tests/test_combine_hashes.py python/tests/test_vllm_save_only_e2e.py python/tests/vllm_helpers.py`
- `uv run --extra test pytest tests/test_vllm_save_only_e2e.py --collect-only -q -m e2e`
- `uv run --extra test pytest tests/test_combine_hashes.py -q`
- `PYTHONPATH=/data/pegadev/pegaflow-save-only-mode/python /data/pegadev/pegaflow/.venv/bin/python -m pytest tests/test_vllm_save_only_e2e.py -m e2e -q -s --model Qwen/Qwen3-0.6B --e2e-port 18100`
- pre-commit hooks, including `cargo test --release`