### PR TITLE
feat(connector): register layer-split KV caches from cache config

### DIFF
--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -136,7 +136,11 @@ class PegaKVConnector(KVConnectorBase_V1):
             # server-side cleanup of the instance's CUDA IPC mappings.
             engine_client.start_session_watcher(instance_id, namespace, tp_size, world_size)
         else:
-            self._worker = WorkerConnector(self._ctx)
+            self._worker = WorkerConnector(
+                self._ctx,
+                vllm_config=vllm_config,
+                kv_cache_config=kv_cache_config,
+            )
 
         logger.debug(
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -158,8 +158,18 @@ class WorkerConnector:
     # to prevent production misconfiguration from dropping every in-flight load.
     LOAD_TIMEOUT_SECONDS: int = _LOAD_TIMEOUT_RAW
 
-    def __init__(self, context: ConnectorContext):
+    def __init__(
+        self,
+        context: ConnectorContext,
+        vllm_config=None,
+        kv_cache_config=None,
+    ):
         self._ctx = context
+        self._kv_cache_config = kv_cache_config
+        additional_config = getattr(vllm_config, "additional_config", {}) or {}
+        self._use_mla_layer_split_registration = context.is_mla and bool(
+            additional_config.get("mla_layer_split_kv_cache", False)
+        )
 
         self._save_queue = queue.Queue()
         self._save_thread = threading.Thread(
@@ -225,6 +235,35 @@ class WorkerConnector:
         assert self._ctx.device_id is not None, (
             "CUDA device id is unknown; cannot register KV caches"
         )
+
+        if self._use_mla_layer_split_registration:
+            kv_cache_tensors = getattr(self._kv_cache_config, "kv_cache_tensors", None)
+            if not kv_cache_tensors:
+                raise RuntimeError(
+                    "Layer-split KV cache registration requires "
+                    "kv_cache_config.kv_cache_tensors"
+                )
+
+            layer_names = [
+                layer_name
+                for kv_cache_tensor in kv_cache_tensors
+                for layer_name in (getattr(kv_cache_tensor, "shared_by", None) or ())
+            ]
+            if not layer_names:
+                raise RuntimeError("Layer-split KV cache registration selected no layers")
+
+            missing_layer_names = [
+                layer_name for layer_name in layer_names if layer_name not in kv_caches
+            ]
+            if missing_layer_names:
+                raise RuntimeError(
+                    "Layer-split KV cache registration is missing layers: "
+                    f"{missing_layer_names[:8]}"
+                )
+
+            kv_caches = {layer_name: kv_caches[layer_name] for layer_name in layer_names}
+        if not kv_caches:
+            raise RuntimeError("No KV cache layers were selected for registration")
 
         self._registered_layers = list(kv_caches.keys())
         self._torch_device = next(iter(kv_caches.values())).device
@@ -760,7 +799,12 @@ class WorkerConnector:
             )
 
     def _should_skip_save_submission(self) -> bool:
-        return self._ctx.is_mla and self._ctx.dcp_world_size == 1 and (self._ctx.tp_rank or 0) != 0
+        return (
+            self._ctx.is_mla
+            and not self._use_mla_layer_split_registration
+            and self._ctx.dcp_world_size == 1
+            and (self._ctx.tp_rank or 0) != 0
+        )
 
     def handle_preemptions(self, preempted_req_ids: set[str] | None) -> None:
         """Wait for preempted requests' saves to complete before blocks are reused.

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -113,6 +113,62 @@ def test_effective_tp_cases(case: str, kwargs: dict, expected_rank: int, expecte
     assert ctx.effective_tp_size == expected_size, case
 
 
+@pytest.mark.parametrize(
+    ("case", "kwargs", "additional_config", "expected"),
+    [
+        pytest.param(
+            "ordinary_mla_replica_skips_nonzero_tp_save",
+            {
+                "is_mla": True,
+                "tp_rank": 1,
+                "tp_size": 2,
+            },
+            {},
+            True,
+            id="ordinary_mla_replica",
+        ),
+        pytest.param(
+            "mla_layer_split_registration_does_not_skip_nonzero_tp_save",
+            {
+                "is_mla": True,
+                "tp_rank": 1,
+                "tp_size": 2,
+            },
+            {"mla_layer_split_kv_cache": True},
+            False,
+            id="mla_layer_split_registration",
+        ),
+        pytest.param(
+            "dcp_mla_does_not_skip_save",
+            {
+                "is_mla": True,
+                "tp_rank": 1,
+                "tp_size": 2,
+                "dcp_world_size": 2,
+                "dcp_rank": 1,
+            },
+            {},
+            False,
+            id="dcp_mla",
+        ),
+    ],
+)
+def test_save_skip_keeps_ordinary_mla_optimization(
+    case: str, kwargs: dict, additional_config: dict, expected: bool
+):
+    from pegaflow.connector.worker import WorkerConnector
+
+    ctx = _make_ctx(**kwargs)
+    worker = WorkerConnector(
+        ctx,
+        vllm_config=SimpleNamespace(additional_config=additional_config),
+    )
+    try:
+        assert worker._should_skip_save_submission() is expected, case
+    finally:
+        worker.shutdown()
+
+
 # ---------------------------------------------------------------------------
 # Tests — SchedulerConnector decode hash refresh
 #

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -92,24 +92,33 @@ class FakeEngineClient:
 def _make_worker(
     pp_rank: int = 0,
     pp_size: int = 1,
+    kv_cache_config=None,
+    vllm_config=None,
+    **ctx_kwargs,
 ) -> tuple[WorkerConnector, FakeEngineClient, MagicMock]:
     client = FakeEngineClient()
     state_manager = MagicMock()
     state_manager.is_available.return_value = True
-    ctx = ConnectorContext(
-        instance_id="test_instance",
-        namespace="ns",
-        block_size=16,
-        tp_size=1,
-        world_size=1,
-        tp_rank=0,
-        device_id=0,
-        engine_client=client,
-        state_manager=state_manager,
-        pp_rank=pp_rank,
-        pp_size=pp_size,
+    defaults = {
+        "instance_id": "test_instance",
+        "namespace": "ns",
+        "block_size": 16,
+        "tp_size": 1,
+        "world_size": 1,
+        "tp_rank": 0,
+        "device_id": 0,
+        "engine_client": client,
+        "state_manager": state_manager,
+        "pp_rank": pp_rank,
+        "pp_size": pp_size,
+    }
+    defaults.update(ctx_kwargs)
+    ctx = ConnectorContext(**defaults)
+    worker = WorkerConnector(
+        ctx,
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
     )
-    worker = WorkerConnector(ctx)
     # cross-layer mode skips forward_context layer enumeration so we can drive
     # start_load_kv with a stub forward_context.
     worker._cross_layer_mode = True
@@ -316,6 +325,86 @@ def test_register_non_version_failure_reports_batch_layers(monkeypatch):
     assert "for layer.1" not in message
     assert len(client.register_calls) == 1
     assert client.register_calls[0][7] == ["layer.0", "layer.1"]
+
+    worker.shutdown()
+
+
+def test_register_kv_caches_ignores_shared_by_without_layer_split_opt_in(monkeypatch):
+    kv_cache_config = MagicMock()
+    kv_cache_config.kv_cache_groups = [
+        MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))
+    ]
+    kv_cache_config.kv_cache_tensors = [
+        MagicMock(shared_by=("layer.1",)),
+    ]
+    worker, client, _ = _make_worker(
+        kv_cache_config=kv_cache_config,
+    )
+
+    monkeypatch.setattr("pegaflow.connector.worker.CudaIPCWrapper", FakeCudaIPCWrapper)
+
+    worker.register_kv_caches(
+        {
+            "layer.0": FakeTensor(),
+            "layer.1": FakeTensor(),
+            "layer.2": FakeTensor(),
+        }
+    )
+
+    assert worker._registered_layers == ["layer.0", "layer.1", "layer.2"]
+    assert len(client.register_calls) == 1
+    assert client.register_calls[0][7] == ["layer.0", "layer.1", "layer.2"]
+
+    worker.shutdown()
+
+
+def test_register_kv_caches_uses_layer_split_shared_by_plan(monkeypatch):
+    kv_cache_config = MagicMock()
+    kv_cache_config.kv_cache_groups = [
+        MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))
+    ]
+    kv_cache_config.kv_cache_tensors = [
+        MagicMock(shared_by=("layer.1",)),
+        MagicMock(shared_by=()),
+        MagicMock(shared_by=("layer.0",)),
+    ]
+    worker, client, _ = _make_worker(
+        kv_cache_config=kv_cache_config,
+        vllm_config=MagicMock(additional_config={"mla_layer_split_kv_cache": True}),
+        is_mla=True,
+    )
+
+    monkeypatch.setattr("pegaflow.connector.worker.CudaIPCWrapper", FakeCudaIPCWrapper)
+
+    worker.register_kv_caches(
+        {
+            "layer.0": FakeTensor(),
+            "layer.1": FakeTensor(),
+            "layer.2": FakeTensor(),
+        }
+    )
+
+    assert worker._registered_layers == ["layer.1", "layer.0"]
+    assert len(client.register_calls) == 1
+    assert client.register_calls[0][7] == ["layer.1", "layer.0"]
+
+    worker.shutdown()
+
+
+def test_register_kv_caches_requires_shared_by_layers(monkeypatch):
+    kv_cache_config = MagicMock()
+    kv_cache_config.kv_cache_groups = [MagicMock(layer_names=("layer.0", "layer.1"))]
+    kv_cache_config.kv_cache_tensors = [MagicMock(shared_by=("layer.1",))]
+    worker, _, _ = _make_worker(
+        kv_cache_config=kv_cache_config,
+        vllm_config=MagicMock(additional_config={"mla_layer_split_kv_cache": True}),
+        is_mla=True,
+    )
+
+    monkeypatch.setattr("pegaflow.connector.worker.CudaIPCWrapper", FakeCudaIPCWrapper)
+
+    with pytest.raises(RuntimeError, match="missing layers"):
+        worker.register_kv_caches({"layer.0": FakeTensor()})
 
     worker.shutdown()
 


### PR DESCRIPTION
## Summary
- Pass vLLM and KV cache config into the Pega worker connector.
- When MLA layer-split KV cache is enabled, register only the KV cache layers listed by kv_cache_tensors.shared_by.
- Keep the existing ordinary MLA nonzero-TP save skip optimization outside layer-split registration.

## Validation
- python -m py_compile python/pegaflow/connector/__init__.py python/pegaflow/connector/worker.py python/tests/test_connector_fault_tolerance.py python/tests/test_combine_hashes.py
- python -m pytest python/tests/test_connector_fault_tolerance.py python/tests/test_combine_hashes.py -q
- git diff --check -- python/pegaflow/connector/__init__.py python/pegaflow/connector/worker.py python/tests/test_combine_hashes.py python/tests/test_connector_fault_tolerance.py
- Manual GLM-5.1 MTP + PegaFlow run on k8s: 8 register_context_batch RPCs completed ok; repeated 4k-token prefix hit produced hit_blocks=16, cached_tokens=4096, load RPCs ok.