### PR TITLE
fix(ci): install libibverbs-dev in release wheel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,10 @@ jobs:
           method: 'network'
           sub-packages: '["nvcc", "nvrtc-dev", "cudart-dev"]'
 
-      - name: Install protobuf compiler
+      - name: Install protobuf compiler and RDMA headers
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler libibverbs-dev
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

The `pegaflow-transfer` v2 RDMA engine (#297) made `pegaflow-transfer/build.rs` require `infiniband/verbs.h` at build time. `ci.yml` was updated to `apt-get install ... libibverbs-dev`, but `release.yml` was not — so the **v0.22.4** release wheel build panicked:

```
thread 'main' panicked at pegaflow-transfer/build.rs:24:13:
libibverbs: required header `include/infiniband/verbs.h` not found.
```

Failed run: https://github.com/novitalabs/pegaflow/actions/runs/26620616554

## Fix

Add `libibverbs-dev` to the `release.yml` apt install step (mirrors the three install steps in `ci.yml`).

## Follow-up

After merge, the `v0.22.4` tag will be moved onto the fixed commit to re-fire the release (the prior run failed before the PyPI publish step, so nothing was published).