### PR TITLE
fix(tests): fail fast on vLLM startup death; align e2e cargo features; cfg-gate rdma-only query path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ venv/
 .pytest_cache/
 examples/bench_results/
 examples/pd_logs/
+python/tests/*.log
 
 # Built binaries in Python package (generated during wheel build)
 python/pegaflow/pegaflow-server

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -3,13 +3,16 @@ use std::collections::HashMap;
 use log::{debug, error, info, warn};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
-    HeartbeatNodeRequest, InsertBlockHashesRequest, NodePrefixResult, QueryPrefixBlocksRequest,
-    RemoveBlockHashesRequest, UnregisterNodeRequest,
+    HeartbeatNodeRequest, InsertBlockHashesRequest, RemoveBlockHashesRequest, UnregisterNodeRequest,
 };
+#[cfg(feature = "rdma")]
+use pegaflow_proto::proto::engine::{NodePrefixResult, QueryPrefixBlocksRequest};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Duration, Instant};
 use tonic::Code;
-use tonic::transport::{Channel, Endpoint};
+use tonic::transport::Channel;
+#[cfg(feature = "rdma")]
+use tonic::transport::Endpoint;
 use uuid::Uuid;
 
 use crate::metrics::core_metrics;
@@ -17,11 +20,13 @@ use crate::metrics::core_metrics;
 pub const DEFAULT_METASERVER_QUEUE_DEPTH: usize = 256;
 
 /// Error type for MetaServer client operations.
+#[cfg(feature = "rdma")]
 #[derive(Debug)]
 pub(crate) enum ClientError {
     RpcFailed(String),
 }
 
+#[cfg(feature = "rdma")]
 impl std::fmt::Display for ClientError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -113,6 +118,7 @@ pub struct MetaServerClient {
     /// Fire-and-forget command channel for insert/remove operations.
     command_tx: mpsc::Sender<MetaServerCommand>,
     /// Lazy-connect query client
+    #[cfg(feature = "rdma")]
     query_client: MetaServerGrpcClient<Channel>,
 }
 
@@ -130,10 +136,13 @@ impl MetaServerClient {
         ));
 
         // Lazy-connect query client: connects on first RPC, not here
-        let channel = Endpoint::from_shared(config.metaserver_addr.clone())
-            .expect("valid metaserver_addr URI")
-            .connect_lazy();
-        let query_client = MetaServerGrpcClient::new(channel);
+        #[cfg(feature = "rdma")]
+        let query_client = {
+            let channel = Endpoint::from_shared(config.metaserver_addr.clone())
+                .expect("valid metaserver_addr URI")
+                .connect_lazy();
+            MetaServerGrpcClient::new(channel)
+        };
 
         info!(
             "MetaServer client started (queue_depth={}, addr={})",
@@ -142,6 +151,7 @@ impl MetaServerClient {
 
         Self {
             command_tx,
+            #[cfg(feature = "rdma")]
             query_client,
         }
     }
@@ -242,6 +252,7 @@ impl MetaServerClient {
 
     /// Query MetaServer for the longest prefix of blocks that exist remotely.
     /// Returns per-node prefix lengths.
+    #[cfg(feature = "rdma")]
     pub(crate) async fn query_prefix(
         &self,
         namespace: &str,
@@ -697,8 +708,9 @@ mod tests {
     use super::*;
     use pegaflow_proto::proto::engine::meta_server_server::{MetaServer, MetaServerServer};
     use pegaflow_proto::proto::engine::{
-        HeartbeatNodeResponse, InsertBlockHashesResponse, QueryPrefixBlocksResponse,
-        RemoveBlockHashesResponse, ResponseStatus, UnregisterNodeResponse,
+        HeartbeatNodeResponse, InsertBlockHashesResponse, QueryPrefixBlocksRequest,
+        QueryPrefixBlocksResponse, RemoveBlockHashesResponse, ResponseStatus,
+        UnregisterNodeResponse,
     };
     use std::collections::BTreeMap;
     use std::net::SocketAddr;

--- a/python/tests/vllm_helpers.py
+++ b/python/tests/vllm_helpers.py
@@ -28,8 +28,11 @@ def _detect_pegaflow_cargo_features() -> list[str]:
     if not cuda_version:
         return []
 
+    # Keep parity with the default feature set (cuda-12 + rdma) so the e2e
+    # server build shares the cargo cache with maturin dev builds instead of
+    # invalidating it on every alternation.
     major = cuda_version.split(".", maxsplit=1)[0]
-    return ["cuda-13"] if major == "13" else []
+    return ["cuda-13", "rdma"] if major == "13" else []
 
 
 class VLLMServer:
@@ -185,6 +188,9 @@ class VLLMServer:
         start_time = time.time()
         print("Waiting for server to be ready...")
         while time.time() - start_time < timeout:
+            if self.process.poll() is not None:
+                hint = f", see {self.log_file}" if self.log_file else ""
+                raise RuntimeError(f"vLLM server exited with code {self.process.returncode}{hint}")
             for endpoint in self.health_endpoints:
                 url = f"http://localhost:{self.port}{endpoint}"
                 try:


### PR DESCRIPTION
## Summary

Three fixes that fell out of an e2e-correctness run + server log review:

1. **`VLLMServer._wait_for_ready` now fails fast when the server process dies.**
   It previously polled health endpoints for up to 600s even after the vLLM
   process had exited, turning every startup crash into a 10-minute timeout.
   `PegaFlowServer._wait_for_ready` already had this liveness check; mirror it
   and point the error at the server log file. (During validation of this PR a
   transient GPU OOM crashed both vLLM phases — the new check surfaced each
   failure in seconds with the exact log path.)

2. **The e2e fixture now builds pegaflow-server with `cuda-13,rdma`,** matching
   maturin dev builds. Previously the feature sets differed (`cuda-13` only),
   so every maturin/e2e alternation invalidated the shared cargo cache and
   recompiled pegaflow-core inside the fixture's 300s readiness window.

3. **`metaserver_client.rs` cfg-gates the rdma-only query path**
   (`ClientError`/`query_client`/`query_prefix`, consumed only by the
   rdma-gated `rdma_fetch`). Non-rdma builds emitted three dead-code warnings
   on every compile; default-feature builds (CI clippy) never saw them, which
   is why they went unnoticed. The registration/heartbeat path stays
   unconditional — `write_path` uses it in all configurations.

Also ignores `python/tests/*.log` (captured server logs tripped the typos
check via hex request IDs).

## Test plan

- `cargo check -p pegaflow-core --no-default-features --features cuda-13 --all-targets` — 0 warnings (previously 3)
- `cargo check` with `cuda-13,rdma` — clean
- `cargo clippy -p pegaflow-core -p pegaflow-server --all-targets -- -D warnings` (default features) — clean
- `cd python && uv run --extra test pytest` — 77 passed
- e2e gate: `pytest -m e2e tests/test_vllm_e2e_correctness.py --model /data/models/Qwen3-4B --max-model-len 4096` — 4 passed in 183.5s, fixture server built with `cuda-13,rdma`

Pre-existing: local `ruff format --check` (0.15.13) wants to reformat
`worker.py`/`test_connector_fault_tolerance.py` on master too — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)