### PR TITLE
refactor(core): use usize for block_ids, validate at RPC boundary

### DIFF
--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -42,7 +42,7 @@ struct BenchFixture {
     _ctx: Arc<CudaContext>,
     _gpu: GpuBuffer,
     num_blocks: usize,
-    block_ids: Vec<i32>,
+    block_ids: Vec<usize>,
 }
 
 impl BenchFixture {
@@ -87,7 +87,7 @@ impl BenchFixture {
             .iter()
             .copied()
             .max()
-            .map(|id| usize::try_from(id).expect("block id must be non-negative") + 1)
+            .map(|id| id + 1)
             .unwrap_or(num_blocks);
         Self::with_config(
             registered_blocks,
@@ -107,7 +107,7 @@ impl BenchFixture {
         registered_blocks: usize,
         bytes_per_block: usize,
         config: StorageConfig,
-        block_ids: Vec<i32>,
+        block_ids: Vec<usize>,
     ) -> Self {
         let ctx = CudaContext::new(DEVICE_ID as usize).expect("CUDA context");
         ctx.bind_to_thread().expect("bind CUDA context");
@@ -244,12 +244,10 @@ impl TransferFragmentLayout {
         }
     }
 
-    fn block_ids(self, num_blocks: usize) -> Vec<i32> {
+    fn block_ids(self, num_blocks: usize) -> Vec<usize> {
         match self {
             Self::Contiguous => block_ids(num_blocks),
-            Self::StridedDevice => (0..num_blocks)
-                .map(|idx| i32::try_from(idx * 2).expect("block index exceeds i32"))
-                .collect(),
+            Self::StridedDevice => (0..num_blocks).map(|idx| idx * 2).collect(),
         }
     }
 }
@@ -713,10 +711,8 @@ fn load_benchmarks(c: &mut Criterion) {
     group.finish();
 }
 
-fn block_ids(num_blocks: usize) -> Vec<i32> {
-    (0..num_blocks)
-        .map(|idx| i32::try_from(idx).expect("block index exceeds i32"))
-        .collect()
+fn block_ids(num_blocks: usize) -> Vec<usize> {
+    (0..num_blocks).collect()
 }
 
 fn bytes_per_iter(num_blocks: usize, bytes_per_block: usize) -> u64 {

--- a/pegaflow-core/src/block.rs
+++ b/pegaflow-core/src/block.rs
@@ -21,7 +21,7 @@ pub type BlockHash = Vec<u8>;
 /// Per-layer save input: layer name + block IDs + content hashes.
 pub struct LayerSave {
     pub layer_name: String,
-    pub block_ids: Vec<i32>,
+    pub block_ids: Vec<usize>,
     pub block_hashes: Vec<Vec<u8>>,
 }
 

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -557,7 +557,7 @@ impl PegaEngine {
         device_id: i32,
         load_state_shm: &str,
         layer_names: &[&str],
-        loads: &[(QueryLeaseId, Vec<i32>)],
+        loads: &[(QueryLeaseId, Vec<usize>)],
     ) -> Result<(), EngineError> {
         let load_state = LoadState::attach(load_state_shm)?;
 
@@ -593,7 +593,7 @@ impl PegaEngine {
         tp_rank: usize,
         device_id: i32,
         layer_names: &[&str],
-        loads: &[(QueryLeaseId, Vec<i32>)],
+        loads: &[(QueryLeaseId, Vec<usize>)],
     ) -> Result<oneshot::Receiver<Result<(), EngineError>>, EngineError> {
         let (reply, rx) = oneshot::channel();
         self.batch_load_kv_blocks_multi_layer_inner(
@@ -617,7 +617,7 @@ impl PegaEngine {
         tp_rank: usize,
         device_id: i32,
         layer_names: &[&str],
-        loads: &[(QueryLeaseId, Vec<i32>)],
+        loads: &[(QueryLeaseId, Vec<usize>)],
         completion: LoadCompletion,
     ) -> Result<(), EngineError> {
         let instance = self.get_instance(instance_id)?;
@@ -678,12 +678,7 @@ impl PegaEngine {
             let slot_id = topology.slot_index(layer_id, tp_rank)?;
 
             let mut blocks = Vec::with_capacity(block_ids.len());
-            for (block_id, block_entry) in block_ids.iter().zip(block_cache.iter()) {
-                let block_idx = usize::try_from(*block_id).map_err(|_| {
-                    EngineError::InvalidArgument(format!(
-                        "negative destination block id {block_id} for layer {layer_name}"
-                    ))
-                })?;
+            for (block_idx, block_entry) in block_ids.iter().copied().zip(block_cache.iter()) {
                 let block = block_entry.get_slot(slot_id).ok_or_else(|| {
                     EngineError::InvalidArgument(format!(
                         "stored block is missing slot {slot_id} for layer {layer_name}"

--- a/pegaflow-core/src/offload.rs
+++ b/pegaflow-core/src/offload.rs
@@ -221,12 +221,11 @@ impl PegaEngine {
             let blocks_to_save: Vec<(usize, Vec<u8>)> = block_ids
                 .into_iter()
                 .zip(block_hashes)
-                .map(|(id, hash)| {
-                    let idx = id as usize;
+                .map(|(idx, hash)| {
                     if idx >= num_blocks {
                         return Err(EngineError::InvalidArgument(format!(
                             "block_id {} out of range (num_blocks={}) for layer {}",
-                            id, num_blocks, layer_name
+                            idx, num_blocks, layer_name
                         )));
                     }
                     Ok((idx, hash))

--- a/pegaflow-core/tests/common/harness.rs
+++ b/pegaflow-core/tests/common/harness.rs
@@ -311,7 +311,7 @@ impl TestEnv {
     /// Save one layer's blocks to cache.
     pub async fn save_layer(&self, layer_index: usize, hashes: &[Vec<u8>]) {
         let layer = &self.layers[layer_index];
-        let block_ids: Vec<i32> = (0..hashes.len() as i32).collect();
+        let block_ids: Vec<usize> = (0..hashes.len()).collect();
         self.engine
             .batch_save_kv_blocks_from_ipc(
                 &self.instance_id,
@@ -388,7 +388,7 @@ impl TestEnv {
 
     /// Load blocks from cache to GPU (lease must be held).
     pub async fn load_to_gpu(&self, lease: QueryLeaseId, block_count: usize) {
-        let block_ids: Vec<i32> = (0..block_count as i32).collect();
+        let block_ids: Vec<usize> = (0..block_count).collect();
         let layer_names: Vec<&str> = self.layers.iter().map(|l| l.name.as_str()).collect();
         let load_state = LoadState::new().expect("create LoadState");
         let shm_name = load_state.shm_name().to_string();
@@ -407,7 +407,7 @@ impl TestEnv {
 
     /// Submit load and assert it fails synchronously with `expected_msg`.
     pub fn expect_load_error(&self, lease: QueryLeaseId, block_count: usize, expected_msg: &str) {
-        let block_ids: Vec<i32> = (0..block_count as i32).collect();
+        let block_ids: Vec<usize> = (0..block_count).collect();
         let layer_names: Vec<&str> = self.layers.iter().map(|l| l.name.as_str()).collect();
         let load_state = LoadState::new().expect("create LoadState");
         let shm_name = load_state.shm_name().to_string();

--- a/pegaflow-core/tests/prefetch_lease.rs
+++ b/pegaflow-core/tests/prefetch_lease.rs
@@ -51,7 +51,7 @@ async fn query_then_load_consumes_reservation_budget() {
     env.load_to_gpu(lease, hashes.len()).await;
     env.data().assert_gpu_matches_expected();
 
-    let block_ids: Vec<i32> = (0..hashes.len() as i32).collect();
+    let block_ids: Vec<usize> = (0..hashes.len()).collect();
     let layer_names: Vec<&str> = env.layers.iter().map(|l| l.name.as_str()).collect();
     let load_state = LoadState::new().expect("create LoadState");
     let err = env

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -39,7 +39,7 @@ message RegisterContextResponse {
 
 message SaveLayer {
   string layer_name = 1;
-  repeated int32 block_ids = 2;
+  repeated uint32 block_ids = 2;
   repeated bytes block_hashes = 3;
 }
 
@@ -66,7 +66,7 @@ message LoadRequest {
 
 message LeaseLoad {
   bytes lease = 1;
-  repeated int32 block_ids = 2;
+  repeated uint32 block_ids = 2;
 }
 
 message LoadResponse {

--- a/pegaflow-server/examples/p2p_bench.rs
+++ b/pegaflow-server/examples/p2p_bench.rs
@@ -332,7 +332,7 @@ async fn run_holder(cli: &Cli, shape: &Shape, pool_bytes: usize) {
     });
 
     let ranks = register_ranks(&engine, shape);
-    let block_ids: Vec<i32> = (0..shape.blocks as i32).collect();
+    let block_ids: Vec<usize> = (0..shape.blocks).collect();
     let layer_names = shape.layer_names();
 
     let mut image = vec![0u8; shape.rank_bytes()];
@@ -473,7 +473,7 @@ async fn verify_set(
         PrefetchStatus::Loading => panic!("verify: set {set} still loading"),
     };
     assert_eq!(blocks.len(), shape.blocks, "verify: incomplete set {set}");
-    let block_ids: Vec<i32> = (0..shape.blocks as i32).collect();
+    let block_ids: Vec<usize> = (0..shape.blocks).collect();
     let layer_names = shape.layer_names();
     let layer_name_refs: Vec<&str> = layer_names.iter().map(|s| s.as_str()).collect();
 

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -155,12 +155,6 @@ impl GrpcEngineService {
                     layer.layer_name
                 )));
             }
-            if let Some(id) = layer.block_ids.iter().find(|id| **id < 0) {
-                return Err(Status::invalid_argument(format!(
-                    "negative block_id {} in layer {}",
-                    id, layer.layer_name
-                )));
-            }
         }
         Ok(())
     }
@@ -432,12 +426,26 @@ impl Engine for GrpcEngineService {
 
             let saves: Vec<LayerSave> = saves
                 .into_iter()
-                .map(|layer| LayerSave {
-                    layer_name: layer.layer_name,
-                    block_ids: layer.block_ids,
-                    block_hashes: layer.block_hashes,
+                .map(|layer| {
+                    let block_ids = layer
+                        .block_ids
+                        .into_iter()
+                        .map(|id| {
+                            usize::try_from(id).map_err(|_| {
+                                Status::invalid_argument(format!(
+                                    "negative block_id {id} in layer {}",
+                                    layer.layer_name
+                                ))
+                            })
+                        })
+                        .collect::<Result<Vec<usize>, _>>()?;
+                    Ok::<_, Status>(LayerSave {
+                        layer_name: layer.layer_name,
+                        block_ids,
+                        block_hashes: layer.block_hashes,
+                    })
                 })
-                .collect();
+                .collect::<Result<_, _>>()?;
 
             debug!(
                 "RPC [save]: instance_id={} tp_rank={} pp_rank={} device_id={} layers={} blocks={} hashes={}",
@@ -521,12 +529,23 @@ impl Engine for GrpcEngineService {
                 load_state_shm.len()
             );
             let layer_refs: Vec<&str> = layer_names.iter().map(|s| s.as_str()).collect();
-            let loads: Vec<(QueryLeaseId, Vec<i32>)> = loads
+            let loads: Vec<(QueryLeaseId, Vec<usize>)> = loads
                 .into_iter()
                 .map(|load| {
-                    QueryLeaseId::from_bytes(&load.lease)
-                        .map(|lease| (lease, load.block_ids))
-                        .map_err(Status::invalid_argument)
+                    let lease =
+                        QueryLeaseId::from_bytes(&load.lease).map_err(Status::invalid_argument)?;
+                    let block_ids = load
+                        .block_ids
+                        .into_iter()
+                        .map(|id| {
+                            usize::try_from(id).map_err(|_| {
+                                Status::invalid_argument(format!(
+                                    "negative destination block_id {id}"
+                                ))
+                            })
+                        })
+                        .collect::<Result<Vec<usize>, _>>()?;
+                    Ok::<_, Status>((lease, block_ids))
                 })
                 .collect::<Result<_, _>>()?;
 

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -426,26 +426,12 @@ impl Engine for GrpcEngineService {
 
             let saves: Vec<LayerSave> = saves
                 .into_iter()
-                .map(|layer| {
-                    let block_ids = layer
-                        .block_ids
-                        .into_iter()
-                        .map(|id| {
-                            usize::try_from(id).map_err(|_| {
-                                Status::invalid_argument(format!(
-                                    "negative block_id {id} in layer {}",
-                                    layer.layer_name
-                                ))
-                            })
-                        })
-                        .collect::<Result<Vec<usize>, _>>()?;
-                    Ok::<_, Status>(LayerSave {
-                        layer_name: layer.layer_name,
-                        block_ids,
-                        block_hashes: layer.block_hashes,
-                    })
+                .map(|layer| LayerSave {
+                    layer_name: layer.layer_name,
+                    block_ids: layer.block_ids.into_iter().map(|id| id as usize).collect(),
+                    block_hashes: layer.block_hashes,
                 })
-                .collect::<Result<_, _>>()?;
+                .collect();
 
             debug!(
                 "RPC [save]: instance_id={} tp_rank={} pp_rank={} device_id={} layers={} blocks={} hashes={}",
@@ -534,17 +520,7 @@ impl Engine for GrpcEngineService {
                 .map(|load| {
                     let lease =
                         QueryLeaseId::from_bytes(&load.lease).map_err(Status::invalid_argument)?;
-                    let block_ids = load
-                        .block_ids
-                        .into_iter()
-                        .map(|id| {
-                            usize::try_from(id).map_err(|_| {
-                                Status::invalid_argument(format!(
-                                    "negative destination block_id {id}"
-                                ))
-                            })
-                        })
-                        .collect::<Result<Vec<usize>, _>>()?;
+                    let block_ids = load.block_ids.into_iter().map(|id| id as usize).collect();
                     Ok::<_, Status>((lease, block_ids))
                 })
                 .collect::<Result<_, _>>()?;

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -200,7 +200,7 @@ impl MockVllmRpcHarness {
             device_id: worker.device_id,
             saves: vec![SaveLayer {
                 layer_name: LAYER_NAME.to_string(),
-                block_ids: (0..hashes.len() as i32).collect(),
+                block_ids: (0..hashes.len() as u32).collect(),
                 block_hashes: hashes.to_vec(),
             }],
             pp_rank: 0,
@@ -375,7 +375,7 @@ impl MockVllmRpcHarness {
             layer_names: vec![LAYER_NAME.to_string()],
             loads: vec![LeaseLoad {
                 lease,
-                block_ids: (0..block_count as i32).collect(),
+                block_ids: (0..block_count as u32).collect(),
             }],
         };
         match self.worker.load(request.clone()).await {

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -94,8 +94,8 @@ fn fill_test_pattern(host_data: &mut [u8], block_size: usize) {
     }
 }
 
-fn make_block_ids(num_blocks: usize) -> Vec<i32> {
-    (0..num_blocks).map(|i| i as i32).collect()
+fn make_block_ids(num_blocks: usize) -> Vec<usize> {
+    (0..num_blocks).collect()
 }
 
 fn make_block_hashes(num_blocks: usize, salt: u8) -> Vec<Vec<u8>> {

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -336,7 +336,7 @@ impl EngineRpcClient {
         tp_rank: u32,
         pp_rank: u32,
         device_id: i32,
-        saves: Vec<(String, Vec<i32>, Vec<Vec<u8>>)>,
+        saves: Vec<(String, Vec<u32>, Vec<Vec<u8>>)>,
     ) -> PyResult<(bool, String)> {
         let saves = saves
             .into_iter()
@@ -389,7 +389,7 @@ impl EngineRpcClient {
         device_id: i32,
         load_state_shm: String,
         layer_names: Vec<String>,
-        loads: Vec<(Vec<u8>, Vec<i32>)>,
+        loads: Vec<(Vec<u8>, Vec<u32>)>,
     ) -> PyResult<(bool, String)> {
         let loads = loads
             .into_iter()


### PR DESCRIPTION
## Summary

`block_id` 是数组索引，但之前在 engine 内部以 `i32` 流转，并在 `lib.rs` 的 layers × blocks 嵌套循环里逐 block 做 `usize::try_from`。本 PR 把这种"不依赖 PegaEngine 状态"的参数校验与类型转换统一上提到 RPC service 边界，engine 内部直接讲 `usize`。

按"值的语义"而非"来源"区分类型：

- **索引 / 计数**(`block_ids`)→ engine 内部统一 `usize`。`i32`/`u32` 只是 protobuf 没有 `usize` 的 wire 产物,应只活在 RPC 边界。
- **`device_id`** 保持 `i32`:它是 CUDA device handle(直接传给 `CudaContext::new` / `numa_for_gpu`,CUDA 用 signed int),不是索引,强转 `usize` 只会在每个 CUDA 调用处再 `as i32`。
- **PyO3 gRPC client** 保持 `Vec<i32>`:那是 protobuf wire 类型,边界本就在那里。

## Changes

- `pegaflow-core`: load API(`batch_load_kv_blocks_multi_layer` / `_inproc` / `_inner`)与 `LayerSave.block_ids` 改为 `Vec<usize>`;移除 `lib.rs` 嵌套循环里的逐 block `usize::try_from` 与 `offload.rs` 的 `id as usize`。
- `pegaflow-server/service.rs`:`i32 -> usize` 转换(含拒绝负值)在 `load` / `save` handler 各做一次,复用既有标量校验风格;`validate_save_layers` 里冗余的负值检查删除。
- 同步更新 test / bench / example 调用点为 `Vec<usize>`。

## Testing

- `cargo build` / `cargo clippy --tests --benches --examples`:clean。
- `cargo test --release -p pegaflow-core --no-default-features --features cuda-13,rdma`:全绿(含 `save_validation`、`prefetch_lease`)。
- `cargo test --release -p pegaflow-server --no-default-features --features cuda-13,rdma`:26 个单测全绿(含 `service.rs` 校验路径)。
- `http_cleanup_hang_repro` 在本机崩溃(torch CUDA/GIL interpreter 冲突),已用 `git stash` 在干净 master 上复现同样崩溃,**与本改动无关**。

> ⚠️ 本机默认 feature 是 `cuda-12`,但运行时是 CUDA 13 driver,需用 `--features cuda-13` 跑 GPU 相关测试。Reviewer 请在 cu13 机器上复跑 e2e gate。

## Breaking change

`batch_load_kv_blocks_multi_layer(_inproc)` 与 `LayerSave.block_ids` 现在接受 `usize` 而非 `i32`。直接调用这些 engine API 的 in-process Rust embedder 需要相应改为传 `usize`。gRPC / proto wire 协议**不变**,Python 侧无感知。
