### PR TITLE
chore: remove unused Rust dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,9 @@ cargo bench --bench uds_latency
 2. **pegaflow-core** (Rust): Core storage engine
    - `PegaEngine`: Main engine managing GPU workers and KV cache storage
    - `storage/`: Modular block storage engine
-     - `mod.rs`: `StorageEngine` — aggregates allocator, read cache, prefetch, write pipeline, SSD store, remote fetch
+     - `mod.rs`: `StorageEngine` — aggregates allocator, read cache, prefetch, write pipeline, SSD store, RDMA fetch
      - `read_cache.rs`: Pin/unpin/consume operations on sealed blocks
-     - `prefetch.rs`: Per-request SSD prefetch state machine
-     - `remote_fetch.rs`: Per-request cross-node remote fetch state machine (oneshot + backpressure)
+     - `prefetch.rs`: Per-request SSD/RDMA prefetch state machine
      - `transfer_lock.rs`: Transfer lock manager — prevents LRU eviction during RDMA transfer
      - `write_path.rs`: Async insert worker thread for batched writes
    - `backing/`: SSD backing store
@@ -71,11 +70,7 @@ cargo bench --bench uds_latency
    - `cache.rs`: LRU cache for blocks
    - `gpu_worker.rs`: Per-GPU worker handling async operations
    - `internode/`: Cross-node communication
-     - `client.rs`: `PegaflowClient` / `PegaflowClientPool` for querying remote nodes
-     - `metaserver_query.rs`: MetaServer query client for block location discovery
-     - `remote_fetch_worker.rs`: Async RDMA fetch worker (MetaServer → gRPC → RDMA READ → SealedBlock)
-     - `registrar.rs`: Fire-and-forget block hash registration with MetaServer
-     - `service_discovery.rs`: Kubernetes pod watcher for PegaFlow instance discovery
+     - `metaserver_client.rs`: MetaServer registration, removal, query, and node heartbeat
 
 3. **pegaflow-proto** (Rust): Protobuf definitions
    - gRPC service definitions built with prost/tonic
@@ -168,16 +163,13 @@ vLLM Worker <--gRPC--> PegaEngine Server <--CUDA IPC--> GPU Memory
 - `pegaflow-common/src/logging.rs`: Unified log initialization
 - `pegaflow-common/src/numa.rs`: NUMA topology detection and CPU affinity
 - `pegaflow-core/src/lib.rs`: Main PegaEngine implementation
-- `pegaflow-core/src/storage/mod.rs`: StorageEngine (allocator, read cache, prefetch, write pipeline, remote fetch)
+- `pegaflow-core/src/storage/mod.rs`: StorageEngine (allocator, read cache, prefetch, write pipeline, RDMA fetch)
 - `pegaflow-core/src/storage/read_cache.rs`: Pin/unpin/consume operations
-- `pegaflow-core/src/storage/prefetch.rs`: SSD prefetch state machine
-- `pegaflow-core/src/storage/remote_fetch.rs`: Cross-node remote fetch state machine
+- `pegaflow-core/src/storage/prefetch.rs`: SSD/RDMA prefetch state machine
 - `pegaflow-core/src/storage/transfer_lock.rs`: Transfer lock manager for RDMA transfers
 - `pegaflow-core/src/storage/write_path.rs`: Async insert worker thread
 - `pegaflow-core/src/backing/ssd.rs`: SSD backing store coordinator
-- `pegaflow-core/src/internode/client.rs`: PegaflowClient/PegaflowClientPool for remote nodes
-- `pegaflow-core/src/internode/metaserver_query.rs`: MetaServer query client
-- `pegaflow-core/src/internode/remote_fetch_worker.rs`: Async RDMA fetch worker
+- `pegaflow-core/src/internode/metaserver_client.rs`: MetaServer registration, query, and node heartbeat
 - `pegaflow-server/src/service.rs`: gRPC service implementation
 - `pegaflow-metaserver/src/lib.rs`: MetaServer entry point and CLI
 - `pegaflow-metaserver/src/service.rs`: MetaServer gRPC service

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,12 +34,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,40 +94,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "async-trait"
@@ -242,17 +202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backon"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
-dependencies = [
- "fastrand",
- "gloo-timers",
- "tokio",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,15 +293,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,7 +377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.0",
 ]
 
