### PR TITLE
fix(server): drain GPU workers before unmapping CUDA IPC tensors

### DIFF
--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -3,6 +3,8 @@ use std::sync::{Arc, mpsc as std_mpsc};
 use cudarc::driver::{CudaContext, CudaStream};
 use log::{debug, error, info, warn};
 use logforth::diagnostic::ThreadLocalDiagnostic;
+use mea::latch::Latch;
+use parking_lot::Mutex;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::block::RawBlock;
@@ -67,8 +69,28 @@ unsafe impl Send for SaveLayerData {}
 /// Per-GPU worker pool with dedicated load and save threads
 pub(crate) struct GpuWorkerPool {
     device_id: i32,
+    /// Task senders, taken by [`Self::close`] to fence new submissions while
+    /// RPC handlers may still hold an `Arc<InstanceContext>`. Dropping the
+    /// senders lets the worker loops drain already-queued tasks and exit.
+    channels: Mutex<Option<WorkerChannels>>,
+    /// Reaches zero when both worker threads have exited, i.e. no task will
+    /// ever dereference a `KVCacheRegistration::data_ptr` from this pool again.
+    workers_exited: Arc<Latch>,
+}
+
+struct WorkerChannels {
     load_tx: mpsc::UnboundedSender<LoadTask>,
     save_tx: mpsc::UnboundedSender<SaveTask>,
+}
+
+/// Counts the latch down when the owning worker thread exits, including the
+/// CUDA-init-failure and panic paths.
+struct CountDownOnDrop(Arc<Latch>);
+
+impl Drop for CountDownOnDrop {
+    fn drop(&mut self) {
+        self.0.count_down();
+    }
 }
 
 impl GpuWorkerPool {
@@ -89,13 +111,16 @@ impl GpuWorkerPool {
         let (save_tx, save_rx) = mpsc::unbounded_channel();
         let (load_ready_tx, load_ready_rx) = std_mpsc::channel();
         let (save_ready_tx, save_ready_rx) = std_mpsc::channel();
+        let workers_exited = Arc::new(Latch::new(2));
 
         // Spawn load worker thread
         let load_device_id = device_id;
         let load_numa = numa_node;
+        let load_exit_guard = CountDownOnDrop(Arc::clone(&workers_exited));
         std::thread::Builder::new()
             .name(format!("gpu{}-load", device_id))
             .spawn(move || {
+                let _exit_guard = load_exit_guard;
                 // Pin thread to NUMA node before any allocations
                 if load_numa.is_valid()
                     && let Err(e) = pin_thread_to_numa_node(load_numa)
@@ -117,9 +142,11 @@ impl GpuWorkerPool {
         // Spawn save worker thread
         let save_device_id = device_id;
         let save_numa = numa_node;
+        let save_exit_guard = CountDownOnDrop(Arc::clone(&workers_exited));
         std::thread::Builder::new()
             .name(format!("gpu{}-save", device_id))
             .spawn(move || {
+                let _exit_guard = save_exit_guard;
                 // Pin thread to NUMA node before any allocations
                 if save_numa.is_valid()
                     && let Err(e) = pin_thread_to_numa_node(save_numa)
@@ -147,14 +174,33 @@ impl GpuWorkerPool {
         );
         Ok(Self {
             device_id,
-            load_tx,
-            save_tx,
+            channels: Mutex::new(Some(WorkerChannels { load_tx, save_tx })),
+            workers_exited,
         })
+    }
+
+    /// Fence new task submissions: drop the senders so the worker loops drain
+    /// already-queued tasks and exit. Idempotent.
+    pub(crate) fn close(&self) {
+        self.channels.lock().take();
+    }
+
+    /// Wait until both worker threads have exited. After this resolves, no
+    /// task from this pool will ever touch GPU memory again, so the caller
+    /// may safely unmap the CUDA IPC mappings the tasks referenced.
+    pub(crate) async fn wait_workers_exited(&self) {
+        self.workers_exited.wait().await;
     }
 
     /// Submit a load task (CPU -> GPU) - fire and forget
     pub(crate) fn submit_load(&self, task: LoadTask) -> Result<(), EngineError> {
-        self.load_tx.send(task).map_err(|_| {
+        let Some(load_tx) = self.channels.lock().as_ref().map(|c| c.load_tx.clone()) else {
+            return Err(EngineError::Storage(format!(
+                "Load worker channel closed for device {}",
+                self.device_id
+            )));
+        };
+        load_tx.send(task).map_err(|_| {
             EngineError::Storage(format!(
                 "Load worker channel closed for device {}",
                 self.device_id
@@ -174,7 +220,13 @@ impl GpuWorkerPool {
             trace_ctx: ::fastrace::prelude::SpanContext::current_local_parent(),
         };
 
-        self.save_tx.send(task).map_err(|_| {
+        let Some(save_tx) = self.channels.lock().as_ref().map(|c| c.save_tx.clone()) else {
+            return Err(EngineError::Storage(format!(
+                "Save worker channel closed for device {}",
+                self.device_id
+            )));
+        };
+        save_tx.send(task).map_err(|_| {
             EngineError::Storage(format!(
                 "Save worker channel closed for device {}",
                 self.device_id

--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -484,6 +484,35 @@ impl InstanceContext {
         Ok(())
     }
 
+    /// Access the instance identifier.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Quiesce all GPU worker pools: fence new task submissions, then wait
+    /// until every worker thread has drained its queue and exited.
+    ///
+    /// After this resolves, no queued or in-flight save/load task of this
+    /// instance can dereference client GPU memory anymore — the caller may
+    /// safely unmap the CUDA IPC mappings backing the registrations.
+    ///
+    /// In-flight RPC handlers that still hold this `InstanceContext` get a
+    /// channel-closed error on submission instead of racing the unmap.
+    pub async fn shutdown(&self) {
+        let gpus: Vec<Arc<GpuContext>> = {
+            let metadata = self.metadata.lock();
+            metadata.gpu_contexts.values().cloned().collect()
+        };
+
+        // Fence all pools first so they drain concurrently, then await each.
+        for gpu in &gpus {
+            gpu.worker_pool().close();
+        }
+        for gpu in &gpus {
+            gpu.worker_pool().wait_workers_exited().await;
+        }
+    }
+
     /// Access the instance namespace.
     pub(crate) fn namespace(&self) -> &str {
         &self.namespace

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -321,38 +321,43 @@ impl PegaEngine {
         Ok(())
     }
 
-    /// Unregister an instance and release all associated resources.
-    pub fn unregister_instance(&self, instance_id: &str) -> Result<(), EngineError> {
+    /// Unregister an instance: fence it from new RPCs and release its query
+    /// leases. Returns the removed [`InstanceContext`] so the caller can
+    /// `shutdown().await` it (drain GPU worker queues) before unmapping the
+    /// CUDA IPC memory its queued tasks still reference.
+    pub fn unregister_instance(
+        &self,
+        instance_id: &str,
+    ) -> Result<Arc<InstanceContext>, EngineError> {
         let removed = self
             .instances
             .write()
             .expect("instances write lock poisoned")
-            .remove(instance_id);
+            .remove(instance_id)
+            .ok_or_else(|| EngineError::InstanceMissing(instance_id.to_string()))?;
 
-        if removed.is_none() {
-            return Err(EngineError::InstanceMissing(instance_id.to_string()));
-        }
         self.query_leases.release_instance(instance_id);
         info!("Unregistered instance: {}", instance_id);
-        Ok(())
+        Ok(removed)
     }
 
-    /// Unregister all instances, returning the IDs that were removed.
-    pub fn unregister_all_instances(&self) -> Vec<String> {
+    /// Unregister all instances, returning the removed contexts. The same
+    /// drain-before-unmap contract as [`Self::unregister_instance`] applies.
+    pub fn unregister_all_instances(&self) -> Vec<Arc<InstanceContext>> {
         let mut instances = self
             .instances
             .write()
             .expect("instances write lock poisoned");
-        let ids: Vec<String> = instances.keys().cloned().collect();
-        instances.clear();
+        let removed: Vec<Arc<InstanceContext>> = instances.drain().map(|(_, ctx)| ctx).collect();
         drop(instances);
-        for id in &ids {
-            self.query_leases.release_instance(id);
+        for instance in &removed {
+            self.query_leases.release_instance(instance.id());
         }
-        if !ids.is_empty() {
+        if !removed.is_empty() {
+            let ids: Vec<&str> = removed.iter().map(|i| i.id()).collect();
             info!("Unregistered all instances: {:?}", ids);
         }
-        ids
+        removed
     }
 
     /// List all registered instance IDs.

--- a/pegaflow-server/src/http_server.rs
+++ b/pegaflow-server/src/http_server.rs
@@ -10,12 +10,12 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 
-use crate::registry::RegistryHandle;
+use crate::teardown::InstanceTeardown;
 
 #[derive(Clone)]
 struct AppState {
     engine: Arc<PegaEngine>,
-    registry: RegistryHandle,
+    teardown: Arc<InstanceTeardown>,
     prometheus_registry: Option<Registry>,
 }
 
@@ -56,6 +56,9 @@ struct CleanupQuery {
 struct CleanupResponse {
     removed_instances: Vec<String>,
     removed_tensors: usize,
+    /// Instances whose GPU workers failed to drain; their CUDA IPC mappings
+    /// are deliberately leaked instead of being unmapped under stale tasks.
+    leaked_instances: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -71,9 +74,10 @@ struct MemoryCacheCleanupResponse {
 /// Without `id`: remove all instances and release all CUDA IPC tensors.
 /// With `id`:    remove only the specified instance.
 ///
-/// Releasing CUDA IPC tensors takes the GIL and runs a blocking
-/// `torch.cuda.empty_cache()`. That work runs on the dedicated registry thread
-/// behind [`RegistryHandle`]; the handler only `.await`s the reply, so a
+/// Both go through [`InstanceTeardown`]: fence the instance, drain its GPU
+/// worker queues, then unmap. Releasing CUDA IPC tensors takes the GIL and
+/// runs a blocking `torch.cuda.empty_cache()`. That work runs on the
+/// dedicated registry thread; the handler only `.await`s the reply, so a
 /// slow/wedged cleanup never occupies an async worker (the outage where a few
 /// `cleanup` calls hung every endpoint, `/health` and `/metrics` included).
 async fn cleanup_handler(
@@ -82,62 +86,67 @@ async fn cleanup_handler(
 ) -> impl IntoResponse {
     match query.id {
         None => {
-            let removed_tensors = state.registry.clear().await;
-            let removed_instances = state.engine.unregister_all_instances();
+            let outcome = state.teardown.cleanup_all("http cleanup").await;
 
-            if !removed_instances.is_empty() || removed_tensors > 0 {
+            if !outcome.removed_instances.is_empty() || outcome.dropped_tensors > 0 {
                 warn!(
-                    "Cleanup all: removed {:?}, {} CUDA tensor(s) released",
-                    removed_instances, removed_tensors
+                    "Cleanup all: removed {:?}, {} CUDA tensor(s) released, leaked {:?}",
+                    outcome.removed_instances, outcome.dropped_tensors, outcome.leaked_instances
                 );
             } else {
                 info!("Cleanup all: nothing to remove");
             }
 
+            let status = if outcome.leaked_instances.is_empty() {
+                StatusCode::OK
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            };
             (
-                StatusCode::OK,
+                status,
                 Json(CleanupResponse {
-                    removed_instances,
-                    removed_tensors,
+                    removed_instances: outcome.removed_instances,
+                    removed_tensors: outcome.dropped_tensors,
+                    leaked_instances: outcome.leaked_instances,
                 })
                 .into_response(),
             )
         }
         Some(instance_id) => {
-            let removed_tensors = state.registry.drop_instance(instance_id.clone()).await;
-            match state.engine.unregister_instance(&instance_id) {
-                Ok(()) => {
-                    warn!(
-                        "Cleanup instance {}: {} CUDA tensor(s) released",
-                        instance_id, removed_tensors
-                    );
-                    cleanup_ok_response(instance_id, removed_tensors)
-                }
-                Err(_) if removed_tensors > 0 => {
-                    warn!(
-                        "Instance {} not in engine but cleaned {} CUDA tensor(s)",
-                        instance_id, removed_tensors
-                    );
-                    cleanup_ok_response(instance_id, removed_tensors)
-                }
-                Err(e) => (StatusCode::NOT_FOUND, format!("{e}").into_response()),
+            let outcome = state.teardown.cleanup(&instance_id, "http cleanup").await;
+            if !outcome.drained {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(CleanupResponse {
+                        removed_instances: vec![instance_id.clone()],
+                        removed_tensors: 0,
+                        leaked_instances: vec![instance_id],
+                    })
+                    .into_response(),
+                );
+            }
+            if outcome.instance_found || outcome.dropped_tensors > 0 {
+                warn!(
+                    "Cleanup instance {}: {} CUDA tensor(s) released",
+                    instance_id, outcome.dropped_tensors
+                );
+                (
+                    StatusCode::OK,
+                    Json(CleanupResponse {
+                        removed_instances: vec![instance_id],
+                        removed_tensors: outcome.dropped_tensors,
+                        leaked_instances: Vec::new(),
+                    })
+                    .into_response(),
+                )
+            } else {
+                (
+                    StatusCode::NOT_FOUND,
+                    format!("instance {instance_id} not found").into_response(),
+                )
             }
         }
     }
-}
-
-fn cleanup_ok_response(
-    instance_id: String,
-    removed_tensors: usize,
-) -> (StatusCode, axum::response::Response) {
-    (
-        StatusCode::OK,
-        Json(CleanupResponse {
-            removed_instances: vec![instance_id],
-            removed_tensors,
-        })
-        .into_response(),
-    )
 }
 
 /// POST /cache/memory/cleanup
@@ -159,7 +168,7 @@ async fn cleanup_memory_cache_handler(
 pub async fn start_http_server(
     addr: std::net::SocketAddr,
     engine: Arc<PegaEngine>,
-    registry: RegistryHandle,
+    teardown: Arc<InstanceTeardown>,
     enable_prometheus: bool,
     prometheus_registry: Option<Registry>,
     shutdown: Arc<Notify>,
@@ -168,7 +177,7 @@ pub async fn start_http_server(
 
     let state = AppState {
         engine,
-        registry,
+        teardown,
         prometheus_registry: if enable_prometheus {
             prometheus_registry
         } else {

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -5,6 +5,8 @@ pub mod proto;
 pub mod registry;
 pub mod service;
 pub mod session;
+mod teardown;
+pub use teardown::InstanceTeardown;
 #[cfg(feature = "tracing")]
 mod trace;
 #[cfg(not(feature = "tracing"))]
@@ -616,6 +618,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             Arc::clone(&shutdown),
             Arc::clone(&hll_tracker),
         );
+        let teardown = service.teardown();
 
         // Spawn background GC task for stale inflight blocks and expired transfer locks
         {
@@ -660,7 +663,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         let http_server_handle = http_server::start_http_server(
             cli.http_addr,
             Arc::clone(&engine),
-            registry,
+            teardown,
             cli.enable_prometheus,
             metrics_state.prometheus_registry.clone(),
             Arc::clone(&shutdown),
@@ -689,7 +692,14 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
             .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE);
 
+        // HTTP/2 PING keepalive: without it, a client host that vanishes
+        // without RST (hard power-off, network partition) leaves the Session
+        // stream half-open and the disconnect watcher never fires. With it,
+        // dead-peer detection is bounded by interval + timeout.
         if let Err(err) = Server::builder()
+            .http2_keepalive_interval(Some(Duration::from_secs(10)))
+            .http2_keepalive_timeout(Some(Duration::from_secs(20)))
+            .tcp_keepalive(Some(Duration::from_secs(30)))
             .add_service(grpc_service)
             .serve_with_shutdown(cli.addr, shutdown_signal)
             .await

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -13,6 +13,7 @@ use crate::proto::engine::{
 };
 use crate::registry::RegistryHandle;
 use crate::session::SessionRegistry;
+use crate::teardown::InstanceTeardown;
 use log::{debug, info, warn};
 use pegaflow_common::NumaNode;
 use pegaflow_core::{EngineError, LayerSave, PegaEngine, PrefetchStatus, QueryLeaseId};
@@ -29,6 +30,7 @@ pub struct GrpcEngineService {
     shutdown: Arc<Notify>,
     hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::MultiWindowHllTracker>>,
     session_registry: Arc<SessionRegistry>,
+    teardown: Arc<InstanceTeardown>,
 }
 
 impl GrpcEngineService {
@@ -38,38 +40,20 @@ impl GrpcEngineService {
         shutdown: Arc<Notify>,
         hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::MultiWindowHllTracker>>,
     ) -> Self {
+        let teardown = InstanceTeardown::new(Arc::clone(&engine), registry.clone());
         Self {
             engine,
             registry,
             shutdown,
             hll_tracker,
             session_registry: SessionRegistry::new(),
+            teardown,
         }
     }
 
-    /// Drop CUDA IPC tensors and engine-side instance state for `instance_id`.
-    /// Idempotent — safe to call after the instance is already gone.
-    async fn cleanup_instance(
-        engine: &PegaEngine,
-        registry: &RegistryHandle,
-        instance_id: &str,
-        reason: &'static str,
-    ) {
-        let removed = registry.drop_instance(instance_id.to_string()).await;
-        if removed > 0 {
-            info!(
-                "Session cleanup ({}): dropped {} CUDA tensors for instance {}",
-                reason, removed, instance_id
-            );
-        }
-        if let Err(err) = engine.unregister_instance(instance_id) {
-            // `InstanceMissing` is normal if the instance was never registered
-            // (vllm died before any register_context_batch). Log at debug.
-            debug!(
-                "Session cleanup ({}): engine.unregister_instance({}) returned {}",
-                reason, instance_id, err
-            );
-        }
+    /// The shared teardown choreography, for wiring into the HTTP admin server.
+    pub fn teardown(&self) -> Arc<InstanceTeardown> {
+        Arc::clone(&self.teardown)
     }
 
     fn context_key(instance_id: &str, tp_rank: u32, pp_rank: u32, device_id: i32) -> String {
@@ -713,17 +697,23 @@ impl Engine for GrpcEngineService {
         let result: Result<Response<UnregisterResponse>, Status> = async {
             let req = request.into_inner();
             debug!("RPC [unregister_context]: instance_id={}", req.instance_id);
-            let removed = self.registry.drop_instance(req.instance_id.clone()).await;
-            if removed > 0 {
-                info!(
-                    "Dropped {} CUDA tensors for instance {}",
-                    removed, req.instance_id
-                );
-            }
+            let outcome = self
+                .teardown
+                .cleanup(&req.instance_id, "unregister rpc")
+                .await;
 
-            self.engine
-                .unregister_instance(&req.instance_id)
-                .map_err(Self::map_engine_error)?;
+            if !outcome.drained {
+                return Err(Status::internal(format!(
+                    "GPU workers for instance {} did not drain in time; \
+                     CUDA IPC mappings leaked",
+                    req.instance_id
+                )));
+            }
+            if !outcome.instance_found {
+                return Err(Self::map_engine_error(EngineError::InstanceMissing(
+                    req.instance_id,
+                )));
+            }
 
             Ok(Response::new(UnregisterResponse {
                 status: Some(Self::build_simple_response()),
@@ -987,8 +977,7 @@ impl Engine for GrpcEngineService {
         let cleanup_tx = tx.clone();
 
         let session_registry = Arc::clone(&self.session_registry);
-        let engine = Arc::clone(&self.engine);
-        let cuda_registry = self.registry.clone();
+        let teardown = Arc::clone(&self.teardown);
         let id_for_watcher = instance_id.clone();
 
         tokio::spawn(async move {
@@ -998,8 +987,7 @@ impl Engine for GrpcEngineService {
                     "Session closed: instance_id={} token={} — running cleanup",
                     id_for_watcher, token
                 );
-                Self::cleanup_instance(&engine, &cuda_registry, &id_for_watcher, "stream closed")
-                    .await;
+                teardown.cleanup(&id_for_watcher, "stream closed").await;
             } else {
                 debug!(
                     "Session closed: instance_id={} token={} superseded — skip cleanup",

--- a/pegaflow-server/src/teardown.rs
+++ b/pegaflow-server/src/teardown.rs
@@ -1,0 +1,226 @@
+//! Per-instance teardown: fence → drain GPU workers → unmap CUDA IPC.
+//!
+//! Queued save/load tasks capture raw device pointers into a client's CUDA
+//! IPC mapping and dereference them only when the per-GPU worker thread
+//! executes them. Unmapping while such a task is still queued either poisons
+//! the CUDA context (dead VA) or — if a new registration reuses the VA —
+//! silently reads/writes another client's live KV cache. Every teardown
+//! entrance (graceful Unregister RPC, session-watcher disconnect cleanup,
+//! admin HTTP endpoint) therefore goes through [`InstanceTeardown`], which
+//! enforces the one ordering that is safe:
+//!
+//! 1. fence: remove the instance from the engine and release its leases,
+//! 2. drain: close the worker channels and wait for the threads to exit,
+//! 3. unmap: only then drop the CUDA IPC tensors.
+//!
+//! Teardowns of different instances are independent (separate worker pools,
+//! separate tensors); only same-instance callers need coordination. The
+//! `draining` set arbitrates that: exactly one caller claims the instance
+//! (the atomic engine-map removal) and owns drain + unmap; concurrent
+//! callers for the same id observe the claim and back off instead of
+//! unmapping memory the owner's drain still protects.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use log::{error, info};
+use parking_lot::Mutex;
+use pegaflow_core::{InstanceContext, PegaEngine};
+
+use crate::registry::RegistryHandle;
+
+/// How long to wait for a dead instance's GPU worker queues to drain. A deep
+/// save backlog drains at PCIe D2H bandwidth (seconds for tens of GiB); only
+/// a wedged GPU exceeds this.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub(crate) struct CleanupOutcome {
+    /// Whether this caller found and tore down the instance.
+    pub instance_found: bool,
+    /// False when the GPU workers failed to drain within [`DRAIN_TIMEOUT`].
+    /// The CUDA IPC mappings are deliberately leaked in that case — unmapping
+    /// memory a stale task may still touch trades a bounded leak for memory
+    /// corruption.
+    pub drained: bool,
+    pub dropped_tensors: usize,
+}
+
+pub(crate) struct CleanupAllOutcome {
+    pub removed_instances: Vec<String>,
+    pub dropped_tensors: usize,
+    /// Instances whose drain timed out; their CUDA IPC mappings are leaked.
+    pub leaked_instances: Vec<String>,
+}
+
+enum Claim {
+    /// This caller removed the instance and owns drain + unmap.
+    Owner(Arc<InstanceContext>),
+    /// Another teardown owns this instance's drain (or leaked it after a
+    /// drain timeout); do not touch its tensors.
+    Draining,
+    /// No instance and no drain in flight — only a tensor sweep applies.
+    Missing,
+}
+
+pub struct InstanceTeardown {
+    engine: Arc<PegaEngine>,
+    registry: RegistryHandle,
+    /// Instance ids whose drain is in flight. An id stays here forever if its
+    /// drain timed out, so later sweeps can never unmap the leaked mappings.
+    ///
+    /// Known hole: registration does not consult this set, so a new
+    /// registration reusing a leaked instance id overwrites the leaked
+    /// tensors in the registry (unmapping them under the wedged tasks).
+    /// Closing it needs incarnation-scoped registrations — deferred.
+    draining: Mutex<HashSet<String>>,
+}
+
+impl InstanceTeardown {
+    pub(crate) fn new(engine: Arc<PegaEngine>, registry: RegistryHandle) -> Arc<Self> {
+        Arc::new(Self {
+            engine,
+            registry,
+            draining: Mutex::new(HashSet::new()),
+        })
+    }
+
+    /// Atomically decide this caller's role for `instance_id`. The lock makes
+    /// "remove from engine map" and "appear in the draining set" one step, so
+    /// a concurrent caller can never see neither.
+    fn claim(&self, instance_id: &str) -> Claim {
+        let mut draining = self.draining.lock();
+        match self.engine.unregister_instance(instance_id) {
+            Ok(instance) => {
+                draining.insert(instance_id.to_string());
+                Claim::Owner(instance)
+            }
+            Err(_) if draining.contains(instance_id) => Claim::Draining,
+            Err(_) => Claim::Missing,
+        }
+    }
+
+    fn release_claim(&self, instance_id: &str) {
+        self.draining.lock().remove(instance_id);
+    }
+
+    /// Tear down one instance. Idempotent: late callers observe `Missing` and
+    /// only sweep leftover tensors (e.g. a partial registration where the
+    /// tensors were materialized but engine registration failed).
+    pub(crate) async fn cleanup(&self, instance_id: &str, reason: &str) -> CleanupOutcome {
+        match self.claim(instance_id) {
+            Claim::Owner(instance) => {
+                if !drain_instance(&instance, reason).await {
+                    // Keep the id claimed forever: it must block any later
+                    // tensor sweep for this id from unmapping the leaked
+                    // mappings while the wedged tasks may still hold them.
+                    return CleanupOutcome {
+                        instance_found: true,
+                        drained: false,
+                        dropped_tensors: 0,
+                    };
+                }
+                // Safe to unmap: fenced, and the worker threads have exited.
+                let dropped_tensors = self.registry.drop_instance(instance_id.to_string()).await;
+                self.release_claim(instance_id);
+                info!(
+                    "Teardown ({reason}): instance {instance_id} removed, \
+                     {dropped_tensors} CUDA IPC tensor(s) dropped"
+                );
+                CleanupOutcome {
+                    instance_found: true,
+                    drained: true,
+                    dropped_tensors,
+                }
+            }
+            Claim::Draining => CleanupOutcome {
+                instance_found: false,
+                drained: true,
+                dropped_tensors: 0,
+            },
+            Claim::Missing => {
+                let dropped_tensors = self.registry.drop_instance(instance_id.to_string()).await;
+                if dropped_tensors > 0 {
+                    info!(
+                        "Teardown ({reason}): swept {dropped_tensors} orphaned CUDA IPC \
+                         tensor(s) for unregistered instance {instance_id}"
+                    );
+                }
+                CleanupOutcome {
+                    instance_found: false,
+                    drained: true,
+                    dropped_tensors,
+                }
+            }
+        }
+    }
+
+    /// Tear down every instance (admin escape hatch). Orphaned tensor
+    /// contexts are swept only when every instance drained cleanly, since the
+    /// sweep cannot distinguish them from a leaked instance's tensors.
+    pub(crate) async fn cleanup_all(&self, reason: &str) -> CleanupAllOutcome {
+        // Claim every instance atomically, same contract as claim().
+        let instances = {
+            let mut draining = self.draining.lock();
+            let instances = self.engine.unregister_all_instances();
+            for instance in &instances {
+                draining.insert(instance.id().to_string());
+            }
+            instances
+        };
+        let removed_instances: Vec<String> = instances.iter().map(|i| i.id().to_string()).collect();
+
+        // Drain concurrently; each instance gets its own timeout.
+        let drains: Vec<_> = instances
+            .iter()
+            .map(|instance| {
+                let instance = Arc::clone(instance);
+                let reason = reason.to_string();
+                tokio::spawn(async move { drain_instance(&instance, &reason).await })
+            })
+            .collect();
+
+        let mut leaked_instances = Vec::new();
+        let mut dropped_tensors = 0;
+        for (instance, drain) in instances.iter().zip(drains) {
+            if drain.await.unwrap_or(false) {
+                dropped_tensors += self.registry.drop_instance(instance.id().to_string()).await;
+                self.release_claim(instance.id());
+            } else {
+                leaked_instances.push(instance.id().to_string());
+            }
+        }
+
+        if leaked_instances.is_empty() {
+            dropped_tensors += self.registry.clear().await;
+        } else {
+            error!(
+                "Teardown ({reason}): {} instance(s) failed to drain, their CUDA IPC \
+                 mappings stay leaked: {leaked_instances:?}",
+                leaked_instances.len()
+            );
+        }
+
+        CleanupAllOutcome {
+            removed_instances,
+            dropped_tensors,
+            leaked_instances,
+        }
+    }
+}
+
+/// Returns true when the instance's GPU workers drained and exited in time.
+async fn drain_instance(instance: &InstanceContext, reason: &str) -> bool {
+    match tokio::time::timeout(DRAIN_TIMEOUT, instance.shutdown()).await {
+        Ok(()) => true,
+        Err(_) => {
+            error!(
+                "Teardown ({reason}): GPU workers for instance {} did not drain within \
+                 {DRAIN_TIMEOUT:?}; leaking its CUDA IPC mappings instead of unmapping \
+                 memory a stale task may still touch",
+                instance.id()
+            );
+            false
+        }
+    }
+}

--- a/pegaflow-server/tests/http_cleanup_hang_repro.rs
+++ b/pegaflow-server/tests/http_cleanup_hang_repro.rs
@@ -277,6 +277,7 @@ fn start_cluster(worker_threads: usize) -> TestCluster {
         Arc::clone(&shutdown),
         hll_tracker,
     );
+    let teardown = service.teardown();
     rt.spawn(async move {
         Server::builder()
             .add_service(EngineServer::new(service))
@@ -289,7 +290,7 @@ fn start_cluster(worker_threads: usize) -> TestCluster {
         start_http_server(
             http_addr,
             Arc::clone(&engine),
-            registry.clone(),
+            teardown,
             true,
             Some(Registry::new()),
             Arc::clone(&shutdown),

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -4,6 +4,7 @@ Provides fixtures for automatically starting/stopping PegaServer
 and test helpers for connector testing against a running server.
 """
 
+import contextlib
 import hashlib
 import logging
 import os
@@ -403,9 +404,12 @@ class PegaServerProcess:
             os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
             self.process.wait(timeout=5)
         except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
-            if self.process:
-                os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
-                self.process.wait(timeout=2)
+            # The process group may already be gone (e.g. the server crashed
+            # before teardown); a second failure must not mask the test.
+            with contextlib.suppress(subprocess.TimeoutExpired, ProcessLookupError, OSError):
+                if self.process:
+                    os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
+                    self.process.wait(timeout=2)
         finally:
             self.process = None
             self._close_log()
@@ -421,8 +425,6 @@ class PegaServerProcess:
         return self._log_path.read_text(errors="replace")
 
     def _close_log(self) -> None:
-        import contextlib
-
         if self._log_file is not None:
             with contextlib.suppress(OSError):
                 self._log_file.close()

--- a/python/tests/save_backlog_kill_helper.py
+++ b/python/tests/save_backlog_kill_helper.py
@@ -1,0 +1,112 @@
+"""Victim worker for test_ipc_mapping_lifetime.
+
+Simulates a vLLM worker SIGKILLed while save RPCs are queued server-side.
+Registers a 2-layer KV cache via CUDA IPC, opens the liveness session
+stream, then runs several threads that loop synchronous save RPCs with
+fresh content hashes — the server's hash filter never dedups them, so
+every RPC queues real GPU->CPU copy work on the per-device save worker.
+
+Appends one line to the progress file per completed save so the parent
+test can SIGKILL this process at a moment when the server's save queue
+has a backlog.
+
+Run as:
+python save_backlog_kill_helper.py <endpoint> <instance_id> <namespace> <ready_file> <progress_file>
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import pickle
+import sys
+import threading
+import uuid
+
+import torch
+
+from pegaflow.ipc_wrapper import CudaIPCWrapper
+
+NUM_LAYERS = 2
+NUM_BLOCKS = 4096
+SEG_BYTES = 16 << 10  # bytes per K (or V) segment per block
+SAVE_THREADS = 12
+# Save every other block: the gaps defeat the server's copy-range merging, so
+# each task enqueues thousands of small cuMemcpy calls and stays on the save
+# worker for tens of milliseconds. A deep, slow-draining backlog is the point:
+# the queue must outlive the session-cleanup latency after SIGKILL.
+SAVE_BLOCK_IDS = list(range(1, NUM_BLOCKS, 2))
+
+
+def main() -> int:
+    endpoint, instance_id, namespace, ready_file, progress_file = sys.argv[1:6]
+
+    pegaflow_module = importlib.import_module("pegaflow.pegaflow")
+    client = pegaflow_module.EngineRpcClient(endpoint)
+
+    device = torch.device("cuda:0")
+    kv_caches = [
+        torch.zeros((2, NUM_BLOCKS, SEG_BYTES), dtype=torch.uint8, device=device)
+        for _ in range(NUM_LAYERS)
+    ]
+    layer_names = [f"layer_{i}" for i in range(NUM_LAYERS)]
+
+    ok, msg = client.register_context_batch(
+        instance_id,
+        namespace,
+        0,  # tp_rank
+        0,  # pp_rank
+        1,  # tp_size
+        1,  # world_size
+        0,  # device_id
+        NUM_LAYERS,
+        layer_names,
+        [pickle.dumps(CudaIPCWrapper(kv)) for kv in kv_caches],
+        [NUM_BLOCKS] * NUM_LAYERS,
+        [SEG_BYTES] * NUM_LAYERS,
+        [NUM_BLOCKS * SEG_BYTES] * NUM_LAYERS,  # kv_stride_bytes
+        [2] * NUM_LAYERS,  # segments
+    )
+    if not ok:
+        print(f"register_context_batch failed: {msg}", file=sys.stderr)
+        return 1
+
+    client.start_session_watcher(instance_id, namespace, 1, 1)
+
+    run_id = uuid.uuid4().hex
+    # Never closed deliberately: this process only exits via SIGKILL.
+    progress = open(progress_file, "w", buffering=1)  # noqa: SIM115
+    progress_lock = threading.Lock()
+
+    def save_loop(tid: int) -> None:
+        thread_client = pegaflow_module.EngineRpcClient(endpoint)
+        i = 0
+        while True:
+            hashes = [
+                hashlib.sha256(f"{run_id}:{tid}:{i}:{b}".encode()).digest() for b in SAVE_BLOCK_IDS
+            ]
+            saves = [(name, SAVE_BLOCK_IDS, hashes) for name in layer_names]
+            ok, msg = thread_client.save(instance_id, 0, 0, 0, saves)
+            with progress_lock:
+                progress.write(f"{'ok' if ok else 'failed'} {tid} {i}\n")
+                progress.flush()
+            i += 1
+
+    threads = [
+        threading.Thread(target=save_loop, args=(tid,), daemon=True, name=f"save-{tid}")
+        for tid in range(SAVE_THREADS)
+    ]
+    for t in threads:
+        t.start()
+
+    with open(ready_file, "w") as f:
+        f.write("ready")
+
+    # Block until SIGKILLed; saves keep flowing on the worker threads.
+    for t in threads:
+        t.join()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/tests/test_ipc_mapping_lifetime.py
+++ b/python/tests/test_ipc_mapping_lifetime.py
@@ -1,0 +1,173 @@
+"""Contract test: a SIGKILLed client must never take pegaflow-server down.
+
+When a vllm process dies, session cleanup drops its CUDA IPC tensors
+(unmapping the IPC VA ranges). Save tasks already queued on the per-device
+save worker still hold raw device pointers into those mappings. If the
+unmap wins the race against a queued task, the task's cuMemcpyDtoHAsync
+either SIGSEGVs the server (VA unmapped — the common case, since a
+restarted vllm takes minutes to re-register) or silently copies another
+mapping's bytes and seals them under the dead client's hashes (VA reused).
+
+Driver-level evidence for both outcomes: scripts/cuda_ipc_kill_probe.py
+(verified on RTX 5070 Ti and H20-3e).
+
+This test drives the real server: a worker subprocess keeps a deep,
+slow-draining save backlog in flight (stride-2 block ids defeat copy-range
+merging, so each task holds the save worker for tens of milliseconds),
+gets SIGKILLed mid-backlog, and the server must stay alive and healthy
+while session cleanup races the queued saves. The race is probabilistic
+but hits reliably with this sizing; the observed pre-fix signature is
+SIGABRT via `c10::AcceleratorError: CUDA error: unspecified launch
+failure` thrown in a tensor destructor after the stale copy poisons the
+CUDA context.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import signal
+import subprocess
+import sys
+import sysconfig
+import time
+from pathlib import Path
+
+import pytest
+
+from .conftest import PegaServerProcess, find_available_port
+
+pytestmark = [pytest.mark.integration, pytest.mark.gpu]
+
+HELPER = Path(__file__).parent / "save_backlog_kill_helper.py"
+READY_TIMEOUT_SEC = 60.0
+# Enough completed saves to know the submit threads outpace the save worker,
+# i.e. the server-side queue has a real backlog when we kill.
+MIN_SAVES_BEFORE_KILL = 8
+CLEANUP_LOG_DEADLINE_SEC = 10.0
+SURVIVAL_WATCH_SEC = 12.0
+
+
+def _worker_env() -> dict[str, str]:
+    """Match the server fixture's environment so the helper finds the same
+    libpython / pegaflow module the server sees."""
+    env = os.environ.copy()
+    if libdir := sysconfig.get_config_var("LIBDIR"):
+        env["LD_LIBRARY_PATH"] = f"{libdir}:{env.get('LD_LIBRARY_PATH', '')}"
+    python_dir = Path(__file__).parent.parent
+    site_packages = next((p for p in sys.path if "site-packages" in p), None)
+    env["PYTHONPATH"] = str(python_dir) + (f":{site_packages}" if site_packages else "")
+    return env
+
+
+@pytest.fixture
+def backlog_server(monkeypatch):
+    """Dedicated server with a pool large enough for a multi-save backlog."""
+    monkeypatch.setenv("RUST_LOG", "info,pegaflow_core=debug,pegaflow_server=debug")
+    server = PegaServerProcess(port=find_available_port(), pool_size="3gb")
+    if not server.start() or not server._binary_path:
+        pytest.skip("PegaServer binary not found or failed to start")
+    yield server
+    server.stop()
+
+
+def _count_progress_lines(progress_file: Path) -> int:
+    if not progress_file.exists():
+        return 0
+    return len(progress_file.read_text(errors="replace").splitlines())
+
+
+def test_server_survives_sigkill_with_save_backlog(backlog_server, tmp_path):
+    instance_id = f"inst-backlog-{os.getpid()}"
+    ready_file = tmp_path / "ready"
+    progress_file = tmp_path / "progress"
+
+    worker = subprocess.Popen(
+        [
+            sys.executable,
+            str(HELPER),
+            backlog_server.endpoint,
+            instance_id,
+            "test-ns",
+            str(ready_file),
+            str(progress_file),
+        ],
+        env=_worker_env(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        deadline = time.monotonic() + READY_TIMEOUT_SEC
+        while time.monotonic() < deadline:
+            if (
+                ready_file.exists()
+                and _count_progress_lines(progress_file) >= MIN_SAVES_BEFORE_KILL
+            ):
+                break
+            if worker.poll() is not None:
+                out, err = worker.communicate()
+                pytest.fail(
+                    f"worker exited early with code {worker.returncode}\n"
+                    f"stdout={out.decode(errors='replace')}\n"
+                    f"stderr={err.decode(errors='replace')}"
+                )
+            time.sleep(0.02)
+        else:
+            pytest.fail(
+                f"worker did not reach {MIN_SAVES_BEFORE_KILL} saves within "
+                f"{READY_TIMEOUT_SEC}s (got {_count_progress_lines(progress_file)})"
+            )
+
+        # Kill while save RPCs are in flight and queued server-side.
+        worker.send_signal(signal.SIGKILL)
+        worker.wait(timeout=5)
+    finally:
+        if worker.poll() is None:
+            worker.kill()
+            worker.wait(timeout=5)
+
+    # Session cleanup must fire (drops the client's CUDA IPC tensors) —
+    # otherwise this test is not exercising the race at all.
+    cleanup_marker = f"Teardown (stream closed): instance {instance_id} removed"
+    cleanup_seen = False
+
+    deadline = time.monotonic() + SURVIVAL_WATCH_SEC
+    cleanup_deadline = time.monotonic() + CLEANUP_LOG_DEADLINE_SEC
+    while time.monotonic() < deadline:
+        if not backlog_server.is_running():
+            rc = backlog_server.process.returncode if backlog_server.process else None
+            tail = backlog_server.read_logs()[-4000:]
+            pytest.fail(
+                f"pegaflow-server died after client SIGKILL (rc={rc}, "
+                f"SIGSEGV={rc == -signal.SIGSEGV}) — queued save tasks used the "
+                f"client's unmapped CUDA IPC pointers\n--- server log tail ---\n{tail}"
+            )
+        if not cleanup_seen and cleanup_marker in backlog_server.read_logs():
+            cleanup_seen = True
+        if not cleanup_seen and time.monotonic() > cleanup_deadline:
+            pytest.fail(
+                f"session cleanup did not fire within {CLEANUP_LOG_DEADLINE_SEC}s — "
+                "test precondition broken (no unmap happened)"
+            )
+        time.sleep(0.1)
+
+    assert cleanup_seen, "session cleanup never observed in server logs"
+
+    # Drain-before-unmap ordering: both GPU worker threads must have exited
+    # (queue fully drained) before the teardown dropped the IPC tensors.
+    logs = backlog_server.read_logs()
+    save_exit = logs.find("Save worker shutting down")
+    load_exit = logs.find("Load worker shutting down")
+    unmap = logs.find(cleanup_marker)
+    assert save_exit != -1 and load_exit != -1, (
+        "GPU worker threads did not exit during teardown — queue was not drained"
+    )
+    assert max(save_exit, load_exit) < unmap, (
+        "CUDA IPC tensors were dropped before the GPU workers exited — unmap raced the queued tasks"
+    )
+
+    # The server must still answer RPCs.
+    pegaflow_module = importlib.import_module("pegaflow.pegaflow")
+    ok, message = pegaflow_module.EngineRpcClient(backlog_server.endpoint).health()
+    assert ok, f"server unhealthy after client SIGKILL: {message}"


### PR DESCRIPTION
## Problem

Queued save/load tasks capture raw device pointers (`data_ptr: u64`) into a client's CUDA IPC mapping at enqueue time and dereference them only when the per-GPU worker OS thread executes them. Session cleanup after a client SIGKILL unmapped the tensors **first**, with no synchronization against those queues. Two failure modes, both reproduced at driver level (`scripts/cuda_ipc_kill_probe.py`, RTX 5070 Ti + H20-3e):

- **VA unmapped** (common case): `cuMemcpyDtoHAsync` poisons the CUDA context; the next tensor destructor throws `c10::AcceleratorError: unspecified launch failure` → SIGABRT takes the whole server down, killing every other healthy client.
- **VA reused** (new registration lands on the same range — deterministic LIFO reuse per driver probe): the stale task silently reads/writes **another client's live KV cache**. The load direction is the worse twin: it writes stale bytes into a new client's GPU memory.

## Fix: fence → drain → unmap

Every teardown entrance (graceful Unregister RPC, session-watcher disconnect, admin HTTP cleanup) now goes through `InstanceTeardown` (`pegaflow-server/src/teardown.rs`):

1. **Fence** — atomically remove the instance from the engine map and claim the id in a per-instance draining set. No new tasks can be enqueued; concurrent teardowns of the same id observe the claim and back off.
2. **Drain** — close the worker channels; the per-GPU save/load OS threads drain every buffered task (tokio mpsc yields all buffered items after senders drop) and exit. Teardown waits on a `mea::latch::Latch` counted down by RAII guards on the worker threads (covers panic/init-failure paths). This is safe because SIGKILL freezes the client's GPU pages while mapped — draining yields correct data, and per-GPU worker threads are the **only** dereferencers of raw device pointers.
3. **Unmap** — only after both workers exited, drop the CUDA IPC tensors on the dedicated registry thread.

A drain exceeding 30s (wedged GPU; a deep backlog drains at PCIe D2H bandwidth in seconds) deliberately **leaks** the mappings instead of unmapping memory a stale task may still touch — bounded leak over memory corruption. The id stays claimed forever so later sweeps can't unmap it, and `POST /instances/cleanup` reports `leaked_instances` with HTTP 500.

Prompt disconnect detection: stream closure alone never fires on a half-open TCP connection (client host dies without FIN/RST), so the server now sets HTTP/2 keepalive pings (10s interval / 20s timeout) and TCP keepalive (30s).

## Deferred: incarnation-scoped registrations

Registration does not consult the draining set, so a *new* registration reusing a *leaked* instance id would overwrite the leaked tensors in the registry and unmap them under the wedged tasks. Closing this needs incarnation scoping — making the session token a generation that scopes registrations, so a re-register can never collide with a previous incarnation's state. That also covers the fast re-register/supersede race. Deferred to a follow-up; the hole requires a wedged GPU *and* a same-id re-registration on that GPU, and is documented at the claim-set declaration in `teardown.rs`.

## Testing

- New regression test `python/tests/test_ipc_mapping_lifetime.py` (integration, GPU): a victim worker keeps a deep slow-draining save backlog (stride-2 block ids defeat copy-range merging) and gets SIGKILLed mid-backlog. Asserts the server survives, **both worker threads exit before the tensors drop** (log-order assertion), and the server still answers RPCs. Reliably SIGABRTs the pre-fix server.
- Live E2E on H20: vLLM + continuous bench, `kill -9` mid-flight → session closed in 88ms → workers drained and exited → 36 IPC tensors dropped after drain (~110ms total) → server healthy → vLLM restart re-registered (token=2) → warm-hit load (143 blocks) served → second teardown clean.
- Full Rust test suite, clippy `-D warnings`, default Python unit gate (77 passed), integration test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)