### PR TITLE
refactor(core): drain GPU workers on unregister via shared-ref shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "ahash",
  "bytesize",
  "criterion",
+ "crossbeam-channel",
  "cudarc",
  "dashmap",
  "fastrace",

--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -16,6 +16,7 @@ tracing = ["fastrace"]
 [dependencies]
 pegaflow-common.workspace = true
 cudarc.workspace = true
+crossbeam-channel.workspace = true
 log.workspace = true
 logforth.workspace = true
 offset-allocator.workspace = true

--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -1,9 +1,14 @@
-use std::sync::{Arc, mpsc as std_mpsc};
+use std::{
+    sync::{Arc, mpsc as std_mpsc},
+    thread::JoinHandle,
+};
 
+use crossbeam_channel::{Receiver, Sender};
 use cudarc::driver::{CudaContext, CudaStream};
 use log::{debug, error, info, warn};
 use logforth::diagnostic::ThreadLocalDiagnostic;
-use tokio::sync::{mpsc, oneshot};
+use parking_lot::Mutex;
+use tokio::sync::oneshot;
 
 use crate::block::RawBlock;
 use crate::metrics::core_metrics;
@@ -67,8 +72,8 @@ unsafe impl Send for SaveLayerData {}
 /// Per-GPU worker pool with dedicated load and save threads
 pub(crate) struct GpuWorkerPool {
     device_id: i32,
-    load_tx: mpsc::UnboundedSender<LoadTask>,
-    save_tx: mpsc::UnboundedSender<SaveTask>,
+    load: Worker<LoadTask>,
+    save: Worker<SaveTask>,
 }
 
 impl GpuWorkerPool {
@@ -85,61 +90,20 @@ impl GpuWorkerPool {
         numa_node: NumaNode,
         transfer_mode: TransferMode,
     ) -> Result<Self, EngineError> {
-        let (load_tx, load_rx) = mpsc::unbounded_channel();
-        let (save_tx, save_rx) = mpsc::unbounded_channel();
-        let (load_ready_tx, load_ready_rx) = std_mpsc::channel();
-        let (save_ready_tx, save_ready_rx) = std_mpsc::channel();
-
-        // Spawn load worker thread
-        let load_device_id = device_id;
-        let load_numa = numa_node;
-        std::thread::Builder::new()
-            .name(format!("gpu{}-load", device_id))
-            .spawn(move || {
-                // Pin thread to NUMA node before any allocations
-                if load_numa.is_valid()
-                    && let Err(e) = pin_thread_to_numa_node(load_numa)
-                {
-                    warn!("Failed to pin load worker to {}: {}", load_numa, e);
-                }
-                match init_worker(load_device_id, transfer_mode) {
-                    Ok(runtime) => {
-                        let _ = load_ready_tx.send(Ok(()));
-                        load_worker_loop(load_device_id, load_rx, runtime);
-                    }
-                    Err(e) => {
-                        let _ = load_ready_tx.send(Err(e));
-                    }
-                }
-            })
-            .map_err(|e| EngineError::CudaInit(format!("Failed to spawn load worker: {e}")))?;
-
-        // Spawn save worker thread
-        let save_device_id = device_id;
-        let save_numa = numa_node;
-        std::thread::Builder::new()
-            .name(format!("gpu{}-save", device_id))
-            .spawn(move || {
-                // Pin thread to NUMA node before any allocations
-                if save_numa.is_valid()
-                    && let Err(e) = pin_thread_to_numa_node(save_numa)
-                {
-                    warn!("Failed to pin save worker to {}: {}", save_numa, e);
-                }
-                match init_worker(save_device_id, transfer_mode) {
-                    Ok(runtime) => {
-                        let _ = save_ready_tx.send(Ok(()));
-                        save_worker_loop(save_device_id, save_rx, runtime);
-                    }
-                    Err(e) => {
-                        let _ = save_ready_tx.send(Err(e));
-                    }
-                }
-            })
-            .map_err(|e| EngineError::CudaInit(format!("Failed to spawn save worker: {e}")))?;
-
-        wait_worker_ready("load", device_id, load_ready_rx)?;
-        wait_worker_ready("save", device_id, save_ready_rx)?;
+        let load = spawn_worker(
+            "load",
+            device_id,
+            numa_node,
+            transfer_mode,
+            load_worker_loop,
+        )?;
+        let save = spawn_worker(
+            "save",
+            device_id,
+            numa_node,
+            transfer_mode,
+            save_worker_loop,
+        )?;
 
         info!(
             "GPU worker pool started: device={}, numa_node={}, transfer_mode={:?}",
@@ -147,25 +111,20 @@ impl GpuWorkerPool {
         );
         Ok(Self {
             device_id,
-            load_tx,
-            save_tx,
+            load,
+            save,
         })
     }
 
     /// Submit a load task (CPU -> GPU) - fire and forget
     pub(crate) fn submit_load(&self, task: LoadTask) -> Result<(), EngineError> {
-        self.load_tx.send(task).map_err(|_| {
-            EngineError::Storage(format!(
-                "Load worker channel closed for device {}",
-                self.device_id
-            ))
-        })
+        self.load.submit(task)
     }
 
-    /// Submit a multi-layer save task (GPU -> CPU) - async, wait for completion.
+    /// Submit a multi-layer save task (GPU -> CPU) and wait for completion.
     /// All layers are copied on the same CUDA stream with a single synchronization,
     /// which is significantly faster than submitting individual per-layer tasks.
-    pub(crate) async fn batch_save(&self, layers: Vec<SaveLayerData>) -> Result<(), EngineError> {
+    pub(crate) async fn save_layers(&self, layers: Vec<SaveLayerData>) -> Result<(), EngineError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let task = SaveTask {
             layers,
@@ -174,12 +133,7 @@ impl GpuWorkerPool {
             trace_ctx: ::fastrace::prelude::SpanContext::current_local_parent(),
         };
 
-        self.save_tx.send(task).map_err(|_| {
-            EngineError::Storage(format!(
-                "Save worker channel closed for device {}",
-                self.device_id
-            ))
-        })?;
+        self.save.submit(task)?;
 
         // Await the result (this is async, won't block tokio runtime)
         reply_rx.await.map_err(|_| {
@@ -189,11 +143,156 @@ impl GpuWorkerPool {
             ))
         })?
     }
+
+    /// Stop accepting new tasks, drain queued work, and join worker threads.
+    ///
+    /// Callable through a shared reference and idempotent: only the first call
+    /// observes the running threads. Joining guarantees no worker is still
+    /// touching GPU memory when this returns, so callers may release CUDA
+    /// tensors afterwards without risking a use-after-unmap.
+    pub(crate) fn shutdown(&self) -> Result<(), EngineError> {
+        // Attempt both regardless of the first result so neither thread leaks.
+        let load = self.load.shutdown();
+        let save = self.save.shutdown();
+        let load = load?;
+        let save = save?;
+        if load || save {
+            debug!("GPU worker pool shut down: device={}", self.device_id);
+        }
+        Ok(())
+    }
+}
+
+impl Drop for GpuWorkerPool {
+    fn drop(&mut self) {
+        if let Err(err) = self.shutdown() {
+            error!("{err}");
+        }
+    }
 }
 
 struct WorkerRuntime {
     stream: Arc<CudaStream>,
     backend: Box<dyn TransferBackend>,
+}
+
+/// A worker thread plus the channel feeding it.
+///
+/// `tx` and `handle` live behind locks so that [`Worker::shutdown`] can close
+/// the channel and join the thread through a shared reference, without needing
+/// to own the `Worker`. This is what lets an instance be torn down while other
+/// tasks still hold an `Arc` to its `GpuContext`.
+struct Worker<T> {
+    name: &'static str,
+    device_id: i32,
+    tx: Mutex<Option<Sender<T>>>,
+    handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl<T> Worker<T> {
+    fn new(name: &'static str, device_id: i32, tx: Sender<T>, handle: JoinHandle<()>) -> Self {
+        Self {
+            name,
+            device_id,
+            tx: Mutex::new(Some(tx)),
+            handle: Mutex::new(Some(handle)),
+        }
+    }
+
+    fn submit(&self, task: T) -> Result<(), EngineError> {
+        let guard = self.tx.lock();
+        let tx = guard.as_ref().ok_or_else(|| {
+            EngineError::Storage(format!(
+                "{} worker is shut down for device {}",
+                self.name, self.device_id
+            ))
+        })?;
+
+        tx.send(task).map_err(|_| {
+            EngineError::Storage(format!(
+                "{} worker channel closed for device {}",
+                self.name, self.device_id
+            ))
+        })
+    }
+
+    /// Close the channel and join the worker thread.
+    ///
+    /// Returns `Ok(true)` if this call joined a live thread, `Ok(false)` if the
+    /// worker was already shut down. Dropping the sole `Sender` makes the loop
+    /// exit only after its queue drains, so in-flight tasks finish first.
+    fn shutdown(&self) -> Result<bool, EngineError> {
+        drop(self.tx.lock().take());
+
+        let Some(handle) = self.handle.lock().take() else {
+            return Ok(false);
+        };
+        handle.join().map_err(|_| {
+            EngineError::Storage(format!(
+                "{} worker panicked on device {}",
+                self.name, self.device_id
+            ))
+        })?;
+        Ok(true)
+    }
+}
+
+impl<T> Drop for Worker<T> {
+    fn drop(&mut self) {
+        // Safety net for a `Worker` dropped without an explicit shutdown, e.g.
+        // when pool construction fails after this worker was already spawned.
+        if let Err(err) = self.shutdown() {
+            error!("{err}");
+        }
+    }
+}
+
+fn spawn_worker<T, F>(
+    name: &'static str,
+    device_id: i32,
+    numa_node: NumaNode,
+    transfer_mode: TransferMode,
+    run_loop: F,
+) -> Result<Worker<T>, EngineError>
+where
+    T: Send + 'static,
+    F: FnOnce(i32, Receiver<T>, WorkerRuntime) + Send + 'static,
+{
+    let (tx, rx) = crossbeam_channel::unbounded();
+    let (ready_tx, ready_rx) = std_mpsc::channel();
+
+    let handle = std::thread::Builder::new()
+        .name(format!("gpu{}-{name}", device_id))
+        .spawn(move || {
+            if numa_node.is_valid()
+                && let Err(e) = pin_thread_to_numa_node(numa_node)
+            {
+                warn!("Failed to pin {name} worker to {numa_node}: {e}");
+            }
+
+            match init_worker(device_id, transfer_mode) {
+                Ok(runtime) => {
+                    let _ = ready_tx.send(Ok(()));
+                    run_loop(device_id, rx, runtime);
+                }
+                Err(e) => {
+                    let _ = ready_tx.send(Err(e));
+                }
+            }
+        })
+        .map_err(|e| EngineError::CudaInit(format!("Failed to spawn {name} worker: {e}")))?;
+
+    if let Err(err) = wait_worker_ready(name, device_id, ready_rx) {
+        drop(tx);
+        if handle.join().is_err() {
+            return Err(EngineError::CudaInit(format!(
+                "{name} worker panicked during CUDA initialization on device {device_id}"
+            )));
+        }
+        return Err(err);
+    }
+
+    Ok(Worker::new(name, device_id, tx, handle))
 }
 
 fn wait_worker_ready(
@@ -247,12 +346,8 @@ fn init_worker(device_id: i32, transfer_mode: TransferMode) -> Result<WorkerRunt
 }
 
 /// Load worker thread main loop
-fn load_worker_loop(
-    device_id: i32,
-    mut rx: mpsc::UnboundedReceiver<LoadTask>,
-    runtime: WorkerRuntime,
-) {
-    while let Some(task) = rx.blocking_recv() {
+fn load_worker_loop(device_id: i32, rx: Receiver<LoadTask>, runtime: WorkerRuntime) {
+    while let Ok(task) = rx.recv() {
         let result = process_load_task(&task, &runtime.stream, runtime.backend.as_ref());
 
         // Attach to LoadState and signal completion
@@ -279,12 +374,8 @@ fn load_worker_loop(
 }
 
 /// Save worker thread main loop
-fn save_worker_loop(
-    device_id: i32,
-    mut rx: mpsc::UnboundedReceiver<SaveTask>,
-    runtime: WorkerRuntime,
-) {
-    while let Some(task) = rx.blocking_recv() {
+fn save_worker_loop(device_id: i32, rx: Receiver<SaveTask>, runtime: WorkerRuntime) {
+    while let Ok(task) = rx.recv() {
         let result = process_save_task(&task, &runtime.stream, runtime.backend.as_ref());
         let _ = task.reply.send(result);
     }

--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::{Arc, mpsc as std_mpsc},
-    thread::JoinHandle,
-};
+use std::{sync::Arc, thread::JoinHandle};
 
 use crossbeam_channel::{Receiver, Sender};
 use cudarc::driver::{CudaContext, CudaStream};
@@ -259,7 +256,8 @@ where
     F: FnOnce(i32, Receiver<T>, WorkerRuntime) + Send + 'static,
 {
     let (tx, rx) = crossbeam_channel::unbounded();
-    let (ready_tx, ready_rx) = std_mpsc::channel();
+    // One-shot handshake: the worker reports CUDA-init success/failure exactly once.
+    let (ready_tx, ready_rx) = crossbeam_channel::bounded(1);
 
     let handle = std::thread::Builder::new()
         .name(format!("gpu{}-{name}", device_id))
@@ -298,7 +296,7 @@ where
 fn wait_worker_ready(
     worker_name: &str,
     device_id: i32,
-    rx: std_mpsc::Receiver<Result<(), EngineError>>,
+    rx: Receiver<Result<(), EngineError>>,
 ) -> Result<(), EngineError> {
     rx.recv().map_err(|_| {
         EngineError::CudaInit(format!(

--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -3,7 +3,7 @@
 //! This module provides the hierarchical context structure for managing
 //! multi-tenant inference instances and their associated GPU resources.
 
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use std::{
     collections::HashMap,
     sync::{
@@ -13,10 +13,101 @@ use std::{
 };
 
 use cudarc::driver::CudaContext;
-use log::info;
+use log::{error, info};
 
 use crate::{EngineError, TransferMode, gpu_worker::GpuWorkerPool};
 use pegaflow_common::NumaNode;
+
+/// Registry of active inference instances.
+pub(crate) struct InstanceRegistry {
+    instances: RwLock<HashMap<String, Arc<InstanceContext>>>,
+}
+
+impl InstanceRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            instances: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn get_or_create(
+        &self,
+        instance_id: &str,
+        namespace: &str,
+        num_layers: usize,
+        tp_size: usize,
+        world_size: usize,
+    ) -> Result<Arc<InstanceContext>, EngineError> {
+        let mut instances = self.instances.write();
+
+        if let Some(instance) = instances.get(instance_id) {
+            instance
+                .verify_topology(num_layers, tp_size, world_size)
+                .map_err(|e| {
+                    EngineError::TopologyMismatch(format!("instance {instance_id} {e}"))
+                })?;
+            return Ok(Arc::clone(instance));
+        }
+
+        let instance = InstanceContext::new(
+            instance_id.to_string(),
+            namespace.to_string(),
+            num_layers,
+            tp_size,
+            world_size,
+        )
+        .map_err(EngineError::InvalidArgument)?;
+        let instance = Arc::new(instance);
+        instances.insert(instance_id.to_string(), Arc::clone(&instance));
+        Ok(instance)
+    }
+
+    pub(crate) fn get(&self, instance_id: &str) -> Result<Arc<InstanceContext>, EngineError> {
+        self.instances
+            .read()
+            .get(instance_id)
+            .cloned()
+            .ok_or_else(|| EngineError::InstanceMissing(instance_id.to_string()))
+    }
+
+    /// Remove an instance and shut down its GPU workers.
+    ///
+    /// Shutdown drains and joins the worker threads, so any in-flight save/load
+    /// finishes touching GPU memory before this returns. The instance is taken
+    /// out of the map first, so a concurrently-submitted save either lands
+    /// before the channel closes (and is drained) or fails cleanly with a
+    /// "channel closed" error — never a use-after-unmap.
+    pub(crate) fn unregister(&self, instance_id: &str) -> Result<(), EngineError> {
+        let instance = self
+            .instances
+            .write()
+            .remove(instance_id)
+            .ok_or_else(|| EngineError::InstanceMissing(instance_id.to_string()))?;
+        instance.shutdown()
+    }
+
+    /// Remove every instance and shut down its GPU workers, best-effort.
+    ///
+    /// A failed shutdown on one instance is logged and does not stop the others
+    /// from being torn down. Returns the IDs that were removed.
+    pub(crate) fn unregister_all(&self) -> Vec<String> {
+        let removed: Vec<(String, Arc<InstanceContext>)> = self.instances.write().drain().collect();
+
+        removed
+            .into_iter()
+            .map(|(instance_id, instance)| {
+                if let Err(err) = instance.shutdown() {
+                    error!("Failed to shut down instance {instance_id}: {err}");
+                }
+                instance_id
+            })
+            .collect()
+    }
+
+    pub(crate) fn list_ids(&self) -> Vec<String> {
+        self.instances.read().keys().cloned().collect()
+    }
+}
 
 /// Layer metadata protected by a single mutex.
 ///
@@ -227,6 +318,10 @@ impl GpuContext {
     /// Access the worker pool for submitting GPU operations.
     pub(crate) fn worker_pool(&self) -> &GpuWorkerPool {
         &self.worker_pool
+    }
+
+    fn shutdown(&self) -> Result<(), EngineError> {
+        self.worker_pool.shutdown()
     }
 }
 
@@ -539,6 +634,39 @@ impl InstanceContext {
         Err(EngineError::InvalidArgument(format!(
             "save NUMA hint {numa_node} is not registered for tp_rank {tp_rank}, pp_rank {pp_rank}; candidates={candidates:?}"
         )))
+    }
+
+    /// Shut down every GPU worker for this instance, draining in-flight
+    /// transfers via the worker-thread join.
+    ///
+    /// Callable through a shared reference, so an instance can be torn down
+    /// while other tasks still hold an `Arc` to it. GPU contexts are cloned out
+    /// from under the metadata lock so the join does not block concurrent
+    /// `get_gpu`. Every GPU is attempted even if one fails, so no thread leaks;
+    /// the first error is returned.
+    pub(crate) fn shutdown(&self) -> Result<(), EngineError> {
+        let gpus: Vec<(i32, Arc<GpuContext>)> = {
+            let metadata = self.metadata.lock();
+            metadata
+                .gpu_contexts
+                .iter()
+                .map(|(device_id, gpu)| (*device_id, Arc::clone(gpu)))
+                .collect()
+        };
+
+        let mut first_err = None;
+        for (device_id, gpu) in gpus {
+            if let Err(err) = gpu.shutdown() {
+                let err = EngineError::Storage(format!(
+                    "failed to shut down GPU worker for instance {} device {device_id}: {err}",
+                    self.id
+                ));
+                error!("{err}");
+                first_err.get_or_insert(err);
+            }
+        }
+
+        first_err.map_or(Ok(()), Err)
     }
 
     /// Verify that the topology matches expected values.

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -47,16 +47,13 @@ pub use sync_state::{LoadState, LoadStateError};
 pub use trace::{set_trace_sample_rate, should_sample};
 pub use transfer::TransferMode;
 
-use std::{
-    collections::HashMap,
-    fmt,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use log::{debug, info};
 
 use crate::backing::SSD_ALIGNMENT;
 use crate::gpu_worker::{LayerLoadData, LoadBlock, LoadTask};
+use crate::instance::InstanceRegistry;
 use crate::lease::QueryLeaseManager;
 use crate::metrics::core_metrics;
 use crate::storage::StorageEngine;
@@ -74,8 +71,6 @@ pub enum EngineError {
     CudaInit(String),
     /// Storage engine error.
     Storage(String),
-    /// Internal lock poisoned.
-    Poisoned(&'static str),
     /// Topology mismatch between registration and existing instance.
     TopologyMismatch(String),
 }
@@ -90,7 +85,6 @@ impl fmt::Display for EngineError {
             EngineError::InvalidArgument(msg) => write!(f, "invalid argument: {msg}"),
             EngineError::CudaInit(msg) => write!(f, "failed to initialize CUDA: {msg}"),
             EngineError::Storage(msg) => write!(f, "storage error: {msg}"),
-            EngineError::Poisoned(what) => write!(f, "internal lock poisoned: {what}"),
             EngineError::TopologyMismatch(msg) => write!(f, "topology mismatch: {msg}"),
         }
     }
@@ -115,7 +109,7 @@ impl From<LoadStateError> for EngineError {
 /// The engine is thread-safe and can be shared across async tasks.
 pub struct PegaEngine {
     /// Active inference instances indexed by instance ID.
-    instances: Arc<RwLock<HashMap<String, Arc<InstanceContext>>>>,
+    instances: InstanceRegistry,
     /// Storage engine for pinned memory, block cache, and SSD tier.
     storage: Arc<StorageEngine>,
     /// GPU-NUMA topology for memory allocation decisions.
@@ -165,7 +159,7 @@ impl PegaEngine {
             .map_err(EngineError::Storage)?;
 
         Ok(PegaEngine {
-            instances: Arc::new(RwLock::new(HashMap::new())),
+            instances: InstanceRegistry::new(),
             storage,
             topology,
             query_leases: QueryLeaseManager::default(),
@@ -185,43 +179,13 @@ impl PegaEngine {
         tp_size: usize,
         world_size: usize,
     ) -> Result<Arc<InstanceContext>, EngineError> {
-        let mut instances = self
-            .instances
-            .write()
-            .expect("instances write lock poisoned");
-
-        if let Some(instance) = instances.get(instance_id) {
-            // Already exists, verify topology
-            instance
-                .verify_topology(num_layers, tp_size, world_size)
-                .map_err(|e| {
-                    EngineError::TopologyMismatch(format!("instance {instance_id} {e}"))
-                })?;
-            return Ok(Arc::clone(instance));
-        }
-
-        // Create new instance
-        let instance = InstanceContext::new(
-            instance_id.to_string(),
-            namespace.to_string(),
-            num_layers,
-            tp_size,
-            world_size,
-        )
-        .map_err(EngineError::InvalidArgument)?;
-
-        let instance = Arc::new(instance);
-        instances.insert(instance_id.to_string(), Arc::clone(&instance));
-        Ok(instance)
+        self.instances
+            .get_or_create(instance_id, namespace, num_layers, tp_size, world_size)
     }
 
     /// Look up an instance by ID.
     fn get_instance(&self, instance_id: &str) -> Result<Arc<InstanceContext>, EngineError> {
-        let instances = self.instances.read().expect("instances read lock poisoned");
-        instances
-            .get(instance_id)
-            .cloned()
-            .ok_or_else(|| EngineError::InstanceMissing(instance_id.to_string()))
+        self.instances.get(instance_id)
     }
 
     /// Batch register multiple KV cache layers for a single GPU.
@@ -322,30 +286,23 @@ impl PegaEngine {
     }
 
     /// Unregister an instance and release all associated resources.
+    ///
+    /// Blocks while joining the instance's GPU worker threads, so callers on a
+    /// Tokio runtime must invoke this from `spawn_blocking`, never directly on a
+    /// runtime worker.
     pub fn unregister_instance(&self, instance_id: &str) -> Result<(), EngineError> {
-        let removed = self
-            .instances
-            .write()
-            .expect("instances write lock poisoned")
-            .remove(instance_id);
-
-        if removed.is_none() {
-            return Err(EngineError::InstanceMissing(instance_id.to_string()));
-        }
+        self.instances.unregister(instance_id)?;
         self.query_leases.release_instance(instance_id);
         info!("Unregistered instance: {}", instance_id);
         Ok(())
     }
 
     /// Unregister all instances, returning the IDs that were removed.
+    ///
+    /// Blocks while joining every instance's GPU worker threads; call from
+    /// `spawn_blocking` on a Tokio runtime, never directly on a runtime worker.
     pub fn unregister_all_instances(&self) -> Vec<String> {
-        let mut instances = self
-            .instances
-            .write()
-            .expect("instances write lock poisoned");
-        let ids: Vec<String> = instances.keys().cloned().collect();
-        instances.clear();
-        drop(instances);
+        let ids = self.instances.unregister_all();
         for id in &ids {
             self.query_leases.release_instance(id);
         }
@@ -357,12 +314,7 @@ impl PegaEngine {
 
     /// List all registered instance IDs.
     pub fn list_instance_ids(&self) -> Vec<String> {
-        self.instances
-            .read()
-            .expect("instances read lock poisoned")
-            .keys()
-            .cloned()
-            .collect()
+        self.instances.list_ids()
     }
 
     /// Return the effective TP size registered for this instance.

--- a/pegaflow-core/src/offload.rs
+++ b/pegaflow-core/src/offload.rs
@@ -556,7 +556,7 @@ impl PegaEngine {
 
         trace_future!(
             "save.gpu_copy",
-            gpu.worker_pool().batch_save(gpu_save_layers)
+            gpu.worker_pool().save_layers(gpu_save_layers)
         )
         .await?;
 

--- a/pegaflow-core/tests/unregister_lifecycle.rs
+++ b/pegaflow-core/tests/unregister_lifecycle.rs
@@ -1,0 +1,171 @@
+//! Instance teardown safety under concurrent transfers.
+//!
+//! These cover the contract that `unregister` exists to provide: shutting an
+//! instance down drains and joins its GPU worker threads, so any save that was
+//! in flight finishes touching GPU memory *before* unregister returns. A caller
+//! can then release the CUDA tensors without a use-after-unmap. The race is set
+//! up so that every interleaving is valid — a save either completes or is
+//! rejected cleanly; a CUDA fault or panic is the regression.
+
+mod common;
+
+use std::sync::Arc;
+
+use common::*;
+use pegaflow_core::{EngineError, LayerSave};
+
+/// A save error that is acceptable when it loses the race against teardown:
+/// the instance was removed, or its worker channel was already closed.
+fn is_teardown_error(msg: &str) -> bool {
+    msg.contains("not found") || msg.contains("channel closed") || msg.contains("shut down")
+}
+
+/// Save one layer through the public engine API. Owns its inputs so the future
+/// is `'static` and can be `tokio::spawn`ed.
+async fn save_one_layer(
+    env: Arc<TestEnv>,
+    instance_id: String,
+    layer: String,
+    num_blocks: usize,
+    salt: u8,
+) -> Result<(), EngineError> {
+    let block_ids: Vec<i32> = (0..num_blocks as i32).collect();
+    env.engine
+        .batch_save_kv_blocks_from_ipc(
+            &instance_id,
+            0,
+            0,
+            0,
+            vec![LayerSave {
+                layer_name: layer,
+                block_ids,
+                block_hashes: make_block_hashes(num_blocks, salt),
+            }],
+        )
+        .await
+}
+
+/// Saves racing with `unregister_instance` never crash, and teardown wins
+/// cleanly: unregister succeeds (workers drained + joined) and the instance is
+/// gone afterwards.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unregister_while_saving_is_safe() {
+    let env = Arc::new(
+        TestEnvBuilder::new("test-unreg-race", "test-ns")
+            .layer("layer_0", 8, 4096)
+            .build(),
+    );
+
+    // Distinct salts → distinct blocks → real GPU->CPU copies (no dedup short
+    // circuit), so the worker threads are genuinely busy during teardown.
+    let savers: Vec<_> = (0..16u8)
+        .map(|salt| {
+            let env = Arc::clone(&env);
+            tokio::spawn(save_one_layer(
+                env,
+                "test-unreg-race".to_string(),
+                "layer_0".to_string(),
+                8,
+                salt,
+            ))
+        })
+        .collect();
+
+    // Tear the instance down. Mirror the server: the blocking join runs off the
+    // runtime workers via spawn_blocking.
+    let unreg_env = Arc::clone(&env);
+    let unreg = tokio::task::spawn_blocking(move || {
+        unreg_env.engine.unregister_instance("test-unreg-race")
+    });
+
+    unreg
+        .await
+        .expect("unregister task panicked")
+        .expect("unregister must succeed: it only joins worker threads");
+
+    // Across runs this races both ways: some saves complete (submitted, then
+    // drained during the join) and some are rejected cleanly (lost the race).
+    // Either is valid; a panic or CUDA fault is the use-after-unmap regression.
+    for saver in savers {
+        if let Err(err) = saver.await.expect("save task panicked") {
+            let msg = err.to_string();
+            assert!(
+                is_teardown_error(&msg),
+                "save failed for an unexpected reason: {msg}"
+            );
+        }
+    }
+
+    assert!(
+        !env.engine
+            .list_instance_ids()
+            .contains(&"test-unreg-race".to_string()),
+        "instance must be gone after unregister"
+    );
+}
+
+/// `unregister_all` drains every instance's workers even under concurrent save
+/// load, returns all removed IDs, and leaves the registry empty — no single
+/// instance can hold the others hostage.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unregister_all_drains_every_instance_under_load() {
+    let env = Arc::new(
+        TestEnvBuilder::new("inst-a", "test-ns")
+            .layer("layer_0", 4, 4096)
+            .build(),
+    );
+
+    // Two more instances in the same engine. Reuse the GPU buffer: this test
+    // exercises teardown, not data correctness, and concurrent D2H reads of the
+    // same region are fine.
+    let layer_infos = vec![LayerInfo {
+        name: "layer_0".to_string(),
+        gpu_ptr: env.data().ptr(),
+        total_size: env.data().total_size(),
+        num_blocks: 4,
+        block_size: 4096,
+        kv_stride: 0,
+        segments: 1,
+    }];
+    for id in ["inst-b", "inst-c"] {
+        register_layers(&env.engine, id, "test-ns", &layer_infos, 0, 0, 0, 1, 1, 1);
+    }
+
+    let instances = ["inst-a", "inst-b", "inst-c"];
+    let mut savers = Vec::new();
+    for (i, id) in instances.iter().enumerate() {
+        for salt in 0..4u8 {
+            let env = Arc::clone(&env);
+            savers.push(tokio::spawn(save_one_layer(
+                env,
+                id.to_string(),
+                "layer_0".to_string(),
+                4,
+                (i as u8) * 16 + salt,
+            )));
+        }
+    }
+
+    let unreg_env = Arc::clone(&env);
+    let mut removed =
+        tokio::task::spawn_blocking(move || unreg_env.engine.unregister_all_instances())
+            .await
+            .expect("unregister-all task panicked");
+    removed.sort();
+    assert_eq!(removed, vec!["inst-a", "inst-b", "inst-c"]);
+
+    for saver in savers {
+        if let Err(err) = saver.await.expect("save task panicked") {
+            let msg = err.to_string();
+            assert!(
+                is_teardown_error(&msg),
+                "save failed for an unexpected reason: {msg}"
+            );
+        }
+    }
+
+    assert!(
+        env.engine.list_instance_ids().is_empty(),
+        "registry must be empty after unregister_all"
+    );
+}

--- a/pegaflow-server/src/http_server.rs
+++ b/pegaflow-server/src/http_server.rs
@@ -3,7 +3,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Json, Router, routing::get, routing::post};
 use log::{info, warn};
-use pegaflow_core::PegaEngine;
+use pegaflow_core::{EngineError, PegaEngine};
 use prometheus::{Registry, TextEncoder};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -82,8 +82,15 @@ async fn cleanup_handler(
 ) -> impl IntoResponse {
     match query.id {
         None => {
+            let removed_instances =
+                match unregister_all_engine_instances(Arc::clone(&state.engine)).await {
+                    Ok(removed_instances) => removed_instances,
+                    Err(err) => {
+                        warn!("Cleanup all failed before CUDA tensor release: {err}");
+                        return (cleanup_error_status(&err), format!("{err}").into_response());
+                    }
+                };
             let removed_tensors = state.registry.clear().await;
-            let removed_instances = state.engine.unregister_all_instances();
 
             if !removed_instances.is_empty() || removed_tensors > 0 {
                 warn!(
@@ -104,25 +111,74 @@ async fn cleanup_handler(
             )
         }
         Some(instance_id) => {
-            let removed_tensors = state.registry.drop_instance(instance_id.clone()).await;
-            match state.engine.unregister_instance(&instance_id) {
+            match unregister_engine_instance(Arc::clone(&state.engine), instance_id.clone()).await {
                 Ok(()) => {
+                    let removed_tensors = state.registry.drop_instance(instance_id.clone()).await;
                     warn!(
                         "Cleanup instance {}: {} CUDA tensor(s) released",
                         instance_id, removed_tensors
                     );
                     cleanup_ok_response(instance_id, removed_tensors)
                 }
-                Err(_) if removed_tensors > 0 => {
-                    warn!(
-                        "Instance {} not in engine but cleaned {} CUDA tensor(s)",
-                        instance_id, removed_tensors
-                    );
-                    cleanup_ok_response(instance_id, removed_tensors)
+                Err(EngineError::InstanceMissing(_)) => {
+                    let removed_tensors = state.registry.drop_instance(instance_id.clone()).await;
+                    if removed_tensors > 0 {
+                        warn!(
+                            "Instance {} not in engine but cleaned {} CUDA tensor(s)",
+                            instance_id, removed_tensors
+                        );
+                        cleanup_ok_response(instance_id, removed_tensors)
+                    } else {
+                        (
+                            StatusCode::NOT_FOUND,
+                            format!("instance {instance_id} not found").into_response(),
+                        )
+                    }
                 }
-                Err(e) => (StatusCode::NOT_FOUND, format!("{e}").into_response()),
+                Err(err) => {
+                    warn!(
+                        "Cleanup instance {} failed before CUDA tensor release: {}",
+                        instance_id, err
+                    );
+                    (cleanup_error_status(&err), format!("{err}").into_response())
+                }
             }
         }
+    }
+}
+
+async fn unregister_engine_instance(
+    engine: Arc<PegaEngine>,
+    instance_id: String,
+) -> Result<(), EngineError> {
+    let task_instance_id = instance_id.clone();
+    tokio::task::spawn_blocking(move || engine.unregister_instance(&task_instance_id))
+        .await
+        .map_err(|err| {
+            EngineError::Storage(format!(
+                "engine unregister join task failed for instance {instance_id}: {err}"
+            ))
+        })?
+}
+
+async fn unregister_all_engine_instances(
+    engine: Arc<PegaEngine>,
+) -> Result<Vec<String>, EngineError> {
+    tokio::task::spawn_blocking(move || engine.unregister_all_instances())
+        .await
+        .map_err(|err| {
+            EngineError::Storage(format!("engine unregister-all join task failed: {err}"))
+        })
+}
+
+fn cleanup_error_status(err: &EngineError) -> StatusCode {
+    match err {
+        EngineError::InvalidArgument(_) => StatusCode::BAD_REQUEST,
+        EngineError::InstanceMissing(_) => StatusCode::NOT_FOUND,
+        EngineError::WorkerMissing(_, _)
+        | EngineError::CudaInit(_)
+        | EngineError::Storage(_)
+        | EngineError::TopologyMismatch(_) => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }
 

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -47,29 +47,61 @@ impl GrpcEngineService {
         }
     }
 
-    /// Drop CUDA IPC tensors and engine-side instance state for `instance_id`.
+    async fn unregister_engine_instance(
+        engine: Arc<PegaEngine>,
+        instance_id: String,
+    ) -> Result<(), EngineError> {
+        let task_instance_id = instance_id.clone();
+        tokio::task::spawn_blocking(move || engine.unregister_instance(&task_instance_id))
+            .await
+            .map_err(|err| {
+                EngineError::Storage(format!(
+                    "engine unregister join task failed for instance {instance_id}: {err}"
+                ))
+            })?
+    }
+
+    /// Drop engine-side instance state, then release CUDA IPC tensors.
     /// Idempotent — safe to call after the instance is already gone.
     async fn cleanup_instance(
-        engine: &PegaEngine,
-        registry: &RegistryHandle,
-        instance_id: &str,
+        engine: Arc<PegaEngine>,
+        registry: RegistryHandle,
+        instance_id: String,
         reason: &'static str,
-    ) {
-        let removed = registry.drop_instance(instance_id.to_string()).await;
+        missing_ok: bool,
+    ) -> Result<usize, EngineError> {
+        let unregister_result =
+            Self::unregister_engine_instance(Arc::clone(&engine), instance_id.clone()).await;
+
+        match unregister_result {
+            Ok(()) => {}
+            Err(EngineError::InstanceMissing(_)) if missing_ok => {
+                debug!(
+                    "Instance cleanup ({}): engine instance {} was already gone",
+                    reason, instance_id
+                );
+            }
+            Err(EngineError::InstanceMissing(_)) => {
+                let removed = registry.drop_instance(instance_id.clone()).await;
+                if removed > 0 {
+                    info!(
+                        "Instance cleanup ({}): dropped {} CUDA tensors for missing instance {}",
+                        reason, removed, instance_id
+                    );
+                }
+                return Err(EngineError::InstanceMissing(instance_id));
+            }
+            Err(err) => return Err(err),
+        }
+
+        let removed = registry.drop_instance(instance_id.clone()).await;
         if removed > 0 {
             info!(
-                "Session cleanup ({}): dropped {} CUDA tensors for instance {}",
+                "Instance cleanup ({}): dropped {} CUDA tensors for instance {}",
                 reason, removed, instance_id
             );
         }
-        if let Err(err) = engine.unregister_instance(instance_id) {
-            // `InstanceMissing` is normal if the instance was never registered
-            // (vllm died before any register_context_batch). Log at debug.
-            debug!(
-                "Session cleanup ({}): engine.unregister_instance({}) returned {}",
-                reason, instance_id, err
-            );
-        }
+        Ok(removed)
     }
 
     fn context_key(instance_id: &str, tp_rank: u32, pp_rank: u32, device_id: i32) -> String {
@@ -90,9 +122,7 @@ impl GrpcEngineService {
                 Status::failed_precondition(err.to_string())
             }
             EngineError::TopologyMismatch(_) => Status::failed_precondition(err.to_string()),
-            EngineError::CudaInit(_) | EngineError::Storage(_) | EngineError::Poisoned(_) => {
-                Status::internal(err.to_string())
-            }
+            EngineError::CudaInit(_) | EngineError::Storage(_) => Status::internal(err.to_string()),
         }
     }
 
@@ -713,17 +743,21 @@ impl Engine for GrpcEngineService {
         let result: Result<Response<UnregisterResponse>, Status> = async {
             let req = request.into_inner();
             debug!("RPC [unregister_context]: instance_id={}", req.instance_id);
-            let removed = self.registry.drop_instance(req.instance_id.clone()).await;
+            let removed = Self::cleanup_instance(
+                Arc::clone(&self.engine),
+                self.registry.clone(),
+                req.instance_id.clone(),
+                "explicit unregister",
+                false,
+            )
+            .await
+            .map_err(Self::map_engine_error)?;
             if removed > 0 {
                 info!(
                     "Dropped {} CUDA tensors for instance {}",
                     removed, req.instance_id
                 );
             }
-
-            self.engine
-                .unregister_instance(&req.instance_id)
-                .map_err(Self::map_engine_error)?;
 
             Ok(Response::new(UnregisterResponse {
                 status: Some(Self::build_simple_response()),
@@ -998,8 +1032,20 @@ impl Engine for GrpcEngineService {
                     "Session closed: instance_id={} token={} — running cleanup",
                     id_for_watcher, token
                 );
-                Self::cleanup_instance(&engine, &cuda_registry, &id_for_watcher, "stream closed")
-                    .await;
+                if let Err(err) = Self::cleanup_instance(
+                    engine,
+                    cuda_registry,
+                    id_for_watcher.clone(),
+                    "stream closed",
+                    true,
+                )
+                .await
+                {
+                    warn!(
+                        "Session cleanup failed: instance_id={} token={} error={}",
+                        id_for_watcher, token, err
+                    );
+                }
             } else {
                 debug!(
                     "Session closed: instance_id={} token={} superseded — skip cleanup",


### PR DESCRIPTION
## What

Instance teardown now **drains and joins each GPU worker thread before returning**, so any in-flight save/load finishes touching GPU memory before the caller releases CUDA tensors. This closes the use-after-unmap window on the unregister / cleanup path (drain-then-unmap).

## Why the rewrite

The earlier approach inferred "in-flight" from `Arc::strong_count` and polled with a 20s/50ms retry loop, refusing to unregister a "busy" instance (`InstanceBusy`). That is fragile (any incidental `Arc` clone breaks it; it doesn't even cover fire-and-forget loads — only the thread `join()` does) and it only existed to work around one constraint: `shutdown` needed **owned** access (`Arc::try_unwrap`) to `join()` the worker.

The fix makes worker shutdown callable through a **shared reference**: `tx`/`handle` live behind `Mutex<Option<…>>`, so `shutdown(&self)` closes the channel (draining queued tasks) and joins the thread without owning the `GpuContext`. The real safety guarantee — the `join()` plus "release tensors after unregister" ordering — is unchanged; the `strong_count` scaffolding is just deleted.

## Changes

- **`gpu_worker.rs`**: `Worker<T>` shutdown via interior mutability; `GpuWorkerPool::shutdown(&self)`. In-flight tasks drain before the join (crossbeam channel semantics).
- **`instance.rs`**: `InstanceContext::shutdown(&self)` / `GpuContext::shutdown(&self)`; registry `unregister` removes-then-shuts-down. Removed `strong_count` gating, `active_gpu_refs`, `InstanceBusy*`, `take_idle*` retry loops, timeout constants. Registry now uses `parking_lot::RwLock` (no poison ceremony, no `.expect()` panic in `list_ids`).
- **`lib.rs`**: dropped `EngineError::{InstanceBusy, Poisoned}`; `unregister_all_instances` is best-effort and returns `Vec<String>` again (one stuck instance no longer blocks teardown of the others). Documented that `unregister_*` block on `join` → must run via `spawn_blocking`.
- **`service.rs` / `http_server.rs`**: error-mapping arms for the removed variants dropped; cleanup keeps the "engine unregister, then release CUDA tensors" order.

## Sync-lock-in-async note

All locks are `parking_lot` (sync). Audited: no guard is held across an `.await` or across the blocking `join` (save submit drops its guard before awaiting the reply; registry write guard is a temporary dropped before `shutdown`; `metadata` is cloned-and-released before joining). Sync is also *required* — `Drop` must be able to call `shutdown` and cannot `.await`, and `join` is blocking (hence `spawn_blocking`). `parking_lot` guards are `!Send`, so holding one across an await wouldn't compile anyway.

## Tests

New GPU integration tests `pegaflow-core/tests/unregister_lifecycle.rs` (real engine, real CUDA, public API, no mocks):

- `unregister_while_saving_is_safe` — 16 concurrent saves race `unregister_instance`. Verified non-vacuous via temporary instrumentation: every run drains some in-flight saves to completion *and* rejects others cleanly; 10× stable.
- `unregister_all_drains_every_instance_under_load` — 3 instances under concurrent save load, `unregister_all` tears all down and empties the registry.

Every interleaving satisfies the invariant (a save either completes or fails cleanly); a panic / CUDA fault is the regression.

Full `cargo test --release --no-default-features --features cuda-13,rdma` workspace suite passes, including `http_cleanup_hang_repro` and `mock_vllm_rpc_e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