@@ -563,15 +503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,15 +527,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -697,16 +619,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "cudarc"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,37 +639,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -782,18 +663,6 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "educe"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "either"
@@ -823,26 +692,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-ordinalize"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,27 +716,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1076,16 +904,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,18 +949,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "h2"
@@ -1204,8 +1010,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -1245,17 +1049,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "hostname"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-link",
 ]
 
 [[package]]
@@ -1335,9 +1128,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "log",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1640,145 +1431,6 @@ checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "json-patch"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90"
-dependencies = [
- "jsonptr",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "jsonpath-rust"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633a7320c4bb672863a3782e89b9094ad70285e097ff6832cddd0ec615beadfa"
-dependencies = [
- "pest",
- "pest_derive",
- "regex",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "jsonptr"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "k8s-openapi"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a6d6f3611ad1d21732adbd7a2e921f598af6c92d71ae6e2620da4b67ee1f0d"
-dependencies = [
- "base64",
- "jiff",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "kube"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96b537b4c4f61fc183594edbecbbefa3037e403feac0701bb24e6eff78e0034"
-dependencies = [
- "k8s-openapi",
- "kube-client",
- "kube-core",
- "kube-runtime",
-]
-
-[[package]]
-name = "kube-client"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af97b8b696eb737e5694f087c498ca725b172c2a5bc3a6916328d160225537ee"
-dependencies = [
- "base64",
- "bytes",
- "either",
- "futures",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-timeout",
- "hyper-util",
- "jiff",
- "jsonpath-rust",
- "k8s-openapi",
- "kube-core",
- "pem",
- "rustls",
- "secrecy",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tower",
- "tower-http",
- "tracing",
-]
-
-[[package]]
-name = "kube-core"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aeade7d2e9f165f96b3c1749ff01a8e2dc7ea954bd333bcfcecc37d5226bdd"
-dependencies = [
- "derive_more",
- "form_urlencoded",
- "http",
- "jiff",
- "json-patch",
- "k8s-openapi",
- "serde",
- "serde-value",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "kube-runtime"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc158473d6d86ec22692874bd5ddccf07474eab5c6bb41f226c522e945da5244"
-dependencies = [
- "ahash",
- "async-broadcast",
- "async-stream",
- "backon",
- "educe",
- "futures",
- "hashbrown 0.16.1",
- "hostname",
- "json-patch",
- "k8s-openapi",
- "kube-client",
- "parking_lot",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -2197,15 +1849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "os_socketaddr"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,12 +1878,6 @@ dependencies = [
  "fnv",
  "unicode-width",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2300,8 +1937,6 @@ dependencies = [
  "futures",
  "hashlink",
  "io-uring",
- "k8s-openapi",
- "kube",
  "libc",
  "log",
  "logforth",
@@ -2313,7 +1948,6 @@ dependencies = [
  "pegaflow-proto",
  "pegaflow-transfer",
  "rand 0.10.0",
- "serde",
  "shared_memory",
  "smallvec",
  "tempfile",
@@ -2335,13 +1969,9 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
  "opentelemetry_sdk",
- "parking_lot",
  "pegaflow-common",
  "pegaflow-proto",
  "prometheus",
- "prost",
- "serde",
- "serde_json",
  "tokio",
  "tonic",
  "uuid",
@@ -2393,7 +2023,6 @@ dependencies = [
  "pegaflow-metaserver",
  "pegaflow-proto",
  "prometheus",
- "prost",
  "pyo3",
  "pyo3-build-config",
  "reqwest 0.13.2",
@@ -2403,7 +2032,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tonic-prost",
  "uuid",
 ]
 
@@ -2437,63 +2065,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "petgraph"
@@ -3214,9 +2789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3321,15 +2894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3366,16 +2930,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
 ]
 
 [[package]]
@@ -3461,30 +3015,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
 ]
 
 [[package]]
@@ -3931,7 +3461,6 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
- "slab",
  "tokio",
 ]
 
@@ -4028,19 +3557,16 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "base64",
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "iri-string",
- "mime",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -4100,18 +3626,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4134,12 +3648,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ uuid = { version = "1.22", features = ["v4"] }
 parking_lot = "0.12"
 clap = { version = "4.5", features = ["derive"] }
 libc = "0.2"
-crossbeam = "0.8"
 dashmap = "6.1"
 opentelemetry = { version = "0.31.0", features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.31.0", features = [
@@ -68,10 +67,6 @@ tokio-stream = "0.1"
 prost = "0.14"
 tonic = "0.14"
 tonic-prost = "0.14"
-
-# Kubernetes
-kube = { version = "3.0", features = ["client", "runtime", "rustls-tls"] }
-k8s-openapi = { version = "0.27", features = ["v1_33"] }
 
 # Python bindings
 pyo3 = { version = "0.28" }

--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -25,7 +25,6 @@ shared_memory.workspace = true
 uuid.workspace = true
 opentelemetry.workspace = true
 bytesize.workspace = true
-serde.workspace = true
 libc.workspace = true
 rand.workspace = true
 ahash.workspace = true
@@ -33,8 +32,6 @@ io-uring = "0.7"
 futures.workspace = true
 parking_lot.workspace = true
 fastrace = { workspace = true, optional = true }
-kube.workspace = true
-k8s-openapi.workspace = true
 tonic.workspace = true
 dashmap.workspace = true
 smallvec.workspace = true

--- a/pegaflow-core/src/internode/README.md
+++ b/pegaflow-core/src/internode/README.md
@@ -1,62 +1,52 @@
 # internode/ — Cross-Node Communication
 
-This module handles all inter-node communication for PegaFlow's multi-node KV cache sharing.
+This module handles MetaServer coordination for PegaFlow's multi-node KV cache sharing.
 
 ## Module Overview
 
 ```
 internode/
-├── mod.rs               Module root + re-exports
-├── types.rs             Shared types: configs, errors, PegaflowInstance
-├── registry.rs          InstanceRegistry — thread-safe store of discovered nodes
-├── service_discovery.rs K8s pod watcher (label: novita.ai/pegaflow=app)
-├── client.rs            gRPC client → remote pegaflow-server (Engine service)
-└── registrar.rs         Fire-and-forget registrar → pegaflow-metaserver (Meta service)
+├── mod.rs                Module root + re-exports
+└── metaserver_client.rs  MetaServer registration, removal, query, and node heartbeat
 ```
 
 ## Data Flow
 
 ```
-                        ┌──────────────┐
-  service_discovery ──► │   registry   │  K8s watches pods, populates registry
-                        └──────┬───────┘
-                               │
-           ┌───────────────────┴───────────────────┐
-           ▼                                       ▼
-    ┌─────────────┐                        ┌──────────────┐
-    │  client.rs  │  READ path             │ registrar.rs │  WRITE path
-    │             │  "do you have          │              │  "I just sealed
-    │  Query /    │   these blocks?"       │  Insert      │   these blocks"
-    │  Health     │                        │  BlockHashes │
-    └──────┬──────┘                        └──────┬───────┘
-           │                                      │
-           ▼                                      ▼
-    Remote pegaflow-server              Central pegaflow-metaserver
-    (per-node Engine gRPC)              (shared Meta gRPC)
+  write path                       read path
+      |                                |
+      v                                v
+  try_register_namespace          query_prefix
+  try_unregister
+      |                                |
+      v                                v
+  background MetaServer loop       lazy MetaServer gRPC client
+      |                                |
+      +--------------+-----------------+
+                     |
+                     v
+            pegaflow-metaserver
 ```
 
-## client.rs vs registrar.rs
+## MetaServer Client Responsibilities
 
-|                  | client.rs                          | registrar.rs                        |
-|------------------|------------------------------------|-------------------------------------|
-| Talks to         | Remote **pegaflow-server**         | Central **pegaflow-metaserver**     |
-| RPC service      | `Engine` (Query, Health)           | `MetaServer` (HeartbeatNode, InsertBlockHashes, RemoveBlockHashes) |
-| Direction        | Read path — query remote cache     | Write path — register sealed blocks |
-| Call pattern     | Request-response (caller awaits)   | Fire-and-forget (`try_send`)        |
-| Connection mgmt  | Pool of connections (multi-node)   | Single lazy connection + node session heartbeat |
-| Failure mode     | Returns error to caller            | Log + metric, drop on queue full    |
-| Used by          | P/D router, cross-node queries     | Write pipeline (after block seal)   |
+| Responsibility | Path | Behavior |
+|----------------|------|----------|
+| Block registration | Write path | Fire-and-forget `try_send` after block seal |
+| Block removal | Eviction path | Best-effort remove messages after local cache eviction |
+| Prefix query | Read path | Request-response query for per-node prefix lengths |
+| Node session | Background task | Heartbeat, stale-session recovery, and graceful unregister |
 
-## How registrar.rs Integrates
+## How Registration Integrates
 
-The registrar plugs into the **write path** via `InsertDeps`:
+The MetaServer client plugs into the **write path** via `InsertDeps`:
 
 ```
 insert_worker_loop (sync thread)
   └─► process_insert_batch
         └─► send_backing_batches
               ├─► SsdBackingStore::ingest_batch()     (SSD write, fire-and-forget)
-              └─► MetaServerRegistrar::try_register()  (metaserver registration, fire-and-forget)
+              └─► MetaServerClient::try_register_namespace() (MetaServer registration, fire-and-forget)
 ```
 
 Both use the same pattern: `tokio::sync::mpsc::try_send()` from the sync insert thread,
@@ -69,7 +59,7 @@ the MetaServer lost state.
 
 ## Configuration
 
-The registrar is enabled via CLI flags on `pegaflow-server`:
+MetaServer registration is enabled via CLI flags on `pegaflow-server`:
 
 ```bash
 pegaflow-server \

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -5,7 +5,7 @@
 //! - Tensor parallelism (TP) across multiple GPUs
 //! - Split-storage layout for efficient K/V batch transfers
 //! - SSD caching tier
-//! - Kubernetes service discovery for inter-node communication
+//! - MetaServer-backed block discovery and RDMA fetch
 
 #[macro_use]
 mod trace;

--- a/pegaflow-metaserver/Cargo.toml
+++ b/pegaflow-metaserver/Cargo.toml
@@ -18,16 +18,12 @@ path = "src/main.rs"
 [dependencies]
 pegaflow-common.workspace = true
 pegaflow-proto = { path = "../pegaflow-proto" }
-prost.workspace = true
 tonic.workspace = true
 tokio.workspace = true
 clap.workspace = true
 log.workspace = true
-parking_lot.workspace = true
 dashmap.workspace = true
 uuid.workspace = true
-serde.workspace = true
-serde_json.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-prometheus.workspace = true

--- a/pegaflow-proto/Cargo.toml
+++ b/pegaflow-proto/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lints]
 workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["prost", "tonic-prost"]
+
 [dependencies]
 prost.workspace = true
 tonic.workspace = true

--- a/pegaflow-server/Cargo.toml
+++ b/pegaflow-server/Cargo.toml
@@ -26,11 +26,9 @@ path = "src/main.rs"
 pegaflow-common.workspace = true
 pegaflow-core = { workspace = true, default-features = false }
 pegaflow-proto = { path = "../pegaflow-proto" }
-prost.workspace = true
 pyo3 = { workspace = true, features = ["auto-initialize"] }
 cudarc.workspace = true
 tonic.workspace = true
-tonic-prost.workspace = true
 tokio.workspace = true
 clap.workspace = true
 log.workspace = true


### PR DESCRIPTION
## Summary
- Remove unused Rust dependencies from core, metaserver, server, and the workspace
- Drop stale Kubernetes/service discovery docs now that internode only uses MetaServer coordination
- Add cargo-machete ignores for proto generated-code dependencies that must stay

## Verification
- cargo machete
- cargo metadata --locked --no-deps --format-version 1
- cargo check -p pegaflow-proto
- cargo check -p pegaflow-metaserver --lib --bin pegaflow-metaserver
- cargo check -p pegaflow-core --no-default-features --features cuda-13 --lib
- cargo check -p pegaflow-server --no-default-features --features cuda-13,rdma --lib --bin pegaflow-server
- pre-commit hooks: cargo fmt, cargo clippy, cargo test --release, typos
