### PR TITLE
fix: enable RDMA for CUDA 13 release wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
             cargo-features: ""
           - cuda-variant: cu13
             cuda-version: '13.0.2'
-            cargo-features: "--no-default-features --features cuda-13"
+            cargo-features: "--no-default-features --features cuda-13,rdma"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -229,7 +229,7 @@ jobs:
             cargo-features: ""
           - cuda-variant: cu13
             cuda-version: '13.0.2'
-            cargo-features: "--no-default-features --features cuda-13"
+            cargo-features: "--no-default-features --features cuda-13,rdma"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
             cargo-features: ""
           - cuda-variant: cu13
             cuda-version: '13.0.2'
-            cargo-features: "--no-default-features --features cuda-13"
+            cargo-features: "--no-default-features --features cuda-13,rdma"
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,7 +1916,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "colored",
  "libc",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "axum",
  "clap",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "prost",
  "tonic",
@@ -1989,7 +1989,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "axum",
  "clap",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.22.5"
+version = "0.22.6"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.22.5"
+version = "0.22.6"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -110,6 +110,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.22.5"
+version = "0.22.6"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## 0.22.5 -> 0.22.6 对照 / Comparison

### 中文

0.22.6 的定位是 P/D 分离的第一个 stable 版本：不仅把 P/D RDMA push 路径的性能稳定性补齐，也把正确性保护、布局兼容和发包完整性补齐。0.22.5 是 release baseline；0.22.6 则适合作为 P/D 分离正式使用的版本。

| 维度 | 0.22.5 | 0.22.6 |
| --- | --- | --- |
| P/D 分离 | 仍是 0.22.x 的基础发布状态 | 第一版 stable：P/D RDMA push、scheduler/worker 协议、decode/prefill 流程和 native RDMA binding 都经过稳定化 |
| 性能 | RDMA 路径还缺少本轮 perf/stability 收敛 | MLA cache layout support；PD RDMA 路径减少不必要等待，补齐完成通知、worker 发送/收包稳定性和链路利用率观测 |
| 正确性 | 存在一些边界保护不足，例如版本不匹配、零命中 query probe、RDMA-only query path | fail early 处理 vLLM/server 版本不匹配；零命中 query probe 不再错误释放 lease；RDMA-only query path cfg-gate；vLLM 启动失败更早暴露 |
| 发包 | CUDA 13 release wheel 因 `--no-default-features --features cuda-13` 漏掉 `rdma` | CUDA 13 release/CI wheel 显式使用 `--features cuda-13,rdma`，cu12/cu13 包都带 RDMA |
| 其他修复 | SSD cache 单路径 | SSD cache 支持多路径；清理未使用 Rust 依赖 |

### English

0.22.6 is the first stable P/D disaggregation release. It closes the loop on both performance and correctness for the P/D RDMA push path, and also fixes the packaging gap that made the CUDA 13 wheel miss RDMA support. 0.22.5 is the release baseline; 0.22.6 is the version to use for stable P/D disaggregation.

| Area | 0.22.5 | 0.22.6 |
| --- | --- | --- |
| P/D disaggregation | Baseline 0.22.x release state | First stable release: P/D RDMA push, scheduler/worker protocol, decode/prefill flow, and native RDMA binding have been stabilized |
| Performance | RDMA path had not yet received this round of perf/stability hardening | Adds MLA cache layout support; improves PD RDMA send/receive stability, completion signaling, wait behavior, and link utilization visibility |
| Correctness | Some edge cases were still under-protected, including version mismatch, zero-hit query probes, and RDMA-only query paths | Fails early on vLLM/server version mismatch; avoids incorrect lease release for zero-hit query probes; cfg-gates RDMA-only query behavior; fails faster when vLLM startup dies |
| Packaging | CUDA 13 release wheel used `--no-default-features --features cuda-13`, which disabled default `rdma` | CUDA 13 release/CI wheels now explicitly use `--features cuda-13,rdma`, so both cu12 and cu13 packages include RDMA |
| Other fixes | Single SSD cache path | Multiple SSD cache paths; unused Rust dependencies removed |

## This PR

- Enables RDMA for CUDA 13 release wheels by changing the cu13 feature set to `--no-default-features --features cuda-13,rdma` in release and CI wheel/check jobs.
- Bumps package metadata from `0.22.5` to `0.22.6` across Rust workspace, Cargo.lock, Python project metadata, and Commitizen config.

## Local verification

- `CUDA_PATH=/usr/local/cuda-13.3 PATH=/usr/local/cuda-13.3/bin:$PATH cargo check -p pegaflow-py --no-default-features --features cuda-13,rdma --lib`
- `CUDA_PATH=/usr/local/cuda-13.3 PATH=/usr/local/cuda-13.3/bin:$PATH cargo check -p pegaflow-core --no-default-features --features cuda-13,rdma`
- `CUDA_PATH=/usr/local/cuda-13.3 PATH=/usr/local/cuda-13.3/bin:$PATH cargo check -p pegaflow-server --no-default-features --features cuda-13,rdma --all-targets`
- Version consistency check passed for `0.22.6`.
- Pre-commit hooks passed during commit, including `cargo test --release`, `cargo clippy`, `cargo fmt`, `typos`, and `commitizen check`.
