### PR TITLE
fix(connector): skip lease release for zero-hit query probes

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -26,8 +26,8 @@ hooks = [{ id = "codespell", additional_dependencies = ["tomli"], files = '^pyth
 repo = "local"
 hooks = [
   { id = "cargo-fmt", name = "cargo fmt", language = "system", entry = "cargo fmt --all -- --check", files = { glob = ["Cargo.toml", "**/Cargo.toml", "**/*.rs"] }, pass_filenames = false, require_serial = true },
-  { id = "cargo-clippy", name = "cargo clippy", language = "system", entry = "cargo clippy --workspace --all-targets -- -D warnings", files = { glob = ["Cargo.toml", "**/Cargo.toml", "**/*.rs"] }, pass_filenames = false, require_serial = true },
-  { id = "cargo-test-release", name = "cargo test --release", language = "system", entry = "cargo test --release", pass_filenames = false, always_run = true, require_serial = true, stages = ["pre-commit"] },
+  { id = "cargo-clippy", name = "cargo clippy", language = "system", entry = "cargo clippy --workspace --all-targets --no-default-features --features cuda-13,rdma -- -D warnings", files = { glob = ["Cargo.toml", "**/Cargo.toml", "**/*.rs"] }, pass_filenames = false, require_serial = true },
+  { id = "cargo-test-release", name = "cargo test --release", language = "system", entry = "cargo test --release --no-default-features --features cuda-13,rdma", pass_filenames = false, always_run = true, require_serial = true, stages = ["pre-commit"] },
 ]
 
 [[repos]]

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -52,10 +52,7 @@ class _QueryProbe:
         return self.hit_blocks is not None
 
     def matches(self, computed_blocks: int, query_hashes: tuple[bytes, ...]) -> bool:
-        return (
-            self.computed_blocks == computed_blocks
-            and self.query_hashes == query_hashes
-        )
+        return self.computed_blocks == computed_blocks and self.query_hashes == query_hashes
 
     def mark_ready(self, ready: QueryReady) -> None:
         hit_blocks = ready.num_hit_blocks
@@ -570,8 +567,8 @@ class SchedulerConnector:
         return self._release_query_probe(req_id, probe)
 
     def _release_query_probe(self, req_id: str, probe: _QueryProbe) -> bool:
-        if not probe.is_ready:
-            return True  # no lease to release yet
+        if not probe.lease:
+            return True  # nothing leased server-side (still loading, or zero-hit Ready)
         try:
             self._ctx.engine_client.release(probe.lease)
         except Exception:

--- a/python/tests/test_vllm_e2e_correctness.py
+++ b/python/tests/test_vllm_e2e_correctness.py
@@ -30,6 +30,7 @@ from .vllm_helpers import (
     VLLMServer,
     call_openai_api,
     fetch_pegaflow_metrics,
+    fetch_pegaflow_rpc_failures,
 )
 
 # ---------------------------------------------------------------------------
@@ -353,4 +354,43 @@ class TestE2ECorrectness:
         print(
             f"\n[Metrics] saves={insertions:.0f} blocks ({save_bytes / 1e6:.1f}MB), "
             f"hits={hits:.0f} blocks ({load_bytes / 1e6:.1f}MB)"
+        )
+
+    def test_no_data_path_rpc_failures(self, pegaflow_results, pegaflow_server: PegaFlowServer):
+        """Every connector<->server RPC must return ok during a correct run.
+
+        Generalizes the 0.22.5 empty-lease regression: that bug surfaced as
+        release/"Client specified an invalid argument" on every cache miss, but
+        the same gate also catches a failed load, save, or query_prefetch — none
+        of which the output-equality test reliably exposes.
+
+        The miss guard makes the gate non-vacuous: it proves the plan actually
+        drove the zero-hit path the bug lived on, so a green run means something.
+        """
+        # pegaflow_results forces the real cache plan to run against this server.
+        del pegaflow_results
+        counters = fetch_pegaflow_metrics(pegaflow_server.metrics_port)
+        assert counters.get("pegaflow_cache_block_misses_total", 0) > 0, (
+            "execution plan exercised no cache miss; the RPC-health gate would be vacuous"
+        )
+        failures = fetch_pegaflow_rpc_failures(pegaflow_server.metrics_port)
+        assert not failures, f"non-ok data-path RPCs during run: {failures}"
+
+    def test_no_kv_load_failures(self, pegaflow_results, pegaflow_server: PegaFlowServer):
+        """KV loads must not fail.
+
+        A load failure is silently masked by test_execution_plan_outputs_match_baseline:
+        vLLM reports the failed blocks via get_block_ids_with_load_errors and
+        recomputes them locally, so the final text still matches baseline. Only
+        the failure counter exposes it, which is why this is a separate gate.
+        """
+        del pegaflow_results
+        counters = fetch_pegaflow_metrics(pegaflow_server.metrics_port)
+        loads_happened = (
+            counters.get("pegaflow_cache_block_hits_total", 0) > 0
+            or counters.get("pegaflow_load_bytes_total", 0) > 0
+        )
+        assert loads_happened, "plan performed no KV load; cannot assert load health"
+        assert counters.get("pegaflow_load_failures_total", 0) == 0, (
+            f"KV load failures during run: {counters.get('pegaflow_load_failures_total')}"
         )

--- a/python/tests/vllm_helpers.py
+++ b/python/tests/vllm_helpers.py
@@ -227,6 +227,36 @@ def fetch_pegaflow_metrics(metrics_port: int) -> dict[str, float]:
     return metrics
 
 
+def fetch_pegaflow_rpc_failures(metrics_port: int, method: str | None = None) -> dict[str, float]:
+    """Return non-ok RPC counts keyed by ``"method/status"``.
+
+    ``fetch_pegaflow_metrics`` collapses label sets, so it cannot tell a failed
+    RPC from a successful one. This keeps the ``method``/``status`` labels so a
+    test can assert that no connector<->server RPC failed. Pass ``method`` to
+    restrict to one RPC; ``None`` (default) reports failures across all methods.
+    """
+    url = f"http://localhost:{metrics_port}/metrics"
+    response = requests.get(url, timeout=5)
+    response.raise_for_status()
+
+    failures: dict[str, float] = {}
+    for line in response.text.splitlines():
+        if not line.startswith("pegaflow_rpc_requests"):
+            continue
+        match = re.match(r"^pegaflow_rpc_requests(?:_total)?\{([^}]*)\}\s+([\d.eE+-]+)$", line)
+        if not match:
+            continue
+        labels = dict(re.findall(r'(\w+)="([^"]*)"', match.group(1)))
+        if labels.get("status") == "ok":
+            continue
+        rpc = labels.get("method", "")
+        if method is not None and rpc != method:
+            continue
+        key = f"{rpc}/{labels.get('status', '')}"
+        failures[key] = failures.get(key, 0.0) + float(match.group(2))
+    return failures
+
+
 def check_pegaflow_server(metrics_port: int) -> bool:
     """Check if PegaFlow server is running and metrics endpoint is available."""
     try:


### PR DESCRIPTION
## Problem

Users on 0.22.5 saw `query lease id must be non-empty` logged continuously.

A cache **miss** makes the server return `Ready(0)` with an **empty** lease (a lease is only minted when `hit > 0`). Since #315 the scheduler stores that zero-hit `Ready` as a `_QueryProbe` and cleans it up via `_release_query_probe`, whose guard was `if not probe.is_ready`. A zero-hit probe **is** ready (`hit_blocks == 0`, not `None`), so the guard didn't short-circuit and the connector called `release(b"")` on **every miss**. The server rejects empty lease bytes with `InvalidArgument` (`query lease id must be non-empty`), which the connector caught and logged via `logger.exception`.

**Impact: cosmetic only.** The empty lease maps to no server-side state (the server validates the bytes before any lookup), the exception is caught, and the probe is already popped — so no leak, no wrong result, no failed request. Just ERROR-log spam (and one wasted release round-trip) per miss.

## Fix

Guard on `probe.lease` instead of `probe.is_ready`. A probe holds a server-side lease iff its lease bytes are non-empty — false for both still-loading and zero-hit probes.

```python
def _release_query_probe(self, req_id, probe):
    if not probe.lease:          # was: if not probe.is_ready
        return True
    ...
```

## Tests — real vLLM + real pegaflow-server e2e, no mocks

Asserts on the server's Prometheus metrics after the real execution plan runs. Expanded beyond the single bug:

- **`test_no_data_path_rpc_failures`** — zero non-ok RPCs across **all** methods (query_prefetch/load/save/release/register), guarded by `cache_block_misses > 0` so the gate is never vacuous. Generalizes the regression: also catches a failed load/save/query.
- **`test_no_kv_load_failures`** — `pegaflow_load_failures_total == 0`. The output-equality test can't catch load failures (vLLM silently recomputes failed blocks locally, so text still matches baseline) — only the counter exposes it.

Added `fetch_pegaflow_rpc_failures()` (label-aware) to `vllm_helpers.py`.

### Reproduce → fix, verified on the GPU box
- Guard reverted (bug live): `FAILED` — `{'release/Client specified an invalid argument': 4.0}` (4 empty-lease releases rejected during the cold prompts).
- Fix applied: both new gates `PASSED`; output-match + cache-metrics still pass.
- Default unit gate: 74 passed. ruff: clean.

## Also

Switch the prek `cargo clippy`/`cargo test` hooks to `--no-default-features --features cuda-13,rdma` so they build against the CUDA 13 runtime on the dev box instead of panicking on the default cuda-12 `libcudart` symbol mismatch (`cudaEventElapsedTime_v2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)