### PR TITLE
fix: split namespace on KV layout factors, bound GPU copies to stored segments

### DIFF
--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -314,15 +314,42 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
                 .block_copies(block.block_idx)
                 .map_err(|e| EngineError::Storage(format!("layer {layer_name}: {e}")))?;
 
+            // The host block may come from a foreign source (shared
+            // namespace, SSD, remote node) whose geometry differs from this
+            // instance's layout. Copy sizes come from the layout, so verify
+            // each host segment is large enough before handing the ranges to
+            // CUDA — an undersized segment would be an out-of-bounds read or
+            // write on the pinned pool.
+            let check_segment = |seg_idx: usize, need: usize| -> Result<(), EngineError> {
+                let have = block
+                    .block
+                    .segment_size(seg_idx)
+                    .expect("caller checked segment presence");
+                if have < need {
+                    return Err(EngineError::Storage(format!(
+                        "layer {layer_name}: stored block segment {seg_idx} has {have} bytes \
+                         but layout needs {need}: namespace is shared by incompatible KV layouts"
+                    )));
+                }
+                Ok(())
+            };
+
             match block_copies {
                 BlockCopies::Split { k, v } => {
                     let k_ptr = block.block.segment_mapped_ptr(0).unwrap();
-                    // SAFETY: For a contiguous host block (segment 1 absent), the
-                    // allocation is 2 * segment size, so k + k.bytes is in bounds.
-                    let v_ptr = block
-                        .block
-                        .segment_mapped_ptr(1)
-                        .unwrap_or_else(|| k_ptr.add(k.bytes));
+                    let v_ptr = match block.block.segment_mapped_ptr(1) {
+                        Some(ptr) => {
+                            check_segment(0, k.bytes)?;
+                            check_segment(1, v.bytes)?;
+                            ptr
+                        }
+                        None => {
+                            // Contiguous host block holding both segments:
+                            // K and V are adjacent in one allocation.
+                            check_segment(0, k.bytes + v.bytes)?;
+                            k_ptr.add(k.bytes)
+                        }
+                    };
 
                     copies.push(CopyDesc {
                         device: k.addr,
@@ -339,6 +366,19 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
                     total_bytes += k.bytes + v.bytes;
                 }
                 BlockCopies::Contiguous(c) => {
+                    // A multi-segment host block stores V in segment 1, not
+                    // at a byte offset inside segment 0 — one contiguous copy
+                    // cannot serve it even when segment 0's padding is large
+                    // enough to pass the size check.
+                    let num_segments = block.block.num_segments();
+                    if num_segments != 1 {
+                        return Err(EngineError::Storage(format!(
+                            "layer {layer_name}: stored block has {num_segments} segments \
+                             but layout expects one contiguous block: \
+                             namespace is shared by incompatible KV layouts"
+                        )));
+                    }
+                    check_segment(0, c.bytes)?;
                     let ptr = block.block.segment_mapped_ptr(0).unwrap();
                     copies.push(CopyDesc {
                         device: c.addr,

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -193,6 +193,28 @@ def resolve_instance_id(vllm_config, dp_rank_suffix: bool = True) -> str:
     return instance_id
 
 
+# Speculative methods whose drafter has no KV cache of its own: the registered
+# KV layer set is identical with or without them, so they share the namespace.
+_SPECULATIVE_METHODS_WITHOUT_KV = frozenset({"ngram", "ngram_gpu", "suffix"})
+
+
+def _speculative_factor(speculative_config) -> str | None:
+    """Namespace factor for the drafter's KV layers.
+
+    MTP/EAGLE-style drafters register extra KV cache layers, changing the
+    block slot layout — blocks saved with the drafter loaded are incompatible
+    with blocks saved without it. Unknown methods are conservatively assumed
+    to carry KV (a needless split is a cold cache; a missed split is
+    cross-contamination).
+    """
+    if speculative_config is None:
+        return None
+    method = speculative_config.method
+    if method in _SPECULATIVE_METHODS_WITHOUT_KV:
+        return None
+    return f"{method}:{speculative_config.model}"
+
+
 def derive_namespace(
     vllm_config,
     tp_size: int,
@@ -203,9 +225,10 @@ def derive_namespace(
     """
     Derive namespace for storage isolation.
 
-    Different DCP/PCP configurations or cross-layer vs per-layer layouts
-    produce incompatible KV data, so all are included as factors to prevent
-    cross-contamination.
+    The namespace must split whenever two deployments would produce
+    incompatible stored blocks: different block geometry (block_size, heads,
+    dtype), different parallelism (TP/DCP/PCP), or a different registered KV
+    layer set (speculative drafters with their own KV cache, e.g. MTP/EAGLE).
     """
     model_config = vllm_config.model_config
     cache_config = vllm_config.cache_config
@@ -218,6 +241,8 @@ def derive_namespace(
         "head_size": model_config.get_head_size(),
         "num_hidden_layers": model_config.get_total_num_hidden_layers(),
         "cache_dtype": str(cache_config.cache_dtype),
+        "block_size": cache_config.block_size,
+        "speculative": _speculative_factor(vllm_config.speculative_config),
         "dcp_world_size": dcp_world_size,
         "pcp_world_size": pcp_world_size,
         "cross_layer_blocks": cross_layer_blocks,

--- a/python/tests/test_namespace.py
+++ b/python/tests/test_namespace.py
@@ -1,0 +1,76 @@
+"""derive_namespace contract: split whenever stored blocks would be incompatible.
+
+Two deployments sharing a namespace must produce byte-compatible blocks.
+The dangerous direction is a missed split: same namespace, different block
+geometry or registered KV layer set (e.g. MTP drafter on vs off) leads to
+phantom hits or cross-contaminated loads.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from pegaflow.connector.common import derive_namespace  # noqa: E402
+
+
+def _vllm_config(block_size: int = 16, speculative_config=None):
+    model_config = SimpleNamespace(
+        model="Qwen3-4B",
+        dtype="bfloat16",
+        get_total_num_kv_heads=lambda: 8,
+        get_head_size=lambda: 128,
+        get_total_num_hidden_layers=lambda: 36,
+    )
+    cache_config = SimpleNamespace(cache_dtype="auto", block_size=block_size)
+    return SimpleNamespace(
+        model_config=model_config,
+        cache_config=cache_config,
+        speculative_config=speculative_config,
+    )
+
+
+def _spec(method: str, model: str | None = None):
+    return SimpleNamespace(method=method, model=model)
+
+
+@pytest.mark.parametrize(
+    ("other", "expect_same"),
+    [
+        # vLLM normalizes all MTP variants ("deepseek_mtp", ...) to "mtp"
+        # before the connector sees them.
+        pytest.param(_vllm_config(speculative_config=_spec("mtp")), False, id="mtp-splits"),
+        pytest.param(
+            _vllm_config(speculative_config=_spec("eagle", "drafter-path")),
+            False,
+            id="eagle-splits",
+        ),
+        pytest.param(
+            _vllm_config(speculative_config=_spec("future_method")),
+            False,
+            id="unknown-method-splits",
+        ),
+        pytest.param(_vllm_config(speculative_config=_spec("ngram")), True, id="ngram-shares"),
+        pytest.param(_vllm_config(block_size=32), False, id="block-size-splits"),
+        pytest.param(_vllm_config(), True, id="identical-shares"),
+    ],
+)
+def test_namespace_splits_on_kv_layout_factors(other, expect_same):
+    base = derive_namespace(_vllm_config(), tp_size=1)
+    derived = derive_namespace(other, tp_size=1)
+    assert (derived == base) is expect_same
+
+
+def test_namespace_golden_value():
+    """The namespace is a cross-process persistent key (read cache, SSD index,
+    metaserver). Any change to the factor set or its serialization invalidates
+    every warm cache in a cluster on upgrade — this pin makes that an explicit
+    decision instead of a refactoring side effect. If you changed the factors
+    on purpose, update the value and say so in the PR.
+    """
+    assert derive_namespace(_vllm_config(), tp_size=1) == "d84eb2db"


### PR DESCRIPTION
## Context

Follow-up to the discussion in #344. Two of the three holes identified there are closed here; the engine-side seal-time fingerprint remains open for discussion in the issue.

## Changes

### 1. `derive_namespace`: cover `block_size` and KV-bearing speculative drafters

The namespace hash missed two factors that change stored-block compatibility:

- **`block_size`** — deployments differing only in tokens-per-block derived the same namespace. In practice vLLM's block-hash grouping kept them from ever matching, but that is protection by accident, not by construction.
- **Speculative drafters with their own KV cache** (MTP, EAGLE, draft model) — the drafter adds registered KV layers, changing the block slot layout. MTP-on and MTP-off deployments of the same model shared a namespace: the warm side keeps reporting hits the other side can never serve (loud load failures since #346, perpetual recompute + error spam).

N-gram-style methods (`ngram`, `ngram_gpu`, `suffix`) have no drafter KV and keep sharing the namespace. Unknown methods conservatively split — a needless split is a cold cache, a missed split is cross-contamination.

**Upgrade note:** all existing namespaces change. This is a one-time cold cache: the SSD index is in-memory, metaserver entries expire via TTL, resident blocks age out through LRU. A golden-value test now pins the hash so future factor changes are explicit decisions instead of refactoring side effects.

### 2. `build_copy_descs`: validate stored block segments before CUDA copy

Copy sizes come from the instance's GPU layout, but the host block may come from a foreign source (shared namespace, SSD, RDMA remote) with different geometry. Previously there was zero size validation — an undersized stored segment meant an out-of-bounds read/write on the pinned pool, silent because the pool mapping is large.

Now every segment is checked against the bytes the layout will copy, and a contiguous-layout copy requires a single-segment host block (a multi-segment block stores V in segment 1, which one contiguous copy cannot serve even when segment 0's padding passes the size check). Legitimate save-path blocks always pass: host segments are allocated at `padded_segment_bytes >= layout segment bytes`.

## Testing

- `cd python && uv run --extra test pytest` — 174 passed (new `test_namespace.py` covers MTP/EAGLE/unknown split, ngram share, block_size split, golden pin)
- Source-only gate (`uv run --isolated --no-project --with pytest --with numpy --with 'requests>=2.26.0' pytest`) — 174 passed
- `cargo test -p pegaflow-core --no-default-features --features cuda-13` — all green
- clippy/fmt clean (pre-existing warnings unchanged)

Refs #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)