### PR TITLE
chore(release): prepare 0.22.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,7 +2279,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "colored",
  "libc",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "ahash",
  "bytesize",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "axum",
  "clap",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "prost",
  "tonic",
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "axum",
  "clap",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.22.4"
+version = "0.22.5"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.22.4"
+version = "0.22.5"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -110,6 +110,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.22.4"
+version = "0.22.5"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## Summary
- Bump workspace and Python package versions to 0.22.5
- Refresh Cargo.lock package versions

## Test
- cargo check --workspace --all-targets --locked

Release workflow note: .github/workflows/release.yml publishes on v* tag push after this PR is merged.