### PR TITLE
refactor(core): own RawBlock slots inside SealedBlock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ cargo build --release
 cargo test
 ```
 
+On CUDA 13 dev machines, pass `--no-default-features --features cuda-13,rdma` to `cargo test`/`cargo clippy` (default `cuda-12` can fail with missing `libcudart` symbols).
+
 ### Python Bindings
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ cargo build --release    # Release build
 cargo test               # Run Rust tests
 ```
 
+On CUDA 13 dev machines, pass `--no-default-features --features cuda-13,rdma` to `cargo test`/`cargo clippy` (default `cuda-12` can fail with missing `libcudart` symbols).
+
 ### CI Checks (Local)
 
 Run all CI checks locally before committing:

--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -444,7 +444,7 @@ async fn fetch_blocks_via_rdma(
     let mut result: PrefetchResult = Vec::with_capacity(block_allocs.len());
     for (hash, slot_allocs) in block_allocs {
         let key = BlockKey::new(namespace.to_string(), hash);
-        let slots: Vec<Arc<RawBlock>> = slot_allocs
+        let slots: Vec<RawBlock> = slot_allocs
             .into_iter()
             .map(|segs| {
                 let segments: Vec<Segment> = segs
@@ -455,7 +455,7 @@ async fn fetch_blocks_via_rdma(
                         Segment::new(ptr, sa.size, sa.alloc)
                     })
                     .collect();
-                Arc::new(RawBlock::new(segments))
+                RawBlock::new(segments)
             })
             .collect();
         let sealed = Arc::new(SealedBlock::from_slots(slots));

--- a/pegaflow-core/src/backing/ssd_cache.rs
+++ b/pegaflow-core/src/backing/ssd_cache.rs
@@ -636,7 +636,7 @@ async fn write_block_to_ssd(
         let iovecs: Vec<_> = block
             .slots()
             .iter()
-            .flat_map(|slot| seal_offload::write_iovecs(slot))
+            .flat_map(seal_offload::write_iovecs)
             .collect();
 
         io.writev_at_async(shard_id, iovecs, offset)?

--- a/pegaflow-core/src/block.rs
+++ b/pegaflow-core/src/block.rs
@@ -195,14 +195,14 @@ impl RawBlock {
 /// Lives in the service/GPU layer, NOT in storage.
 ///
 /// Invariant: inner RawBlock has >= 1 segment.
-pub struct LayerBlock {
-    raw: Arc<RawBlock>,
+pub struct LayerBlock<'a> {
+    raw: &'a RawBlock,
 }
 
-impl LayerBlock {
+impl<'a> LayerBlock<'a> {
     /// Wrap a RawBlock as a KV layer block.
     /// Panics if the block has zero segments (violated invariant from construction).
-    pub fn new(raw: Arc<RawBlock>) -> Self {
+    pub fn new(raw: &'a RawBlock) -> Self {
         debug_assert!(
             raw.num_segments() > 0,
             "LayerBlock requires at least 1 segment"
@@ -242,7 +242,7 @@ impl LayerBlock {
 
 /// Immutable block after all slots are filled. Exposed to callers.
 pub struct SealedBlock {
-    slots: Box<[Arc<RawBlock>]>,
+    slots: Box<[RawBlock]>,
     footprint: u64,
     /// Per-slot NUMA affinity, carried from InflightBlock for SSD write path.
     /// Empty when reconstructed from SSD prefetch (NUMA info lives in SlotMeta).
@@ -250,7 +250,7 @@ pub struct SealedBlock {
 }
 
 impl SealedBlock {
-    pub(crate) fn get_slot(&self, slot_id: usize) -> Option<&Arc<RawBlock>> {
+    pub(crate) fn get_slot(&self, slot_id: usize) -> Option<&RawBlock> {
         self.slots.get(slot_id)
     }
 
@@ -259,7 +259,7 @@ impl SealedBlock {
     }
 
     /// Get all slots (for serialization / cross-node transfer)
-    pub fn slots(&self) -> &[Arc<RawBlock>] {
+    pub fn slots(&self) -> &[RawBlock] {
         &self.slots
     }
 
@@ -269,7 +269,7 @@ impl SealedBlock {
     }
 
     /// Create from a vec of slots (for deserialization / prefetch rebuild)
-    pub(crate) fn from_slots(slots: Vec<Arc<RawBlock>>) -> Self {
+    pub(crate) fn from_slots(slots: Vec<RawBlock>) -> Self {
         let footprint = slots.iter().map(|s| s.memory_footprint()).sum();
         Self {
             slots: slots.into_boxed_slice(),
@@ -280,7 +280,7 @@ impl SealedBlock {
 
     /// Create from slots with pre-computed footprint (internal use)
     fn from_slots_with_footprint(
-        slots: Box<[Arc<RawBlock>]>,
+        slots: Box<[RawBlock]>,
         footprint: u64,
         slot_numas: Vec<NumaNode>,
     ) -> Self {
@@ -293,10 +293,10 @@ impl SealedBlock {
 
     /// Create from a fully populated, slot-id ordered insert batch.
     pub(crate) fn from_ordered_slot_inserts(
-        slots: Vec<(usize, Arc<RawBlock>)>,
+        slots: Vec<(usize, RawBlock)>,
         total_slots: usize,
         numa_node: NumaNode,
-    ) -> Result<Self, Vec<(usize, Arc<RawBlock>)>> {
+    ) -> Result<Self, Vec<(usize, RawBlock)>> {
         if slots.len() != total_slots
             || slots
                 .iter()
@@ -342,7 +342,7 @@ pub(crate) enum SlotInsertResult {
 
 /// Block that is still being written. Internal to StorageEngine.
 pub(crate) struct InflightBlock {
-    slots: Vec<Option<Arc<RawBlock>>>,
+    slots: Vec<Option<RawBlock>>,
     remaining: usize,
     total_slots: usize,
     footprint: u64,
@@ -355,7 +355,7 @@ pub(crate) struct InflightBlock {
 impl InflightBlock {
     pub(crate) fn new(total_slots: usize) -> Self {
         Self {
-            slots: vec![None; total_slots],
+            slots: (0..total_slots).map(|_| None).collect(),
             remaining: total_slots,
             total_slots,
             footprint: 0,
@@ -388,7 +388,7 @@ impl InflightBlock {
     pub(crate) fn insert_slot(
         &mut self,
         slot_id: usize,
-        block: Arc<RawBlock>,
+        block: RawBlock,
         numa_node: NumaNode,
     ) -> SlotInsertResult {
         debug_assert!(
@@ -420,7 +420,7 @@ impl InflightBlock {
     /// Seal the block, converting to immutable SealedBlock.
     /// Panics if not all slots are filled.
     pub(crate) fn seal(self) -> SealedBlock {
-        let slots: Vec<Arc<RawBlock>> = self
+        let slots: Vec<RawBlock> = self
             .slots
             .into_iter()
             .map(|opt| opt.expect("all slots must be filled before sealing"))

--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -6,7 +6,7 @@ use logforth::diagnostic::ThreadLocalDiagnostic;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::EngineError;
-use crate::block::RawBlock;
+use crate::block::{RawBlock, SealedBlock};
 use crate::layout::{BlockCopies, KVCacheLayout};
 use crate::metrics::core_metrics;
 use crate::sync_state::LoadState;
@@ -59,11 +59,33 @@ pub(crate) struct LayerTransferData {
     pub blocks: Vec<TransferBlock>,
 }
 
+/// Host-side block image for a GPU transfer.
+pub(crate) enum HostBlock {
+    /// Save path: uniquely owned, moved through the GPU worker and returned.
+    Owned(RawBlock),
+    /// Load path: slot borrowed from a cached sealed block.
+    Cached {
+        sealed: Arc<SealedBlock>,
+        slot_id: usize,
+    },
+}
+
+impl HostBlock {
+    pub(crate) fn raw(&self) -> &RawBlock {
+        match self {
+            Self::Owned(block) => block,
+            Self::Cached { sealed, slot_id } => sealed
+                .get_slot(*slot_id)
+                .expect("cached slot_id validated at construction"),
+        }
+    }
+}
+
 /// One block in a transfer: the GPU slot index and its host-side image.
 /// Loads copy `block` -> GPU slot, saves copy GPU slot -> `block`.
 pub(crate) struct TransferBlock {
     pub block_idx: usize,
-    pub block: Arc<RawBlock>,
+    pub block: HostBlock,
 }
 
 /// A task to save KV blocks from GPU to CPU for multiple layers.
@@ -71,7 +93,7 @@ pub(crate) struct TransferBlock {
 /// All layers are copied on the same CUDA stream with a single synchronization.
 pub(crate) struct SaveTask {
     pub layers: Vec<LayerTransferData>,
-    pub reply: oneshot::Sender<Result<(), EngineError>>,
+    pub reply: oneshot::Sender<Result<Vec<LayerTransferData>, EngineError>>,
     #[cfg(feature = "tracing")]
     pub trace_ctx: Option<::fastrace::prelude::SpanContext>,
 }
@@ -180,7 +202,7 @@ impl GpuWorkerPool {
     pub(crate) async fn batch_save(
         &self,
         layers: Vec<LayerTransferData>,
-    ) -> Result<(), EngineError> {
+    ) -> Result<Vec<LayerTransferData>, EngineError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let task = SaveTask {
             layers,
@@ -288,8 +310,21 @@ fn save_worker_loop(
     runtime: WorkerRuntime,
 ) {
     while let Some(task) = rx.blocking_recv() {
-        let result = process_save_task(&task, &runtime.stream, runtime.backend.as_ref());
-        let _ = task.reply.send(result);
+        let SaveTask {
+            layers,
+            reply,
+            #[cfg(feature = "tracing")]
+            trace_ctx,
+        } = task;
+        let result = process_save_task(
+            &layers,
+            &runtime.stream,
+            runtime.backend.as_ref(),
+            #[cfg(feature = "tracing")]
+            trace_ctx,
+        )
+        .map(|()| layers);
+        let _ = reply.send(result);
     }
 
     info!("Save worker shutting down: device={}", device_id);
@@ -316,11 +351,11 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
 
             match block_copies {
                 BlockCopies::Split { k, v } => {
-                    let k_ptr = block.block.segment_mapped_ptr(0).unwrap();
+                    let raw = block.block.raw();
+                    let k_ptr = raw.segment_mapped_ptr(0).unwrap();
                     // SAFETY: For a contiguous host block (segment 1 absent), the
                     // allocation is 2 * segment size, so k + k.bytes is in bounds.
-                    let v_ptr = block
-                        .block
+                    let v_ptr = raw
                         .segment_mapped_ptr(1)
                         .unwrap_or_else(|| k_ptr.add(k.bytes));
 
@@ -339,7 +374,7 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
                     total_bytes += k.bytes + v.bytes;
                 }
                 BlockCopies::Contiguous(c) => {
-                    let ptr = block.block.segment_mapped_ptr(0).unwrap();
+                    let ptr = block.block.raw().segment_mapped_ptr(0).unwrap();
                     copies.push(CopyDesc {
                         device: c.addr,
                         host: ptr.host().as_ptr(),
@@ -413,15 +448,16 @@ fn process_load_task(
 /// and segments are collected into one descriptor batch, handed to a single
 /// backend, then synchronized once.
 fn process_save_task(
-    task: &SaveTask,
+    layers: &[LayerTransferData],
     stream: &Arc<CudaStream>,
     backend: &dyn TransferBackend,
+    #[cfg(feature = "tracing")] trace_ctx: Option<::fastrace::prelude::SpanContext>,
 ) -> Result<(), EngineError> {
-    trace_child!("gpu.save_task", task.trace_ctx);
+    trace_child!("gpu.save_task", trace_ctx);
     let start = std::time::Instant::now();
-    let total_blocks: usize = task.layers.iter().map(|l| l.blocks.len()).sum();
+    let total_blocks: usize = layers.iter().map(|l| l.blocks.len()).sum();
 
-    let (copies, total_bytes) = build_copy_descs(&task.layers)?;
+    let (copies, total_bytes) = build_copy_descs(layers)?;
 
     backend.d2h(&copies, stream).map_err(EngineError::Storage)?;
 
@@ -442,7 +478,7 @@ fn process_save_task(
 
     debug!(
         "Save task completed: layers={} blocks={} copies={} bytes={} elapsed_ms={:.2} bandwidth_gbps={:.2} backend={}",
-        task.layers.len(),
+        layers.len(),
         total_blocks,
         copies.len(),
         total_bytes,

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -59,7 +59,7 @@ use std::{
 use log::{debug, info};
 
 use crate::backing::SSD_ALIGNMENT;
-use crate::gpu_worker::{LayerTransferData, LoadCompletion, LoadTask, TransferBlock};
+use crate::gpu_worker::{HostBlock, LayerTransferData, LoadCompletion, LoadTask, TransferBlock};
 use crate::lease::QueryLeaseManager;
 use crate::metrics::core_metrics;
 use crate::storage::StorageEngine;
@@ -679,14 +679,17 @@ impl PegaEngine {
 
             let mut blocks = Vec::with_capacity(block_ids.len());
             for (block_idx, block_entry) in block_ids.iter().copied().zip(block_cache.iter()) {
-                let block = block_entry.get_slot(slot_id).ok_or_else(|| {
-                    EngineError::InvalidArgument(format!(
+                if block_entry.get_slot(slot_id).is_none() {
+                    return Err(EngineError::InvalidArgument(format!(
                         "stored block is missing slot {slot_id} for layer {layer_name}"
-                    ))
-                })?;
+                    )));
+                }
                 blocks.push(TransferBlock {
                     block_idx,
-                    block: Arc::clone(block),
+                    block: HostBlock::Cached {
+                        sealed: Arc::clone(block_entry),
+                        slot_id,
+                    },
                 });
             }
 

--- a/pegaflow-core/src/offload.rs
+++ b/pegaflow-core/src/offload.rs
@@ -15,8 +15,8 @@ use log::{debug, info};
 use crate::block::{BlockKey, LayerSave, RawBlock, Segment};
 
 /// Grouped insert entries: each hash maps to its per-slot `RawBlock`s.
-pub(crate) type InsertEntries = Vec<(BlockKey, Vec<(usize, Arc<RawBlock>)>)>;
-use crate::gpu_worker::{LayerTransferData, TransferBlock};
+pub(crate) type InsertEntries = Vec<(BlockKey, Vec<(usize, RawBlock)>)>;
+use crate::gpu_worker::{HostBlock, LayerTransferData, TransferBlock};
 use crate::layout::KVCacheLayout;
 use crate::metrics::core_metrics;
 use crate::{EngineError, PegaEngine};
@@ -36,7 +36,7 @@ pub(crate) struct RawSaveLayer {
     /// Padded block size (SSD-aligned). Becomes `RawBlock.total_size` → `SlotMeta.total_size()`.
     pub padded_block_size: usize,
     /// Saved blocks, parallel to `block_hashes`.
-    pub blocks: Vec<Arc<RawBlock>>,
+    pub blocks: Vec<RawBlock>,
     /// Block hashes in save order.
     pub block_hashes: Vec<Vec<u8>>,
 }
@@ -58,15 +58,15 @@ struct LayerContext {
     /// Blocks to save: (block_idx, hash). Filtered in Phase 1.
     blocks_to_save: Vec<(usize, Vec<u8>)>,
     /// Host-side block images, parallel to `blocks_to_save`.
-    /// Constructed in Phase 2; shared with the GPU copy task.
-    raw_blocks: Vec<Arc<RawBlock>>,
+    /// Filled after the GPU save task returns the moved blocks.
+    raw_blocks: Vec<RawBlock>,
 }
 
 /// Build insert entries from a raw batch (called by the insert worker).
 ///
 /// Returns `(entries, total_bytes, total_blocks)` where entries is grouped
-/// by hash: `Vec<(BlockKey, Vec<(slot_id, Arc<RawBlock>)>)>`.
-pub(crate) fn build_insert_entries(batch: &RawSaveBatch) -> (InsertEntries, u64, usize) {
+/// by hash: `Vec<(BlockKey, Vec<(slot_id, RawBlock)>)>`.
+pub(crate) fn build_insert_entries(batch: RawSaveBatch) -> (InsertEntries, u64, usize) {
     let mut total_bytes: u64 = 0;
     let mut total_blocks: usize = 0;
     for layer in &batch.layers {
@@ -75,52 +75,65 @@ pub(crate) fn build_insert_entries(batch: &RawSaveBatch) -> (InsertEntries, u64,
         total_bytes += (layer.padded_block_size as u64).saturating_mul(layer_blocks as u64);
     }
 
-    let entries =
-        build_ordered_insert_entries(batch).unwrap_or_else(|| build_hashed_insert_entries(batch));
+    let entries = if can_use_ordered_fast_path(&batch.layers) {
+        build_ordered_insert_entries(batch.namespace, batch.layers)
+    } else {
+        build_hashed_insert_entries(batch.namespace, batch.layers)
+    };
     (entries, total_bytes, total_blocks)
+}
+
+fn can_use_ordered_fast_path(layers: &[RawSaveLayer]) -> bool {
+    let Some(first_layer) = layers.first() else {
+        return false;
+    };
+    layers
+        .iter()
+        .all(|layer| layer.block_hashes == first_layer.block_hashes)
 }
 
 /// Fast path: all layers share one hash order, so entries can be built
 /// block-by-block without a hash map.
-fn build_ordered_insert_entries(batch: &RawSaveBatch) -> Option<InsertEntries> {
-    let first_layer = batch.layers.first()?;
-    if batch
-        .layers
-        .iter()
-        .any(|layer| layer.block_hashes != first_layer.block_hashes)
-    {
-        return None;
+fn build_ordered_insert_entries(namespace: String, layers: Vec<RawSaveLayer>) -> InsertEntries {
+    let hashes = layers
+        .first()
+        .map(|layer| layer.block_hashes.clone())
+        .unwrap_or_default();
+    let num_blocks = hashes.len();
+    let mut per_block_slots: Vec<Vec<(usize, RawBlock)>> =
+        (0..num_blocks).map(|_| Vec::new()).collect();
+
+    for layer in layers {
+        let slot_id = layer.slot_id;
+        for (block_idx, block) in layer.blocks.into_iter().enumerate() {
+            per_block_slots[block_idx].push((slot_id, block));
+        }
     }
 
-    let mut entries = Vec::with_capacity(first_layer.block_hashes.len());
-    for (block_idx, hash) in first_layer.block_hashes.iter().enumerate() {
-        let slots = batch
-            .layers
-            .iter()
-            .map(|layer| (layer.slot_id, Arc::clone(&layer.blocks[block_idx])))
-            .collect();
-        entries.push((BlockKey::new(batch.namespace.clone(), hash.clone()), slots));
-    }
-    Some(entries)
+    hashes
+        .into_iter()
+        .zip(per_block_slots)
+        .map(|(hash, slots)| (BlockKey::new(namespace.clone(), hash), slots))
+        .collect()
 }
 
 /// Fallback for heterogeneous per-layer hash sets: group via a hash map.
-fn build_hashed_insert_entries(batch: &RawSaveBatch) -> InsertEntries {
+fn build_hashed_insert_entries(namespace: String, layers: Vec<RawSaveLayer>) -> InsertEntries {
     use std::collections::HashMap;
 
-    let mut hash_entries: HashMap<Vec<u8>, Vec<(usize, Arc<RawBlock>)>> = HashMap::new();
-    for layer in &batch.layers {
-        for (i, hash) in layer.block_hashes.iter().enumerate() {
+    let mut hash_entries: HashMap<Vec<u8>, Vec<(usize, RawBlock)>> = HashMap::new();
+    for layer in layers {
+        for (block, hash) in layer.blocks.into_iter().zip(layer.block_hashes) {
             hash_entries
-                .entry(hash.clone())
+                .entry(hash)
                 .or_default()
-                .push((layer.slot_id, Arc::clone(&layer.blocks[i])));
+                .push((layer.slot_id, block));
         }
     }
 
     hash_entries
         .into_iter()
-        .map(|(hash, slots)| (BlockKey::new(batch.namespace.clone(), hash), slots))
+        .map(|(hash, slots)| (BlockKey::new(namespace.clone(), hash), slots))
         .collect()
 }
 
@@ -327,7 +340,7 @@ impl PegaEngine {
             // Allocate pinned memory and construct the host-side RawBlocks in
             // save order. Strides are padded (SSD-aligned); GPU copies later
             // use actual (unpadded) sizes, leaving the padding tail unused.
-            let mut raw_blocks: Vec<Arc<RawBlock>> = Vec::with_capacity(num_blocks);
+            let mut raw_blocks: Vec<RawBlock> = Vec::with_capacity(num_blocks);
             for _ in 0..alloc_count {
                 if layout.is_split() {
                     let stride = layout.padded_segment_bytes();
@@ -336,7 +349,7 @@ impl PegaEngine {
                     for i in 0..blocks_per_alloc {
                         let offset = i * stride;
                         // Safety: offsets are within the just-made allocations.
-                        raw_blocks.push(Arc::new(RawBlock::two_segments(
+                        raw_blocks.push(RawBlock::two_segments(
                             Segment::new(
                                 k_alloc.mapped_ptr().add(offset).host(),
                                 stride,
@@ -347,18 +360,18 @@ impl PegaEngine {
                                 stride,
                                 Arc::clone(&v_alloc),
                             ),
-                        )));
+                        ));
                     }
                 } else {
                     let stride = layout.padded_block_bytes();
                     let alloc = alloc_pinned(stride, "block buffer")?;
                     for i in 0..blocks_per_alloc {
                         // Safety: offset is within the just-made allocation.
-                        raw_blocks.push(Arc::new(RawBlock::single_segment(Segment::new(
+                        raw_blocks.push(RawBlock::single_segment(Segment::new(
                             alloc.mapped_ptr().add(i * stride).host(),
                             stride,
                             Arc::clone(&alloc),
-                        ))));
+                        )));
                     }
                 }
             }
@@ -366,10 +379,10 @@ impl PegaEngine {
             let save_blocks: Vec<TransferBlock> = ctx
                 .blocks_to_save
                 .iter()
-                .zip(&raw_blocks)
+                .zip(raw_blocks)
                 .map(|((block_idx, _), block)| TransferBlock {
                     block_idx: *block_idx,
-                    block: Arc::clone(block),
+                    block: HostBlock::Owned(block),
                 })
                 .collect();
 
@@ -378,17 +391,29 @@ impl PegaEngine {
                 layout: layout.clone(),
                 blocks: save_blocks,
             });
-            ctx.raw_blocks = raw_blocks;
         }
         trace_drop!(_s);
 
         // ── Phase 3: Submit all GPU copies as one batch task (single sync) ──
 
-        trace_future!(
+        let returned_layers = trace_future!(
             "save.gpu_copy",
             gpu_context.worker_pool().batch_save(gpu_save_layers)
         )
         .await?;
+
+        for (ctx, layer) in layer_contexts.iter_mut().zip(returned_layers) {
+            ctx.raw_blocks = layer
+                .blocks
+                .into_iter()
+                .map(|transfer_block| match transfer_block.block {
+                    HostBlock::Owned(block) => block,
+                    HostBlock::Cached { .. } => {
+                        panic!("save path must return HostBlock::Owned blocks")
+                    }
+                })
+                .collect();
+        }
 
         // ── Phase 4 (deferred): Build RawBlocks + insert — sent to worker ──
 

--- a/pegaflow-core/src/seal_offload.rs
+++ b/pegaflow-core/src/seal_offload.rs
@@ -57,7 +57,7 @@ pub(crate) unsafe fn reconstruct_raw_block(
     meta: &SlotMeta,
     allocation: Arc<PinnedAllocation>,
     base_offset: usize,
-) -> Arc<RawBlock> {
+) -> RawBlock {
     let base_ptr = allocation.as_ptr() as *mut u8;
     debug_assert!(
         !base_ptr.is_null(),
@@ -85,7 +85,7 @@ pub(crate) unsafe fn reconstruct_raw_block(
         ));
         offset += seg_size as usize;
     }
-    Arc::new(RawBlock::new(segments))
+    RawBlock::new(segments)
 }
 
 /// Build iovecs for writing a slot's RawBlock to SSD.

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -108,13 +108,13 @@ fn process_raw_save_batch(
     batch: crate::offload::RawSaveBatch,
 ) {
     let start = std::time::Instant::now();
-    let namespace = &batch.namespace;
+    let namespace = batch.namespace.clone();
     let numa_node = batch.numa_node;
     let total_slots = batch.total_slots;
 
-    let (entries, total_bytes, total_blocks) = crate::offload::build_insert_entries(&batch);
+    let (entries, total_bytes, total_blocks) = crate::offload::build_insert_entries(batch);
 
-    process_insert_batch(inflight, deps, entries, total_slots, numa_node, namespace);
+    process_insert_batch(inflight, deps, entries, total_slots, numa_node, &namespace);
 
     debug!(
         "insert_worker: batch sealed blocks={} bytes={} ms={:.2}",
@@ -203,7 +203,7 @@ fn process_insert_batch(
 fn insert_partial_slots(
     inflight: &mut HashMap<BlockKey, InflightBlock>,
     key: BlockKey,
-    slots: Vec<(usize, Arc<crate::block::RawBlock>)>,
+    slots: Vec<(usize, crate::block::RawBlock)>,
     total_slots: usize,
     numa_node: NumaNode,
     namespace: &str,
@@ -329,13 +329,13 @@ mod tests {
     use crate::block::RawBlock;
     use crate::storage::{StorageConfig, StorageEngine};
 
-    fn make_raw_block(engine: &StorageEngine, size: u64) -> Arc<RawBlock> {
+    fn make_raw_block(engine: &StorageEngine, size: u64) -> RawBlock {
         use crate::block::Segment;
         let alloc = engine
             .allocate(NonZeroU64::new(size).unwrap(), None)
             .expect("test pool should have space");
         let ptr = alloc.as_non_null();
-        Arc::new(RawBlock::new(vec![Segment::new(ptr, size as usize, alloc)]))
+        RawBlock::new(vec![Segment::new(ptr, size as usize, alloc)])
     }
 
     fn make_deps(engine: &StorageEngine) -> Arc<InsertDeps> {

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -177,10 +177,10 @@ impl GrpcEngineService {
     }
 
     fn build_transfer_slot_info(
-        raw_block: &Arc<pegaflow_core::RawBlock>,
+        raw_block: &pegaflow_core::RawBlock,
         numa_node: pegaflow_common::NumaNode,
     ) -> TransferSlotInfo {
-        let layer_block = pegaflow_core::LayerBlock::new(Arc::clone(raw_block));
+        let layer_block = pegaflow_core::LayerBlock::new(raw_block);
         if let Some(v_ptr) = layer_block.v_ptr() {
             TransferSlotInfo {
                 k_ptr: layer_block.k_ptr() as u64,


### PR DESCRIPTION
## Summary
- Store `SealedBlock` slots as owned `RawBlock` values instead of `Arc<RawBlock>`, keeping sharing at the `Arc<SealedBlock>` cache/lease boundary.
- Introduce `HostBlock` for GPU transfers: save moves `Owned(RawBlock)` through the worker and back; load pins `Cached { sealed, slot_id }` for the duration of H2D.
- Update rebuild paths (SSD/RDMA), `LayerBlock<'a>`, and docs with a CUDA 13 test/clippy note.

## Test plan
- [x] `cargo test -p pegaflow-core --no-default-features --features cuda-13,rdma`
- [x] `cargo test -p pegaflow-server --no-default-features --features cuda-13,rdma`
- [x] `cargo clippy -p pegaflow-core -p pegaflow-server --no-default-features --features cuda-13,rdma -- -D warnings`
- [x] GPU save/load smoke on CUDA 13 dev machine:
  - `engine_basic`: `save_query_load_roundtrip`, `save_query_load_roundtrip_with_numa`, `save_query_load_roundtrip_split_storage`, `kernel_backend_roundtrip_split_storage`
  - `prefetch_lease`: query → load lease path
  - `mock_vllm_rpc_e2e`: `mock_vllm_save_query_load_roundtrip_over_rpc`