### PR TITLE
docs(readme): add News section with vLLM x Novita AI blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 - **Production-ready observability** — built-in Prometheus metrics and OTLP export, not an afterthought
 - **Pluggable** — works with vLLM as a drop-in KV connector
 
+## News
+
+- **2026-05-18** — [vLLM x Novita AI: PegaFlow for Production-Grade External KV Cache](https://vllm.ai/blog/2026-05-18-pegaflow), a joint blog post with the vLLM team.
+
 ## Architecture
 
 <div align="center">


### PR DESCRIPTION
## What

Add a **News** section to the README with the joint vLLM x Novita AI blog post:

- 2026-05-18 — [vLLM x Novita AI: PegaFlow for Production-Grade External KV Cache](https://vllm.ai/blog/2026-05-18-pegaflow)

## Why

We co-published this blog post with the vLLM team; surfacing it in the README gives readers an entry point to the announcement.

Docs-only change. No code or behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)