### PR TITLE
fix(connector): register explicit layer ids

### DIFF
--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -137,6 +137,7 @@ impl BenchFixture {
                 1,
                 1,
                 &[LAYER_NAME.to_string()],
+                &[0],
                 &[gpu.as_u64()],
                 &[total_bytes],
                 &[registered_blocks],
@@ -303,6 +304,7 @@ impl MultiLayerBenchFixture {
         let layer_names: Vec<String> = (0..MULTI_LAYER_COUNT)
             .map(|idx| format!("layer_{idx}"))
             .collect();
+        let layer_ids: Vec<usize> = (0..MULTI_LAYER_COUNT).collect();
         let layer_ptrs: Vec<u64> = match layout {
             MultiLayerGpuLayout::SharedSource => vec![gpu.as_u64(); MULTI_LAYER_COUNT],
             MultiLayerGpuLayout::DistinctLayerSources => (0..MULTI_LAYER_COUNT)
@@ -324,8 +326,9 @@ impl MultiLayerBenchFixture {
                 0,
                 1,
                 1,
-                1,
+                MULTI_LAYER_COUNT,
                 &layer_names,
+                &layer_ids,
                 &layer_ptrs,
                 &layer_sizes,
                 &layer_blocks,

--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -4,13 +4,7 @@
 //! multi-tenant inference instances and their associated GPU resources.
 
 use parking_lot::Mutex;
-use std::{
-    collections::HashMap,
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
-};
+use std::{collections::HashMap, sync::Arc};
 
 use cudarc::driver::CudaContext;
 use log::info;
@@ -27,7 +21,7 @@ struct LayerMetadata {
     name_to_id: HashMap<String, usize>,
 
     /// Inverse mapping from IDs to layer names.
-    names: Vec<String>,
+    names: Vec<Option<String>>,
 
     /// GPU contexts indexed by CUDA device ID.
     gpu_contexts: HashMap<i32, Arc<GpuContext>>,
@@ -154,6 +148,9 @@ impl KVCacheRegistration {
 /// - Asynchronous worker pool for load/save operations
 /// - NUMA affinity for memory allocation optimization
 pub struct GpuContext {
+    /// CUDA device ID for diagnostics and duplicate registration checks.
+    device_id: i32,
+
     /// Effective TP rank represented by this GPU context.
     tp_rank: usize,
 
@@ -195,6 +192,7 @@ impl GpuContext {
         let worker_pool = GpuWorkerPool::spawn(device_id, numa_node, transfer_mode)?;
 
         Ok(Self {
+            device_id,
             tp_rank,
             pp_rank,
             preferred_numa: numa_node,
@@ -207,6 +205,11 @@ impl GpuContext {
     /// Get the preferred NUMA node for this GPU.
     pub(crate) fn preferred_numa(&self) -> NumaNode {
         self.preferred_numa
+    }
+
+    /// CUDA device ID represented by this shard.
+    pub(crate) fn device_id(&self) -> i32 {
+        self.device_id
     }
 
     /// Effective TP rank represented by this shard.
@@ -230,6 +233,16 @@ impl GpuContext {
     }
 }
 
+pub(crate) struct GpuRegistration {
+    pub(crate) device_id: i32,
+    pub(crate) tp_rank: usize,
+    pub(crate) pp_rank: usize,
+    pub(crate) numa_node: NumaNode,
+    pub(crate) transfer_mode: TransferMode,
+    pub(crate) kv_caches: HashMap<String, KVCacheRegistration>,
+    pub(crate) layer_ids_by_name: HashMap<String, usize>,
+}
+
 /// Instance context for a model inference process.
 ///
 /// An `InstanceContext` represents a single inference instance (e.g., one
@@ -242,9 +255,8 @@ pub struct InstanceContext {
     /// Namespace for model isolation (e.g., model name or tenant ID).
     namespace: String,
 
-    /// Number of transformer layers in the model.
-    /// Grows via `expand_num_layers` when PP ranks register additional layers.
-    num_layers: AtomicUsize,
+    /// Number of connector-declared logical layers for this instance.
+    num_layers: usize,
 
     /// Tensor parallelism degree (number of GPUs per instance).
     tp_size: usize,
@@ -278,36 +290,125 @@ impl InstanceContext {
         Ok(Self {
             id,
             namespace,
-            num_layers: AtomicUsize::new(num_layers),
+            num_layers,
             tp_size,
             world_size,
             metadata: Mutex::new(LayerMetadata {
                 name_to_id: HashMap::new(),
-                names: Vec::new(),
+                names: vec![None; num_layers],
                 gpu_contexts: HashMap::new(),
             }),
         })
     }
 
-    /// Get existing layer ID or allocate a new one.
-    ///
-    /// This is idempotent: calling multiple times with the same layer name
-    /// returns the same ID. Used for MLA where multiple TP ranks register
-    /// the same layer name on different devices.
-    fn get_or_allocate_layer_id(&self, layer_name: &str) -> usize {
-        let mut metadata = self.metadata.lock();
-
-        if let Some(&id) = metadata.name_to_id.get(layer_name) {
-            return id;
+    /// Register the connector-declared numeric ID for a layer name.
+    #[cfg(test)]
+    fn register_layer_id(&self, layer_name: &str, layer_id: usize) -> Result<(), EngineError> {
+        if layer_id >= self.num_layers {
+            return Err(EngineError::InvalidArgument(format!(
+                "layer {layer_name} id {layer_id} out of range (num_layers {})",
+                self.num_layers
+            )));
         }
 
-        let id = metadata.names.len();
-        metadata.names.push(layer_name.to_string());
-        metadata.name_to_id.insert(layer_name.to_string(), id);
-        // Grow num_layers to cover the newly allocated layer ID so that
-        // total_slots() and get_slot_index() stay in bounds.
-        self.num_layers.fetch_max(id + 1, Ordering::Relaxed);
-        id
+        let mut metadata = self.metadata.lock();
+
+        if let Some(&id) = metadata.name_to_id.get(layer_name)
+            && id != layer_id
+        {
+            return Err(EngineError::InvalidArgument(format!(
+                "layer {layer_name} already registered with id {id}, got {layer_id}"
+            )));
+        }
+
+        if let Some(existing_name) = &metadata.names[layer_id]
+            && existing_name != layer_name
+        {
+            return Err(EngineError::InvalidArgument(format!(
+                "layer id {layer_id} already registered for {existing_name}, got {layer_name}"
+            )));
+        }
+
+        metadata.names[layer_id] = Some(layer_name.to_string());
+        metadata.name_to_id.insert(layer_name.to_string(), layer_id);
+        Ok(())
+    }
+
+    fn build_layer_id_assignments(
+        &self,
+        kv_caches: &HashMap<String, KVCacheRegistration>,
+        layer_ids_by_name: &HashMap<String, usize>,
+    ) -> Result<Vec<(String, usize)>, EngineError> {
+        let mut assignments = Vec::with_capacity(kv_caches.len());
+        let mut names_by_id = HashMap::with_capacity(kv_caches.len());
+
+        for layer_name in kv_caches.keys() {
+            let layer_id = *layer_ids_by_name.get(layer_name).ok_or_else(|| {
+                EngineError::InvalidArgument(format!("missing layer id for {layer_name}"))
+            })?;
+
+            if layer_id >= self.num_layers {
+                return Err(EngineError::InvalidArgument(format!(
+                    "layer {layer_name} id {layer_id} out of range (num_layers {})",
+                    self.num_layers
+                )));
+            }
+
+            if let Some(existing_name) = names_by_id.insert(layer_id, layer_name.as_str()) {
+                return Err(EngineError::InvalidArgument(format!(
+                    "layer id {layer_id} appears more than once in registration batch: {existing_name}, {layer_name}"
+                )));
+            }
+
+            assignments.push((layer_name.clone(), layer_id));
+        }
+
+        Ok(assignments)
+    }
+
+    fn validate_layer_id_assignments(
+        &self,
+        metadata: &LayerMetadata,
+        assignments: &[(String, usize)],
+    ) -> Result<(), EngineError> {
+        for (layer_name, layer_id) in assignments {
+            if let Some(&id) = metadata.name_to_id.get(layer_name)
+                && id != *layer_id
+            {
+                return Err(EngineError::InvalidArgument(format!(
+                    "layer {layer_name} already registered with id {id}, got {layer_id}"
+                )));
+            }
+
+            if let Some(existing_name) = &metadata.names[*layer_id]
+                && existing_name != layer_name
+            {
+                return Err(EngineError::InvalidArgument(format!(
+                    "layer id {layer_id} already registered for {existing_name}, got {layer_name}"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn commit_layer_id_assignments(metadata: &mut LayerMetadata, assignments: &[(String, usize)]) {
+        for (layer_name, layer_id) in assignments {
+            metadata.names[*layer_id] = Some(layer_name.clone());
+            metadata.name_to_id.insert(layer_name.clone(), *layer_id);
+        }
+    }
+
+    fn ensure_device_unregistered(
+        metadata: &LayerMetadata,
+        device_id: i32,
+    ) -> Result<(), EngineError> {
+        if metadata.gpu_contexts.contains_key(&device_id) {
+            return Err(EngineError::InvalidArgument(format!(
+                "GPU context for device {device_id} already exists"
+            )));
+        }
+        Ok(())
     }
 
     /// Look up the numeric ID for a layer name.
@@ -322,7 +423,7 @@ impl InstanceContext {
     ///
     /// Slots are organized as a flattened 2D array: `[layer][tp_rank]`.
     pub(crate) fn total_slots(&self) -> usize {
-        self.num_layers.load(Ordering::Relaxed) * self.tp_size
+        self.num_layers * self.tp_size
     }
 
     /// Compute the slot index for a specific layer and TP rank.
@@ -337,11 +438,10 @@ impl InstanceContext {
         layer_id: usize,
         tp_rank: usize,
     ) -> Result<usize, EngineError> {
-        let num_layers = self.num_layers.load(Ordering::Relaxed);
-        if layer_id >= num_layers {
+        if layer_id >= self.num_layers {
             return Err(EngineError::InvalidArgument(format!(
                 "layer_id {} out of range ({} layers)",
-                layer_id, num_layers
+                layer_id, self.num_layers
             )));
         }
         if tp_rank >= self.tp_size {
@@ -353,7 +453,7 @@ impl InstanceContext {
         Ok(layer_id * self.tp_size + tp_rank)
     }
 
-    /// Get or create a GPU context for the specified device.
+    /// Build a GPU context for the specified device.
     ///
     /// This method lazily initializes CUDA contexts as devices are first accessed.
     /// The `numa_node` should be obtained from `NumaTopology::numa_for_gpu()`.
@@ -361,7 +461,7 @@ impl InstanceContext {
     /// # Errors
     /// Returns `EngineError::InvalidArgument` for negative device IDs,
     /// or `EngineError::CudaInit` if CUDA context creation fails.
-    fn create_gpu(
+    fn build_gpu_context(
         &self,
         device_id: i32,
         tp_rank: usize,
@@ -377,22 +477,10 @@ impl InstanceContext {
             )));
         }
 
-        // Check if context already exists
-        {
-            let metadata = self.metadata.lock();
-            if metadata.gpu_contexts.contains_key(&device_id) {
-                return Err(EngineError::InvalidArgument(format!(
-                    "GPU context for device {} already exists",
-                    device_id
-                )));
-            }
-        }
-
-        // Create new context
         let cuda_ctx = CudaContext::new(device_id as usize)
             .map_err(|e| EngineError::CudaInit(format!("{e:?}")))?;
 
-        let ctx = Arc::new(GpuContext::new(
+        Ok(Arc::new(GpuContext::new(
             cuda_ctx,
             device_id,
             tp_rank,
@@ -400,26 +488,7 @@ impl InstanceContext {
             numa_node,
             transfer_mode,
             kv_caches,
-        )?);
-
-        // Insert and return
-        let mut metadata = self.metadata.lock();
-
-        // Double-check after acquiring lock
-        if metadata.gpu_contexts.contains_key(&device_id) {
-            return Err(EngineError::InvalidArgument(format!(
-                "GPU context for device {} already exists",
-                device_id
-            )));
-        }
-
-        metadata.gpu_contexts.insert(device_id, Arc::clone(&ctx));
-
-        info!(
-            "Initialized GPU context: device_id={}, numa_node={}",
-            device_id, numa_node
-        );
-        Ok(ctx)
+        )?))
     }
 
     /// Get an existing GPU context without creating one.
@@ -457,23 +526,42 @@ impl InstanceContext {
     /// - `EngineError::CudaInit` if GPU context creation fails
     pub(crate) fn register_new_gpu(
         &self,
-        device_id: i32,
-        tp_rank: usize,
-        pp_rank: usize,
-        numa_node: NumaNode,
-        transfer_mode: TransferMode,
-        kv_caches: HashMap<String, KVCacheRegistration>,
+        registration: GpuRegistration,
     ) -> Result<(), EngineError> {
+        let GpuRegistration {
+            device_id,
+            tp_rank,
+            pp_rank,
+            numa_node,
+            transfer_mode,
+            kv_caches,
+            layer_ids_by_name,
+        } = registration;
+
         if tp_rank >= self.tp_size {
             return Err(EngineError::InvalidArgument(format!(
                 "tp_rank {} out of range (tp_size {})",
                 tp_rank, self.tp_size
             )));
         }
-        for layer_name in kv_caches.keys() {
-            self.get_or_allocate_layer_id(layer_name);
+        if kv_caches.len() != layer_ids_by_name.len() {
+            return Err(EngineError::InvalidArgument(format!(
+                "layer id count {} does not match layer cache count {}",
+                layer_ids_by_name.len(),
+                kv_caches.len()
+            )));
         }
-        self.create_gpu(
+
+        let layer_id_assignments =
+            self.build_layer_id_assignments(&kv_caches, &layer_ids_by_name)?;
+
+        {
+            let metadata = self.metadata.lock();
+            Self::ensure_device_unregistered(&metadata, device_id)?;
+            self.validate_layer_id_assignments(&metadata, &layer_id_assignments)?;
+        }
+
+        let ctx = self.build_gpu_context(
             device_id,
             tp_rank,
             pp_rank,
@@ -481,6 +569,75 @@ impl InstanceContext {
             transfer_mode,
             kv_caches,
         )?;
+
+        {
+            let mut metadata = self.metadata.lock();
+            Self::ensure_device_unregistered(&metadata, device_id)?;
+            self.validate_layer_id_assignments(&metadata, &layer_id_assignments)?;
+            Self::commit_layer_id_assignments(&mut metadata, &layer_id_assignments);
+            metadata.gpu_contexts.insert(device_id, ctx);
+        }
+
+        info!("Initialized GPU context: device_id={device_id}, numa_node={numa_node}");
+        Ok(())
+    }
+
+    /// Verify every declared logical layer has a registered slot for every TP rank.
+    pub(crate) fn ensure_all_slots_registered(&self) -> Result<(), EngineError> {
+        let metadata = self.metadata.lock();
+        let total_slots = self.total_slots();
+        let mut owners: Vec<Option<String>> = vec![None; total_slots];
+
+        for gpu in metadata.gpu_contexts.values() {
+            if gpu.tp_rank() >= self.tp_size {
+                return Err(EngineError::InvalidArgument(format!(
+                    "registered gpu device {} has tp_rank {} out of range (tp_size {})",
+                    gpu.device_id(),
+                    gpu.tp_rank(),
+                    self.tp_size
+                )));
+            }
+
+            for layer_name in gpu.kv_caches.keys() {
+                let layer_id = metadata.name_to_id.get(layer_name).ok_or_else(|| {
+                    EngineError::InvalidArgument(format!(
+                        "layer {layer_name} registered on device {} without a layer id",
+                        gpu.device_id()
+                    ))
+                })?;
+                let slot_id = layer_id * self.tp_size + gpu.tp_rank();
+                if slot_id >= total_slots {
+                    return Err(EngineError::InvalidArgument(format!(
+                        "slot_id {slot_id} out of range (total_slots {total_slots})"
+                    )));
+                }
+                let owner = format!(
+                    "device={} pp_rank={} tp_rank={} layer={}",
+                    gpu.device_id(),
+                    gpu.pp_rank(),
+                    gpu.tp_rank(),
+                    layer_name
+                );
+                if let Some(existing_owner) = owners[slot_id].replace(owner.clone()) {
+                    return Err(EngineError::InvalidArgument(format!(
+                        "slot {slot_id} registered twice: {existing_owner}; {owner}"
+                    )));
+                }
+            }
+        }
+
+        let registered_slots = owners.iter().filter(|owner| owner.is_some()).count();
+        if registered_slots != total_slots {
+            let first_missing = owners
+                .iter()
+                .position(Option::is_none)
+                .expect("missing slot must exist when counts differ");
+            return Err(EngineError::InvalidArgument(format!(
+                "instance {} has incomplete KV registration: registered_slots={} expected_slots={} first_missing_slot={}",
+                self.id, registered_slots, total_slots, first_missing
+            )));
+        }
+
         Ok(())
     }
 
@@ -546,178 +703,21 @@ impl InstanceContext {
     /// Returns `Ok(())` if matches, or an error message describing the mismatch.
     pub(crate) fn verify_topology(
         &self,
-        _num_layers: usize,
+        num_layers: usize,
         tp_size: usize,
         world_size: usize,
     ) -> Result<(), String> {
-        if self.tp_size != tp_size || self.world_size != world_size {
+        if self.num_layers != num_layers || self.tp_size != tp_size || self.world_size != world_size
+        {
             return Err(format!(
-                "exists with tp={}, world={}; \
-                 requested tp={}, world={}",
-                self.tp_size, self.world_size, tp_size, world_size
+                "exists with layers={}, tp={}, world={}; \
+                 requested layers={}, tp={}, world={}",
+                self.num_layers, self.tp_size, self.world_size, num_layers, tp_size, world_size
             ));
         }
-        // num_layers grows automatically in get_or_allocate_layer_id
-        // when PP ranks register new layers, so no check needed here.
         Ok(())
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn registration_valid() {
-        let reg = KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap();
-        assert_eq!(reg.block_size_bytes, 1024);
-    }
-
-    #[test]
-    fn registration_null_pointer_rejected() {
-        assert!(KVCacheRegistration::new(0, 1024, 10, 64, 0, 1).is_err());
-    }
-
-    #[test]
-    fn registration_memory_too_small() {
-        let err = KVCacheRegistration::new(0x1000, 5120, 10, 1024, 0, 1).unwrap_err();
-        assert!(err.contains("too small"));
-    }
-
-    #[test]
-    fn padded_block_size() {
-        // Unaligned: 8848 % 512 = 144, padded to 9216
-        let reg = KVCacheRegistration::new(0x1000, 10_000_000, 100, 8848, 0, 1)
-            .unwrap()
-            .with_ssd_padding(512);
-        assert_eq!(reg.padded_bytes_per_block, 9216);
-        assert_eq!(reg.padded_block_size_bytes, 9216);
-
-        // Already aligned: no change
-        let reg = KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1)
-            .unwrap()
-            .with_ssd_padding(512);
-        assert_eq!(reg.padded_bytes_per_block, 1024);
-        assert_eq!(reg.padded_block_size_bytes, 1024);
-
-        // Split layout: padded per segment, total = padded * segments
-        let reg = KVCacheRegistration::new(0x1000, 10_000_000, 100, 8848, 900_000, 2)
-            .unwrap()
-            .with_ssd_padding(512);
-        assert_eq!(reg.padded_bytes_per_block, 9216);
-        assert_eq!(reg.padded_block_size_bytes, 9216 * 2);
-    }
-
-    /// Simulates the inference-side registration flow (single GPU).
-    /// Covers: instance creation -> GPU context creation -> batch layer registration.
-    #[test]
-    fn inference_registration_flow() {
-        // 1. Create instance (like get_or_create_instance)
-        let instance = InstanceContext::new(
-            "test-instance-1".to_string(),
-            "model-ns".to_string(),
-            64, // num_layers
-            8,  // tp_size
-            8,  // world_size
-        )
-        .expect("create instance");
-
-        // Use UNKNOWN NUMA node for tests (no actual GPU/NUMA in CI)
-        let numa = NumaNode::UNKNOWN;
-
-        // 2. Build all layer registrations for device 0
-        let mut kv_caches = HashMap::new();
-        for layer_id in 0..4 {
-            let layer_name = format!("layer_{}", layer_id);
-            let reg = KVCacheRegistration::new(
-                0x1000 + layer_id as u64 * 0x10000,
-                1024 * 1024,
-                100,
-                1024,
-                0,
-                1,
-            )
-            .unwrap();
-            kv_caches.insert(layer_name, reg);
-        }
-
-        // 3. Register all layers at once
-        instance
-            .register_new_gpu(0, 0, 0, numa, TransferMode::Direct, kv_caches)
-            .expect("register gpu with layers");
-
-        // 4. Verify topology checking
-        assert!(instance.verify_topology(64, 8, 8).is_ok());
-        // num_layers can grow (PP ranks register incrementally), so smaller is ok
-        assert!(instance.verify_topology(32, 8, 8).is_ok());
-        // tp_size / world_size mismatch is still rejected
-        assert!(instance.verify_topology(64, 4, 8).is_err());
-        assert!(instance.verify_topology(64, 8, 4).is_err());
-
-        // 5. Verify duplicate GPU registration fails
-        let dup_caches = HashMap::from([(
-            "layer_0".to_string(),
-            KVCacheRegistration::new(0x2000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
-        )]);
-        let err = instance
-            .register_new_gpu(0, 0, 0, numa, TransferMode::Direct, dup_caches)
-            .expect_err("duplicate GPU registration should fail");
-        assert!(err.to_string().contains("already exists"));
-
-        // 6. Verify we can get the registered layer back
-        let gpu = instance.get_gpu(0).expect("get gpu context");
-        let reg = gpu.get_registration("layer_0").expect("get registration");
-        assert_eq!(reg.data_ptr, 0x1000);
-        assert_eq!(reg.num_blocks, 100);
-    }
-
-    /// Tests MLA-style registration where the same layer name is used
-    /// by multiple TP ranks. Verifies layer ID allocation is idempotent.
-    #[test]
-    fn mla_layer_id_allocation() {
-        let instance = InstanceContext::new(
-            "mla-instance".to_string(),
-            "mla-ns".to_string(),
-            10, // num_layers
-            1,  // tp_size (MLA uses tp_size=1)
-            8,  // world_size (8 TP ranks, but treated as 1 for storage)
-        )
-        .expect("create instance");
-
-        // Simulate 8 TP ranks calling get_or_allocate_layer_id for the same layer
-        // This is the MLA pattern where all ranks share the same KV data
-        for _ in 0..8 {
-            // All calls should return the same layer_id=0
-            let layer_id = instance.get_or_allocate_layer_id("layer_0");
-            assert_eq!(layer_id, 0, "all calls should get same layer_id");
-        }
-
-        // Verify only one layer was allocated
-        assert_eq!(instance.get_layer_id("layer_0"), Some(0));
-
-        // Allocate another layer
-        let layer_id = instance.get_or_allocate_layer_id("layer_1");
-        assert_eq!(layer_id, 1);
-
-        // Verify both layers exist with correct IDs
-        assert_eq!(instance.get_layer_id("layer_0"), Some(0));
-        assert_eq!(instance.get_layer_id("layer_1"), Some(1));
-    }
-
-    #[test]
-    fn save_numa_hint_validation_rejects_unknown_or_unregistered_nodes() {
-        let instance =
-            InstanceContext::new("hint-instance".to_string(), "hint-ns".to_string(), 1, 1, 1)
-                .expect("create instance");
-
-        let err = instance
-            .validate_save_numa_hint(0, 0, NumaNode::UNKNOWN)
-            .expect_err("unknown NUMA hint should fail");
-        assert!(err.to_string().contains("valid NUMA node"));
-
-        let err = instance
-            .validate_save_numa_hint(0, 0, NumaNode(0))
-            .expect_err("unregistered NUMA hint should fail");
-        assert!(err.to_string().contains("not registered"));
-    }
-}
+mod tests;

--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -301,39 +301,6 @@ impl InstanceContext {
         })
     }
 
-    /// Register the connector-declared numeric ID for a layer name.
-    #[cfg(test)]
-    fn register_layer_id(&self, layer_name: &str, layer_id: usize) -> Result<(), EngineError> {
-        if layer_id >= self.num_layers {
-            return Err(EngineError::InvalidArgument(format!(
-                "layer {layer_name} id {layer_id} out of range (num_layers {})",
-                self.num_layers
-            )));
-        }
-
-        let mut metadata = self.metadata.lock();
-
-        if let Some(&id) = metadata.name_to_id.get(layer_name)
-            && id != layer_id
-        {
-            return Err(EngineError::InvalidArgument(format!(
-                "layer {layer_name} already registered with id {id}, got {layer_id}"
-            )));
-        }
-
-        if let Some(existing_name) = &metadata.names[layer_id]
-            && existing_name != layer_name
-        {
-            return Err(EngineError::InvalidArgument(format!(
-                "layer id {layer_id} already registered for {existing_name}, got {layer_name}"
-            )));
-        }
-
-        metadata.names[layer_id] = Some(layer_name.to_string());
-        metadata.name_to_id.insert(layer_name.to_string(), layer_id);
-        Ok(())
-    }
-
     fn build_layer_id_assignments(
         &self,
         kv_caches: &HashMap<String, KVCacheRegistration>,

--- a/pegaflow-core/src/instance/tests.rs
+++ b/pegaflow-core/src/instance/tests.rs
@@ -1,0 +1,370 @@
+use super::*;
+
+#[test]
+fn registration_valid() {
+    let reg = KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap();
+    assert_eq!(reg.block_size_bytes, 1024);
+}
+
+#[test]
+fn registration_null_pointer_rejected() {
+    assert!(KVCacheRegistration::new(0, 1024, 10, 64, 0, 1).is_err());
+}
+
+#[test]
+fn registration_memory_too_small() {
+    let err = KVCacheRegistration::new(0x1000, 5120, 10, 1024, 0, 1).unwrap_err();
+    assert!(err.contains("too small"));
+}
+
+#[test]
+fn padded_block_size() {
+    // Unaligned: 8848 % 512 = 144, padded to 9216
+    let reg = KVCacheRegistration::new(0x1000, 10_000_000, 100, 8848, 0, 1)
+        .unwrap()
+        .with_ssd_padding(512);
+    assert_eq!(reg.padded_bytes_per_block, 9216);
+    assert_eq!(reg.padded_block_size_bytes, 9216);
+
+    // Already aligned: no change
+    let reg = KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1)
+        .unwrap()
+        .with_ssd_padding(512);
+    assert_eq!(reg.padded_bytes_per_block, 1024);
+    assert_eq!(reg.padded_block_size_bytes, 1024);
+
+    // Split layout: padded per segment, total = padded * segments
+    let reg = KVCacheRegistration::new(0x1000, 10_000_000, 100, 8848, 900_000, 2)
+        .unwrap()
+        .with_ssd_padding(512);
+    assert_eq!(reg.padded_bytes_per_block, 9216);
+    assert_eq!(reg.padded_block_size_bytes, 9216 * 2);
+}
+
+/// Simulates the inference-side registration flow (single GPU).
+/// Covers: instance creation -> GPU context creation -> batch layer registration.
+#[test]
+fn inference_registration_flow() {
+    // 1. Create instance (like get_or_create_instance)
+    let instance = InstanceContext::new(
+        "test-instance-1".to_string(),
+        "model-ns".to_string(),
+        64, // num_layers
+        8,  // tp_size
+        8,  // world_size
+    )
+    .expect("create instance");
+
+    // Use UNKNOWN NUMA node for tests (no actual GPU/NUMA in CI)
+    let numa = NumaNode::UNKNOWN;
+
+    // 2. Build all layer registrations for device 0
+    let mut kv_caches = HashMap::new();
+    let mut layer_ids = HashMap::new();
+    for layer_id in 0..4 {
+        let layer_name = format!("layer_{}", layer_id);
+        let reg = KVCacheRegistration::new(
+            0x1000 + layer_id as u64 * 0x10000,
+            1024 * 1024,
+            100,
+            1024,
+            0,
+            1,
+        )
+        .unwrap();
+        layer_ids.insert(layer_name.clone(), layer_id);
+        kv_caches.insert(layer_name, reg);
+    }
+
+    // 3. Register all layers at once
+    instance
+        .register_new_gpu(GpuRegistration {
+            device_id: 0,
+            tp_rank: 0,
+            pp_rank: 0,
+            numa_node: numa,
+            transfer_mode: TransferMode::Direct,
+            kv_caches,
+            layer_ids_by_name: layer_ids,
+        })
+        .expect("register gpu with layers");
+
+    // 4. Verify topology checking
+    assert!(instance.verify_topology(64, 8, 8).is_ok());
+    // num_layers is fixed by the connector-declared topology.
+    assert!(instance.verify_topology(32, 8, 8).is_err());
+    // tp_size / world_size mismatch is still rejected
+    assert!(instance.verify_topology(64, 4, 8).is_err());
+    assert!(instance.verify_topology(64, 8, 4).is_err());
+
+    // 5. Verify duplicate GPU registration fails
+    let dup_caches = HashMap::from([(
+        "layer_0".to_string(),
+        KVCacheRegistration::new(0x2000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
+    )]);
+    let dup_ids = HashMap::from([("layer_0".to_string(), 0)]);
+    let err = instance
+        .register_new_gpu(GpuRegistration {
+            device_id: 0,
+            tp_rank: 0,
+            pp_rank: 0,
+            numa_node: numa,
+            transfer_mode: TransferMode::Direct,
+            kv_caches: dup_caches,
+            layer_ids_by_name: dup_ids,
+        })
+        .expect_err("duplicate GPU registration should fail");
+    assert!(err.to_string().contains("already exists"));
+
+    // 6. Verify we can get the registered layer back
+    let gpu = instance.get_gpu(0).expect("get gpu context");
+    let reg = gpu.get_registration("layer_0").expect("get registration");
+    assert_eq!(reg.data_ptr, 0x1000);
+    assert_eq!(reg.num_blocks, 100);
+}
+
+/// Tests MLA-style registration where the same layer name is used
+/// by multiple TP ranks. Verifies explicit layer IDs are idempotent.
+#[test]
+fn explicit_layer_id_registration_is_idempotent() {
+    let instance = InstanceContext::new(
+        "mla-instance".to_string(),
+        "mla-ns".to_string(),
+        10, // num_layers
+        1,  // tp_size (MLA uses tp_size=1)
+        8,  // world_size (8 TP ranks, but treated as 1 for storage)
+    )
+    .expect("create instance");
+
+    for _ in 0..8 {
+        instance
+            .register_layer_id("layer_0", 0)
+            .expect("same layer id is idempotent");
+    }
+
+    assert_eq!(instance.get_layer_id("layer_0"), Some(0));
+
+    instance
+        .register_layer_id("layer_1", 1)
+        .expect("register another explicit layer id");
+
+    assert_eq!(instance.get_layer_id("layer_0"), Some(0));
+    assert_eq!(instance.get_layer_id("layer_1"), Some(1));
+}
+
+#[test]
+fn explicit_layer_id_rejects_out_of_range_and_conflicts() {
+    let instance = InstanceContext::new("id-instance".to_string(), "id-ns".to_string(), 2, 1, 1)
+        .expect("create instance");
+
+    instance
+        .register_layer_id("layer_0", 0)
+        .expect("register first layer");
+
+    let err = instance
+        .register_layer_id("layer_0", 1)
+        .expect_err("same name cannot change id");
+    assert!(err.to_string().contains("already registered with id 0"));
+
+    let err = instance
+        .register_layer_id("other_layer", 0)
+        .expect_err("same id cannot point to another name");
+    assert!(err.to_string().contains("already registered for layer_0"));
+
+    let err = instance
+        .register_layer_id("layer_2", 2)
+        .expect_err("id must stay inside fixed num_layers");
+    assert!(err.to_string().contains("out of range"));
+}
+
+#[test]
+fn failed_batch_registration_does_not_commit_layer_ids() {
+    let instance = InstanceContext::new(
+        "batch-conflict-instance".to_string(),
+        "batch-conflict-ns".to_string(),
+        3,
+        1,
+        1,
+    )
+    .expect("create instance");
+
+    let kv_caches = HashMap::from([
+        (
+            "layer_0".to_string(),
+            KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
+        ),
+        (
+            "layer_1".to_string(),
+            KVCacheRegistration::new(0x2000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
+        ),
+    ]);
+    let duplicate_ids = HashMap::from([("layer_0".to_string(), 0), ("layer_1".to_string(), 0)]);
+
+    let err = instance
+        .register_new_gpu(GpuRegistration {
+            device_id: 0,
+            tp_rank: 0,
+            pp_rank: 0,
+            numa_node: NumaNode::UNKNOWN,
+            transfer_mode: TransferMode::Direct,
+            kv_caches,
+            layer_ids_by_name: duplicate_ids,
+        })
+        .expect_err("duplicate ids in one batch must fail");
+    assert!(err.to_string().contains("appears more than once"));
+    assert_eq!(instance.get_layer_id("layer_0"), None);
+    assert_eq!(instance.get_layer_id("layer_1"), None);
+
+    instance
+        .register_layer_id("layer_0", 0)
+        .expect("failed batch did not poison layer_0");
+    instance
+        .register_layer_id("layer_1", 1)
+        .expect("failed batch did not poison layer_1");
+}
+
+#[test]
+fn failed_batch_conflict_does_not_commit_valid_prefix() {
+    let instance = InstanceContext::new(
+        "batch-prefix-instance".to_string(),
+        "batch-prefix-ns".to_string(),
+        3,
+        1,
+        1,
+    )
+    .expect("create instance");
+    instance
+        .register_layer_id("layer_0", 0)
+        .expect("register existing layer");
+
+    let kv_caches = HashMap::from([
+        (
+            "layer_1".to_string(),
+            KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
+        ),
+        (
+            "other_layer_0".to_string(),
+            KVCacheRegistration::new(0x2000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
+        ),
+    ]);
+    let layer_ids = HashMap::from([("layer_1".to_string(), 1), ("other_layer_0".to_string(), 0)]);
+
+    let err = instance
+        .register_new_gpu(GpuRegistration {
+            device_id: 0,
+            tp_rank: 0,
+            pp_rank: 0,
+            numa_node: NumaNode::UNKNOWN,
+            transfer_mode: TransferMode::Direct,
+            kv_caches,
+            layer_ids_by_name: layer_ids,
+        })
+        .expect_err("conflicting id must fail the whole batch");
+    assert!(err.to_string().contains("already registered for layer_0"));
+    assert_eq!(instance.get_layer_id("layer_0"), Some(0));
+    assert_eq!(instance.get_layer_id("layer_1"), None);
+    assert_eq!(instance.get_layer_id("other_layer_0"), None);
+}
+
+#[test]
+fn cross_layer_pp_slots_are_order_independent() {
+    let producer = InstanceContext::new(
+        "producer-instance".to_string(),
+        "pp-ns".to_string(),
+        4,
+        1,
+        4,
+    )
+    .expect("create producer");
+    let consumer = InstanceContext::new(
+        "consumer-instance".to_string(),
+        "pp-ns".to_string(),
+        4,
+        1,
+        4,
+    )
+    .expect("create consumer");
+
+    for pp_rank in [2, 3, 1, 0] {
+        producer
+            .register_layer_id(&format!("ALL_LAYERS_pp{pp_rank}"), pp_rank)
+            .expect("producer registers explicit pp id");
+    }
+    for pp_rank in [3, 1, 2, 0] {
+        consumer
+            .register_layer_id(&format!("ALL_LAYERS_pp{pp_rank}"), pp_rank)
+            .expect("consumer registers explicit pp id");
+    }
+
+    for pp_rank in 0..4 {
+        let layer_name = format!("ALL_LAYERS_pp{pp_rank}");
+        assert_eq!(producer.get_layer_id(&layer_name), Some(pp_rank));
+        assert_eq!(consumer.get_layer_id(&layer_name), Some(pp_rank));
+        assert_eq!(producer.get_slot_index(pp_rank, 0).unwrap(), pp_rank);
+        assert_eq!(consumer.get_slot_index(pp_rank, 0).unwrap(), pp_rank);
+    }
+}
+
+#[test]
+fn completeness_check_rejects_missing_slots() {
+    let instance = InstanceContext::new(
+        "complete-instance".to_string(),
+        "complete-ns".to_string(),
+        1,
+        1,
+        1,
+    )
+    .expect("create instance");
+    let kv_caches = HashMap::from([(
+        "layer_0".to_string(),
+        KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
+    )]);
+    let layer_ids = HashMap::from([("layer_0".to_string(), 0)]);
+    instance
+        .register_new_gpu(GpuRegistration {
+            device_id: 0,
+            tp_rank: 0,
+            pp_rank: 0,
+            numa_node: NumaNode::UNKNOWN,
+            transfer_mode: TransferMode::Direct,
+            kv_caches,
+            layer_ids_by_name: layer_ids,
+        })
+        .expect("complete single-slot registration");
+    instance
+        .ensure_all_slots_registered()
+        .expect("all slots are registered");
+
+    let sparse = InstanceContext::new(
+        "sparse-instance".to_string(),
+        "sparse-ns".to_string(),
+        2,
+        1,
+        1,
+    )
+    .expect("create sparse instance");
+    sparse
+        .register_layer_id("layer_0", 0)
+        .expect("register one layer id");
+    let err = sparse
+        .ensure_all_slots_registered()
+        .expect_err("missing slots must be rejected");
+    assert!(err.to_string().contains("incomplete KV registration"));
+}
+
+#[test]
+fn save_numa_hint_validation_rejects_unknown_or_unregistered_nodes() {
+    let instance =
+        InstanceContext::new("hint-instance".to_string(), "hint-ns".to_string(), 1, 1, 1)
+            .expect("create instance");
+
+    let err = instance
+        .validate_save_numa_hint(0, 0, NumaNode::UNKNOWN)
+        .expect_err("unknown NUMA hint should fail");
+    assert!(err.to_string().contains("valid NUMA node"));
+
+    let err = instance
+        .validate_save_numa_hint(0, 0, NumaNode(0))
+        .expect_err("unregistered NUMA hint should fail");
+    assert!(err.to_string().contains("not registered"));
+}

--- a/pegaflow-core/src/instance/tests.rs
+++ b/pegaflow-core/src/instance/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+// --- KVCacheRegistration layout validation (pure, no device) ---
+
 #[test]
 fn registration_valid() {
     let reg = KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap();
@@ -41,30 +43,22 @@ fn padded_block_size() {
     assert_eq!(reg.padded_block_size_bytes, 9216 * 2);
 }
 
-/// Simulates the inference-side registration flow (single GPU).
-/// Covers: instance creation -> GPU context creation -> batch layer registration.
-#[test]
-fn inference_registration_flow() {
-    // 1. Create instance (like get_or_create_instance)
-    let instance = InstanceContext::new(
-        "test-instance-1".to_string(),
-        "model-ns".to_string(),
-        64, // num_layers
-        8,  // tp_size
-        8,  // world_size
-    )
-    .expect("create instance");
+// --- Real registration path ---
+//
+// Every layer-id assertion below exercises `register_new_gpu`, the exact path
+// the gRPC service calls. There is no test-only shim that re-implements the
+// validation: pre-CUDA rejections (out-of-range / in-batch / cross-device
+// conflicts) never touch a device, while a committed GPU uses device 0.
 
-    // Use UNKNOWN NUMA node for tests (no actual GPU/NUMA in CI)
-    let numa = NumaNode::UNKNOWN;
-
-    // 2. Build all layer registrations for device 0
+/// Build a `GpuRegistration` whose layers carry explicit connector-declared ids.
+/// Data pointers are assigned deterministically from the slice order so callers
+/// can assert on `get_registration`.
+fn gpu_registration(device_id: i32, tp_rank: usize, layers: &[(&str, usize)]) -> GpuRegistration {
     let mut kv_caches = HashMap::new();
-    let mut layer_ids = HashMap::new();
-    for layer_id in 0..4 {
-        let layer_name = format!("layer_{}", layer_id);
+    let mut layer_ids_by_name = HashMap::new();
+    for (index, (name, id)) in layers.iter().enumerate() {
         let reg = KVCacheRegistration::new(
-            0x1000 + layer_id as u64 * 0x10000,
+            0x1000 + index as u64 * 0x10000,
             1024 * 1024,
             100,
             1024,
@@ -72,280 +66,157 @@ fn inference_registration_flow() {
             1,
         )
         .unwrap();
-        layer_ids.insert(layer_name.clone(), layer_id);
-        kv_caches.insert(layer_name, reg);
+        kv_caches.insert((*name).to_string(), reg);
+        layer_ids_by_name.insert((*name).to_string(), *id);
     }
+    GpuRegistration {
+        device_id,
+        tp_rank,
+        pp_rank: 0,
+        numa_node: NumaNode::UNKNOWN,
+        transfer_mode: TransferMode::Direct,
+        kv_caches,
+        layer_ids_by_name,
+    }
+}
 
-    // 3. Register all layers at once
+/// Inference-side registration: instance creation -> GPU context creation ->
+/// batch layer registration, then topology and lookup checks. Commits device 0.
+#[test]
+fn inference_registration_flow() {
+    let instance =
+        InstanceContext::new("test-instance-1".into(), "model-ns".into(), 64, 8, 8).unwrap();
+
     instance
-        .register_new_gpu(GpuRegistration {
-            device_id: 0,
-            tp_rank: 0,
-            pp_rank: 0,
-            numa_node: numa,
-            transfer_mode: TransferMode::Direct,
-            kv_caches,
-            layer_ids_by_name: layer_ids,
-        })
+        .register_new_gpu(gpu_registration(
+            0,
+            0,
+            &[
+                ("layer_0", 0),
+                ("layer_1", 1),
+                ("layer_2", 2),
+                ("layer_3", 3),
+            ],
+        ))
         .expect("register gpu with layers");
 
-    // 4. Verify topology checking
-    assert!(instance.verify_topology(64, 8, 8).is_ok());
     // num_layers is fixed by the connector-declared topology.
+    assert!(instance.verify_topology(64, 8, 8).is_ok());
     assert!(instance.verify_topology(32, 8, 8).is_err());
-    // tp_size / world_size mismatch is still rejected
+    // tp_size / world_size mismatch is still rejected.
     assert!(instance.verify_topology(64, 4, 8).is_err());
     assert!(instance.verify_topology(64, 8, 4).is_err());
 
-    // 5. Verify duplicate GPU registration fails
-    let dup_caches = HashMap::from([(
-        "layer_0".to_string(),
-        KVCacheRegistration::new(0x2000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
-    )]);
-    let dup_ids = HashMap::from([("layer_0".to_string(), 0)]);
+    // Explicit ids are stored and drive slot placement (tp_size = 8).
+    assert_eq!(instance.get_layer_id("layer_2"), Some(2));
+    assert_eq!(instance.get_slot_index(2, 0).unwrap(), 2 * 8);
+
+    // Duplicate GPU registration fails.
     let err = instance
-        .register_new_gpu(GpuRegistration {
-            device_id: 0,
-            tp_rank: 0,
-            pp_rank: 0,
-            numa_node: numa,
-            transfer_mode: TransferMode::Direct,
-            kv_caches: dup_caches,
-            layer_ids_by_name: dup_ids,
-        })
+        .register_new_gpu(gpu_registration(0, 0, &[("layer_0", 0)]))
         .expect_err("duplicate GPU registration should fail");
     assert!(err.to_string().contains("already exists"));
 
-    // 6. Verify we can get the registered layer back
+    // The registered layer is retrievable with its original layout.
     let gpu = instance.get_gpu(0).expect("get gpu context");
     let reg = gpu.get_registration("layer_0").expect("get registration");
     assert_eq!(reg.data_ptr, 0x1000);
     assert_eq!(reg.num_blocks, 100);
 }
 
-/// Tests MLA-style registration where the same layer name is used
-/// by multiple TP ranks. Verifies explicit layer IDs are idempotent.
+/// An id outside `[0, num_layers)` is rejected while building assignments,
+/// before any device work, and commits nothing.
 #[test]
-fn explicit_layer_id_registration_is_idempotent() {
-    let instance = InstanceContext::new(
-        "mla-instance".to_string(),
-        "mla-ns".to_string(),
-        10, // num_layers
-        1,  // tp_size (MLA uses tp_size=1)
-        8,  // world_size (8 TP ranks, but treated as 1 for storage)
-    )
-    .expect("create instance");
-
-    for _ in 0..8 {
-        instance
-            .register_layer_id("layer_0", 0)
-            .expect("same layer id is idempotent");
-    }
-
-    assert_eq!(instance.get_layer_id("layer_0"), Some(0));
-
-    instance
-        .register_layer_id("layer_1", 1)
-        .expect("register another explicit layer id");
-
-    assert_eq!(instance.get_layer_id("layer_0"), Some(0));
-    assert_eq!(instance.get_layer_id("layer_1"), Some(1));
-}
-
-#[test]
-fn explicit_layer_id_rejects_out_of_range_and_conflicts() {
-    let instance = InstanceContext::new("id-instance".to_string(), "id-ns".to_string(), 2, 1, 1)
-        .expect("create instance");
-
-    instance
-        .register_layer_id("layer_0", 0)
-        .expect("register first layer");
-
+fn register_rejects_out_of_range_layer_id() {
+    let instance =
+        InstanceContext::new("range-instance".into(), "range-ns".into(), 2, 1, 1).unwrap();
     let err = instance
-        .register_layer_id("layer_0", 1)
-        .expect_err("same name cannot change id");
-    assert!(err.to_string().contains("already registered with id 0"));
-
-    let err = instance
-        .register_layer_id("other_layer", 0)
-        .expect_err("same id cannot point to another name");
-    assert!(err.to_string().contains("already registered for layer_0"));
-
-    let err = instance
-        .register_layer_id("layer_2", 2)
+        .register_new_gpu(gpu_registration(0, 0, &[("layer_2", 2)]))
         .expect_err("id must stay inside fixed num_layers");
     assert!(err.to_string().contains("out of range"));
+    assert_eq!(instance.get_layer_id("layer_2"), None);
 }
 
+/// Two layers in one batch claiming the same id are rejected before commit,
+/// and the rejection leaves no poison: a valid batch then commits cleanly.
 #[test]
-fn failed_batch_registration_does_not_commit_layer_ids() {
-    let instance = InstanceContext::new(
-        "batch-conflict-instance".to_string(),
-        "batch-conflict-ns".to_string(),
-        3,
-        1,
-        1,
-    )
-    .expect("create instance");
-
-    let kv_caches = HashMap::from([
-        (
-            "layer_0".to_string(),
-            KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
-        ),
-        (
-            "layer_1".to_string(),
-            KVCacheRegistration::new(0x2000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
-        ),
-    ]);
-    let duplicate_ids = HashMap::from([("layer_0".to_string(), 0), ("layer_1".to_string(), 0)]);
+fn register_rejects_in_batch_duplicate_layer_id() {
+    let instance =
+        InstanceContext::new("batch-dup-instance".into(), "batch-dup-ns".into(), 3, 1, 1).unwrap();
 
     let err = instance
-        .register_new_gpu(GpuRegistration {
-            device_id: 0,
-            tp_rank: 0,
-            pp_rank: 0,
-            numa_node: NumaNode::UNKNOWN,
-            transfer_mode: TransferMode::Direct,
-            kv_caches,
-            layer_ids_by_name: duplicate_ids,
-        })
+        .register_new_gpu(gpu_registration(0, 0, &[("layer_0", 0), ("layer_1", 0)]))
         .expect_err("duplicate ids in one batch must fail");
     assert!(err.to_string().contains("appears more than once"));
     assert_eq!(instance.get_layer_id("layer_0"), None);
     assert_eq!(instance.get_layer_id("layer_1"), None);
 
     instance
-        .register_layer_id("layer_0", 0)
-        .expect("failed batch did not poison layer_0");
-    instance
-        .register_layer_id("layer_1", 1)
-        .expect("failed batch did not poison layer_1");
+        .register_new_gpu(gpu_registration(0, 0, &[("layer_0", 0), ("layer_1", 1)]))
+        .expect("valid batch commits after a rejected one");
+    assert_eq!(instance.get_layer_id("layer_0"), Some(0));
+    assert_eq!(instance.get_layer_id("layer_1"), Some(1));
 }
 
+/// A batch that conflicts with already-committed ids is rejected atomically:
+/// neither the conflicting entry nor a valid prefix in the same batch commits,
+/// and the prior state is preserved. Commits device 0; conflicting batches on
+/// device 1 fail validation before any CUDA context is created.
 #[test]
-fn failed_batch_conflict_does_not_commit_valid_prefix() {
-    let instance = InstanceContext::new(
-        "batch-prefix-instance".to_string(),
-        "batch-prefix-ns".to_string(),
-        3,
-        1,
-        1,
-    )
-    .expect("create instance");
+fn register_rejects_conflicting_id_and_preserves_committed_state() {
+    let instance =
+        InstanceContext::new("conflict-instance".into(), "conflict-ns".into(), 3, 1, 1).unwrap();
     instance
-        .register_layer_id("layer_0", 0)
-        .expect("register existing layer");
+        .register_new_gpu(gpu_registration(0, 0, &[("layer_0", 0)]))
+        .expect("commit first device");
 
-    let kv_caches = HashMap::from([
-        (
-            "layer_1".to_string(),
-            KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
-        ),
-        (
-            "other_layer_0".to_string(),
-            KVCacheRegistration::new(0x2000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
-        ),
-    ]);
-    let layer_ids = HashMap::from([("layer_1".to_string(), 1), ("other_layer_0".to_string(), 0)]);
-
+    // Same name, different id.
     let err = instance
-        .register_new_gpu(GpuRegistration {
-            device_id: 0,
-            tp_rank: 0,
-            pp_rank: 0,
-            numa_node: NumaNode::UNKNOWN,
-            transfer_mode: TransferMode::Direct,
-            kv_caches,
-            layer_ids_by_name: layer_ids,
-        })
+        .register_new_gpu(gpu_registration(1, 0, &[("layer_0", 1)]))
+        .expect_err("same name cannot change id");
+    assert!(err.to_string().contains("already registered with id 0"));
+
+    // Same id, different name.
+    let err = instance
+        .register_new_gpu(gpu_registration(1, 0, &[("other_layer", 0)]))
+        .expect_err("same id cannot point to another name");
+    assert!(err.to_string().contains("already registered for layer_0"));
+
+    // Valid prefix (layer_1 -> 1) + conflicting entry (other_layer_0 -> 0):
+    // the whole batch is rejected, so the valid prefix must NOT leak in.
+    let err = instance
+        .register_new_gpu(gpu_registration(
+            1,
+            0,
+            &[("layer_1", 1), ("other_layer_0", 0)],
+        ))
         .expect_err("conflicting id must fail the whole batch");
     assert!(err.to_string().contains("already registered for layer_0"));
+
     assert_eq!(instance.get_layer_id("layer_0"), Some(0));
     assert_eq!(instance.get_layer_id("layer_1"), None);
+    assert_eq!(instance.get_layer_id("other_layer"), None);
     assert_eq!(instance.get_layer_id("other_layer_0"), None);
 }
 
+/// Completeness check: a fully covered topology passes; a topology with an
+/// unregistered slot is rejected. Both commit device 0.
 #[test]
-fn cross_layer_pp_slots_are_order_independent() {
-    let producer = InstanceContext::new(
-        "producer-instance".to_string(),
-        "pp-ns".to_string(),
-        4,
-        1,
-        4,
-    )
-    .expect("create producer");
-    let consumer = InstanceContext::new(
-        "consumer-instance".to_string(),
-        "pp-ns".to_string(),
-        4,
-        1,
-        4,
-    )
-    .expect("create consumer");
-
-    for pp_rank in [2, 3, 1, 0] {
-        producer
-            .register_layer_id(&format!("ALL_LAYERS_pp{pp_rank}"), pp_rank)
-            .expect("producer registers explicit pp id");
-    }
-    for pp_rank in [3, 1, 2, 0] {
-        consumer
-            .register_layer_id(&format!("ALL_LAYERS_pp{pp_rank}"), pp_rank)
-            .expect("consumer registers explicit pp id");
-    }
-
-    for pp_rank in 0..4 {
-        let layer_name = format!("ALL_LAYERS_pp{pp_rank}");
-        assert_eq!(producer.get_layer_id(&layer_name), Some(pp_rank));
-        assert_eq!(consumer.get_layer_id(&layer_name), Some(pp_rank));
-        assert_eq!(producer.get_slot_index(pp_rank, 0).unwrap(), pp_rank);
-        assert_eq!(consumer.get_slot_index(pp_rank, 0).unwrap(), pp_rank);
-    }
-}
-
-#[test]
-fn completeness_check_rejects_missing_slots() {
-    let instance = InstanceContext::new(
-        "complete-instance".to_string(),
-        "complete-ns".to_string(),
-        1,
-        1,
-        1,
-    )
-    .expect("create instance");
-    let kv_caches = HashMap::from([(
-        "layer_0".to_string(),
-        KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap(),
-    )]);
-    let layer_ids = HashMap::from([("layer_0".to_string(), 0)]);
-    instance
-        .register_new_gpu(GpuRegistration {
-            device_id: 0,
-            tp_rank: 0,
-            pp_rank: 0,
-            numa_node: NumaNode::UNKNOWN,
-            transfer_mode: TransferMode::Direct,
-            kv_caches,
-            layer_ids_by_name: layer_ids,
-        })
+fn ensure_all_slots_registered_detects_missing_slot() {
+    let complete =
+        InstanceContext::new("complete-instance".into(), "complete-ns".into(), 1, 1, 1).unwrap();
+    complete
+        .register_new_gpu(gpu_registration(0, 0, &[("layer_0", 0)]))
         .expect("complete single-slot registration");
-    instance
+    complete
         .ensure_all_slots_registered()
         .expect("all slots are registered");
 
-    let sparse = InstanceContext::new(
-        "sparse-instance".to_string(),
-        "sparse-ns".to_string(),
-        2,
-        1,
-        1,
-    )
-    .expect("create sparse instance");
+    let sparse =
+        InstanceContext::new("sparse-instance".into(), "sparse-ns".into(), 2, 1, 1).unwrap();
     sparse
-        .register_layer_id("layer_0", 0)
-        .expect("register one layer id");
+        .register_new_gpu(gpu_registration(0, 0, &[("layer_0", 0)]))
+        .expect("register one of two slots");
     let err = sparse
         .ensure_all_slots_registered()
         .expect_err("missing slots must be rejected");

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -35,6 +35,7 @@ pub use backing::{
 pub use block::{
     BlockHash, BlockKey, LayerBlock, LayerSave, PrefetchStatus, RawBlock, SealedBlock,
 };
+use instance::GpuRegistration;
 pub use instance::{GpuContext, InstanceContext, KVCacheRegistration};
 pub use internode::{DEFAULT_METASERVER_QUEUE_DEPTH, MetaServerClient, MetaServerClientConfig};
 pub use lease::QueryLeaseId;
@@ -234,6 +235,7 @@ impl PegaEngine {
     /// - `num_layers`, `tp_size`, and `world_size` must be non-zero.
     /// - `tp_rank` must be less than `tp_size`.
     /// - Layer metadata arrays must all have the same length as `layer_names`.
+    /// - `layer_ids` must be connector-declared IDs in `0..num_layers`.
     /// - Registration sizes and pointers must describe a valid KV cache layout.
     #[allow(
         clippy::too_many_arguments,
@@ -250,6 +252,7 @@ impl PegaEngine {
         world_size: usize,
         num_layers: usize,
         layer_names: &[String],
+        layer_ids: &[usize],
         data_ptrs: &[u64],
         size_bytes_list: &[usize],
         num_blocks_list: &[usize],
@@ -260,7 +263,27 @@ impl PegaEngine {
         // Build all registrations
         let ssd_enabled = self.storage.is_ssd_enabled();
         let batch_size = layer_names.len();
+        if layer_ids.len() != batch_size
+            || data_ptrs.len() != batch_size
+            || size_bytes_list.len() != batch_size
+            || num_blocks_list.len() != batch_size
+            || bytes_per_block_list.len() != batch_size
+            || kv_stride_bytes_list.len() != batch_size
+            || segments_list.len() != batch_size
+        {
+            return Err(EngineError::InvalidArgument(format!(
+                "registration metadata length mismatch: layer_names={batch_size}, layer_ids={}, data_ptrs={}, size_bytes={}, num_blocks={}, bytes_per_block={}, kv_stride_bytes={}, segments={}",
+                layer_ids.len(),
+                data_ptrs.len(),
+                size_bytes_list.len(),
+                num_blocks_list.len(),
+                bytes_per_block_list.len(),
+                kv_stride_bytes_list.len(),
+                segments_list.len()
+            )));
+        }
         let mut kv_caches = HashMap::with_capacity(batch_size);
+        let mut layer_ids_by_name = HashMap::with_capacity(batch_size);
 
         for i in 0..batch_size {
             let layer_name = &layer_names[i];
@@ -284,7 +307,12 @@ impl PegaEngine {
                 }
             }
 
-            kv_caches.insert(layer_name.clone(), registration);
+            if kv_caches.insert(layer_name.clone(), registration).is_some() {
+                return Err(EngineError::InvalidArgument(format!(
+                    "duplicate layer name in registration batch: {layer_name}"
+                )));
+            }
+            layer_ids_by_name.insert(layer_name.clone(), layer_ids[i]);
         }
 
         // Get or create instance
@@ -305,14 +333,15 @@ impl PegaEngine {
         }
 
         // Register GPU with all layers
-        instance.register_new_gpu(
+        instance.register_new_gpu(GpuRegistration {
             device_id,
             tp_rank,
             pp_rank,
             numa_node,
-            self.transfer_mode,
+            transfer_mode: self.transfer_mode,
             kv_caches,
-        )?;
+            layer_ids_by_name,
+        })?;
 
         info!(
             "Registered context batch: instance={instance_id}, namespace={namespace}, \
@@ -508,6 +537,7 @@ impl PegaEngine {
         loads: &[(QueryLeaseId, Vec<i32>)],
     ) -> Result<(), EngineError> {
         let instance = self.get_instance(instance_id)?;
+        instance.ensure_all_slots_registered()?;
         let gpu = instance
             .get_gpu(device_id)
             .ok_or_else(|| EngineError::WorkerMissing(instance_id.to_string(), device_id))?;

--- a/pegaflow-core/src/offload.rs
+++ b/pegaflow-core/src/offload.rs
@@ -235,6 +235,7 @@ impl PegaEngine {
         let total_layers = saves.len();
         self.query_leases.sweep_expired();
         let instance = self.get_instance(instance_id)?;
+        instance.ensure_all_slots_registered()?;
         let namespace = instance.namespace().to_string();
         let total_slots = instance.total_slots();
 

--- a/pegaflow-core/tests/common/helpers.rs
+++ b/pegaflow-core/tests/common/helpers.rs
@@ -40,6 +40,7 @@ pub fn register_layers(
     num_layers: usize,
 ) {
     let layer_names: Vec<String> = layers.iter().map(|l| l.name.clone()).collect();
+    let layer_ids: Vec<usize> = (0..layers.len()).collect();
     let gpu_ptrs: Vec<u64> = layers.iter().map(|l| l.gpu_ptr).collect();
     let total_sizes: Vec<usize> = layers.iter().map(|l| l.total_size).collect();
     let num_blocks_list: Vec<usize> = layers.iter().map(|l| l.num_blocks).collect();
@@ -58,6 +59,7 @@ pub fn register_layers(
             world_size,
             num_layers,
             &layer_names,
+            &layer_ids,
             &gpu_ptrs,
             &total_sizes,
             &num_blocks_list,

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -24,6 +24,7 @@ message RegisterContextRequest {
   repeated uint32 segments = 13;
   uint32 pp_rank = 14;
   string client_version = 15;
+  repeated uint32 layer_ids = 16;
 }
 
 message RegisterContextResponse {

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -1,7 +1,7 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug, Clone)]
@@ -64,31 +64,50 @@ impl CudaTensorRegistry {
         }
     }
 
-    fn register_layer(
+    fn register_layers(
         &mut self,
         context_key: &str,
-        layer_name: &str,
         device_id: i32,
-        wrapper_bytes: &[u8],
-    ) -> PyResult<TensorMetadata> {
-        let layer_tensor = Self::materialize_tensor(device_id, wrapper_bytes)?;
-        let metadata = layer_tensor.metadata.clone();
-
-        let context = self
-            .contexts
-            .entry(context_key.to_string())
-            .or_insert_with(|| ContextState::new(device_id));
-
-        if context.device_id != metadata.device_id {
+        layers: Vec<(String, Vec<u8>)>,
+    ) -> PyResult<Vec<TensorMetadata>> {
+        if self.contexts.contains_key(context_key) {
             return Err(PyValueError::new_err(format!(
-                "context {context_key} is pinned to device {} but got {}",
-                context.device_id, metadata.device_id
+                "context {context_key} is already registered"
             )));
         }
 
-        context.tensors.insert(layer_name.to_string(), layer_tensor);
+        let mut seen_layers = HashSet::with_capacity(layers.len());
+        for (layer_name, _) in &layers {
+            if !seen_layers.insert(layer_name.as_str()) {
+                return Err(PyValueError::new_err(format!(
+                    "layer {layer_name} appears more than once in context {context_key}"
+                )));
+            }
+        }
 
-        Ok(metadata)
+        let mut context = ContextState::new(device_id);
+        let mut metadatas = Vec::with_capacity(layers.len());
+        for (layer_name, wrapper_bytes) in layers {
+            let layer_tensor = Self::materialize_tensor(device_id, &wrapper_bytes)?;
+            let metadata = layer_tensor.metadata.clone();
+
+            if context.device_id != metadata.device_id {
+                return Err(PyValueError::new_err(format!(
+                    "context {context_key} is pinned to device {} but got {}",
+                    context.device_id, metadata.device_id
+                )));
+            }
+
+            context.tensors.insert(layer_name, layer_tensor);
+            metadatas.push(metadata);
+        }
+
+        self.contexts.insert(context_key.to_string(), context);
+        Ok(metadatas)
+    }
+
+    fn drop_context(&mut self, context_key: &str) -> usize {
+        self.release_contexts(vec![context_key.to_string()])
     }
 
     fn drop_instance(&mut self, instance_id: &str) -> usize {
@@ -200,6 +219,10 @@ enum RegistryCommand {
         instance_id: String,
         reply: oneshot::Sender<usize>,
     },
+    DropContext {
+        context_key: String,
+        reply: oneshot::Sender<usize>,
+    },
     Clear {
         reply: oneshot::Sender<usize>,
     },
@@ -236,11 +259,10 @@ impl RegistryHandle {
     }
 
     /// Materialize and register a batch of layers under `context_key`. Returns
-    /// per-layer metadata in input order; on the first layer that fails to
-    /// materialize it returns that error (already stringified on the registry
-    /// thread). Fail-fast mirrors the original loop: layers registered before
-    /// the failing one stay registered and must be cleaned up via
-    /// [`Self::drop_instance`].
+    /// per-layer metadata in input order. The batch is transactional with
+    /// respect to the registry: an existing context is rejected before any
+    /// tensor is materialized, and a materialization failure does not publish a
+    /// partial context.
     pub async fn register_layers(
         &self,
         context_key: String,
@@ -263,6 +285,14 @@ impl RegistryHandle {
     pub async fn drop_instance(&self, instance_id: String) -> usize {
         let (reply, rx) = oneshot::channel();
         self.dispatch(RegistryCommand::DropInstance { instance_id, reply })
+            .await;
+        rx.await.expect("cuda-registry thread dropped reply")
+    }
+
+    /// Drop exactly one context; returns the number of CUDA tensors released.
+    pub async fn drop_context(&self, context_key: String) -> usize {
+        let (reply, rx) = oneshot::channel();
+        self.dispatch(RegistryCommand::DropContext { context_key, reply })
             .await;
         rx.await.expect("cuda-registry thread dropped reply")
     }
@@ -293,12 +323,8 @@ fn registry_actor(mut registry: CudaTensorRegistry, mut rx: mpsc::Receiver<Regis
                 layers,
                 reply,
             } => {
-                let result = layers
-                    .iter()
-                    .map(|(layer_name, wrapper_bytes)| {
-                        registry.register_layer(&context_key, layer_name, device_id, wrapper_bytes)
-                    })
-                    .collect::<PyResult<Vec<_>>>()
+                let result = registry
+                    .register_layers(&context_key, device_id, layers)
                     // Stringify here, on the GIL-owning thread, so the gRPC
                     // handler never needs `Python::attach` just to read the message.
                     .map_err(|err| Python::attach(|py| err.value(py).to_string()));
@@ -307,9 +333,56 @@ fn registry_actor(mut registry: CudaTensorRegistry, mut rx: mpsc::Receiver<Regis
             RegistryCommand::DropInstance { instance_id, reply } => {
                 let _ = reply.send(registry.drop_instance(&instance_id));
             }
+            RegistryCommand::DropContext { context_key, reply } => {
+                let _ = reply.send(registry.drop_context(&context_key));
+            }
             RegistryCommand::Clear { reply } => {
                 let _ = reply.send(registry.clear_and_count());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drop_context_removes_only_that_context() {
+        let mut registry = CudaTensorRegistry::empty();
+        registry
+            .contexts
+            .insert("instance-a:tp0:pp0:dev0".to_string(), ContextState::new(0));
+        registry
+            .contexts
+            .insert("instance-a:tp0:pp1:dev1".to_string(), ContextState::new(1));
+
+        assert_eq!(registry.drop_context("instance-a:tp0:pp0:dev0"), 0);
+
+        assert!(!registry.contexts.contains_key("instance-a:tp0:pp0:dev0"));
+        assert!(registry.contexts.contains_key("instance-a:tp0:pp1:dev1"));
+    }
+
+    #[test]
+    fn register_layers_rejects_existing_context_before_materializing() {
+        let mut registry = CudaTensorRegistry::empty();
+        registry
+            .contexts
+            .insert("instance-a:tp0:pp0:dev0".to_string(), ContextState::new(7));
+
+        let err = registry
+            .register_layers("instance-a:tp0:pp0:dev0", 0, Vec::new())
+            .expect_err("existing context must be rejected");
+
+        let message = Python::attach(|py| err.value(py).to_string());
+        assert!(message.contains("already registered"));
+        assert_eq!(
+            registry
+                .contexts
+                .get("instance-a:tp0:pp0:dev0")
+                .expect("existing context remains")
+                .device_id,
+            7
+        );
     }
 }

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -263,7 +263,7 @@ impl Engine for GrpcEngineService {
         let result: Result<Response<RegisterContextResponse>, Status> = async {
             let req = request.into_inner();
             debug!(
-                "RPC [register_context_batch]: instance_id={} namespace={} device_id={} tp_rank={} pp_rank={} tp_size={} world_size={} num_layers={} layer_names={:?} num_blocks={:?} bytes_per_block={:?} kv_stride_bytes={:?} segments={:?} wrapper_bytes_lens={:?}",
+                "RPC [register_context_batch]: instance_id={} namespace={} device_id={} tp_rank={} pp_rank={} tp_size={} world_size={} num_layers={} layer_names={:?} layer_ids={:?} num_blocks={:?} bytes_per_block={:?} kv_stride_bytes={:?} segments={:?} wrapper_bytes_lens={:?}",
                 req.instance_id,
                 req.namespace,
                 req.device_id,
@@ -273,6 +273,7 @@ impl Engine for GrpcEngineService {
                 req.world_size,
                 req.num_layers,
                 req.layer_names,
+                req.layer_ids,
                 req.num_blocks,
                 req.bytes_per_block,
                 req.kv_stride_bytes,
@@ -290,6 +291,7 @@ impl Engine for GrpcEngineService {
             let batch_len = req.layer_names.len();
             if batch_len == 0
                 || req.wrapper_bytes.len() != batch_len
+                || req.layer_ids.len() != batch_len
                 || req.num_blocks.len() != batch_len
                 || req.bytes_per_block.len() != batch_len
                 || req.kv_stride_bytes.len() != batch_len
@@ -304,36 +306,23 @@ impl Engine for GrpcEngineService {
                     "layer batch size {batch_len} exceeds instance num_layers {num_layers}"
                 )));
             }
-
-            // Materialize tensors and collect data_ptr/size_bytes
-            let context_key =
-                Self::context_key(&req.instance_id, req.tp_rank, req.pp_rank, req.device_id);
-            // Materialize on the dedicated registry thread (GIL + CUDA IPC) and
-            // await the result, so this RPC never blocks an async worker. Move
-            // the (large) wrapper bytes over; clone the layer names since the
-            // engine call below still needs them.
-            let layers: Vec<(String, Vec<u8>)> = req
-                .layer_names
-                .iter()
-                .cloned()
-                .zip(req.wrapper_bytes)
-                .collect();
-            let metadatas = self
-                .registry
-                .register_layers(context_key, req.device_id, layers)
-                .await
-                .map_err(|message| Status::internal(format!("register tensor failed: {message}")))?;
-            let mut data_ptrs = Vec::with_capacity(num_layers);
-            let mut size_bytes_list = Vec::with_capacity(num_layers);
-            for metadata in &metadatas {
-                data_ptrs.push(metadata.data_ptr);
-                size_bytes_list.push(metadata.size_bytes);
+            if let Some(layer_id) = req.layer_ids.iter().find(|layer_id| **layer_id >= req.num_layers)
+            {
+                return Err(Status::invalid_argument(format!(
+                    "layer_id {layer_id} out of range (num_layers {})",
+                    req.num_layers
+                )));
             }
 
             let num_blocks_list: Vec<usize> = req
                 .num_blocks
                 .into_iter()
                 .map(|v| Self::usize_from_u64(v, "num_blocks"))
+                .collect::<Result<_, _>>()?;
+            let layer_ids: Vec<usize> = req
+                .layer_ids
+                .into_iter()
+                .map(|v| Self::usize_from_u32(v, "layer_ids"))
                 .collect::<Result<_, _>>()?;
             let bytes_per_block_list: Vec<usize> = req
                 .bytes_per_block
@@ -356,26 +345,60 @@ impl Engine for GrpcEngineService {
             let tp_size = Self::usize_from_u32(req.tp_size, "tp_size")?;
             let world_size = Self::usize_from_u32(req.world_size, "world_size")?;
 
+            // Materialize tensors and collect data_ptr/size_bytes
+            let context_key =
+                Self::context_key(&req.instance_id, req.tp_rank, req.pp_rank, req.device_id);
+            // Materialize on the dedicated registry thread (GIL + CUDA IPC) and
+            // await the result, so this RPC never blocks an async worker. Move
+            // the (large) wrapper bytes over; clone the layer names since the
+            // engine call below still needs them.
+            let layers: Vec<(String, Vec<u8>)> = req
+                .layer_names
+                .iter()
+                .cloned()
+                .zip(req.wrapper_bytes)
+                .collect();
+            let metadatas = self
+                .registry
+                .register_layers(context_key.clone(), req.device_id, layers)
+                .await
+                .map_err(|message| Status::internal(format!("register tensor failed: {message}")))?;
+            let mut data_ptrs = Vec::with_capacity(num_layers);
+            let mut size_bytes_list = Vec::with_capacity(num_layers);
+            for metadata in &metadatas {
+                data_ptrs.push(metadata.data_ptr);
+                size_bytes_list.push(metadata.size_bytes);
+            }
+
             // Call engine batch registration
-            self.engine
-                .register_context_layer_batch(
-                    &req.instance_id,
-                    &req.namespace,
-                    req.device_id,
-                    tp_rank,
-                    pp_rank,
-                    tp_size,
-                    world_size,
-                    num_layers,
-                    &req.layer_names,
-                    &data_ptrs,
-                    &size_bytes_list,
-                    &num_blocks_list,
-                    &bytes_per_block_list,
-                    &kv_stride_bytes_list,
-                    &segments_list,
-                )
-                .map_err(Self::map_engine_error)?;
+            if let Err(err) = self.engine.register_context_layer_batch(
+                &req.instance_id,
+                &req.namespace,
+                req.device_id,
+                tp_rank,
+                pp_rank,
+                tp_size,
+                world_size,
+                num_layers,
+                &req.layer_names,
+                &layer_ids,
+                &data_ptrs,
+                &size_bytes_list,
+                &num_blocks_list,
+                &bytes_per_block_list,
+                &kv_stride_bytes_list,
+                &segments_list,
+            ) {
+                let status = Self::map_engine_error(err);
+                let removed = self.registry.drop_context(context_key.clone()).await;
+                if removed > 0 {
+                    warn!(
+                        "Rolled back {} CUDA tensor(s) for failed register_context_batch context {}",
+                        removed, context_key
+                    );
+                }
+                return Err(status);
+            }
 
             Ok(Response::new(Self::build_register_context_response()))
         }
@@ -1053,6 +1076,7 @@ mod tests {
             device_id: 0,
             num_layers: 1,
             layer_names: Vec::new(),
+            layer_ids: Vec::new(),
             wrapper_bytes: Vec::new(),
             num_blocks: Vec::new(),
             bytes_per_block: Vec::new(),
@@ -1078,6 +1102,7 @@ mod tests {
             device_id: 0,
             num_layers: 1,
             layer_names: Vec::new(),
+            layer_ids: Vec::new(),
             wrapper_bytes: Vec::new(),
             num_blocks: Vec::new(),
             bytes_per_block: Vec::new(),

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -528,6 +528,7 @@ fn register_instance_layers(
                 world_size,
                 1,
                 &[LAYER_NAME.to_string()],
+                &[0],
                 &[gpu.ptr()],
                 &[gpu.total_size()],
                 &[BLOCK_COUNT],

--- a/pegaflow-server/tests/http_cleanup_hang_repro.rs
+++ b/pegaflow-server/tests/http_cleanup_hang_repro.rs
@@ -242,6 +242,7 @@ fn wedge_register_request(i: usize) -> RegisterContextRequest {
         device_id: 0,
         num_layers: 1,
         layer_names: vec!["k0".to_string()],
+        layer_ids: vec![0],
         wrapper_bytes: vec![vec![0u8; 4]],
         num_blocks: vec![1],
         bytes_per_block: vec![1],

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -315,6 +315,7 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
             1, // world_size
             1, // num_layers
             &[LAYER.to_string()],
+            &[0],
             &[gpu_a.as_u64()],
             &[TOTAL_SIZE],
             &[NUM_BLOCKS],
@@ -387,6 +388,7 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
             1, // world_size
             1, // num_layers
             &[LAYER.to_string()],
+            &[0],
             &[gpu_b.as_u64()],
             &[TOTAL_SIZE],
             &[NUM_BLOCKS],

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -14,6 +14,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
 )
 from vllm.distributed.parallel_state import get_pp_group, get_tensor_model_parallel_rank
+from vllm.model_executor.models.utils import extract_layer_index
 
 from pegaflow.connector.common import (
     ConnectorContext,
@@ -30,6 +31,41 @@ from pegaflow.connector.scheduler import SchedulerConnector
 from pegaflow.connector.state_manager import ServiceStateManager
 from pegaflow.connector.worker import WorkerConnector
 from pegaflow.pegaflow import EngineRpcClient
+
+
+def _build_layer_id_by_name(kv_cache_config, num_layers: int) -> dict[str, int]:
+    if kv_cache_config is None:
+        return {}
+
+    names: list[str] = []
+    for group in getattr(kv_cache_config, "kv_cache_groups", ()):
+        names.extend(getattr(group, "layer_names", ()))
+    for tensor in getattr(kv_cache_config, "kv_cache_tensors", ()):
+        names.extend(getattr(tensor, "shared_by", ()))
+
+    ordered_names = list(dict.fromkeys(names))
+    layer_id_by_name: dict[str, int] = {}
+    unknown_names: list[str] = []
+    for name in ordered_names:
+        try:
+            layer_id_by_name[name] = extract_layer_index(name)
+        except (AssertionError, ValueError):
+            unknown_names.append(name)
+
+    if unknown_names:
+        if len(ordered_names) < num_layers:
+            logger.warning(
+                "[PegaKVConnector] Cannot assign fallback layer ids for non-standard "
+                "layer names from a PP-local subset: %s",
+                unknown_names,
+            )
+            return layer_id_by_name
+
+        next_id = max(layer_id_by_name.values(), default=-1) + 1
+        for offset, name in enumerate(sorted(unknown_names)):
+            layer_id_by_name[name] = next_id + offset
+
+    return layer_id_by_name
 
 
 class PegaKVConnector(KVConnectorBase_V1):
@@ -69,6 +105,7 @@ class PegaKVConnector(KVConnectorBase_V1):
         )
         num_layers = getattr(vllm_config.model_config.hf_text_config, "num_hidden_layers", 0)
         block_size = vllm_config.cache_config.block_size
+        layer_id_by_name = _build_layer_id_by_name(kv_cache_config, num_layers)
 
         tp_rank: int | None = None
         device_id: int | None = None
@@ -126,6 +163,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             pp_rank=pp_rank,
             pp_size=pp_size,
             mode=mode,
+            layer_id_by_name=layer_id_by_name,
         )
 
         self._scheduler: SchedulerConnector | None = None

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -33,39 +33,45 @@ from pegaflow.connector.worker import WorkerConnector
 from pegaflow.pegaflow import EngineRpcClient
 
 
-def _build_layer_id_by_name(kv_cache_config, num_layers: int) -> dict[str, int]:
+def _build_layer_id_space(kv_cache_config, num_hidden_layers: int) -> tuple[dict[str, int], int]:
+    """Map each KV-cache layer name to a globally unique, role-independent id.
+
+    The id and the total layer count must be identical on every process that
+    touches the same KV (producer, local consumer, RDMA consumer) and on every
+    PP rank, because the engine stores blocks by ``layer_id * tp_size + tp_rank``.
+
+    The id must therefore be anchored to something every process derives the same
+    way regardless of how pipeline parallelism shards the layers across ranks --
+    a rank only ever sees its own slice of ``kv_cache_groups``, so any id based on
+    local position would collide across ranks. The layer's in-model index
+    (``extract_layer_index``) is that anchor: it is global and identical on every
+    rank. A bare index is not unique, though -- DeepSeek-V3.2-style models register
+    two caches per transformer layer (the main MLA attention and the sparse
+    indexer) that share an index, and because the connector is not ``SupportsHMA``
+    vLLM coalesces them into a single kv-cache group, so a group ordinal cannot
+    tell them apart. We give each cache that shares an index a stable intra-layer
+    ordinal (its rank among those names in sorted order) and lay the space out as
+    ``index * caches_per_layer + ordinal`` over ``[0, num_hidden_layers *
+    caches_per_layer)``. For a conventional one-cache-per-layer model this reduces
+    to the in-model index, so previously stored caches stay addressable. An
+    unparsable layer name is a genuinely unsupported topology and raises here
+    rather than being papered over with an invented id.
+    """
     if kv_cache_config is None:
-        return {}
+        return {}, num_hidden_layers
 
-    names: list[str] = []
-    for group in getattr(kv_cache_config, "kv_cache_groups", ()):
-        names.extend(getattr(group, "layer_names", ()))
-    for tensor in getattr(kv_cache_config, "kv_cache_tensors", ()):
-        names.extend(getattr(tensor, "shared_by", ()))
+    names_by_index: dict[int, list[str]] = {}
+    for group in kv_cache_config.kv_cache_groups:
+        for name in group.layer_names:
+            names_by_index.setdefault(extract_layer_index(name), []).append(name)
 
-    ordered_names = list(dict.fromkeys(names))
+    caches_per_layer = max((len(names) for names in names_by_index.values()), default=1)
     layer_id_by_name: dict[str, int] = {}
-    unknown_names: list[str] = []
-    for name in ordered_names:
-        try:
-            layer_id_by_name[name] = extract_layer_index(name)
-        except (AssertionError, ValueError):
-            unknown_names.append(name)
+    for index, names in names_by_index.items():
+        for ordinal, name in enumerate(sorted(names)):
+            layer_id_by_name[name] = index * caches_per_layer + ordinal
 
-    if unknown_names:
-        if len(ordered_names) < num_layers:
-            logger.warning(
-                "[PegaKVConnector] Cannot assign fallback layer ids for non-standard "
-                "layer names from a PP-local subset: %s",
-                unknown_names,
-            )
-            return layer_id_by_name
-
-        next_id = max(layer_id_by_name.values(), default=-1) + 1
-        for offset, name in enumerate(sorted(unknown_names)):
-            layer_id_by_name[name] = next_id + offset
-
-    return layer_id_by_name
+    return layer_id_by_name, num_hidden_layers * caches_per_layer
 
 
 class PegaKVConnector(KVConnectorBase_V1):
@@ -103,9 +109,12 @@ class PegaKVConnector(KVConnectorBase_V1):
             pcp_world_size,
             cross_layer_blocks=cross_layer_blocks,
         )
-        num_layers = getattr(vllm_config.model_config.hf_text_config, "num_hidden_layers", 0)
+        num_hidden_layers = getattr(vllm_config.model_config.hf_text_config, "num_hidden_layers", 0)
         block_size = vllm_config.cache_config.block_size
-        layer_id_by_name = _build_layer_id_by_name(kv_cache_config, num_layers)
+        # `num_layers` is the flattened KV-layer id space the engine stores into,
+        # which is wider than num_hidden_layers when a layer owns several caches
+        # (e.g. DeepSeek-V3.2 main attention + sparse indexer).
+        layer_id_by_name, num_layers = _build_layer_id_space(kv_cache_config, num_hidden_layers)
 
         tp_rank: int | None = None
         device_id: int | None = None

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -61,6 +61,7 @@ class ConnectorContext:
     pp_rank: int = 0
     pp_size: int = 1
     mode: PegaConnectorMode = PegaConnectorMode.READ_WRITE
+    layer_id_by_name: dict[str, int] | None = None
 
     @property
     def read_enabled(self) -> bool:

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -47,6 +47,8 @@ class ConnectorContext:
     instance_id: str
     namespace: str
     block_size: int
+    # Size of the flattened KV-layer id space (>= num_hidden_layers; e.g. doubled
+    # for DeepSeek-V3.2 where each layer owns a main + an indexer cache).
     num_layers: int
     tp_size: int
     world_size: int

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -216,7 +216,30 @@ class WorkerConnector:
 
         self._registered_layers.clear()
 
-    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+    def _canonical_layer_id(self, layer_name: str) -> int:
+        layer_id_by_name = self._ctx.layer_id_by_name or {}
+        if layer_name in layer_id_by_name:
+            layer_id = layer_id_by_name[layer_name]
+        else:
+            raise RuntimeError(
+                f"Cannot determine canonical layer id for {layer_name}; "
+                "vLLM did not expose a parseable layer index"
+            )
+
+        if layer_id < 0 or layer_id >= self._ctx.num_layers:
+            raise RuntimeError(
+                f"Canonical layer id {layer_id} for {layer_name} is out of "
+                f"range for num_layers={self._ctx.num_layers}"
+            )
+        return layer_id
+
+    def register_kv_caches(
+        self,
+        kv_caches: dict[str, torch.Tensor],
+        *,
+        layer_ids: list[int] | None = None,
+        instance_num_layers: int | None = None,
+    ):
         assert self._ctx.device_id is not None, (
             "CUDA device id is unknown; cannot register KV caches"
         )
@@ -224,19 +247,26 @@ class WorkerConnector:
         self._registered_layers = list(kv_caches.keys())
         self._torch_device = next(iter(kv_caches.values())).device
 
+        if layer_ids is None:
+            layer_ids = [self._canonical_layer_id(layer_name) for layer_name in kv_caches]
+        if len(layer_ids) != len(kv_caches):
+            raise RuntimeError(
+                f"layer_ids length {len(layer_ids)} does not match kv_caches length {len(kv_caches)}"
+            )
+
         self._layer_name_to_id.clear()
-        for layer_id, layer_name in enumerate(kv_caches.keys()):
+        for layer_id, layer_name in zip(layer_ids, kv_caches.keys(), strict=True):
             self._layer_name_to_id[layer_name] = layer_id
 
-        # Use actual number of registered layers, not model's num_hidden_layers.
-        # This is important for models like DSA where indexer layers are separate.
-        # With PP>1 each rank registers only its local layers; the Rust engine
-        # grows the instance-wide total dynamically via verify_topology.
-        actual_num_layers = len(kv_caches)
+        if instance_num_layers is None:
+            instance_num_layers = self._ctx.num_layers
+        if instance_num_layers <= 0:
+            raise RuntimeError(f"instance_num_layers must be positive, got {instance_num_layers}")
 
         layout = "unknown"
 
         layer_names = []
+        rpc_layer_ids = []
         ipc_wrappers = []
         layer_num_blocks = []
         layer_bytes_per_block = []
@@ -262,6 +292,7 @@ class WorkerConnector:
             layout = registration.layout
 
             layer_names.append(layer_name)
+            rpc_layer_ids.append(self._layer_name_to_id[layer_name])
             ipc_wrappers.append(wrapper_bytes)
             layer_num_blocks.append(registration.num_blocks)
             layer_bytes_per_block.append(registration.bytes_per_block)
@@ -289,8 +320,9 @@ class WorkerConnector:
             self._ctx.effective_tp_size,
             self._ctx.world_size,
             self._ctx.device_id,
-            actual_num_layers,
+            instance_num_layers,
             layer_names,
+            rpc_layer_ids,
             ipc_wrappers,
             layer_num_blocks,
             layer_bytes_per_block,
@@ -328,7 +360,11 @@ class WorkerConnector:
             self._cross_layer_key = f"{_CROSS_LAYER_KEY}_pp{self._ctx.pp_rank}"
         else:
             self._cross_layer_key = _CROSS_LAYER_KEY
-        self.register_kv_caches({self._cross_layer_key: kv_cache})
+        self.register_kv_caches(
+            {self._cross_layer_key: kv_cache},
+            layer_ids=[self._ctx.pp_rank],
+            instance_num_layers=self._ctx.pp_size,
+        )
 
     def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str] | None, set[str] | None]:
         finished_sending: set[str] | None = None

--- a/python/pegaflow/pd_connector/layout_mapping.py
+++ b/python/pegaflow/pd_connector/layout_mapping.py
@@ -94,12 +94,15 @@ def build_push_layout_plan(
         total_heads=total_num_kv_heads,
     )
     for local_idx, global_head in enumerate(local_heads):
-        if _owner_rank_for_global_head(
-            global_head,
-            rank_count=prefill_tp_size,
-            local_heads=local_num_kv_heads,
-            total_heads=total_num_kv_heads,
-        ) != prefill_tp_rank:
+        if (
+            _owner_rank_for_global_head(
+                global_head,
+                rank_count=prefill_tp_size,
+                local_heads=local_num_kv_heads,
+                total_heads=total_num_kv_heads,
+            )
+            != prefill_tp_rank
+        ):
             continue
         decode_rank = _owner_rank_for_global_head(
             global_head,
@@ -195,9 +198,7 @@ def _build_mla_plan(
             f"prefill_tp={prefill_tp_size} decode_tp={decode_tp_size}"
         )
         ratio = decode_tp_size // prefill_tp_size
-        decode_ranks = tuple(
-            range(prefill_tp_rank * ratio, (prefill_tp_rank + 1) * ratio)
-        )
+        decode_ranks = tuple(range(prefill_tp_rank * ratio, (prefill_tp_rank + 1) * ratio))
         return PushLayoutPlan(
             targets=tuple(
                 PushTargetPlan(

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -71,6 +71,7 @@ class EngineRpcClient:
         device_id: int,
         num_layers: int,
         layer_names: list[str],
+        layer_ids: list[int],
         wrapper_bytes_list: list[bytes],
         num_blocks_list: list[int],
         bytes_per_block_list: list[int],
@@ -93,6 +94,7 @@ class EngineRpcClient:
             device_id: CUDA device ID.
             num_layers: Number of model layers.
             layer_names: List of layer names.
+            layer_ids: Canonical numeric layer IDs parallel to layer_names.
             wrapper_bytes_list: List of serialized CUDA IPC tensor wrappers.
             num_blocks_list: List of block counts per layer.
             bytes_per_block_list: List of block sizes per layer.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -258,6 +258,7 @@ impl EngineRpcClient {
     ///     device_id: CUDA device ID of the worker
     ///     num_layers: Total number of layers in the model
     ///     layer_names: List of layer names
+    ///     layer_ids: Canonical numeric layer IDs parallel to layer_names
     ///     wrapper_bytes_list: List of serialized CUDA tensor wrappers
     ///     num_blocks_list: List of block counts per layer
     ///     bytes_per_block_list: List of block sizes per layer
@@ -269,7 +270,7 @@ impl EngineRpcClient {
         clippy::too_many_arguments,
         reason = "PyO3 binding mirrors the public batch registration call shape"
     )]
-    #[pyo3(signature = (instance_id, namespace, tp_rank, pp_rank, tp_size, world_size, device_id, num_layers, layer_names, wrapper_bytes_list, num_blocks_list, bytes_per_block_list, kv_stride_bytes_list, segments_list))]
+    #[pyo3(signature = (instance_id, namespace, tp_rank, pp_rank, tp_size, world_size, device_id, num_layers, layer_names, layer_ids, wrapper_bytes_list, num_blocks_list, bytes_per_block_list, kv_stride_bytes_list, segments_list))]
     fn register_context_batch(
         &self,
         py: Python<'_>,
@@ -282,6 +283,7 @@ impl EngineRpcClient {
         device_id: i32,
         num_layers: u32,
         layer_names: Vec<String>,
+        layer_ids: Vec<u32>,
         wrapper_bytes_list: Vec<Vec<u8>>,
         num_blocks_list: Vec<u64>,
         bytes_per_block_list: Vec<u64>,
@@ -300,6 +302,7 @@ impl EngineRpcClient {
                     device_id,
                     num_layers,
                     layer_names,
+                    layer_ids,
                     wrapper_bytes: wrapper_bytes_list,
                     num_blocks: num_blocks_list,
                     bytes_per_block: bytes_per_block_list,

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -252,6 +252,7 @@ class ClientContext:
                 self.device_id,
                 self.num_layers,
                 [layer_name],
+                [self._layer_name_to_id[layer_name]],
                 [wrapper_bytes],
                 [num_blocks],
                 [bytes_per_block],

--- a/python/tests/session_crash_helper.py
+++ b/python/tests/session_crash_helper.py
@@ -47,6 +47,7 @@ def main() -> int:
         0,  # device_id
         1,  # num_layers
         ["layer_0"],
+        [0],
         [wrapper_bytes],
         [num_blocks],
         [bytes_per_block],

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -89,7 +89,10 @@ class FakeEngineClient:
         self.release_calls.append(lease)
 
 
-def _make_worker() -> tuple[WorkerConnector, FakeEngineClient, MagicMock]:
+def _make_worker(
+    pp_rank: int = 0,
+    pp_size: int = 1,
+) -> tuple[WorkerConnector, FakeEngineClient, MagicMock]:
     client = FakeEngineClient()
     state_manager = MagicMock()
     state_manager.is_available.return_value = True
@@ -97,13 +100,16 @@ def _make_worker() -> tuple[WorkerConnector, FakeEngineClient, MagicMock]:
         instance_id="test_instance",
         namespace="ns",
         block_size=16,
-        num_layers=1,
+        num_layers=2,
         tp_size=1,
         world_size=1,
         tp_rank=0,
         device_id=0,
         engine_client=client,
         state_manager=state_manager,
+        pp_rank=pp_rank,
+        pp_size=pp_size,
+        layer_id_by_name={"layer.0": 0, "layer.1": 1},
     )
     worker = WorkerConnector(ctx)
     # cross-layer mode skips forward_context layer enumeration so we can drive
@@ -311,6 +317,24 @@ def test_register_non_version_failure_reports_batch_layers(monkeypatch):
     assert "Register context batch failed for layers ['layer.0', 'layer.1']" in message
     assert "for layer.1" not in message
     assert len(client.register_calls) == 1
+    assert client.register_calls[0][7] == 2
+    assert client.register_calls[0][8] == ["layer.0", "layer.1"]
+    assert client.register_calls[0][9] == [0, 1]
+
+    worker.shutdown()
+
+
+def test_cross_layer_registration_uses_pp_rank_as_layer_id(monkeypatch):
+    worker, client, _ = _make_worker(pp_rank=1, pp_size=4)
+
+    monkeypatch.setattr("pegaflow.connector.worker.CudaIPCWrapper", FakeCudaIPCWrapper)
+
+    worker.register_cross_layers_kv_cache(FakeTensor(), attn_backend=object())
+
+    assert len(client.register_calls) == 1
+    assert client.register_calls[0][7] == 4
+    assert client.register_calls[0][8] == ["ALL_LAYERS_pp1"]
+    assert client.register_calls[0][9] == [1]
 
     worker.shutdown()
 

--- a/python/tests/test_vllm_p2p_pp4_e2e.py
+++ b/python/tests/test_vllm_p2p_pp4_e2e.py
@@ -1,0 +1,719 @@
+"""Real vLLM PP4 + PegaFlow P2P correctness probe.
+
+This test is intentionally hardware-gated. It starts:
+
+1. one source PegaFlow server with RDMA enabled and a PP4 producer vLLM,
+2. one local PP4 consumer on the source server,
+3. one remote PegaFlow server plus a PP4 consumer that fetches the same KV over RDMA.
+
+The local consumer and the RDMA consumer both load KV produced by the same
+producer run. That avoids false failures from independent PP replicas choosing
+slightly different greedy outputs on numerically close logits.
+
+Run on an 8-GPU RDMA node:
+
+    PEGAFLOW_NICS=mlx5_... PEGAFLOW_HOST_IP=172.31.13.39 \
+      uv run python -m pytest -m e2e python/tests/test_vllm_p2p_pp4_e2e.py \
+      --model /data/models/Qwen3-8B --pegaflow-pool-size 60gb -s -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import sysconfig
+import time
+from contextlib import ExitStack, suppress
+from pathlib import Path
+from typing import Any
+
+import pytest
+import requests
+
+from .vllm_helpers import fetch_pegaflow_metrics, find_available_port
+
+PP_SIZE = 4
+TP_SIZE = 1
+MODEL_ALIAS = "pegaflow-p2p-pp4"
+DEFAULT_MAX_MODEL_LEN = 512
+DEFAULT_GPU_MEMORY_UTILIZATION = 0.55
+DEFAULT_POOL_SIZE = "30gb"
+STARTUP_TIMEOUT_SECONDS = 900
+RDMA_FETCH_COUNTER_NAMES = (
+    "pegaflow_rdma_fetch_total",
+    "pegaflow_rdma_fetch_total_total",
+    "pegaflow_rdma_fetch",
+)
+RDMA_FETCH_BYTES_COUNTER_NAMES = (
+    "pegaflow_rdma_fetch_bytes",
+    "pegaflow_rdma_fetch_bytes_total",
+    "pegaflow_rdma_fetch_bytes_total_total",
+)
+
+PROMPTS = [
+    (
+        "A warehouse is auditing a shipment with three product categories and "
+        "two stages of discounts. Category A has 18 boxes with 24 units per "
+        "box. Category B has 27 boxes with 16 units per box. Category C has 9 "
+        "boxes with 48 units per box. The auditor removes 37 damaged units, "
+        "then applies a promotion that gives away 3 units for every complete "
+        "batch of 50 remaining units. Shipping costs are computed after the "
+        "giveaway: the first 600 shipped units cost 4 dollars each, every "
+        "additional shipped unit costs 7 dollars each, and the whole invoice "
+        "gets a final 12 percent discount. Check the arithmetic carefully, "
+        "keep the batch giveaway as an integer floor division, and report the "
+        "final invoice in dollars. Step by step, the total shipped units and "
+        "final invoice are"
+    ),
+    (
+        "A serving cluster has four pipeline stages. Stage P0 handles layers "
+        "0 through 8, P1 handles layers 9 through 17, P2 handles layers 18 "
+        "through 26, and P3 handles layers 27 through 35. A request contains "
+        "224 prompt tokens and needs 32 generated tokens. Each pipeline stage "
+        "can process 16 tokens per microbatch, so the prompt is split into "
+        "ceil(224 / 16) microbatches. The scheduler starts one microbatch on "
+        "P0 every 5 milliseconds, each stage takes 11 milliseconds per "
+        "microbatch, and a stage cannot start a microbatch until the previous "
+        "stage has finished it. Separately, a cache verifier receives slot "
+        "ids in this order: 2, 3, 0, 1 on the producer and 1, 0, 3, 2 on the "
+        "consumer. Explain whether the numeric slot order is safe, compute "
+        "the earliest finish time for the last prompt microbatch on P3, and "
+        "state the exact reason a wrong cache slot would corrupt the answer. "
+        "The correct conclusion is"
+    ),
+]
+
+
+def _project_root() -> Path:
+    return Path(__file__).parent.parent.parent
+
+
+def _server_cmd(binary_name: str) -> list[str]:
+    if path := shutil.which(binary_name):
+        return [path]
+
+    release_binary = _project_root() / "target" / "release" / binary_name
+    if release_binary.exists():
+        return [str(release_binary)]
+
+    return ["cargo", "run", "-r", "--bin", binary_name, "--"]
+
+
+def _env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = "0"
+    env["VLLM_BATCH_INVARIANT"] = "1"
+    env["PYO3_PYTHON"] = sys.executable
+    env["PYTHONHOME"] = sys.base_prefix
+    env.setdefault("VLLM_USE_V2_MODEL_RUNNER", "0")
+
+    if libdir := sysconfig.get_config_var("LIBDIR"):
+        env["LD_LIBRARY_PATH"] = f"{libdir}:{env.get('LD_LIBRARY_PATH', '')}"
+
+    python_dir = str(Path(__file__).parent.parent)
+    site_packages = next((p for p in sys.path if "site-packages" in p), None)
+    env["PYTHONPATH"] = f"{python_dir}" + (f":{site_packages}" if site_packages else "")
+    env["PATH"] = f"{Path(sys.executable).parent}:{env.get('PATH', '')}"
+    return env
+
+
+class ManagedProcess:
+    def __init__(
+        self,
+        label: str,
+        cmd: list[str],
+        log_file: Path,
+        ready_url: str,
+        cwd: Path,
+        env: dict[str, str],
+        timeout: int = STARTUP_TIMEOUT_SECONDS,
+    ) -> None:
+        self.label = label
+        self.cmd = cmd
+        self.log_file = log_file
+        self.ready_url = ready_url
+        self.cwd = cwd
+        self.env = env
+        self.timeout = timeout
+        self.process: subprocess.Popen[bytes] | None = None
+        self._log_handle = None
+
+    def __enter__(self):
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
+        self._log_handle = self.log_file.open("wb")
+        print(f"[{self.label}] log: {self.log_file}")
+        self.process = subprocess.Popen(
+            self.cmd,
+            cwd=self.cwd,
+            env=self.env,
+            stdout=self._log_handle,
+            stderr=subprocess.STDOUT,
+            preexec_fn=os.setsid,
+        )
+        self._wait_ready()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.process is not None:
+            with suppress(ProcessLookupError, OSError):
+                os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
+            try:
+                self.process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                with suppress(ProcessLookupError, OSError):
+                    os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
+                self.process.wait(timeout=30)
+        if self._log_handle is not None:
+            self._log_handle.close()
+
+    def _wait_ready(self) -> None:
+        assert self.process is not None
+        deadline = time.time() + self.timeout
+        while time.time() < deadline:
+            if self.process.poll() is not None:
+                raise RuntimeError(
+                    f"{self.label} exited with code {self.process.returncode}\n"
+                    f"log tail:\n{self.tail()}"
+                )
+            try:
+                if requests.get(self.ready_url, timeout=1).status_code == 200:
+                    print(f"[{self.label}] ready: {self.ready_url}")
+                    time.sleep(2)
+                    return
+            except requests.RequestException:
+                pass
+            time.sleep(2)
+        raise TimeoutError(f"{self.label} did not become ready\nlog tail:\n{self.tail()}")
+
+    def tail(self, limit: int = 4000) -> str:
+        if not self.log_file.exists():
+            return ""
+        return self.log_file.read_text(errors="replace")[-limit:]
+
+
+class MetaServer(ManagedProcess):
+    def __init__(self, log_dir: Path, host: str) -> None:
+        self.grpc_port = find_available_port()
+        self.http_port = find_available_port()
+
+        cmd = _server_cmd("pegaflow-metaserver")
+        cmd.extend(
+            [
+                "--addr",
+                f"{host}:{self.grpc_port}",
+                "--http-addr",
+                f"{host}:{self.http_port}",
+                "--log-level",
+                os.environ.get("PEGAFLOW_LOG_LEVEL", "debug"),
+            ]
+        )
+
+        super().__init__(
+            "metaserver",
+            cmd,
+            log_dir / "metaserver.log",
+            f"http://{host}:{self.http_port}/health",
+            _project_root(),
+            _env(),
+        )
+
+
+class PegaServer(ManagedProcess):
+    def __init__(
+        self,
+        label: str,
+        devices: str,
+        log_dir: Path,
+        pool_size: str,
+        transfer_backend: str,
+        metaserver: MetaServer,
+        nics: str,
+        advertise_host: str,
+    ) -> None:
+        self.grpc_port = find_available_port()
+        self.http_port = find_available_port()
+        self.grpc_host = advertise_host
+
+        cmd = _server_cmd("pegaflow-server")
+        cmd.extend(
+            [
+                "--addr",
+                f"{advertise_host}:{self.grpc_port}",
+                "--http-addr",
+                f"127.0.0.1:{self.http_port}",
+                "--devices",
+                devices,
+                "--pool-size",
+                pool_size,
+                "--transfer-backend",
+                transfer_backend,
+                "--log-level",
+                os.environ.get("PEGAFLOW_LOG_LEVEL", "debug"),
+                "--disable-numa-affinity",
+                "--enable-prometheus",
+                "--metaserver-addr",
+                f"http://{advertise_host}:{metaserver.grpc_port}",
+                "--nics",
+                nics,
+            ]
+        )
+        if os.environ.get("PEGAFLOW_USE_HUGEPAGES", "0") == "1":
+            cmd.append("--use-hugepages")
+
+        super().__init__(
+            f"pega-{label}",
+            cmd,
+            log_dir / f"pega-{label}.log",
+            f"http://127.0.0.1:{self.http_port}/health",
+            _project_root(),
+            _env(),
+        )
+
+    @property
+    def metrics_port(self) -> int:
+        return self.http_port
+
+
+class VllmReplica(ManagedProcess):
+    def __init__(
+        self,
+        label: str,
+        model: str,
+        port: int,
+        devices: str,
+        pega_server: PegaServer,
+        log_dir: Path,
+        max_model_len: int,
+    ) -> None:
+        kv_config = {
+            "kv_connector": "PegaKVConnector",
+            "kv_connector_module_path": "pegaflow.connector",
+            "kv_role": "kv_both",
+            "kv_connector_extra_config": {
+                "pegaflow.host": f"http://{pega_server.grpc_host}",
+                "pegaflow.port": pega_server.grpc_port,
+                "pegaflow.mode": "read_write",
+            },
+        }
+        env = _env()
+        env["CUDA_VISIBLE_DEVICES"] = devices
+        env["PEGAFLOW_PORT"] = str(pega_server.grpc_port)
+
+        cmd = [
+            "vllm",
+            "serve",
+            model,
+            "--served-model-name",
+            MODEL_ALIAS,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--pipeline-parallel-size",
+            str(PP_SIZE),
+            "--tensor-parallel-size",
+            str(TP_SIZE),
+            "--max-model-len",
+            str(max_model_len),
+            "--gpu-memory-utilization",
+            os.environ.get(
+                "PEGAFLOW_GPU_MEMORY_UTILIZATION",
+                str(DEFAULT_GPU_MEMORY_UTILIZATION),
+            ),
+            "--enforce-eager",
+            "--no-enable-prefix-caching",
+            "--disable-hybrid-kv-cache-manager",
+            "--kv-transfer-config",
+            json.dumps(kv_config, separators=(",", ":")),
+        ]
+        cmd.extend(shlex.split(os.environ.get("PEGAFLOW_VLLM_EXTRA_ARGS", "")))
+
+        super().__init__(
+            f"vllm-{label}",
+            cmd,
+            log_dir / f"vllm-{label}.log",
+            f"http://127.0.0.1:{port}/v1/models",
+            _project_root(),
+            env,
+        )
+
+
+def _require_gpus(count: int) -> None:
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    if torch.cuda.device_count() < count:
+        pytest.skip(f"requires {count} visible GPUs")
+
+
+def _metric_delta(before: dict[str, float], after: dict[str, float], name: str) -> float:
+    return after.get(name, 0.0) - before.get(name, 0.0)
+
+
+def _metric_sum(
+    before: dict[str, float],
+    after: dict[str, float],
+    names: tuple[str, ...],
+) -> float:
+    return sum(_metric_delta(before, after, name) for name in names)
+
+
+def _metric_value(
+    metrics_port: int,
+    names: tuple[str, ...],
+    *,
+    labels: dict[str, str] | None = None,
+) -> float:
+    response = requests.get(f"http://localhost:{metrics_port}/metrics", timeout=5)
+    response.raise_for_status()
+
+    total = 0.0
+    name_pattern = "|".join(re.escape(name) for name in names)
+    pattern = re.compile(rf"^({name_pattern})(?:\{{([^}}]*)\}})?\s+([\d.eE+-]+)$")
+    for line in response.text.splitlines():
+        match = pattern.match(line)
+        if not match:
+            continue
+
+        metric_labels = dict(re.findall(r'(\w+)="([^"]*)"', match.group(2) or ""))
+        if labels is not None and any(
+            metric_labels.get(key) != value for key, value in labels.items()
+        ):
+            continue
+        total += float(match.group(3))
+    return total
+
+
+def _metric_value_delta(
+    metrics_port: int,
+    before: dict[tuple[tuple[str, ...], tuple[tuple[str, str], ...]], float],
+    names: tuple[str, ...],
+    *,
+    labels: dict[str, str] | None = None,
+) -> float:
+    label_items = tuple(sorted((labels or {}).items()))
+    key = (names, label_items)
+    return _metric_value(metrics_port, names, labels=labels) - before.get(key, 0.0)
+
+
+def _snapshot_metrics(
+    metrics_port: int,
+    series: tuple[tuple[tuple[str, ...], dict[str, str] | None], ...],
+) -> dict[tuple[tuple[str, ...], tuple[tuple[str, str], ...]], float]:
+    return {
+        (names, tuple(sorted((labels or {}).items()))): _metric_value(
+            metrics_port,
+            names,
+            labels=labels,
+        )
+        for names, labels in series
+    }
+
+
+def _fetch_rpc_failures(
+    metrics_port: int,
+    *,
+    ignored_methods: frozenset[str] = frozenset(),
+) -> dict[str, float]:
+    response = requests.get(f"http://localhost:{metrics_port}/metrics", timeout=5)
+    response.raise_for_status()
+
+    failures: dict[str, float] = {}
+    for line in response.text.splitlines():
+        if not line.startswith("pegaflow_rpc_requests"):
+            continue
+        match = re.match(r"^pegaflow_rpc_requests(?:_total)?\{([^}]*)\}\s+([\d.eE+-]+)$", line)
+        if not match:
+            continue
+        labels = dict(re.findall(r'(\w+)="([^"]*)"', match.group(1)))
+        if labels.get("status") == "ok":
+            continue
+        method = labels.get("method", "")
+        if method in ignored_methods:
+            continue
+        key = f"{method}/{labels.get('status', '')}"
+        failures[key] = failures.get(key, 0.0) + float(match.group(2))
+    return failures
+
+
+def _wait_for_metrics(
+    metrics_port: int,
+    before: dict[str, float],
+    names: tuple[str, ...],
+    timeout: int = 90,
+) -> dict[str, float]:
+    deadline = time.time() + timeout
+    current = fetch_pegaflow_metrics(metrics_port)
+    while time.time() < deadline:
+        current = fetch_pegaflow_metrics(metrics_port)
+        if any(_metric_delta(before, current, name) > 0 for name in names):
+            return current
+        time.sleep(2)
+    return current
+
+
+def _call_batch(port: int, prompts: list[str], max_tokens: int) -> list[dict[str, Any]]:
+    response = requests.post(
+        f"http://127.0.0.1:{port}/v1/completions",
+        json={
+            "model": MODEL_ALIAS,
+            "prompt": prompts,
+            "temperature": 0,
+            "max_tokens": max_tokens,
+            "seed": 42,
+            "logprobs": 5,
+        },
+        timeout=180,
+    )
+    response.raise_for_status()
+    choices = sorted(response.json()["choices"], key=lambda choice: choice["index"])
+    return [
+        {
+            "text": choice.get("text", ""),
+            "token_logprobs": (choice.get("logprobs") or {}).get("token_logprobs"),
+            "finish_reason": choice.get("finish_reason"),
+        }
+        for choice in choices
+    ]
+
+
+def _assert_outputs_match(
+    expected: list[dict[str, Any]],
+    actual: list[dict[str, Any]],
+    *,
+    label: str,
+) -> None:
+    mismatches = []
+    for idx, (left, right) in enumerate(zip(expected, actual, strict=True)):
+        if left != right:
+            mismatches.append(
+                f"{label} choice {idx} mismatch\n"
+                f"expected={json.dumps(left, ensure_ascii=True, sort_keys=True)}\n"
+                f"actual={json.dumps(right, ensure_ascii=True, sort_keys=True)}"
+            )
+    assert not mismatches, "\n\n".join(mismatches)
+
+
+@pytest.mark.e2e
+@pytest.mark.gpu
+def test_pp4_p2p_matches_local_cache_load(
+    model: str,
+    max_model_len: int | None,
+    pegaflow_transfer_backend: str,
+    pegaflow_pool_size: str,
+    tmp_path: Path,
+) -> None:
+    _require_gpus(8)
+
+    nics = os.environ.get("PEGAFLOW_NICS", "")
+    if not nics:
+        pytest.skip("PEGAFLOW_NICS is required for PP4 P2P E2E")
+
+    server_host = os.environ.get("PEGAFLOW_HOST_IP", "127.0.0.1")
+    producer_devices = os.environ.get("PEGAFLOW_PRODUCER_GPUS", "0,1,2,3")
+    consumer_devices = os.environ.get("PEGAFLOW_CONSUMER_GPUS", "4,5,6,7")
+    source_devices = os.environ.get(
+        "PEGAFLOW_SOURCE_SERVER_GPUS",
+        f"{producer_devices},{consumer_devices}",
+    )
+    pool_size = os.environ.get("PEGAFLOW_POOL_SIZE", pegaflow_pool_size or DEFAULT_POOL_SIZE)
+    request_max_tokens = int(os.environ.get("PEGAFLOW_REQUEST_MAX_TOKENS", "8"))
+    server_max_model_len = int(
+        os.environ.get("PEGAFLOW_MAX_MODEL_LEN", max_model_len or DEFAULT_MAX_MODEL_LEN)
+    )
+
+    log_dir = tmp_path / "p2p_pp4_logs"
+    producer_port = find_available_port()
+    local_consumer_port = find_available_port()
+    rdma_consumer_port = find_available_port()
+
+    with ExitStack() as stack:
+        metaserver = stack.enter_context(MetaServer(log_dir, server_host))
+        source_pega = stack.enter_context(
+            PegaServer(
+                "source",
+                source_devices,
+                log_dir,
+                pool_size,
+                pegaflow_transfer_backend,
+                metaserver,
+                nics,
+                server_host,
+            )
+        )
+        stack.enter_context(
+            VllmReplica(
+                "producer",
+                model,
+                producer_port,
+                producer_devices,
+                source_pega,
+                log_dir,
+                server_max_model_len,
+            )
+        )
+
+        producer_before = fetch_pegaflow_metrics(source_pega.metrics_port)
+        _call_batch(producer_port, PROMPTS, request_max_tokens)
+        producer_after = _wait_for_metrics(
+            source_pega.metrics_port,
+            producer_before,
+            (
+                "pegaflow_save_bytes_total",
+                "pegaflow_save_bytes",
+                "pegaflow_cache_block_insertions_total",
+                "pegaflow_cache_block_insertions",
+            ),
+        )
+
+        with VllmReplica(
+            "local-consumer",
+            model,
+            local_consumer_port,
+            consumer_devices,
+            source_pega,
+            log_dir,
+            server_max_model_len,
+        ):
+            local_before = fetch_pegaflow_metrics(source_pega.metrics_port)
+            local_outputs = _call_batch(local_consumer_port, PROMPTS, request_max_tokens)
+            local_after = _wait_for_metrics(
+                source_pega.metrics_port,
+                local_before,
+                (
+                    "pegaflow_load_bytes_total",
+                    "pegaflow_load_bytes",
+                    "pegaflow_cache_block_hits_total",
+                    "pegaflow_cache_block_hits",
+                ),
+            )
+
+        remote_pega = stack.enter_context(
+            PegaServer(
+                "remote",
+                consumer_devices,
+                log_dir,
+                pool_size,
+                pegaflow_transfer_backend,
+                metaserver,
+                nics,
+                server_host,
+            )
+        )
+        with VllmReplica(
+            "rdma-consumer",
+            model,
+            rdma_consumer_port,
+            consumer_devices,
+            remote_pega,
+            log_dir,
+            server_max_model_len,
+        ):
+            rdma_before = fetch_pegaflow_metrics(remote_pega.metrics_port)
+            rdma_series_before = _snapshot_metrics(
+                remote_pega.metrics_port,
+                (
+                    (RDMA_FETCH_COUNTER_NAMES, {"status": "ok"}),
+                    (RDMA_FETCH_COUNTER_NAMES, {"status": "error"}),
+                    (RDMA_FETCH_BYTES_COUNTER_NAMES, {"status": "ok"}),
+                ),
+            )
+            rdma_outputs = _call_batch(rdma_consumer_port, PROMPTS, request_max_tokens)
+            rdma_after = _wait_for_metrics(
+                remote_pega.metrics_port,
+                rdma_before,
+                (
+                    "pegaflow_rdma_fetch_total",
+                    "pegaflow_rdma_fetch_bytes_total",
+                    "pegaflow_rdma_fetch_bytes",
+                    "pegaflow_load_bytes_total",
+                    "pegaflow_load_bytes",
+                ),
+            )
+
+        # The producer computes the full prompt, while both consumers take the
+        # external-prefix path and only recompute the tail. With PP this can
+        # legitimately expose tiny numerical differences on close logits. The
+        # P2P invariant is stricter and narrower: RDMA-loaded KV must produce
+        # the same outputs as a same-server load from the same saved KV.
+        _assert_outputs_match(local_outputs, rdma_outputs, label="rdma load")
+
+        producer_saved = _metric_sum(
+            producer_before,
+            producer_after,
+            (
+                "pegaflow_save_bytes_total",
+                "pegaflow_save_bytes",
+                "pegaflow_cache_block_insertions_total",
+                "pegaflow_cache_block_insertions",
+            ),
+        )
+        local_loaded = _metric_sum(
+            local_before,
+            local_after,
+            (
+                "pegaflow_load_bytes_total",
+                "pegaflow_load_bytes",
+                "pegaflow_cache_block_hits_total",
+                "pegaflow_cache_block_hits",
+            ),
+        )
+        rdma_loaded = _metric_sum(
+            rdma_before,
+            rdma_after,
+            (
+                "pegaflow_rdma_fetch_total",
+                "pegaflow_rdma_fetch_bytes_total",
+                "pegaflow_rdma_fetch_bytes",
+                "pegaflow_load_bytes_total",
+                "pegaflow_load_bytes",
+            ),
+        )
+
+        assert producer_saved > 0, f"producer produced no save evidence; logs={log_dir}"
+        assert local_loaded > 0, f"local consumer produced no load evidence; logs={log_dir}"
+        assert rdma_loaded > 0, f"RDMA consumer produced no fetch/load evidence; logs={log_dir}"
+        assert (
+            _metric_value_delta(
+                remote_pega.metrics_port,
+                rdma_series_before,
+                RDMA_FETCH_COUNTER_NAMES,
+                labels={"status": "ok"},
+            )
+            > 0
+        ), f"RDMA consumer produced no successful RDMA fetch; logs={log_dir}"
+        assert (
+            _metric_value_delta(
+                remote_pega.metrics_port,
+                rdma_series_before,
+                RDMA_FETCH_COUNTER_NAMES,
+                labels={"status": "error"},
+            )
+            == 0
+        ), f"RDMA consumer recorded RDMA fetch errors; logs={log_dir}"
+        assert (
+            _metric_value_delta(
+                remote_pega.metrics_port,
+                rdma_series_before,
+                RDMA_FETCH_BYTES_COUNTER_NAMES,
+                labels={"status": "ok"},
+            )
+            > 0
+        ), f"RDMA consumer fetched no RDMA bytes; logs={log_dir}"
+
+        source_failures = _fetch_rpc_failures(source_pega.metrics_port)
+        # The RDMA consumer validates the read path. PegaFlow currently has no
+        # read-only connector mode, so vLLM may submit a best-effort save for
+        # the generated tail after the load has already completed.
+        remote_failures = _fetch_rpc_failures(
+            remote_pega.metrics_port,
+            ignored_methods=frozenset({"save"}),
+        )
+        assert not source_failures, f"source RPC failures: {source_failures}; logs={log_dir}"
+        assert not remote_failures, f"remote RPC failures: {remote_failures}; logs={log_dir}"

--- a/python/tests/unit_stubs.py
+++ b/python/tests/unit_stubs.py
@@ -137,6 +137,22 @@ def _install_vllm_stubs() -> None:
     parallel_state.get_pp_group = lambda: _PPGroup()
 
     _ensure_module("vllm.config").VllmConfig = object
+    models_utils = _ensure_module("vllm.model_executor.models.utils")
+
+    def extract_layer_index(layer_name: str, num_attn_module: int = 1) -> int:
+        int_vals: list[int] = []
+        for subname in layer_name.split("."):
+            try:
+                int_vals.append(int(subname))
+            except ValueError:
+                continue
+        if num_attn_module == 1 or "attn" not in layer_name:
+            assert len(int_vals) == 1, f"layer name {layer_name} should only contain one integer"
+            return int_vals[0]
+        assert len(int_vals) <= 2, f"layer name {layer_name} should contain most two integers"
+        return int_vals[0] * num_attn_module + int_vals[1] if len(int_vals) == 2 else int_vals[0]
+
+    models_utils.extract_layer_index = extract_layer_index
     _ensure_module("vllm.v1")
     _ensure_module("vllm.v1.metrics")
     _ensure_module("vllm.v1.metrics.utils").create_metric_per_engine = lambda *_args, **_kwargs: {}


### PR DESCRIPTION
## Summary

- move layer identity ownership to the vLLM connector: `RegisterContextRequest` now carries explicit `layer_ids`, and Python/PyO3 pass canonical IDs alongside layer names
- make the engine store by connector-declared IDs, reject out-of-range/conflicting IDs, and keep `num_layers` fixed instead of inferring/growing layer tables from registration order
- make GPU/context registration transactional across layer metadata and CUDA tensor registry rollback paths
- add a single-file pp4 P2P E2E that reproduces the old output/logprob divergence and verifies fixed RDMA load output equality

Phase 2 items intentionally stay out of this PR: cross-role namespace identity and identity-on-wire for remote slots.

## Repro / Fix Evidence

Old code (`311e0f0`, parent of this fix) on self hosted failed the local-load-vs-RDMA-load E2E after successful RDMA fetch/load:

- artifacts: `/tmp/pytest-of-root/pytest-10/test_pp4_p2p_matches_local_cac0/p2p_pp4_logs`
- local-load choice 0 text: `"的的\n\n\n\n\n\n\n"`
- RDMA-load choice 0 text: `" 0 or for identity for 0"`
- local-load choice 1 text: `" ，      "`
- RDMA-load choice 1 text: `"00000010"`
- remote RDMA evidence: `pega-remote.log:203`, `:210`, `:212`, `:220-231`

Fixed branch  passed the same pp4 P2P E2E after the final reviewer fixes:

- command: `.venv/bin/python -m pytest -m e2e python/tests/test_vllm_p2p_pp4_e2e.py --model /data/models/Qwen3-8B --pegaflow-pool-size 60gb -s -v`
- result: `1 passed in 129.65s`
- artifacts: `/tmp/pytest-of-root/pytest-15/test_pp4_p2p_matches_local_cac0/p2p_pp4_logs`
- remote RDMA evidence: `pega-remote.log:199`, `:202`, `:204`, `:214-223`
- registration order still differed across producer/local/remote, but each request carried canonical `layer_ids`

## Validation

- `./scripts/check.sh`
- `cargo test -p pegaflow-core instance::tests -- --nocapture`
- `cargo test -p pegaflow-server registry::tests -- --nocapture`
- `uv run --with pytest pytest python/tests/test_connector_fault_tolerance.py python/tests/test_worker_kv_layout.py -q`
- `uv run --with pytest --with requests pytest --collect-only -m e2e python/tests/test_vllm_p2p_pp4_e2e.py -q`
- jiuzhang 39 remote build:
  - `python -m maturin develop --release --uv --manifest-path python/Cargo.toml`
  - `cargo build --release --bin pegaflow-server-py --bin pegaflow-metaserver-py`
- jiuzhang 39 pp4 P2P E2E: `1 passed in 129.65s`
- toxic reviewer sub-agent: ready for review
