### PR TITLE
chore: bump version to 0.22.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "colored",
  "libc",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "axum",
  "clap",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "prost",
  "tonic",
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "axum",
  "clap",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.22.7"
+version = "0.22.8"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.22.7"
+version = "0.22.8"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -114,6 +114,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.22.7"
+version = "0.22.8"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## Summary
- bump workspace and Python package versions to 0.22.8
- refresh Cargo.lock package versions for workspace crates

## Tests
- cargo metadata --locked --no-deps
- uv run --no-project python -c "import pathlib, tomllib; p=tomllib.loads(pathlib.Path('python/pyproject.toml').read_text()); assert p['project']['version']=='0.22.8'; assert p['tool']['commitizen']['version']=='0.22.8'; print('python metadata version ok')"
- pre-commit hooks during commit, including cargo test --release