### PR TITLE
refactor(core): replace KVCacheRegistration with validated KVCacheLayout

### DIFF
--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -5,19 +5,17 @@ use log::{debug, error, info, warn};
 use logforth::diagnostic::ThreadLocalDiagnostic;
 use tokio::sync::{mpsc, oneshot};
 
+use crate::EngineError;
 use crate::block::RawBlock;
+use crate::layout::{BlockCopies, KVCacheLayout};
 use crate::metrics::core_metrics;
-use crate::pinned_pool::MappedPinnedPtr;
 use crate::sync_state::LoadState;
-use crate::transfer::{
-    self, CopyDesc, KernelBackend, MemcpyBackend, TransferBackend, TransferMode,
-};
-use crate::{EngineError, KVCacheRegistration};
+use crate::transfer::{CopyDesc, KernelBackend, MemcpyBackend, TransferBackend, TransferMode};
 use pegaflow_common::{NumaNode, pin_thread_to_numa_node};
 
 /// A task to load KV blocks from CPU to GPU for multiple layers
 pub(crate) struct LoadTask {
-    pub layers: Vec<LayerLoadData>,
+    pub layers: Vec<LayerTransferData>,
     pub completion: LoadCompletion,
 }
 
@@ -53,48 +51,30 @@ impl LoadCompletion {
     }
 }
 
