### PR TITLE
fix: add aarch64 support

### DIFF
--- a/pegaflow-core/src/sync_state.rs
+++ b/pegaflow-core/src/sync_state.rs
@@ -1,10 +1,14 @@
 //! Shared-memory synchronization state for async KV cache loading.
 //!
-//! Only the batch-level `LoadState` is supported. Other platforms are not
-//! supported; compilation will fail outside x86_64 Linux.
+//! Only the batch-level `LoadState` is supported. It requires 64-bit Linux
+//! with 64-bit atomics; compilation will fail on other platforms.
 
-#[cfg(not(all(target_arch = "x86_64", target_os = "linux")))]
-compile_error!("LoadState is only supported on x86_64 Linux");
+#[cfg(not(all(
+    target_os = "linux",
+    target_pointer_width = "64",
+    target_has_atomic = "64"
+)))]
+compile_error!("LoadState requires 64-bit Linux with 64-bit atomics");
 
 use shared_memory::{Shmem, ShmemConf, ShmemError};
 use std::{


### PR DESCRIPTION
# Motivation

pegaflow is hard coded for x86_64. If we run pegaflow on GB200 or similar architectures, we need to add support for arm64.

# Fix

Currently pegaflow does not bind to specific architectures. The only hardware platform architecture specific bindings are (1) 64-bit pointers, (2) 64-bit atomics via AtomicI64. Both of which are supported by arm64. Thus pegaflow can run on arm64 / aarch64 platforms.

The fix is very simple and straightforward:

Instead of using 
```rust
#[cfg(not(all(target_arch = "x86_64", target_os = "linux")))]
```
We can use 
```rust
+#[cfg(not(all(target_os = "linux", target_pointer_width = "64", target_has_atomic = "64")))]
```
to allow any architecture that supports linux (shared memory) and 64-bit points and 64-bit atomic. arm64/aarch64 naturally follows in this category.
