### PR TITLE
chore(release): bump version to 0.22.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,7 +2279,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "colored",
  "libc",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "ahash",
  "bytesize",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "axum",
  "clap",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "prost",
  "tonic",
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "axum",
  "clap",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.22.3"
+version = "0.22.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.22.3"
+version = "0.22.4"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -110,6 +110,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.22.3"
+version = "0.22.4"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## chore(release): bump version to 0.22.4

Bumps the Rust workspace, the `pegaflow-llm` Python package, the commitizen version, and the `Cargo.lock` workspace package versions from `0.22.3` to `0.22.4`.

---

## Release notes — 0.22.3 → 0.22.4

18 PRs landed on `master` since `v0.22.3` (2026-05-15). Grouped below for release notes.

### Highlights

- **Disaggregated prefill/decode over RDMA push** (#297) — a brand-new vLLM v1 KV connector (`PdConnector`) plus a v2 RDMA transfer engine (`pegaflow-transfer/src/v2`). KV is pushed prefill→decode layer-by-layer via one-sided RDMA WRITE as each attention layer completes, overlapping transfer with the forward pass instead of pulling after prefill finishes (vLLM NIXL model). On H20 / Qwen3-8B the added TTFT is **2–4× lower than NIXL** across 512–16k input lengths.
- **Query leases replace query pinning** (#284, #288) — the query/load/release control path moved from pin refcounts to lease-backed ownership. Query results collapse to `Loading`/`Ready` only; `Ready` carries `num_hit_blocks` plus an opaque lease that transfers scheduler→worker and is released on cleanup/failure, with a TTL sweeper reclaiming abandoned leases.
- **Save-only connector mode** (#300) — new `pegaflow.mode` config; `save_only` skips Pega query/load while still advancing save metadata, so an instance can populate the cache without serving reads.

### Features

- feat(pd): RDMA push connector for disaggregated prefill/decode (#297)
- feat(connector): add save-only pegaflow mode (#300)
- feat(storage): sharded SSD cache — cache spread across multiple files, uring engine dispatches across shards, prefetch ready-blocks now ordered by requested keys (#299)
- feat(rdma): per-peer N QPs with WQE-level round-robin — new `--qps-per-peer` (default 2), round-robin at WQE level so one in-flight task saturates all QPs; handshake validates both sides agree on N (#291)
- feat(metaserver): node lifecycle fencing — heartbeat-based node tracking with per-node UUID fencing, stale nodes hidden via `--node-stale-secs` (#285, closes #222)
- feat(connector): replace query pinning with leases (#284)

### Fixes

- fix(connector): preserve non-MLA KV layout registration so cross-layer layouts (e.g. GLM-4.7-FP8) register by block stride; limit logical/physical block splitting to MLA (#295, closes #294)
- fix(numa): allocate pinned pools on GPU-local NUMA nodes instead of the full CPU NUMA set, avoiding wasted capacity on CPU-only nodes (#293)
- fix(connector): handle split physical KV blocks — group split physical rows into one logical block when FlashMLA uses smaller physical blocks (#292)
- fix(connector): allow a query lease to be consumed once per registered worker, fixing multi-worker `query lease is unknown or expired` (#288)
- fix(server): fail on invalid RDMA NICs — accept comma/space-separated `--nics`, reject empty names, propagate RDMA init failures instead of silently disabling P2P (#283, fixes #276)
- fix(connector): remove the unused scheduler pending-save request limit and save-drop accounting (#282)
- fix(connector): demote `cache_lookup_reuse` log from INFO to DEBUG to stop log spam under cache pressure (#280)

### Performance

- perf: CPU-path Criterion benchmarks + long-block save optimizations — e.g. `query_prefetch_lease/32768` ~12.3 ms → ~6.1 ms, `save_flush_unique/8192` ~21.3 ms → ~13.1 ms via reduced prefix-key cloning, ordered multi-layer save grouping, and RawBlock inline-segment allocation (#290)

### Internal / refactor / tests

- refactor(metrics): centralize histogram buckets behind a `build_buckets` helper (#298)
- refactor(core): make prefetch tasks terminal (Ready results carry RAM prefix blocks); default storage admission to no TinyLFU unless explicitly enabled (#287)
- test(server): mock vLLM gRPC E2E harness covering save/query/load/release/session contracts (#289)
- chore: tune transfer duration histogram buckets toward long-tail visibility (#281)

### Notable behavior & config changes (upgrade notes)

- **Query API**: query results are now `Loading`/`Ready` only; `Ready` exposes `num_hit_blocks` + an opaque lease. Pin/unpin refcount semantics are gone (#284, #288).
- **Release RPC**: unknown/expired leases now return `FailedPrecondition` instead of being silently accepted (#289).
- **`--nics`**: now rejects empty entries (e.g. `mlx5_0,,mlx5_1`) and fails startup on RDMA init errors rather than silently falling back to no-P2P (#283).
- **New CLI flags**: `--qps-per-peer` (default 2) (#291), `--node-stale-secs` for metaserver (#285).
- **New connector config**: `pegaflow.mode` with `read_write` (default) / `save_only` (#300).
- **Storage admission**: TinyLFU is now off unless explicitly enabled (#287).

### Full PR list

```
#298 refactor(metrics): use build_buckets helper for histogram buckets
#300 feat(connector): add save-only pegaflow mode
#299 feat(storage): add sharded SSD cache support
#297 feat(pd): RDMA push connector for disaggregated prefill/decode
#290 perf: add cpu path benchmarks and optimize long-block saves
#295 fix(connector): preserve non-MLA kv layout registration
#293 fix(numa): allocate pinned pools on GPU-local NUMA nodes
#292 fix(connector): handle split physical kv blocks
#291 feat(rdma): per-peer N QPs with WQE-level round-robin
#285 feat(metaserver): add node lifecycle fencing
#287 refactor(core): make prefetch task terminal
#289 test(server): add mock vLLM RPC E2E coverage
#288 fix(connector): allow query leases across workers
#284 feat(connector): replace query pinning with leases
#283 fix(server): fail on invalid rdma nics
#282 fix(connector): remove scheduler save limit
#281 chore: tune transfer duration buckets
#280 fix(connector): demote cache_lookup_reuse log to debug
```
