### PR TITLE
feat: reject vllm register version mismatch

### DIFF
--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -23,6 +23,7 @@ message RegisterContextRequest {
   repeated uint64 kv_stride_bytes = 12;
   repeated uint32 segments = 13;
   uint32 pp_rank = 14;
+  string client_version = 15;
 }
 
 message RegisterContextResponse {

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -118,6 +118,17 @@ impl GrpcEngineService {
     }
 
     fn validate_register_context_request(req: &RegisterContextRequest) -> Result<(), Status> {
+        let server_version = env!("CARGO_PKG_VERSION");
+        if req.client_version != server_version {
+            return Err(Status::failed_precondition(format!(
+                "PegaFlow version mismatch: client={} server={server_version}",
+                if req.client_version.is_empty() {
+                    "<missing>"
+                } else {
+                    &req.client_version
+                }
+            )));
+        }
         Self::validate_device_id(req.device_id)?;
         if req.num_layers == 0 {
             return Err(Status::invalid_argument("num_layers must be > 0"));
@@ -1035,6 +1046,7 @@ mod tests {
         let err = GrpcEngineService::validate_register_context_request(&RegisterContextRequest {
             instance_id: "instance".to_string(),
             namespace: "namespace".to_string(),
+            client_version: env!("CARGO_PKG_VERSION").to_string(),
             tp_rank: 1,
             tp_size: 1,
             world_size: 1,
@@ -1052,6 +1064,36 @@ mod tests {
 
         assert_eq!(err.code(), Code::InvalidArgument);
         assert!(err.message().contains("tp_rank"));
+    }
+
+    #[test]
+    fn validate_register_context_rejects_client_version_mismatch() {
+        let err = GrpcEngineService::validate_register_context_request(&RegisterContextRequest {
+            instance_id: "instance".to_string(),
+            namespace: "namespace".to_string(),
+            client_version: "0.0.0-test-mismatch".to_string(),
+            tp_rank: 0,
+            tp_size: 1,
+            world_size: 1,
+            device_id: 0,
+            num_layers: 1,
+            layer_names: Vec::new(),
+            wrapper_bytes: Vec::new(),
+            num_blocks: Vec::new(),
+            bytes_per_block: Vec::new(),
+            kv_stride_bytes: Vec::new(),
+            segments: Vec::new(),
+            pp_rank: 0,
+        })
+        .expect_err("client/server version mismatch must be rejected before registration");
+
+        assert_eq!(err.code(), Code::FailedPrecondition);
+        assert!(err.message().contains("PegaFlow version mismatch"));
+        assert!(err.message().contains("client=0.0.0-test-mismatch"));
+        assert!(
+            err.message()
+                .contains(concat!("server=", env!("CARGO_PKG_VERSION")))
+        );
     }
 
     #[test]

--- a/pegaflow-server/tests/http_cleanup_hang_repro.rs
+++ b/pegaflow-server/tests/http_cleanup_hang_repro.rs
@@ -235,6 +235,7 @@ fn wedge_register_request(i: usize) -> RegisterContextRequest {
     RegisterContextRequest {
         instance_id: format!("wedge-{i}"),
         namespace: "wedge".to_string(),
+        client_version: env!("CARGO_PKG_VERSION").to_string(),
         tp_rank: 0,
         tp_size: 1,
         world_size: 1,

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -305,7 +305,11 @@ class WorkerConnector:
         )
 
         if not ok:
-            raise RuntimeError(f"Register context failed: {message}")
+            if "PegaFlow version mismatch" in message:
+                raise RuntimeError(f"Register context failed: {message}")
+            raise RuntimeError(
+                f"Register context batch failed for layers {layer_names}: {message}"
+            )
 
         if split_layer_count:
             logger.info(

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -305,7 +305,7 @@ class WorkerConnector:
         )
 
         if not ok:
-            raise RuntimeError(f"Register context failed for {layer_name}: {message}")
+            raise RuntimeError(f"Register context failed: {message}")
 
         if split_layer_count:
             logger.info(

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -293,6 +293,7 @@ impl EngineRpcClient {
                 .register_context_batch(RegisterContextRequest {
                     instance_id,
                     namespace,
+                    client_version: env!("CARGO_PKG_VERSION").to_string(),
                     tp_rank,
                     tp_size,
                     world_size,

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -293,6 +293,28 @@ def test_register_version_mismatch_raises_startup_error(monkeypatch):
     worker.shutdown()
 
 
+def test_register_non_version_failure_reports_batch_layers(monkeypatch):
+    worker, client, _ = _make_worker()
+    client.register_response = (False, "invalid tensor metadata")
+
+    monkeypatch.setattr("pegaflow.connector.worker.CudaIPCWrapper", FakeCudaIPCWrapper)
+
+    with pytest.raises(RuntimeError, match="invalid tensor metadata") as exc_info:
+        worker.register_kv_caches(
+            {
+                "layer.0": FakeTensor(),
+                "layer.1": FakeTensor(),
+            }
+        )
+
+    message = str(exc_info.value)
+    assert "Register context batch failed for layers ['layer.0', 'layer.1']" in message
+    assert "for layer.1" not in message
+    assert len(client.register_calls) == 1
+
+    worker.shutdown()
+
+
 def test_register_version_mismatch_rpc_error_stops_startup(monkeypatch):
     worker, client, _ = _make_worker()
     client.register_exception = RuntimeError(

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -42,6 +42,9 @@ class FakeEngineClient:
         self.fail_load_with_ok_false = False
         self.fail_load_with_exception: Exception | None = None
         self.load_calls: list[tuple] = []
+        self.register_response: tuple[bool, str] = (True, "ok")
+        self.register_exception: Exception | None = None
+        self.register_calls: list[tuple] = []
         self.release_calls: list[bytes] = []
 
     def load(
@@ -69,6 +72,12 @@ class FakeEngineClient:
         if self.fail_load_with_ok_false:
             return (False, "simulated load failure")
         return (True, "ok")
+
+    def register_context_batch(self, *args) -> tuple[bool, str]:
+        self.register_calls.append(args)
+        if self.register_exception is not None:
+            raise self.register_exception
+        return self.register_response
 
     def health(self) -> tuple[bool, str]:
         return (True, "ok")
@@ -238,5 +247,67 @@ def test_load_uses_registered_layer_names_before_forward_context_names():
 
     assert len(client.load_calls) == 1
     assert client.load_calls[0][4] == ["registered.layer.0", "registered.layer.1"]
+
+    worker.shutdown()
+
+
+class FakeTensor:
+    shape = (1, 16)
+
+    def storage_offset(self) -> int:
+        return 0
+
+    @property
+    def device(self) -> str:
+        return "cuda:0"
+
+    def stride(self) -> tuple[int, int]:
+        return (16, 1)
+
+    def element_size(self) -> int:
+        return 2
+
+
+class FakeCudaIPCWrapper:
+    def __init__(self, _tensor) -> None:
+        pass
+
+
+def test_register_version_mismatch_raises_startup_error(monkeypatch):
+    worker, client, _ = _make_worker()
+    client.register_response = (
+        False,
+        "PegaFlow version mismatch: client=0.22.4 server=0.22.5",
+    )
+
+    monkeypatch.setattr("pegaflow.connector.worker.CudaIPCWrapper", FakeCudaIPCWrapper)
+
+    with pytest.raises(RuntimeError, match="PegaFlow version mismatch") as exc_info:
+        worker.register_kv_caches({"layer.0": FakeTensor()})
+
+    assert "client=0.22.4" in str(exc_info.value)
+    assert "server=0.22.5" in str(exc_info.value)
+    assert "for layer.0" not in str(exc_info.value)
+    assert len(client.register_calls) == 1
+
+    worker.shutdown()
+
+
+def test_register_version_mismatch_rpc_error_stops_startup(monkeypatch):
+    worker, client, _ = _make_worker()
+    client.register_exception = RuntimeError(
+        "register_context_batch RPC failed: status: FailedPrecondition, "
+        "message: \"PegaFlow version mismatch: client=0.22.4 server=0.22.5\""
+    )
+
+    monkeypatch.setattr("pegaflow.connector.worker.CudaIPCWrapper", FakeCudaIPCWrapper)
+
+    with pytest.raises(RuntimeError, match="PegaFlow version mismatch") as exc_info:
+        worker.register_kv_caches({"layer.0": FakeTensor()})
+
+    assert "FailedPrecondition" in str(exc_info.value)
+    assert "client=0.22.4" in str(exc_info.value)
+    assert "server=0.22.5" in str(exc_info.value)
+    assert len(client.register_calls) == 1
 
     worker.shutdown()


### PR DESCRIPTION
## Summary
- Add a `client_version` field to `RegisterContextRequest` and have the PyO3 client send its Cargo package version during vLLM KV cache registration.
- Reject register requests on the server when the client and server PegaFlow versions differ, returning a `FailedPrecondition` error with both versions in the message.
- Keep the vLLM worker startup path fail-fast by surfacing register failures, and add focused unit coverage for version mismatch propagation.

## Validation
- `cargo fmt --check`
- `cargo test -p pegaflow-server --no-default-features --features cuda-12 validate_register_context`
- `cargo check -p pegaflow-py --no-default-features --features cuda-12`
- `cd python && python -m pytest tests/test_connector_fault_tolerance.py`
- h20b smoke: new `0.22.5` server rejected old `0.22.3` Python extension register request with `PegaFlow version mismatch: client=<missing> server=0.22.5`.

## Notes
- Full default Rust test was not used locally because this machine's RDMA headers fail `rdma-mummy-sys`; the targeted checks use `--no-default-features --features cuda-12`.
- Full vLLM correctness E2E was not completed on h20b because `/data/models/Qwen3-4B` is not a valid model directory there and existing Kubernetes-managed vLLM pods were running on that host. The focused register smoke covers this PR's version-mismatch behavior.