-/// Data for loading a single layer
-pub(crate) struct LayerLoadData {
+/// One layer in a transfer task (either direction): GPU layout plus the
+/// blocks to move.
+pub(crate) struct LayerTransferData {
     pub layer_name: String,
-    pub registration: KVCacheRegistration,
-    pub blocks: Vec<LoadBlock>,
+    pub layout: KVCacheLayout,
+    pub blocks: Vec<TransferBlock>,
 }
 
-pub(crate) struct LoadBlock {
+/// One block in a transfer: the GPU slot index and its host-side image.
+/// Loads copy `block` -> GPU slot, saves copy GPU slot -> `block`.
+pub(crate) struct TransferBlock {
     pub block_idx: usize,
     pub block: Arc<RawBlock>,
 }
 
 /// A task to save KV blocks from GPU to CPU for multiple layers.
-/// Caller pre-allocates pinned memory, worker does the GPU->CPU copy.
+/// Caller pre-allocates the host blocks, worker does the GPU->CPU copy.
 /// All layers are copied on the same CUDA stream with a single synchronization.
 pub(crate) struct SaveTask {
-    pub layers: Vec<SaveLayerData>,
+    pub layers: Vec<LayerTransferData>,
     pub reply: oneshot::Sender<Result<(), EngineError>>,
     #[cfg(feature = "tracing")]
     pub trace_ctx: Option<::fastrace::prelude::SpanContext>,
 }
-
-/// Data for saving a single layer's blocks from GPU to CPU.
-pub(crate) struct SaveLayerData {
-    pub layer_name: String,
-    pub registration: KVCacheRegistration,
-    pub blocks: Vec<SaveBlock>,
-}
-
-pub(crate) struct SaveBlock {
-    pub block_idx: usize,
-    pub k_dst: MappedPinnedPtr,
-    pub v_dst: Option<MappedPinnedPtr>,
-}
-
-// SAFETY: SaveBlock contains raw pointers to pinned memory that is managed
-// by PinnedAllocation. The caller ensures the backing memory stays alive
-// until the task completes.
-unsafe impl Send for SaveBlock {}
-// SAFETY: SaveLayerData contains SaveBlocks which hold raw pointers to pinned
-// memory. Same safety guarantees as SaveBlock apply.
-unsafe impl Send for SaveLayerData {}
 
 /// Per-GPU worker pool with dedicated load and save threads
 pub(crate) struct GpuWorkerPool {
@@ -197,7 +177,10 @@ impl GpuWorkerPool {
     /// Submit a multi-layer save task (GPU -> CPU) - async, wait for completion.
     /// All layers are copied on the same CUDA stream with a single synchronization,
     /// which is significantly faster than submitting individual per-layer tasks.
-    pub(crate) async fn batch_save(&self, layers: Vec<SaveLayerData>) -> Result<(), EngineError> {
+    pub(crate) async fn batch_save(
+        &self,
+        layers: Vec<LayerTransferData>,
+    ) -> Result<(), EngineError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let task = SaveTask {
             layers,
@@ -312,120 +295,81 @@ fn save_worker_loop(
     info!("Save worker shutting down: device={}", device_id);
 }
 
-fn device_addr(
-    registration: &KVCacheRegistration,
-    offset: usize,
-    size: usize,
-    layer_name: &str,
-) -> Result<u64, EngineError> {
-    let end = offset.checked_add(size).ok_or_else(|| {
-        EngineError::Storage(format!(
-            "layer {layer_name}: GPU copy range overflow: offset={offset} size={size}"
-        ))
-    })?;
-    if end > registration.size_bytes {
-        return Err(EngineError::Storage(format!(
-            "layer {layer_name}: GPU copy range exceeds registration: offset={offset} size={size} registration_size={}",
-            registration.size_bytes
-        )));
+/// Build one `CopyDesc` per GPU segment of every block across all layers,
+/// pairing device ranges from the layout with the host segments of each
+/// block's `RawBlock`. Direction-agnostic: load and save submit the same
+/// descriptors to `h2d`/`d2h` respectively.
+///
+/// Returns `(copies, total_bytes)`.
+fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usize), EngineError> {
+    let mut copies: Vec<CopyDesc> = Vec::new();
+    let mut total_bytes = 0usize;
+
+    for layer in layers {
+        let layer_name = &layer.layer_name;
+
+        for block in &layer.blocks {
+            let block_copies = layer
+                .layout
+                .block_copies(block.block_idx)
+                .map_err(|e| EngineError::Storage(format!("layer {layer_name}: {e}")))?;
+
+            match block_copies {
+                BlockCopies::Split { k, v } => {
+                    let k_ptr = block.block.segment_mapped_ptr(0).unwrap();
+                    // SAFETY: For a contiguous host block (segment 1 absent), the
+                    // allocation is 2 * segment size, so k + k.bytes is in bounds.
+                    let v_ptr = block
+                        .block
+                        .segment_mapped_ptr(1)
+                        .unwrap_or_else(|| k_ptr.add(k.bytes));
+
+                    copies.push(CopyDesc {
+                        device: k.addr,
+                        host: k_ptr.host().as_ptr(),
+                        host_device: k_ptr.device().as_ptr() as u64,
+                        size: k.bytes,
+                    });
+                    copies.push(CopyDesc {
+                        device: v.addr,
+                        host: v_ptr.host().as_ptr(),
+                        host_device: v_ptr.device().as_ptr() as u64,
+                        size: v.bytes,
+                    });
+                    total_bytes += k.bytes + v.bytes;
+                }
+                BlockCopies::Contiguous(c) => {
+                    let ptr = block.block.segment_mapped_ptr(0).unwrap();
+                    copies.push(CopyDesc {
+                        device: c.addr,
+                        host: ptr.host().as_ptr(),
+                        host_device: ptr.device().as_ptr() as u64,
+                        size: c.bytes,
+                    });
+                    total_bytes += c.bytes;
+                }
+            }
+        }
     }
 
-    let addr = registration
-        .data_ptr
-        .checked_add(offset as u64)
-        .ok_or_else(|| {
-            EngineError::Storage(format!(
-                "layer {layer_name}: GPU pointer overflow: base=0x{:x} offset={offset}",
-                registration.data_ptr
-            ))
-        })?;
-    addr.checked_add(size as u64).ok_or_else(|| {
-        EngineError::Storage(format!(
-            "layer {layer_name}: GPU pointer range overflow: addr=0x{addr:x} size={size}"
-        ))
-    })?;
-    Ok(addr)
+    Ok((copies, total_bytes))
 }
 
 /// Process a load task: copy blocks from CPU pinned memory to GPU for multiple
 /// layers. All layers and segments are collected into one descriptor batch,
 /// handed to a single backend (memcpy or kernel), then synchronized once.
 fn process_load_task(
-    layers: &[LayerLoadData],
+    layers: &[LayerTransferData],
     stream: &Arc<CudaStream>,
     backend: &dyn TransferBackend,
 ) -> Result<(), EngineError> {
     trace_root!("gpu.load_task", _root);
     let start = std::time::Instant::now();
-    let mut total_bytes = 0usize;
     // Use the first layer's block count as the physical block count (all layers have the same)
     let total_blocks = layers.first().map(|l| l.blocks.len()).unwrap_or(0);
     let metrics = core_metrics();
 
-    let mut copies: Vec<CopyDesc> = Vec::new();
-
-    for layer_data in layers {
-        let registration = &layer_data.registration;
-        let layer_name = &layer_data.layer_name;
-
-        if layer_data.blocks.is_empty() {
-            continue;
-        }
-
-        if registration.segments == 2 && registration.kv_stride_bytes > registration.bytes_per_block
-        {
-            // Layer-first layout with KV stride: K and V live in separate
-            // regions. Actual (unpadded) GPU segment size matches GPU layout.
-            let segment_size = registration.bytes_per_block;
-
-            for block in &layer_data.blocks {
-                let k_offset = transfer::segment_offset(registration, block.block_idx, 0)
-                    .map_err(EngineError::Storage)?;
-                let v_offset = transfer::segment_offset(registration, block.block_idx, 1)
-                    .map_err(EngineError::Storage)?;
-
-                let k_ptr = block.block.segment_mapped_ptr(0).unwrap();
-                // SAFETY: For contiguous layout (segment 1 absent), the allocation
-                // is 2 * segment_size bytes, so k_host + segment_size is in bounds.
-                let v_ptr = block
-                    .block
-                    .segment_mapped_ptr(1)
-                    .unwrap_or_else(|| k_ptr.add(segment_size));
-
-                copies.push(CopyDesc {
-                    device: device_addr(registration, k_offset, segment_size, layer_name)?,
-                    host: k_ptr.host().as_ptr(),
-                    host_device: k_ptr.device().as_ptr() as u64,
-                    size: segment_size,
-                });
-                copies.push(CopyDesc {
-                    device: device_addr(registration, v_offset, segment_size, layer_name)?,
-                    host: v_ptr.host().as_ptr(),
-                    host_device: v_ptr.device().as_ptr() as u64,
-                    size: segment_size,
-                });
-            }
-
-            total_bytes += layer_data.blocks.len() * segment_size * 2;
-        } else {
-            // Contiguous or single-segment layout. Actual (unpadded) block size.
-            let block_size = registration.block_size_bytes;
-
-            for block in &layer_data.blocks {
-                let offset = transfer::segment_offset(registration, block.block_idx, 0)
-                    .map_err(EngineError::Storage)?;
-                let ptr = block.block.segment_mapped_ptr(0).unwrap();
-                copies.push(CopyDesc {
-                    device: device_addr(registration, offset, block_size, layer_name)?,
-                    host: ptr.host().as_ptr(),
-                    host_device: ptr.device().as_ptr() as u64,
-                    size: block_size,
-                });
-            }
-
-            total_bytes += layer_data.blocks.len() * block_size;
-        }
-    }
+    let (copies, total_bytes) = build_copy_descs(layers)?;
 
     backend.h2d(&copies, stream).map_err(EngineError::Storage)?;
 
@@ -475,67 +419,9 @@ fn process_save_task(
 ) -> Result<(), EngineError> {
     trace_child!("gpu.save_task", task.trace_ctx);
     let start = std::time::Instant::now();
-    let mut total_bytes = 0usize;
-    let mut total_blocks = 0usize;
+    let total_blocks: usize = task.layers.iter().map(|l| l.blocks.len()).sum();
 
-    let mut copies: Vec<CopyDesc> = Vec::new();
-
-    for layer in &task.layers {
-        let registration = &layer.registration;
-        let layer_name = &layer.layer_name;
-
-        if layer.blocks.is_empty() {
-            continue;
-        }
-        total_blocks += layer.blocks.len();
-
-        if registration.segments == 2 && registration.kv_stride_bytes > registration.bytes_per_block
-        {
-            // Layer-first layout: K and V segments stored separately. Actual
-            // (unpadded) GPU segment size — pinned memory may use a larger
-            // padded stride, but CUDA copies only the real data.
-            let segment_size = registration.bytes_per_block;
-
-            for block in &layer.blocks {
-                let k_offset = transfer::segment_offset(registration, block.block_idx, 0)
-                    .map_err(EngineError::Storage)?;
-                let v_offset = transfer::segment_offset(registration, block.block_idx, 1)
-                    .map_err(EngineError::Storage)?;
-                let v_dst = block.v_dst.unwrap_or_else(|| block.k_dst.add(segment_size));
-
-                copies.push(CopyDesc {
-                    device: device_addr(registration, k_offset, segment_size, layer_name)?,
-                    host: block.k_dst.host().as_ptr(),
-                    host_device: block.k_dst.device().as_ptr() as u64,
-                    size: segment_size,
-                });
-                copies.push(CopyDesc {
-                    device: device_addr(registration, v_offset, segment_size, layer_name)?,
-                    host: v_dst.host().as_ptr(),
-                    host_device: v_dst.device().as_ptr() as u64,
-                    size: segment_size,
-                });
-            }
-
-            total_bytes += layer.blocks.len() * segment_size * 2;
-        } else {
-            // Contiguous or single-segment layout. Actual (unpadded) block size.
-            let block_size = registration.block_size_bytes;
-
-            for block in &layer.blocks {
-                let offset = transfer::segment_offset(registration, block.block_idx, 0)
-                    .map_err(EngineError::Storage)?;
-                copies.push(CopyDesc {
-                    device: device_addr(registration, offset, block_size, layer_name)?,
-                    host: block.k_dst.host().as_ptr(),
-                    host_device: block.k_dst.device().as_ptr() as u64,
-                    size: block_size,
-                });
-            }
-
-            total_bytes += layer.blocks.len() * block_size;
-        }
-    }
+    let (copies, total_bytes) = build_copy_descs(&task.layers)?;
 
     backend.d2h(&copies, stream).map_err(EngineError::Storage)?;
 

--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -9,6 +9,7 @@ use std::{collections::HashMap, sync::Arc};
 use cudarc::driver::CudaContext;
 use log::info;
 
+use crate::layout::KVCacheLayout;
 use crate::{EngineError, TransferMode, gpu_worker::GpuWorkerPool};
 use pegaflow_common::NumaNode;
 
@@ -25,176 +26,6 @@ struct LayerMetadata {
 
     /// GPU contexts indexed by CUDA device ID.
     gpu_contexts: HashMap<i32, Arc<GpuContext>>,
-}
-
-/// Registration information for a KV cache layer.
-///
-/// This struct captures the memory layout of a layer's KV cache,
-/// supporting both contiguous and split (K/V-separated) storage formats.
-#[derive(Debug, Clone)]
-pub struct KVCacheRegistration {
-    /// GPU memory base pointer for this layer's KV cache.
-    pub data_ptr: u64,
-
-    /// Total size of the registered GPU memory region in bytes.
-    pub size_bytes: usize,
-
-    /// Number of blocks in this layer's cache.
-    pub num_blocks: usize,
-
-    /// Actual GPU-side segment size in bytes (one of K or V).
-    /// Used for CUDA memcpy sizes and GPU offset calculations.
-    pub bytes_per_block: usize,
-
-    /// Byte stride between a layer's consecutive blocks. Defaults to
-    /// `bytes_per_block` (dense layer-first); override via
-    /// [`KVCacheRegistration::with_block_stride`] when the step exceeds the
-    /// per-block copy size.
-    pub block_stride_bytes: usize,
-
-    /// Actual GPU-side total block size (`bytes_per_block * segments`).
-    pub block_size_bytes: usize,
-
-    /// Stride in bytes between K and V segments for split storage layouts.
-    /// Zero when using contiguous single-segment storage.
-    pub kv_stride_bytes: usize,
-
-    /// Number of segments per block (1 for contiguous, 2 for K/V split).
-    pub segments: usize,
-
-    /// CPU/SSD-side segment size, rounded up to SSD alignment.
-    /// Controls pinned memory allocation stride and SSD iovec lengths.
-    /// Equals `bytes_per_block` when no SSD padding is needed.
-    pub padded_bytes_per_block: usize,
-
-    /// CPU/SSD-side total block size (`padded_bytes_per_block * segments`).
-    /// Becomes `RawBlock.total_size` → `SlotMeta.total_size()` for SSD I/O.
-    pub padded_block_size_bytes: usize,
-}
-
-impl KVCacheRegistration {
-    /// Construct and validate a new registration.
-    ///
-    /// # Errors
-    /// Returns a simple error message string if validation fails.
-    pub(crate) fn new(
-        data_ptr: u64,
-        size_bytes: usize,
-        num_blocks: usize,
-        bytes_per_block: usize,
-        kv_stride_bytes: usize,
-        segments: usize,
-    ) -> Result<Self, String> {
-        // Basic non-zero checks
-        if data_ptr == 0 {
-            return Err("data_ptr must not be null".into());
-        }
-        if size_bytes == 0 {
-            return Err("size_bytes must be > 0".into());
-        }
-        if bytes_per_block == 0 || num_blocks == 0 || segments == 0 {
-            return Err("bytes_per_block, num_blocks, and segments must be non-zero".into());
-        }
-        if segments > 1 && kv_stride_bytes == 0 {
-            return Err("kv_stride_bytes must be > 0 when segments > 1".into());
-        }
-
-        // Compute block_size_bytes (may overflow)
-        let block_size_bytes = bytes_per_block
-            .checked_mul(segments)
-            .ok_or_else(|| "block_size_bytes overflow".to_string())?;
-
-        // Default: dense layer-first layout — block step equals the copied size.
-        let block_stride_bytes = bytes_per_block;
-        Self::check_layout_bounds(
-            num_blocks,
-            block_stride_bytes,
-            bytes_per_block,
-            kv_stride_bytes,
-            segments,
-            size_bytes,
-        )?;
-
-        Ok(Self {
-            data_ptr,
-            size_bytes,
-            num_blocks,
-            bytes_per_block,
-            block_stride_bytes,
-            block_size_bytes,
-            kv_stride_bytes,
-            segments,
-            padded_bytes_per_block: bytes_per_block,
-            padded_block_size_bytes: block_size_bytes,
-        })
-    }
-
-    /// Validate that `num_blocks` blocks, stepped by `block_stride` and reaching
-    /// `bytes_per_block` past the last segment, fit within `size_bytes`.
-    fn check_layout_bounds(
-        num_blocks: usize,
-        block_stride: usize,
-        bytes_per_block: usize,
-        kv_stride_bytes: usize,
-        segments: usize,
-        size_bytes: usize,
-    ) -> Result<(), String> {
-        let max_block_offset = (num_blocks - 1)
-            .checked_mul(block_stride)
-            .and_then(|o| o.checked_add((segments - 1).checked_mul(kv_stride_bytes)?))
-            .ok_or_else(|| "memory layout overflow".to_string())?;
-
-        let end = max_block_offset
-            .checked_add(bytes_per_block)
-            .ok_or_else(|| "memory layout end overflow".to_string())?;
-
-        if end > size_bytes {
-            return Err(format!(
-                "registered memory too small: need {} bytes, got {}",
-                end, size_bytes
-            ));
-        }
-        Ok(())
-    }
-
-    /// Override the per-block stride for a non-contiguous per-layer view — e.g.
-    /// one layer's blocks inside a fused buffer holding all layers per block,
-    /// where consecutive blocks sit `page_stride` apart but each copy spans only
-    /// `bytes_per_block`. Defaults to `bytes_per_block` (a contiguous per-layer
-    /// region, where the block step already equals the copy size).
-    ///
-    /// # Errors
-    /// `stride < bytes_per_block` (blocks would overlap), or the strided layout
-    /// overflows the registered region.
-    pub(crate) fn with_block_stride(mut self, stride: usize) -> Result<Self, String> {
-        if stride < self.bytes_per_block {
-            return Err(format!(
-                "block_stride {} must be >= bytes_per_block {}",
-                stride, self.bytes_per_block
-            ));
-        }
-        Self::check_layout_bounds(
-            self.num_blocks,
-            stride,
-            self.bytes_per_block,
-            self.kv_stride_bytes,
-            self.segments,
-            self.size_bytes,
-        )?;
-        self.block_stride_bytes = stride;
-        Ok(self)
-    }
-
-    /// Apply SSD alignment padding to segment sizes.
-    ///
-    /// Each segment (`bytes_per_block`) is rounded up to the next multiple of
-    /// `alignment` so that every iovec in split writev is independently aligned.
-    pub(crate) fn with_ssd_padding(mut self, alignment: usize) -> Self {
-        let padded = self.bytes_per_block.next_multiple_of(alignment);
-        self.padded_bytes_per_block = padded;
-        self.padded_block_size_bytes = padded * self.segments;
-        self
-    }
 }
 
 /// Per-GPU execution context.
@@ -217,8 +48,8 @@ pub struct GpuContext {
     /// Preferred NUMA node for this GPU (for memory allocation).
     preferred_numa: NumaNode,
 
-    /// KV cache layout registrations by layer name.
-    kv_caches: HashMap<String, KVCacheRegistration>,
+    /// KV cache layouts by layer name.
+    kv_caches: HashMap<String, KVCacheLayout>,
 
     /// CUDA context handle (kept alive for the lifetime of this context).
     _cuda_ctx: Arc<CudaContext>,
@@ -244,7 +75,7 @@ impl GpuContext {
         pp_rank: usize,
         numa_node: NumaNode,
         transfer_mode: TransferMode,
-        kv_caches: HashMap<String, KVCacheRegistration>,
+        kv_caches: HashMap<String, KVCacheLayout>,
     ) -> Result<Self, EngineError> {
         let worker_pool = GpuWorkerPool::spawn(device_id, numa_node, transfer_mode)?;
 
@@ -279,8 +110,8 @@ impl GpuContext {
         self.pp_rank
     }
 
-    /// Retrieve a layer's registration information.
-    pub(crate) fn get_registration(&self, layer_name: &str) -> Option<KVCacheRegistration> {
+    /// Retrieve a layer's KV cache layout.
+    pub(crate) fn get_layout(&self, layer_name: &str) -> Option<KVCacheLayout> {
         self.kv_caches.get(layer_name).cloned()
     }
 
@@ -296,7 +127,7 @@ pub(crate) struct GpuRegistration {
     pub(crate) pp_rank: usize,
     pub(crate) numa_node: NumaNode,
     pub(crate) transfer_mode: TransferMode,
-    pub(crate) kv_caches: HashMap<String, KVCacheRegistration>,
+    pub(crate) kv_caches: HashMap<String, KVCacheLayout>,
     pub(crate) layer_ids_by_name: HashMap<String, usize>,
 }
 
@@ -360,7 +191,7 @@ impl InstanceContext {
 
     fn build_layer_id_assignments(
         &self,
-        kv_caches: &HashMap<String, KVCacheRegistration>,
+        kv_caches: &HashMap<String, KVCacheLayout>,
         layer_ids_by_name: &HashMap<String, usize>,
     ) -> Result<Vec<(String, usize)>, EngineError> {
         let mut assignments = Vec::with_capacity(kv_caches.len());
@@ -492,7 +323,7 @@ impl InstanceContext {
         pp_rank: usize,
         numa_node: NumaNode,
         transfer_mode: TransferMode,
-        kv_caches: HashMap<String, KVCacheRegistration>,
+        kv_caches: HashMap<String, KVCacheLayout>,
     ) -> Result<Arc<GpuContext>, EngineError> {
         if device_id < 0 {
             return Err(EngineError::InvalidArgument(format!(
@@ -623,28 +454,12 @@ impl InstanceContext {
         let mut owners: Vec<Option<(i32, usize)>> = vec![None; total_slots];
 
         for gpu in metadata.gpu_contexts.values() {
-            if gpu.tp_rank() >= self.tp_size {
-                return Err(EngineError::InvalidArgument(format!(
-                    "registered gpu device {} has tp_rank {} out of range (tp_size {})",
-                    gpu.device_id(),
-                    gpu.tp_rank(),
-                    self.tp_size
-                )));
-            }
-
             for layer_name in gpu.kv_caches.keys() {
-                let layer_id = metadata.name_to_id.get(layer_name).ok_or_else(|| {
-                    EngineError::InvalidArgument(format!(
-                        "layer {layer_name} registered on device {} without a layer id",
-                        gpu.device_id()
-                    ))
-                })?;
+                let layer_id = metadata
+                    .name_to_id
+                    .get(layer_name)
+                    .expect("registered layer must have a committed id");
                 let slot_id = layer_id * self.tp_size + gpu.tp_rank();
-                if slot_id >= total_slots {
-                    return Err(EngineError::InvalidArgument(format!(
-                        "slot_id {slot_id} out of range (total_slots {total_slots})"
-                    )));
-                }
                 match owners[slot_id] {
                     None => owners[slot_id] = Some((gpu.device_id(), gpu.pp_rank())),
                     Some((existing_device, existing_pp_rank)) => {

--- a/pegaflow-core/src/instance/tests.rs
+++ b/pegaflow-core/src/instance/tests.rs
@@ -1,90 +1,7 @@
 use super::*;
+use crate::layout::BlockCopies;
 
-// --- KVCacheRegistration layout validation (pure, no device) ---
-
-#[test]
-fn registration_valid() {
-    let reg = KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap();
-    assert_eq!(reg.block_size_bytes, 1024);
-}
-
-#[test]
-fn block_stride_decouples_step_from_copy_size() {
-    use crate::transfer::segment_offset;
-
-    let bytes_per_block = 4096 * 2;
-    let page_stride_bytes = 8192 * 2;
-    let num_blocks = 8;
-    let size_bytes = num_blocks * page_stride_bytes;
-
-    let reg = KVCacheRegistration::new(0x10000, size_bytes, num_blocks, bytes_per_block, 0, 1)
-        .unwrap()
-        .with_block_stride(page_stride_bytes)
-        .unwrap();
-
-    assert_eq!(reg.block_stride_bytes, page_stride_bytes);
-    assert_eq!(segment_offset(&reg, 0, 0).unwrap(), 0);
-    assert_eq!(segment_offset(&reg, 3, 0).unwrap(), 3 * page_stride_bytes);
-    assert_eq!(segment_offset(&reg, 7, 0).unwrap(), 7 * page_stride_bytes);
-}
-
-#[test]
-fn block_stride_defaults_to_dense_and_validates() {
-    use crate::transfer::segment_offset;
-
-    let reg = KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap();
-    assert_eq!(reg.block_stride_bytes, 1024);
-    assert_eq!(segment_offset(&reg, 5, 0).unwrap(), 5 * 1024);
-
-    assert!(
-        KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1)
-            .unwrap()
-            .with_block_stride(512)
-            .is_err()
-    );
-
-    assert!(
-        KVCacheRegistration::new(0x1000, 8 * 1024, 8, 1024, 0, 1)
-            .unwrap()
-            .with_block_stride(4096)
-            .is_err()
-    );
-}
-
-#[test]
-fn registration_null_pointer_rejected() {
-    assert!(KVCacheRegistration::new(0, 1024, 10, 64, 0, 1).is_err());
-}
-
-#[test]
-fn registration_memory_too_small() {
-    let err = KVCacheRegistration::new(0x1000, 5120, 10, 1024, 0, 1).unwrap_err();
-    assert!(err.contains("too small"));
-}
-
-#[test]
-fn padded_block_size() {
-    // Unaligned: 8848 % 512 = 144, padded to 9216
-    let reg = KVCacheRegistration::new(0x1000, 10_000_000, 100, 8848, 0, 1)
-        .unwrap()
-        .with_ssd_padding(512);
-    assert_eq!(reg.padded_bytes_per_block, 9216);
-    assert_eq!(reg.padded_block_size_bytes, 9216);
-
-    // Already aligned: no change
-    let reg = KVCacheRegistration::new(0x1000, 1024 * 1024, 100, 1024, 0, 1)
-        .unwrap()
-        .with_ssd_padding(512);
-    assert_eq!(reg.padded_bytes_per_block, 1024);
-    assert_eq!(reg.padded_block_size_bytes, 1024);
-
-    // Split layout: padded per segment, total = padded * segments
-    let reg = KVCacheRegistration::new(0x1000, 10_000_000, 100, 8848, 900_000, 2)
-        .unwrap()
-        .with_ssd_padding(512);
-    assert_eq!(reg.padded_bytes_per_block, 9216);
-    assert_eq!(reg.padded_block_size_bytes, 9216 * 2);
-}
+// Pure layout validation tests live in `crate::layout::tests`.
 
 // --- Real registration path ---
 //
@@ -100,7 +17,7 @@ fn gpu_registration(device_id: i32, tp_rank: usize, layers: &[(&str, usize)]) ->
     let mut kv_caches = HashMap::new();
     let mut layer_ids_by_name = HashMap::new();
     for (index, (name, id)) in layers.iter().enumerate() {
-        let reg = KVCacheRegistration::new(
+        let layout = KVCacheLayout::new(
             0x1000 + index as u64 * 0x10000,
             1024 * 1024,
             100,
@@ -109,7 +26,7 @@ fn gpu_registration(device_id: i32, tp_rank: usize, layers: &[(&str, usize)]) ->
             1,
         )
         .unwrap();
-        kv_caches.insert((*name).to_string(), reg);
+        kv_caches.insert((*name).to_string(), layout);
         layer_ids_by_name.insert((*name).to_string(), *id);
     }
     GpuRegistration {
@@ -162,9 +79,12 @@ fn inference_registration_flow() {
 
     // The registered layer is retrievable with its original layout.
     let gpu = instance.get_gpu(0).expect("get gpu context");
-    let reg = gpu.get_registration("layer_0").expect("get registration");
-    assert_eq!(reg.data_ptr, 0x1000);
-    assert_eq!(reg.num_blocks, 100);
+    let layout = gpu.get_layout("layer_0").expect("get layout");
+    assert_eq!(layout.num_blocks(), 100);
+    match layout.block_copies(0).expect("block 0 in range") {
+        BlockCopies::Contiguous(c) => assert_eq!(c.addr, 0x1000),
+        BlockCopies::Split { .. } => panic!("dense test layout must be contiguous"),
+    }
 }
 
 /// An id outside `[0, num_layers)` is rejected while building assignments,

--- a/pegaflow-core/src/layout.rs
+++ b/pegaflow-core/src/layout.rs
@@ -1,0 +1,373 @@
+//! Per-layer KV cache layout.
+//!
+//! Every layout PegaFlow supports (dense layer-first, fused-buffer strided,
+//! MLA single-segment, K/V split) is a parameterization of one affine formula:
+//! `addr = data_ptr + block_idx * block_stride + segment_idx * kv_stride`.
+//!
+//! All validation happens at construction. After that,
+//! [`KVCacheLayout::block_copies`] is the only layout question the GPU copy
+//! paths ask, and it cannot produce an out-of-bounds range for a valid block
+//! index. Padded sizes govern pinned-memory strides and SSD iovecs; GPU copies
+//! always use actual (unpadded) sizes.
+
+/// How a block's segments are addressed on the GPU.
+#[derive(Debug, Clone, Copy)]
+enum SegmentLayout {
+    /// The whole block is one contiguous range: a single segment, or K/V
+    /// adjacent with no gap (`kv_stride == segment_bytes`).
+    Contiguous,
+    /// K and V live in separate regions, `kv_stride_bytes` apart: two copies
+    /// per block.
+    Split { kv_stride_bytes: usize },
+}
+
+/// One contiguous device address range.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BlockCopy {
+    pub addr: u64,
+    pub bytes: usize,
+}
+
+/// Device address ranges making up one block on the GPU.
+pub(crate) enum BlockCopies {
+    /// One contiguous copy.
+    Contiguous(BlockCopy),
+    /// Two copies: K and V segments in separate regions.
+    Split { k: BlockCopy, v: BlockCopy },
+}
+
+/// Layout of one layer's KV cache: GPU addressing plus the host-side block
+/// shape derived from it.
+#[derive(Debug, Clone)]
+pub(crate) struct KVCacheLayout {
+    /// GPU memory base pointer for this layer's KV cache.
+    data_ptr: u64,
+    /// Total size of the registered GPU memory region in bytes.
+    size_bytes: usize,
+    /// Number of blocks in this layer's cache.
+    num_blocks: usize,
+    /// Byte step between consecutive blocks (per segment region for split
+    /// layouts). Defaults to `segment_bytes` (dense); overridden via
+    /// [`KVCacheLayout::with_block_stride`] for fused buffers.
+    block_stride_bytes: usize,
+    /// GPU-side segment size in bytes (one of K or V).
+    segment_bytes: usize,
+    /// Segments per block (1 contiguous/MLA, 2 for K/V).
+    segments: usize,
+    /// CPU/SSD-side segment stride, `segment_bytes` rounded up to SSD
+    /// alignment. Equals `segment_bytes` when SSD is disabled.
+    padded_segment_bytes: usize,
+    seg: SegmentLayout,
+}
+
+impl KVCacheLayout {
+    /// Construct and validate a layout. Rejects null/oversized regions and
+    /// overlapping segment configurations (crash early instead of copying
+    /// garbage later).
+    ///
+    /// `segment_bytes` is the size of ONE segment — for K/V split layouts
+    /// that is K or V alone, not the whole block. (The registration RPC calls
+    /// this field `bytes_per_block` for historical reasons; passing a whole
+    /// split block here would mostly pass validation with every address
+    /// wrong.)
+    pub(crate) fn new(
+        data_ptr: u64,
+        size_bytes: usize,
+        num_blocks: usize,
+        segment_bytes: usize,
+        kv_stride_bytes: usize,
+        segments: usize,
+    ) -> Result<Self, String> {
+        if data_ptr == 0 {
+            return Err("data_ptr must not be null".into());
+        }
+        if size_bytes == 0 {
+            return Err("size_bytes must be > 0".into());
+        }
+        if segment_bytes == 0 || num_blocks == 0 || segments == 0 {
+            return Err("segment_bytes, num_blocks, and segments must be non-zero".into());
+        }
+        data_ptr
+            .checked_add(size_bytes as u64)
+            .ok_or_else(|| "data_ptr + size_bytes overflows the address space".to_string())?;
+        segment_bytes
+            .checked_mul(segments)
+            .ok_or_else(|| "block size overflow".to_string())?;
+
+        let seg = if segments == 1 {
+            SegmentLayout::Contiguous
+        } else if kv_stride_bytes == 0 {
+            return Err("kv_stride_bytes must be > 0 when segments > 1".into());
+        } else if kv_stride_bytes < segment_bytes {
+            return Err(format!(
+                "kv_stride_bytes {kv_stride_bytes} < segment_bytes {segment_bytes}: segments would overlap"
+            ));
+        } else if kv_stride_bytes == segment_bytes {
+            SegmentLayout::Contiguous
+        } else if segments == 2 {
+            SegmentLayout::Split { kv_stride_bytes }
+        } else {
+            return Err(format!(
+                "split layout (kv_stride_bytes {kv_stride_bytes} > segment_bytes {segment_bytes}) supports exactly 2 segments, got {segments}"
+            ));
+        };
+
+        let layout = Self {
+            data_ptr,
+            size_bytes,
+            num_blocks,
+            block_stride_bytes: segment_bytes,
+            segment_bytes,
+            segments,
+            padded_segment_bytes: segment_bytes,
+            seg,
+        };
+        layout.check_bounds()?;
+        Ok(layout)
+    }
+
+    /// Override the per-block stride for a non-contiguous per-layer view —
+    /// e.g. one layer's blocks inside a fused buffer holding all layers per
+    /// block, where consecutive blocks sit `stride` apart but each copy spans
+    /// only the layer's own bytes.
+    ///
+    /// # Errors
+    /// Stride smaller than a block's extent (blocks would overlap), or the
+    /// strided layout exceeds the registered region.
+    pub(crate) fn with_block_stride(mut self, stride: usize) -> Result<Self, String> {
+        let min_stride = match self.seg {
+            SegmentLayout::Contiguous => self.block_bytes(),
+            SegmentLayout::Split { .. } => self.segment_bytes,
+        };
+        if stride < min_stride {
+            return Err(format!(
+                "block_stride {stride} must be >= {min_stride}: blocks would overlap"
+            ));
+        }
+        self.block_stride_bytes = stride;
+        self.check_bounds()?;
+        Ok(self)
+    }
+
+    /// Apply SSD alignment padding to the host-side segment stride so every
+    /// iovec in a split writev is independently aligned.
+    pub(crate) fn with_ssd_padding(mut self, alignment: usize) -> Self {
+        self.padded_segment_bytes = self.segment_bytes.next_multiple_of(alignment);
+        self
+    }
+
+    /// Validate that the last block's last byte fits in `size_bytes`.
+    fn check_bounds(&self) -> Result<(), String> {
+        let per_block_extent = match self.seg {
+            SegmentLayout::Contiguous => self.block_bytes(),
+            SegmentLayout::Split { kv_stride_bytes } => kv_stride_bytes
+                .checked_add(self.segment_bytes)
+                .ok_or_else(|| "memory layout overflow".to_string())?,
+        };
+        let end = (self.num_blocks - 1)
+            .checked_mul(self.block_stride_bytes)
+            .and_then(|o| o.checked_add(per_block_extent))
+            .ok_or_else(|| "memory layout overflow".to_string())?;
+        if end > self.size_bytes {
+            return Err(format!(
+                "registered memory too small: need {end} bytes, got {}",
+                self.size_bytes
+            ));
+        }
+        Ok(())
+    }
+
+    /// Device address ranges for `block_idx`.
+    ///
+    /// Construction already proved the last block fits, so any valid index is
+    /// in bounds and the arithmetic below cannot overflow.
+    pub(crate) fn block_copies(&self, block_idx: usize) -> Result<BlockCopies, String> {
+        if block_idx >= self.num_blocks {
+            return Err(format!(
+                "block {block_idx} out of range ({} blocks)",
+                self.num_blocks
+            ));
+        }
+        let base = self.data_ptr + (block_idx * self.block_stride_bytes) as u64;
+        Ok(match self.seg {
+            SegmentLayout::Contiguous => BlockCopies::Contiguous(BlockCopy {
+                addr: base,
+                bytes: self.block_bytes(),
+            }),
+            SegmentLayout::Split { kv_stride_bytes } => BlockCopies::Split {
+                k: BlockCopy {
+                    addr: base,
+                    bytes: self.segment_bytes,
+                },
+                v: BlockCopy {
+                    addr: base + kv_stride_bytes as u64,
+                    bytes: self.segment_bytes,
+                },
+            },
+        })
+    }
+
+    pub(crate) fn num_blocks(&self) -> usize {
+        self.num_blocks
+    }
+
+    /// True when K and V need separate pinned segment pools.
+    pub(crate) fn is_split(&self) -> bool {
+        matches!(self.seg, SegmentLayout::Split { .. })
+    }
+
+    /// Actual (unpadded) GPU-side segment size.
+    pub(crate) fn segment_bytes(&self) -> usize {
+        self.segment_bytes
+    }
+
+    /// Actual (unpadded) total block size on the GPU.
+    fn block_bytes(&self) -> usize {
+        self.segment_bytes * self.segments
+    }
+
+    /// Host-side per-segment stride (SSD-aligned).
+    pub(crate) fn padded_segment_bytes(&self) -> usize {
+        self.padded_segment_bytes
+    }
+
+    /// Host-side total block size: pinned allocation footprint and
+    /// `RawBlock.total_size` → `SlotMeta.total_size()` for SSD I/O.
+    pub(crate) fn padded_block_bytes(&self) -> usize {
+        self.padded_segment_bytes * self.segments
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contiguous_addr(layout: &KVCacheLayout, block_idx: usize) -> u64 {
+        match layout.block_copies(block_idx).unwrap() {
+            BlockCopies::Contiguous(c) => c.addr,
+            BlockCopies::Split { .. } => panic!("expected contiguous copies"),
+        }
+    }
+
+    #[test]
+    fn dense_layout_addresses() {
+        let layout = KVCacheLayout::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap();
+        assert!(!layout.is_split());
+        assert_eq!(layout.padded_block_bytes(), 1024);
+        assert_eq!(contiguous_addr(&layout, 0), 0x1000);
+        assert_eq!(contiguous_addr(&layout, 5), 0x1000 + 5 * 1024);
+        assert!(layout.block_copies(100).is_err());
+    }
+
+    #[test]
+    fn split_layout_addresses() {
+        // 100 K blocks contiguous, then 100 V blocks: kv_stride = region size.
+        let layout = KVCacheLayout::new(0x1000, 200 * 1024, 100, 1024, 100 * 1024, 2).unwrap();
+        assert!(layout.is_split());
+        match layout.block_copies(3).unwrap() {
+            BlockCopies::Split { k, v } => {
+                assert_eq!(k.addr, 0x1000 + 3 * 1024);
+                assert_eq!(v.addr, 0x1000 + (100 + 3) * 1024);
+                assert_eq!(k.bytes, 1024);
+                assert_eq!(v.bytes, 1024);
+            }
+            BlockCopies::Contiguous(_) => panic!("expected split copies"),
+        }
+    }
+
+    #[test]
+    fn adjacent_kv_collapses_to_contiguous() {
+        // kv_stride == segment_bytes: one copy of both segments.
+        let layout = KVCacheLayout::new(0x1000, 200 * 1024, 100, 1024, 1024, 2).unwrap();
+        assert!(!layout.is_split());
+        match layout.block_copies(0).unwrap() {
+            BlockCopies::Contiguous(c) => assert_eq!(c.bytes, 2048),
+            BlockCopies::Split { .. } => panic!("expected contiguous copies"),
+        }
+    }
+
+    #[test]
+    fn overlapping_kv_stride_rejected() {
+        let err = KVCacheLayout::new(0x1000, 200 * 1024, 100, 1024, 512, 2).unwrap_err();
+        assert!(err.contains("overlap"), "{err}");
+    }
+
+    #[test]
+    fn block_stride_decouples_step_from_copy_size() {
+        let segment_bytes = 4096 * 2;
+        let page_stride_bytes = 8192 * 2;
+        let num_blocks = 8;
+        let size_bytes = num_blocks * page_stride_bytes;
+
+        let layout = KVCacheLayout::new(0x10000, size_bytes, num_blocks, segment_bytes, 0, 1)
+            .unwrap()
+            .with_block_stride(page_stride_bytes)
+            .unwrap();
+
+        assert_eq!(
+            contiguous_addr(&layout, 3),
+            0x10000 + 3 * page_stride_bytes as u64
+        );
+        assert_eq!(
+            contiguous_addr(&layout, 7),
+            0x10000 + 7 * page_stride_bytes as u64
+        );
+    }
+
+    #[test]
+    fn block_stride_defaults_to_dense_and_validates() {
+        let layout = KVCacheLayout::new(0x1000, 1024 * 1024, 100, 1024, 0, 1).unwrap();
+        assert_eq!(contiguous_addr(&layout, 5), 0x1000 + 5 * 1024);
+
+        // Stride smaller than the block: overlap.
+        assert!(
+            KVCacheLayout::new(0x1000, 1024 * 1024, 100, 1024, 0, 1)
+                .unwrap()
+                .with_block_stride(512)
+                .is_err()
+        );
+
+        // Strided layout exceeds the registered region.
+        assert!(
+            KVCacheLayout::new(0x1000, 8 * 1024, 8, 1024, 0, 1)
+                .unwrap()
+                .with_block_stride(4096)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn null_pointer_rejected() {
+        assert!(KVCacheLayout::new(0, 1024, 10, 64, 0, 1).is_err());
+    }
+
+    #[test]
+    fn memory_too_small_rejected() {
+        let err = KVCacheLayout::new(0x1000, 5120, 10, 1024, 0, 1).unwrap_err();
+        assert!(err.contains("too small"), "{err}");
+    }
+
+    #[test]
+    fn ssd_padding() {
+        // Unaligned: 8848 % 512 = 144, padded to 9216.
+        let layout = KVCacheLayout::new(0x1000, 10_000_000, 100, 8848, 0, 1)
+            .unwrap()
+            .with_ssd_padding(512);
+        assert_eq!(layout.padded_segment_bytes(), 9216);
+        assert_eq!(layout.padded_block_bytes(), 9216);
+
+        // Already aligned: no change.
+        let layout = KVCacheLayout::new(0x1000, 1024 * 1024, 100, 1024, 0, 1)
+            .unwrap()
+            .with_ssd_padding(512);
+        assert_eq!(layout.padded_segment_bytes(), 1024);
+        assert_eq!(layout.padded_block_bytes(), 1024);
+
+        // Split layout: padded per segment, total = padded * segments.
+        let layout = KVCacheLayout::new(0x1000, 10_000_000, 100, 8848, 900_000, 2)
+            .unwrap()
+            .with_ssd_padding(512);
+        assert_eq!(layout.padded_segment_bytes(), 9216);
+        assert_eq!(layout.padded_block_bytes(), 9216 * 2);
+    }
+}

--- a/pegaflow-core/src/layout.rs
+++ b/pegaflow-core/src/layout.rs
@@ -90,7 +90,7 @@ impl KVCacheLayout {
         data_ptr
             .checked_add(size_bytes as u64)
             .ok_or_else(|| "data_ptr + size_bytes overflows the address space".to_string())?;
-        segment_bytes
+        let block_bytes = segment_bytes
             .checked_mul(segments)
             .ok_or_else(|| "block size overflow".to_string())?;
 
@@ -116,7 +116,10 @@ impl KVCacheLayout {
             data_ptr,
             size_bytes,
             num_blocks,
-            block_stride_bytes: segment_bytes,
+            block_stride_bytes: match seg {
+                SegmentLayout::Contiguous => block_bytes,
+                SegmentLayout::Split { .. } => segment_bytes,
+            },
             segment_bytes,
             segments,
             padded_segment_bytes: segment_bytes,
@@ -156,24 +159,68 @@ impl KVCacheLayout {
         self
     }
 
-    /// Validate that the last block's last byte fits in `size_bytes`.
+    /// Validate that all addressed bytes fit in `size_bytes` and no two block
+    /// ranges alias the same device memory.
     fn check_bounds(&self) -> Result<(), String> {
-        let per_block_extent = match self.seg {
-            SegmentLayout::Contiguous => self.block_bytes(),
-            SegmentLayout::Split { kv_stride_bytes } => kv_stride_bytes
-                .checked_add(self.segment_bytes)
-                .ok_or_else(|| "memory layout overflow".to_string())?,
+        let end = match self.seg {
+            SegmentLayout::Contiguous => {
+                let block_bytes = self.block_bytes();
+                if self.block_stride_bytes < block_bytes {
+                    return Err(format!(
+                        "block_stride {} must be >= block_bytes {block_bytes}: blocks would overlap",
+                        self.block_stride_bytes
+                    ));
+                }
+                (self.num_blocks - 1)
+                    .checked_mul(self.block_stride_bytes)
+                    .and_then(|o| o.checked_add(block_bytes))
+                    .ok_or_else(|| "memory layout overflow".to_string())?
+            }
+            SegmentLayout::Split { kv_stride_bytes } => {
+                if self.block_stride_bytes < self.segment_bytes {
+                    return Err(format!(
+                        "block_stride {} must be >= segment_bytes {}: blocks would overlap",
+                        self.block_stride_bytes, self.segment_bytes
+                    ));
+                }
+                self.check_split_segments_disjoint(kv_stride_bytes)?;
+                let last_segment_end = (self.num_blocks - 1)
+                    .checked_mul(self.block_stride_bytes)
+                    .and_then(|o| o.checked_add(self.segment_bytes))
+                    .ok_or_else(|| "memory layout overflow".to_string())?;
+                kv_stride_bytes
+                    .checked_add(last_segment_end)
+                    .ok_or_else(|| "memory layout overflow".to_string())?
+            }
         };
-        let end = (self.num_blocks - 1)
-            .checked_mul(self.block_stride_bytes)
-            .and_then(|o| o.checked_add(per_block_extent))
-            .ok_or_else(|| "memory layout overflow".to_string())?;
         if end > self.size_bytes {
             return Err(format!(
                 "registered memory too small: need {end} bytes, got {}",
                 self.size_bytes
             ));
         }
+        Ok(())
+    }
+
+    fn check_split_segments_disjoint(&self, kv_stride_bytes: usize) -> Result<(), String> {
+        let max_block_distance = self.num_blocks - 1;
+        let nearest = kv_stride_bytes / self.block_stride_bytes;
+
+        for distance in [nearest, nearest.saturating_add(1)] {
+            if distance == 0 || distance > max_block_distance {
+                continue;
+            }
+            let block_distance_bytes = distance
+                .checked_mul(self.block_stride_bytes)
+                .ok_or_else(|| "memory layout overflow".to_string())?;
+            let gap = kv_stride_bytes.abs_diff(block_distance_bytes);
+            if gap < self.segment_bytes {
+                return Err(format!(
+                    "kv_stride_bytes {kv_stride_bytes} overlaps blocks {distance} apart"
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -284,12 +331,58 @@ mod tests {
             BlockCopies::Contiguous(c) => assert_eq!(c.bytes, 2048),
             BlockCopies::Split { .. } => panic!("expected contiguous copies"),
         }
+        assert_eq!(contiguous_addr(&layout, 1), 0x1000 + 2048);
     }
 
     #[test]
     fn overlapping_kv_stride_rejected() {
         let err = KVCacheLayout::new(0x1000, 200 * 1024, 100, 1024, 512, 2).unwrap_err();
         assert!(err.contains("overlap"), "{err}");
+    }
+
+    #[test]
+    fn split_kv_regions_must_not_overlap() {
+        let err = KVCacheLayout::new(0x1000, 200 * 1024, 100, 1024, 2048, 2).unwrap_err();
+        assert!(err.contains("overlaps blocks 2 apart"), "{err}");
+    }
+
+    #[test]
+    fn sparse_split_layout_can_have_interleaved_disjoint_segments() {
+        let layout = KVCacheLayout::new(0x1000, 1_600, 2, 100, 500, 2)
+            .unwrap()
+            .with_block_stride(1_000)
+            .unwrap();
+
+        match layout.block_copies(0).unwrap() {
+            BlockCopies::Split { k, v } => {
+                assert_eq!(k.addr, 0x1000);
+                assert_eq!(v.addr, 0x1000 + 500);
+            }
+            BlockCopies::Contiguous(_) => panic!("expected split copies"),
+        }
+        match layout.block_copies(1).unwrap() {
+            BlockCopies::Split { k, v } => {
+                assert_eq!(k.addr, 0x1000 + 1_000);
+                assert_eq!(v.addr, 0x1000 + 1_500);
+            }
+            BlockCopies::Contiguous(_) => panic!("expected split copies"),
+        }
+    }
+
+    #[test]
+    fn adjacent_kv_default_stride_keeps_blocks_disjoint() {
+        let layout = KVCacheLayout::new(0x1000, 200 * 1024, 100, 1024, 1024, 2).unwrap();
+
+        let block0 = match layout.block_copies(0).unwrap() {
+            BlockCopies::Contiguous(c) => c,
+            BlockCopies::Split { .. } => panic!("expected contiguous copies"),
+        };
+        let block1 = match layout.block_copies(1).unwrap() {
+            BlockCopies::Contiguous(c) => c,
+            BlockCopies::Split { .. } => panic!("expected contiguous copies"),
+        };
+
+        assert_eq!(block0.addr + block0.bytes as u64, block1.addr);
     }
 
     #[test]
@@ -334,6 +427,14 @@ mod tests {
                 .with_block_stride(4096)
                 .is_err()
         );
+
+        // Split K/V regions that are disjoint with the default dense stride can
+        // overlap again if the explicit per-block stride grows too far.
+        let err = KVCacheLayout::new(0x1000, 200 * 1024, 100, 1024, 100 * 1024, 2)
+            .unwrap()
+            .with_block_stride(2048)
+            .unwrap_err();
+        assert!(err.contains("overlaps blocks 50 apart"), "{err}");
     }
 
     #[test]

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -17,6 +17,7 @@ mod cache;
 mod gpu_worker;
 mod instance;
 mod internode;
+mod layout;
 mod lease;
 pub use pegaflow_common::logging;
 mod metrics;
@@ -36,8 +37,9 @@ pub use block::{
     BlockHash, BlockKey, LayerBlock, LayerSave, PrefetchStatus, RawBlock, SealedBlock,
 };
 use instance::GpuRegistration;
-pub use instance::{GpuContext, InstanceContext, KVCacheRegistration};
+pub use instance::{GpuContext, InstanceContext};
 pub use internode::{DEFAULT_METASERVER_QUEUE_DEPTH, MetaServerClient, MetaServerClientConfig};
+use layout::KVCacheLayout;
 pub use lease::QueryLeaseId;
 pub use pegaflow_common::NumaNode;
 use pegaflow_common::NumaTopology;
@@ -57,7 +59,7 @@ use std::{
 use log::{debug, info};
 
 use crate::backing::SSD_ALIGNMENT;
-use crate::gpu_worker::{LayerLoadData, LoadBlock, LoadCompletion, LoadTask};
+use crate::gpu_worker::{LayerTransferData, LoadCompletion, LoadTask, TransferBlock};
 use crate::lease::QueryLeaseManager;
 use crate::metrics::core_metrics;
 use crate::storage::StorageEngine;
@@ -346,7 +348,7 @@ impl PegaEngine {
 
         for i in 0..batch_size {
             let layer_name = &layer_names[i];
-            let mut registration = KVCacheRegistration::new(
+            let mut layout = KVCacheLayout::new(
                 data_ptrs[i],
                 size_bytes_list[i],
                 num_blocks_list[i],
@@ -357,22 +359,23 @@ impl PegaEngine {
             .map_err(|e| EngineError::InvalidArgument(format!("layer {layer_name}: {e}")))?;
 
             if let Some(strides) = block_stride_bytes_list {
-                registration = registration.with_block_stride(strides[i]).map_err(|e| {
+                layout = layout.with_block_stride(strides[i]).map_err(|e| {
                     EngineError::InvalidArgument(format!("layer {layer_name}: {e}"))
                 })?;
             }
 
             if ssd_enabled {
-                registration = registration.with_ssd_padding(SSD_ALIGNMENT);
-                if registration.padded_bytes_per_block != registration.bytes_per_block {
+                layout = layout.with_ssd_padding(SSD_ALIGNMENT);
+                if layout.padded_segment_bytes() != layout.segment_bytes() {
                     info!(
                         "SSD alignment padding: layer={layer_name}, bytes_per_block={} -> padded={}",
-                        registration.bytes_per_block, registration.padded_bytes_per_block
+                        layout.segment_bytes(),
+                        layout.padded_segment_bytes()
                     );
                 }
             }
 
-            if kv_caches.insert(layer_name.clone(), registration).is_some() {
+            if kv_caches.insert(layer_name.clone(), layout).is_some() {
                 return Err(EngineError::InvalidArgument(format!(
                     "duplicate layer name in registration batch: {layer_name}"
                 )));
@@ -668,7 +671,7 @@ impl PegaEngine {
                 ))
             })?;
 
-            let registration = gpu.get_registration(layer_name).ok_or_else(|| {
+            let layout = gpu.get_layout(layer_name).ok_or_else(|| {
                 EngineError::InvalidArgument(format!(
                     "layer {layer_name} not registered on device {device_id}"
                 ))
@@ -684,16 +687,16 @@ impl PegaEngine {
                 let Some(block) = block_entry.get_slot(slot_id) else {
                     continue;
                 };
-                blocks.push(LoadBlock {
+                blocks.push(TransferBlock {
                     block_idx,
                     block: Arc::clone(block),
                 });
             }
 
             if !blocks.is_empty() {
-                layers.push(LayerLoadData {
+                layers.push(LayerTransferData {
                     layer_name: (*layer_name).to_string(),
-                    registration,
+                    layout,
                     blocks,
                 });
             }

--- a/pegaflow-core/src/offload.rs
+++ b/pegaflow-core/src/offload.rs
@@ -13,14 +13,12 @@ use std::sync::Arc;
 use log::{debug, info};
 
 use crate::block::{BlockKey, LayerSave, RawBlock, Segment};
-use crate::pinned_pool::MappedPinnedPtr;
 
 /// Grouped insert entries: each hash maps to its per-slot `RawBlock`s.
 pub(crate) type InsertEntries = Vec<(BlockKey, Vec<(usize, Arc<RawBlock>)>)>;
-use crate::gpu_worker::{SaveBlock, SaveLayerData};
-use crate::instance::KVCacheRegistration;
+use crate::gpu_worker::{LayerTransferData, TransferBlock};
+use crate::layout::KVCacheLayout;
 use crate::metrics::core_metrics;
-use crate::pinned_pool::PinnedAllocation;
 use crate::{EngineError, PegaEngine};
 use pegaflow_common::NumaNode;
 
@@ -28,69 +26,18 @@ use pegaflow_common::NumaNode;
 // Types sent to the insert worker (deferred Phase 4)
 // ============================================================================
 
-/// How a layer's blocks are laid out in pinned memory after GPU copy.
+/// One layer's saved blocks, ready for cache insertion.
 ///
-/// Sizes here are *padded* (SSD-aligned). GPU copies use actual (unpadded)
-/// sizes from `KVCacheRegistration`; the padding tail is unused.
-pub(crate) enum LayerAlloc {
-    Split {
-        k_allocation: Arc<PinnedAllocation>,
-        v_allocation: Arc<PinnedAllocation>,
-        k_base: MappedPinnedPtr,
-        v_base: MappedPinnedPtr,
-        /// Per-segment stride in pinned memory (padded for SSD alignment).
-        padded_segment_size: usize,
-    },
-    Contiguous {
-        allocation: Arc<PinnedAllocation>,
-        base: MappedPinnedPtr,
-    },
-}
-
-impl LayerAlloc {
-    /// Construct a `RawBlock` for the i-th block in this allocation.
-    fn make_raw_block(&self, index: usize, block_size: usize) -> Arc<RawBlock> {
-        match self {
-            LayerAlloc::Split {
-                k_allocation,
-                v_allocation,
-                k_base,
-                v_base,
-                padded_segment_size,
-                ..
-            } => {
-                let half = block_size / 2;
-                let k_ptr = k_base.add(index * padded_segment_size).host();
-                let v_ptr = v_base.add(index * padded_segment_size).host();
-                // Safety: pointers are within pinned allocations, validated during allocation.
-                Arc::new(RawBlock::two_segments(
-                    Segment::new(k_ptr, half, Arc::clone(k_allocation)),
-                    Segment::new(v_ptr, half, Arc::clone(v_allocation)),
-                ))
-            }
-            LayerAlloc::Contiguous {
-                allocation, base, ..
-            } => {
-                let ptr = base.add(index * block_size).host();
-                // Safety: pointer is within pinned allocation, validated during allocation.
-                Arc::new(RawBlock::single_segment(Segment::new(
-                    ptr,
-                    block_size,
-                    Arc::clone(allocation),
-                )))
-            }
-        }
-    }
-}
-
-/// Per-layer data for deferred RawBlock construction.
+/// The `RawBlock`s are constructed at allocation time (Phase 2) and shared
+/// with the GPU copy task; their segments own the pinned allocations, so no
+/// separate allocation bookkeeping is needed.
 pub(crate) struct RawSaveLayer {
     pub slot_id: usize,
     /// Padded block size (SSD-aligned). Becomes `RawBlock.total_size` → `SlotMeta.total_size()`.
     pub padded_block_size: usize,
-    /// Allocations for this layer. Vec length is 1 (batch) or num_blocks (blockwise).
-    pub allocs: Vec<LayerAlloc>,
-    /// Block hashes in allocation order.
+    /// Saved blocks, parallel to `block_hashes`.
+    pub blocks: Vec<Arc<RawBlock>>,
+    /// Block hashes in save order.
     pub block_hashes: Vec<Vec<u8>>,
 }
 
@@ -102,84 +49,79 @@ pub(crate) struct RawSaveBatch {
     pub layers: Vec<RawSaveLayer>,
 }
 
+/// Unified per-layer context for the save pipeline.
+/// Combines metadata, filtered blocks, and allocation results.
+struct LayerContext {
+    layer_name: String,
+    layout: KVCacheLayout,
+    slot_id: usize,
+    /// Blocks to save: (block_idx, hash). Filtered in Phase 1.
+    blocks_to_save: Vec<(usize, Vec<u8>)>,
+    /// Host-side block images, parallel to `blocks_to_save`.
+    /// Constructed in Phase 2; shared with the GPU copy task.
+    raw_blocks: Vec<Arc<RawBlock>>,
+}
+
 /// Build insert entries from a raw batch (called by the insert worker).
 ///
 /// Returns `(entries, total_bytes, total_blocks)` where entries is grouped
 /// by hash: `Vec<(BlockKey, Vec<(slot_id, Arc<RawBlock>)>)>`.
 pub(crate) fn build_insert_entries(batch: &RawSaveBatch) -> (InsertEntries, u64, usize) {
-    use std::collections::HashMap;
-
-    if let Some(entries) = build_ordered_insert_entries(batch) {
-        return entries;
-    }
-
-    let mut hash_entries: HashMap<Vec<u8>, Vec<(usize, Arc<RawBlock>)>> = HashMap::new();
     let mut total_bytes: u64 = 0;
     let mut total_blocks: usize = 0;
-
     for layer in &batch.layers {
-        let blockwise = layer.allocs.len() > 1;
-        for (i, hash) in layer.block_hashes.iter().enumerate() {
-            let (alloc_idx, offset_in_alloc) = if blockwise {
-                (i, 0) // Each block has its own allocation
-            } else {
-                (0, i) // All blocks in one allocation
-            };
-            let block =
-                layer.allocs[alloc_idx].make_raw_block(offset_in_alloc, layer.padded_block_size);
-            hash_entries
-                .entry(hash.clone())
-                .or_default()
-                .push((layer.slot_id, block));
-        }
         let layer_blocks = layer.block_hashes.len();
         total_blocks += layer_blocks;
         total_bytes += (layer.padded_block_size as u64).saturating_mul(layer_blocks as u64);
     }
 
-    let entries: InsertEntries = hash_entries
-        .into_iter()
-        .map(|(hash, slots)| (BlockKey::new(batch.namespace.clone(), hash), slots))
-        .collect();
-
+    let entries =
+        build_ordered_insert_entries(batch).unwrap_or_else(|| build_hashed_insert_entries(batch));
     (entries, total_bytes, total_blocks)
 }
 
-fn build_ordered_insert_entries(batch: &RawSaveBatch) -> Option<(InsertEntries, u64, usize)> {
+/// Fast path: all layers share one hash order, so entries can be built
+/// block-by-block without a hash map.
+fn build_ordered_insert_entries(batch: &RawSaveBatch) -> Option<InsertEntries> {
     let first_layer = batch.layers.first()?;
-    let num_entries = first_layer.block_hashes.len();
-    if batch.layers.iter().any(|layer| {
-        layer.block_hashes.len() != num_entries || layer.block_hashes != first_layer.block_hashes
-    }) {
+    if batch
+        .layers
+        .iter()
+        .any(|layer| layer.block_hashes != first_layer.block_hashes)
+    {
         return None;
     }
 
-    let mut total_blocks = 0usize;
-    let mut total_bytes = 0u64;
-    for layer in &batch.layers {
-        total_blocks += layer.block_hashes.len();
-        total_bytes +=
-            (layer.padded_block_size as u64).saturating_mul(layer.block_hashes.len() as u64);
-    }
-
-    let mut entries = Vec::with_capacity(num_entries);
+    let mut entries = Vec::with_capacity(first_layer.block_hashes.len());
     for (block_idx, hash) in first_layer.block_hashes.iter().enumerate() {
-        let mut slots = Vec::with_capacity(batch.layers.len());
-        for layer in &batch.layers {
-            let blockwise = layer.allocs.len() > 1;
-            let (alloc_idx, offset_in_alloc) = if blockwise {
-                (block_idx, 0)
-            } else {
-                (0, block_idx)
-            };
-            let block =
-                layer.allocs[alloc_idx].make_raw_block(offset_in_alloc, layer.padded_block_size);
-            slots.push((layer.slot_id, block));
-        }
+        let slots = batch
+            .layers
+            .iter()
+            .map(|layer| (layer.slot_id, Arc::clone(&layer.blocks[block_idx])))
+            .collect();
         entries.push((BlockKey::new(batch.namespace.clone(), hash.clone()), slots));
     }
+    Some(entries)
+}
 
-    Some((entries, total_bytes, total_blocks))
+/// Fallback for heterogeneous per-layer hash sets: group via a hash map.
+fn build_hashed_insert_entries(batch: &RawSaveBatch) -> InsertEntries {
+    use std::collections::HashMap;
+
+    let mut hash_entries: HashMap<Vec<u8>, Vec<(usize, Arc<RawBlock>)>> = HashMap::new();
+    for layer in &batch.layers {
+        for (i, hash) in layer.block_hashes.iter().enumerate() {
+            hash_entries
+                .entry(hash.clone())
+                .or_default()
+                .push((layer.slot_id, Arc::clone(&layer.blocks[i])));
+        }
+    }
+
+    hash_entries
+        .into_iter()
+        .map(|(hash, slots)| (BlockKey::new(batch.namespace.clone(), hash), slots))
+        .collect()
 }
 
 // ============================================================================
@@ -231,9 +173,11 @@ impl PegaEngine {
         saves: Vec<LayerSave>,
         numa_hint: Option<NumaNode>,
     ) -> Result<(), EngineError> {
+        self.query_leases.sweep_expired();
+
         let batch_start = std::time::Instant::now();
         let total_layers = saves.len();
-        self.query_leases.sweep_expired();
+
         let instance = self.get_instance(instance_id)?;
         instance.ensure_all_slots_registered()?;
         let namespace = instance.namespace().to_string();
@@ -242,23 +186,10 @@ impl PegaEngine {
         // ── Phase 0: Resolve per-layer metadata and build valid_blocks ──
         trace_scope!("save.resolve_metadata", _s);
 
-        /// Unified per-layer context for the save pipeline.
-        /// Combines metadata, filtered blocks, and allocation results.
-        struct LayerContext {
-            layer_name: String,
-            registration: KVCacheRegistration,
-            slot_id: usize,
-            padded_block_size: usize,
-            /// Blocks to save: (block_idx, hash). Filtered in Phase 1.
-            blocks_to_save: Vec<(usize, Vec<u8>)>,
-            /// Allocation results, populated in Phase 2.
-            /// Vec to support blockwise allocation (1 element for batch, N for blockwise).
-            allocs: Vec<LayerAlloc>,
-        }
+        let gpu_context = instance.get_gpu_for_save_group(device_id, tp_rank, pp_rank)?;
 
-        let gpu = instance.get_gpu_for_save_group(device_id, tp_rank, pp_rank)?;
-
-        let mut layers: Vec<LayerContext> = Vec::with_capacity(saves.len());
+        let mut layer_contexts: Vec<LayerContext> = Vec::with_capacity(saves.len());
+        let mut hashes_to_save: HashSet<Vec<u8>> = HashSet::new();
 
         for LayerSave {
             layer_name,
@@ -266,6 +197,8 @@ impl PegaEngine {
             block_hashes,
         } in saves
         {
+            // Engine-level contract: in-process callers bypass the RPC-layer
+            // validation in service.rs, and zip below would silently truncate.
             if block_ids.len() != block_hashes.len() {
                 return Err(EngineError::InvalidArgument(format!(
                     "block_ids length {} does not match block_hashes {} for layer {}",
@@ -279,49 +212,48 @@ impl PegaEngine {
                 EngineError::InvalidArgument(format!("layer {layer_name} unknown"))
             })?;
 
-            let registration = gpu.get_registration(&layer_name).ok_or_else(|| {
+            let layout = gpu_context.get_layout(&layer_name).ok_or_else(|| {
                 EngineError::InvalidArgument(format!("layer {layer_name} not registered on device"))
             })?;
 
             let slot_id = instance.get_slot_index(layer_id, tp_rank)?;
-            if slot_id >= total_slots {
-                return Err(EngineError::InvalidArgument(format!(
-                    "slot_id {} out of range (total_slots {})",
-                    slot_id, total_slots
-                )));
-            }
+
+            let num_blocks = layout.num_blocks();
 
             let blocks_to_save: Vec<(usize, Vec<u8>)> = block_ids
                 .into_iter()
                 .zip(block_hashes)
-                .filter(|(id, _)| *id >= 0)
-                .filter_map(|(id, hash)| {
+                .map(|(id, hash)| {
                     let idx = id as usize;
-                    if idx < registration.num_blocks {
-                        Some((idx, hash))
-                    } else {
-                        None
+                    if idx >= num_blocks {
+                        return Err(EngineError::InvalidArgument(format!(
+                            "block_id {} out of range (num_blocks={}) for layer {}",
+                            id, num_blocks, layer_name
+                        )));
                     }
+                    Ok((idx, hash))
                 })
-                .collect();
+                .collect::<Result<_, _>>()?;
 
             if blocks_to_save.is_empty() {
                 continue;
             }
 
-            let padded_block_size = registration.padded_block_size_bytes;
-            layers.push(LayerContext {
+            for (_, hash) in &blocks_to_save {
+                hashes_to_save.insert(hash.clone());
+            }
+
+            layer_contexts.push(LayerContext {
                 layer_name,
-                registration,
+                layout,
                 slot_id,
-                padded_block_size,
                 blocks_to_save,
-                allocs: Vec::new(),
+                raw_blocks: Vec::new(),
             });
         }
         trace_drop!(_s);
 
-        if layers.is_empty() {
+        if layer_contexts.is_empty() {
             info!(
                 "save_batch skipped (no valid blocks): instance_id={} tp_rank={} device_id={} layers={}",
                 instance_id, tp_rank, device_id, total_layers
@@ -329,38 +261,9 @@ impl PegaEngine {
             return Ok(());
         }
 
-        // ── Phase 1: Union-filter hashes across all layers ──
-        //
-        // Layers may have different hash sets (heterogeneous). Compute the
-        // union of all hashes, filter once against the cache, then per-layer
-        // in-memory filter to determine which blocks each layer needs to save.
+        // ── Phase 1: Filter hashes against cache ──
 
         trace_scope!("save.hash_filter", _s);
-
-        let shared_hash_order = if let Some((first_layer, rest_layers)) = layers.split_first() {
-            rest_layers.iter().all(|layer| {
-                layer.blocks_to_save.len() == first_layer.blocks_to_save.len()
-                    && layer
-                        .blocks_to_save
-                        .iter()
-                        .zip(&first_layer.blocks_to_save)
-                        .all(|((_, hash), (_, first_hash))| hash == first_hash)
-            })
-        } else {
-            false
-        };
-
-        let mut hashes_to_save: HashSet<Vec<u8>> = HashSet::new();
-        let hash_source_layers = if shared_hash_order {
-            &layers[..1]
-        } else {
-            &layers[..]
-        };
-        for layer in hash_source_layers {
-            for (_, hash) in &layer.blocks_to_save {
-                hashes_to_save.insert(hash.clone());
-            }
-        }
 
         // Single in-place cache filter for all unique hashes
         self.storage
@@ -368,23 +271,18 @@ impl PegaEngine {
 
         if hashes_to_save.is_empty() {
             trace_drop!(_s);
-            debug!(
-                "save_batch skipped (all cached): instance_id={} tp_rank={} device_id={} layers={}",
-                instance_id, tp_rank, device_id, total_layers
-            );
             return Ok(());
         }
 
         // Per-layer filter: keep only blocks whose hash needs saving
         let mut total_blocks_to_save = 0usize;
-        for layer in &mut layers {
-            layer
-                .blocks_to_save
+        for ctx in &mut layer_contexts {
+            ctx.blocks_to_save
                 .retain(|(_, hash)| hashes_to_save.contains(hash.as_slice()));
-            total_blocks_to_save += layer.blocks_to_save.len();
+            total_blocks_to_save += ctx.blocks_to_save.len();
         }
         // Remove layers with no blocks to save
-        layers.retain(|layer| !layer.blocks_to_save.is_empty());
+        layer_contexts.retain(|ctx| !ctx.blocks_to_save.is_empty());
 
         trace_drop!(_s, || {
             [
@@ -393,11 +291,7 @@ impl PegaEngine {
             ]
         });
 
-        if layers.is_empty() {
-            debug!(
-                "save_batch skipped (all filtered): instance_id={} tp_rank={} device_id={} layers={}",
-                instance_id, tp_rank, device_id, total_layers
-            );
+        if layer_contexts.is_empty() {
             return Ok(());
         }
 
@@ -406,150 +300,88 @@ impl PegaEngine {
         trace_scope!("save.pinned_alloc", _s);
         let save_numa_node = match numa_hint {
             Some(hint) => instance.validate_save_numa_hint(tp_rank, pp_rank, hint)?,
-            None => gpu.preferred_numa(),
+            None => gpu_context.preferred_numa(),
         };
         let numa_node = Some(save_numa_node);
         let blockwise = self.storage.blockwise_alloc();
 
-        let mut gpu_save_layers: Vec<SaveLayerData> = Vec::with_capacity(layers.len());
+        let mut gpu_save_layers: Vec<LayerTransferData> = Vec::with_capacity(layer_contexts.len());
 
-        for layer in &mut layers {
-            let registration = &layer.registration;
-            let num_blocks = layer.blocks_to_save.len();
+        for ctx in &mut layer_contexts {
+            let layout = &ctx.layout;
+            let num_blocks = ctx.blocks_to_save.len();
 
             // Blockwise: allocate once per block; Batch: allocate once for all blocks
             let alloc_count = if blockwise { num_blocks } else { 1 };
             let blocks_per_alloc = if blockwise { 1 } else { num_blocks };
 
-            let is_split = registration.segments == 2
-                && registration.kv_stride_bytes > registration.bytes_per_block;
+            let alloc_pinned = |stride: usize, what: &str| {
+                let alloc_size = (stride as u64)
+                    .checked_mul(blocks_per_alloc as u64)
+                    .and_then(NonZeroU64::new)
+                    .ok_or_else(|| {
+                        EngineError::Storage(format!("allocation size overflow for {what}"))
+                    })?;
+                self.storage.allocate(alloc_size, numa_node).ok_or_else(|| {
+                    EngineError::Storage(format!("pinned pool exhausted while allocating {what}"))
+                })
+            };
 
-            if is_split {
-                let padded_segment_size = registration.padded_bytes_per_block;
-
-                for _ in 0..alloc_count {
-                    let alloc_size = (padded_segment_size as u64)
-                        .checked_mul(blocks_per_alloc as u64)
-                        .and_then(NonZeroU64::new)
-                        .ok_or_else(|| {
-                            EngineError::Storage(
-                                "allocation size overflow for K segments".to_string(),
-                            )
-                        })?;
-
-                    let k_allocation =
-                        self.storage
-                            .allocate(alloc_size, numa_node)
-                            .ok_or_else(|| {
-                                EngineError::Storage(
-                                    "pinned pool exhausted while allocating K segment buffer"
-                                        .to_string(),
-                                )
-                            })?;
-                    let v_allocation =
-                        self.storage
-                            .allocate(alloc_size, numa_node)
-                            .ok_or_else(|| {
-                                EngineError::Storage(
-                                    "pinned pool exhausted while allocating V segment buffer"
-                                        .to_string(),
-                                )
-                            })?;
-
-                    let k_base = k_allocation.mapped_ptr();
-                    let v_base = v_allocation.mapped_ptr();
-
-                    layer.allocs.push(LayerAlloc::Split {
-                        k_allocation,
-                        v_allocation,
-                        k_base,
-                        v_base,
-                        padded_segment_size,
-                    });
+            // Allocate pinned memory and construct the host-side RawBlocks in
+            // save order. Strides are padded (SSD-aligned); GPU copies later
+            // use actual (unpadded) sizes, leaving the padding tail unused.
+            let mut raw_blocks: Vec<Arc<RawBlock>> = Vec::with_capacity(num_blocks);
+            for _ in 0..alloc_count {
+                if layout.is_split() {
+                    let stride = layout.padded_segment_bytes();
+                    let k_alloc = alloc_pinned(stride, "K segment buffer")?;
+                    let v_alloc = alloc_pinned(stride, "V segment buffer")?;
+                    for i in 0..blocks_per_alloc {
+                        let offset = i * stride;
+                        // Safety: offsets are within the just-made allocations.
+                        raw_blocks.push(Arc::new(RawBlock::two_segments(
+                            Segment::new(
+                                k_alloc.mapped_ptr().add(offset).host(),
+                                stride,
+                                Arc::clone(&k_alloc),
+                            ),
+                            Segment::new(
+                                v_alloc.mapped_ptr().add(offset).host(),
+                                stride,
+                                Arc::clone(&v_alloc),
+                            ),
+                        )));
+                    }
+                } else {
+                    let stride = layout.padded_block_bytes();
+                    let alloc = alloc_pinned(stride, "block buffer")?;
+                    for i in 0..blocks_per_alloc {
+                        // Safety: offset is within the just-made allocation.
+                        raw_blocks.push(Arc::new(RawBlock::single_segment(Segment::new(
+                            alloc.mapped_ptr().add(i * stride).host(),
+                            stride,
+                            Arc::clone(&alloc),
+                        ))));
+                    }
                 }
-
-                // Build SaveBlocks from layer.allocs
-                let save_blocks: Vec<SaveBlock> = layer
-                    .blocks_to_save
-                    .iter()
-                    .enumerate()
-                    .map(|(i, (block_idx, _))| {
-                        let (alloc_idx, offset_in_alloc) = if blockwise { (i, 0) } else { (0, i) };
-                        let (k_base, v_base) = match &layer.allocs[alloc_idx] {
-                            LayerAlloc::Split { k_base, v_base, .. } => (*k_base, *v_base),
-                            _ => unreachable!(),
-                        };
-                        let offset = offset_in_alloc * padded_segment_size;
-                        let k_dst = k_base.add(offset);
-                        let v_dst = v_base.add(offset);
-                        SaveBlock {
-                            block_idx: *block_idx,
-                            k_dst,
-                            v_dst: Some(v_dst),
-                        }
-                    })
-                    .collect();
-
-                gpu_save_layers.push(SaveLayerData {
-                    layer_name: layer.layer_name.clone(),
-                    registration: registration.clone(),
-                    blocks: save_blocks,
-                });
-            } else {
-                let padded_block_size = layer.padded_block_size;
-
-                for _ in 0..alloc_count {
-                    let alloc_size = (padded_block_size as u64)
-                        .checked_mul(blocks_per_alloc as u64)
-                        .and_then(NonZeroU64::new)
-                        .ok_or_else(|| {
-                            EngineError::Storage("allocation size overflow".to_string())
-                        })?;
-
-                    let allocation =
-                        self.storage
-                            .allocate(alloc_size, numa_node)
-                            .ok_or_else(|| {
-                                EngineError::Storage(
-                                    "pinned pool exhausted while allocating contiguous block buffer"
-                                        .to_string(),
-                                )
-                            })?;
-
-                    let base = allocation.mapped_ptr();
-
-                    layer
-                        .allocs
-                        .push(LayerAlloc::Contiguous { allocation, base });
-                }
-
-                // Build SaveBlocks from layer.allocs
-                let save_blocks: Vec<SaveBlock> = layer
-                    .blocks_to_save
-                    .iter()
-                    .enumerate()
-                    .map(|(i, (block_idx, _))| {
-                        let (alloc_idx, offset_in_alloc) = if blockwise { (i, 0) } else { (0, i) };
-                        let base = match &layer.allocs[alloc_idx] {
-                            LayerAlloc::Contiguous { base, .. } => *base,
-                            _ => unreachable!(),
-                        };
-                        let offset = offset_in_alloc * padded_block_size;
-                        let dst = base.add(offset);
-                        SaveBlock {
-                            block_idx: *block_idx,
-                            k_dst: dst,
-                            v_dst: None,
-                        }
-                    })
-                    .collect();
-
-                gpu_save_layers.push(SaveLayerData {
-                    layer_name: layer.layer_name.clone(),
-                    registration: registration.clone(),
-                    blocks: save_blocks,
-                });
             }
+
+            let save_blocks: Vec<TransferBlock> = ctx
+                .blocks_to_save
+                .iter()
+                .zip(&raw_blocks)
+                .map(|((block_idx, _), block)| TransferBlock {
+                    block_idx: *block_idx,
+                    block: Arc::clone(block),
+                })
+                .collect();
+
+            gpu_save_layers.push(LayerTransferData {
+                layer_name: ctx.layer_name.clone(),
+                layout: layout.clone(),
+                blocks: save_blocks,
+            });
+            ctx.raw_blocks = raw_blocks;
         }
         trace_drop!(_s);
 
@@ -557,7 +389,7 @@ impl PegaEngine {
 
         trace_future!(
             "save.gpu_copy",
-            gpu.worker_pool().batch_save(gpu_save_layers)
+            gpu_context.worker_pool().batch_save(gpu_save_layers)
         )
         .await?;
 
@@ -566,9 +398,9 @@ impl PegaEngine {
         // Record metrics on the RPC path (cheap, measures RPC-visible latency)
         let metrics = core_metrics();
         let mut total_bytes = 0u64;
-        for layer in &layers {
-            let num_blocks = layer.blocks_to_save.len();
-            let bytes = (layer.padded_block_size as u64)
+        for ctx in &layer_contexts {
+            let num_blocks = ctx.blocks_to_save.len();
+            let bytes = (ctx.layout.padded_block_bytes() as u64)
                 .checked_mul(num_blocks as u64)
                 .unwrap_or(0);
             total_bytes += bytes;
@@ -587,7 +419,7 @@ impl PegaEngine {
             pp_rank,
             device_id,
             total_layers,
-            layers.len(),
+            layer_contexts.len(),
             total_blocks_to_save,
             total_bytes,
             save_numa_node,
@@ -595,18 +427,18 @@ impl PegaEngine {
         );
 
         // Build RawSaveBatch and send to insert worker (fire-and-forget)
-        let raw_layers: Vec<RawSaveLayer> = layers
+        let raw_layers: Vec<RawSaveLayer> = layer_contexts
             .into_iter()
-            .map(|layer| {
-                let block_hashes: Vec<Vec<u8>> = layer
+            .map(|ctx| {
+                let block_hashes: Vec<Vec<u8>> = ctx
                     .blocks_to_save
                     .into_iter()
                     .map(|(_, hash)| hash)
                     .collect();
                 RawSaveLayer {
-                    slot_id: layer.slot_id,
-                    padded_block_size: layer.padded_block_size,
-                    allocs: layer.allocs,
+                    slot_id: ctx.slot_id,
+                    padded_block_size: ctx.layout.padded_block_bytes(),
+                    blocks: ctx.raw_blocks,
                     block_hashes,
                 }
             })

--- a/pegaflow-core/src/transfer/mod.rs
+++ b/pegaflow-core/src/transfer/mod.rs
@@ -25,8 +25,6 @@ use std::sync::Arc;
 
 use cudarc::driver::CudaStream;
 
-use crate::KVCacheRegistration;
-
 /// One contiguous copy between device memory and mapped, pinned host memory.
 ///
 /// `device` is an absolute device virtual address. `host` is the host virtual
@@ -84,37 +82,4 @@ impl std::str::FromStr for TransferMode {
             )),
         }
     }
-}
-
-/// Calculate the byte offset for a given block/segment combination, relative to
-/// the layer's `data_ptr`.
-pub(crate) fn segment_offset(
-    registration: &KVCacheRegistration,
-    block_idx: usize,
-    segment_idx: usize,
-) -> Result<usize, String> {
-    if segment_idx >= registration.segments {
-        return Err("Segment index out of range".to_string());
-    }
-
-    let base = block_idx
-        .checked_mul(registration.block_stride_bytes)
-        .ok_or_else(|| "Block offset overflow".to_string())?;
-
-    let segment_offset = segment_idx
-        .checked_mul(registration.kv_stride_bytes)
-        .ok_or_else(|| "Segment offset overflow".to_string())?;
-
-    let offset = base
-        .checked_add(segment_offset)
-        .ok_or_else(|| "Combined offset overflow".to_string())?;
-
-    if offset + registration.bytes_per_block > registration.size_bytes {
-        return Err(format!(
-            "Block {} segment {} exceeds registered memory (offset {}, size {}, limit {})",
-            block_idx, segment_idx, offset, registration.bytes_per_block, registration.size_bytes
-        ));
-    }
-
-    Ok(offset)
 }

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -158,6 +158,12 @@ impl GrpcEngineService {
                     layer.layer_name
                 )));
             }
+            if let Some(id) = layer.block_ids.iter().find(|id| **id < 0) {
+                return Err(Status::invalid_argument(format!(
+                    "negative block_id {} in layer {}",
+                    id, layer.layer_name
+                )));
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Why

`KVCacheRegistration` was an 11-public-field bag whose layout semantics were re-derived at every consumer:

- The `segments == 2 && kv_stride > bytes_per_block` is_split predicate was hand-copied in **three places** (load path, save path, pinned allocator).
- Host-side block pointers were computed **twice** with two hand-written copies of the same offset formula: once for GPU copy destinations (Phase 2), once for deferred `RawBlock` construction in the insert worker (Phase 4) — these must agree for correctness, and nothing enforced that.
- Validation was spread across runtime checked-math on the hot path instead of happening once at registration.

## What

**New `layout` module** — `KVCacheLayout` with private fields:
- All validation at construction; split-vs-contiguous is normalized into a `SegmentLayout` enum (invariant in the type, not in runtime re-checks).
- `block_copies(block_idx)` is the single GPU-addressing question the copy paths may ask. `transfer::segment_offset` and `gpu_worker::device_addr` are absorbed; the hot path is plain arithmetic, no checked ops.
- Constructor takes `segment_bytes` (not the misleading `bytes_per_block`) — for K/V split layouts the RPC field `bytes_per_block` is actually one segment, and passing a whole block would mostly pass validation with every address wrong.
- Previously-silent broken configs are now rejected at registration: overlapping `kv_stride < segment_bytes`, split with >2 segments, contiguous multi-segment with overlapping block stride.

**`RawBlock` constructed once, at allocation time** — the save path builds `Arc<RawBlock>` in Phase 2 and shares it with the GPU copy task:
- `LayerAlloc`, its `block_dst`/`make_raw_block` pair, and the blockwise-vs-batch `(alloc_idx, offset_in_alloc)` index dance are deleted — host pointers are computed exactly once.
- The insert worker is now a pure group-by-hash over prebuilt blocks.
- Load and save share one data shape (`TransferBlock` / `LayerTransferData`) and one `build_copy_descs`; `SaveBlock`'s two `unsafe impl Send` are gone (`RawBlock` is already `Send + Sync`).

**Crash early over silent degradation**:
- `service.rs` rejects negative `block_ids` at the RPC boundary; the engine rejects out-of-range block ids instead of silently skipping them; the engine-level length-mismatch check stays (in-process callers bypass RPC validation).
- Redundant downstream invariant re-checks removed (slot range checks in `ensure_all_slots_registered` and the save path, `unreachable!()` re-matches).

Net: **-200 lines**, `instance.rs` down to topology-only concerns, one source of truth each for GPU-side and host-side addressing.

## Verification

- `cargo test --release --no-default-features --features cuda-13,rdma` — full workspace green except `http_cleanup_hang_repro`, which aborts identically on master (pre-existing, tracked in #339).
- `cargo clippy --workspace --all-targets` with `-D warnings` — clean.
- vLLM E2E correctness gate: `pytest -m e2e tests/test_vllm_e2e_correctness.py --model Qwen3-4B --max-model-len 4096` — **4/4 passed** (baseline match, cache metrics, no data-path RPC failures, no KV load failures).

Reviewer note per repo convention: please rerun the E2E gate on the GPU machine. Related tooling friction filed as #338 (E2E version-mismatch preflight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)