### PR TITLE
feat(transfer)!: encode per-slot schema + NUMA source map in QueryBlocksForTransfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,6 +1927,7 @@ dependencies = [
  "pegaflow-common",
  "pegaflow-proto",
  "pegaflow-transfer",
+ "pegaflow-transfer-wire",
  "rand 0.10.0",
  "shared_memory",
  "smallvec",
@@ -2050,6 +2051,15 @@ dependencies = [
  "syscalls",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "pegaflow-transfer-wire"
+version = "0.22.9"
+dependencies = [
+ "postcard",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,6 +2012,7 @@ dependencies = [
  "pegaflow-core",
  "pegaflow-metaserver",
  "pegaflow-proto",
+ "pegaflow-transfer-wire",
  "prometheus",
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "pegaflow-server",
   "pegaflow-metaserver",
   "pegaflow-pd-wire",
+  "pegaflow-transfer-wire",
   "pegaflow-transfer",
   "python",
 ]
@@ -21,6 +22,7 @@ license = "Apache-2.0"
 pegaflow-common = { path = "pegaflow-common" }
 pegaflow-core = { path = "pegaflow-core", default-features = false }
 pegaflow-pd-wire = { path = "pegaflow-pd-wire" }
+pegaflow-transfer-wire = { path = "pegaflow-transfer-wire" }
 pegaflow-transfer = { path = "pegaflow-transfer", default-features = false }
 sideway = "0.4.3"
 rdma-mummy-sys = "0.2.4"

--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -36,6 +36,7 @@ tonic.workspace = true
 dashmap.workspace = true
 smallvec.workspace = true
 pegaflow-proto = { path = "../pegaflow-proto" }
+pegaflow-transfer-wire.workspace = true
 pegaflow-transfer = { path = "../pegaflow-transfer", default-features = false, optional = true }
 mea.workspace = true
 

--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -12,6 +12,8 @@ cuda-12 = ["cudarc/cuda-12080", "cudarc/nvrtc", "pegaflow-transfer?/cuda-12"]
 cuda-13 = ["cudarc/cuda-13000", "cudarc/nvrtc", "pegaflow-transfer?/cuda-13"]
 rdma = ["dep:pegaflow-transfer"]
 tracing = ["fastrace"]
+# Exposes `bench_support` for criterion benches; not for production builds.
+bench = []
 
 [dependencies]
 pegaflow-common.workspace = true
@@ -62,6 +64,24 @@ harness = false
 [[bench]]
 name = "transfer_h2d"
 harness = false
+
+[[bench]]
+name = "transfer_rebuild"
+harness = false
+required-features = ["bench", "rdma"]
+
+[[bench]]
+name = "transfer_query"
+harness = false
+required-features = ["bench", "rdma"]
+
+[[example]]
+name = "rebuild_profile"
+required-features = ["bench", "rdma"]
+
+[[example]]
+name = "encode_profile"
+required-features = ["bench", "rdma"]
 
 [[example]]
 name = "pinned_alloc"

--- a/pegaflow-core/benches/transfer_query.rs
+++ b/pegaflow-core/benches/transfer_query.rs
@@ -1,0 +1,41 @@
+//! Reproduces the `QueryBlocksForTransfer` CPU cost: building + postcard-encoding
+//! the `TransferPlan` from sealed blocks (server side), and decoding + validating
+//! it (client side). The wire stage breakdown showed query ~182 ms for 4500
+//! blocks, scaling with `blocks * slots`.
+//!
+//! Run:
+//!   cargo bench -p pegaflow-core --no-default-features \
+//!       --features bench,cuda-13,rdma --bench transfer_query
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use pegaflow_core::bench_support::QueryFixture;
+
+fn bench_query(c: &mut Criterion) {
+    const SLOTS: usize = 288; // layers(36) * tp(8), split K/V
+    const SEG_BYTES: usize = 16;
+
+    for stage in ["encode", "decode"] {
+        let mut group = c.benchmark_group(format!("query_{stage}"));
+        for &blocks in &[70usize, 281, 4500] {
+            let fixture = QueryFixture::new(blocks, SLOTS, SEG_BYTES);
+            if blocks == 4500 {
+                eprintln!("wire bytes (4500 blocks) = {}", fixture.wire_len());
+            }
+            group.throughput(Throughput::Elements((blocks * SLOTS * 2) as u64));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(blocks),
+                &fixture,
+                |b, fixture| match stage {
+                    "encode" => b.iter(|| black_box(fixture.encode())),
+                    _ => b.iter(|| black_box(fixture.decode())),
+                },
+            );
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_query);
+criterion_main!(benches);

--- a/pegaflow-core/benches/transfer_rebuild.rs
+++ b/pegaflow-core/benches/transfer_rebuild.rs
@@ -1,0 +1,45 @@
+//! Reproduces the cross-node `rebuild_sealed_blocks` cost observed on the wire.
+//!
+//! The p2p stage breakdown showed rebuild dominating the small-block regime
+//! (~359 ms for 4500 blocks, vs ~73 ms RDMA wait), scaling with cell count
+//! (`blocks * slots * 2`), not bytes. This bench rebuilds vLLM-shaped plans
+//! (`slots = layers*tp = 288`, split K/V) so the cost can be profiled locally
+//! with no GPU or RDMA.
+//!
+//! Run:
+//!   cargo bench -p pegaflow-core --no-default-features \
+//!       --features bench,cuda-13,rdma --bench transfer_rebuild
+//! Profile (flamegraph / perf) the same target binary under `--profile-time`.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use pegaflow_core::bench_support::RebuildFixture;
+
+fn bench_rebuild(c: &mut Criterion) {
+    // vLLM-shaped: slots = layers(36) * tp(8) = 288, split K/V (2 segments).
+    // Cost is count-driven, so tiny segment bytes keep the slab small.
+    const SLOTS: usize = 288;
+    const SEG_BYTES: usize = 16;
+
+    let mut group = c.benchmark_group("rebuild_sealed_blocks");
+    // 70 = 256 KiB load, 281 = 64 KiB load, 4500 = 4 KiB load (per the p2p A/B).
+    for &blocks in &[70usize, 281, 4500] {
+        let fixture = RebuildFixture::new(blocks, SLOTS, SEG_BYTES);
+        let (placements, chunks, cells) = fixture.stats();
+        eprintln!(
+            "shape blocks={blocks} slots={SLOTS} segs=2 cells={cells} \
+             placements={placements} chunks={chunks}"
+        );
+        group.throughput(Throughput::Elements(cells as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(blocks),
+            &fixture,
+            |b, fixture| b.iter(|| black_box(fixture.rebuild())),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_rebuild);
+criterion_main!(benches);

--- a/pegaflow-core/examples/encode_profile.rs
+++ b/pegaflow-core/examples/encode_profile.rs
@@ -1,0 +1,32 @@
+//! Isolated profiling driver for the `QueryBlocksForTransfer` encode path.
+//! Builds one vLLM-shaped fixture once, then encodes it in a tight loop so a
+//! sampling profiler sees ~only the plan-build + postcard-encode hot path.
+//!
+//!   cargo build --example encode_profile --release --no-default-features \
+//!       --features bench,cuda-13,rdma
+//!   samply record -- target/release/examples/encode_profile
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use pegaflow_core::bench_support::QueryFixture;
+
+const BLOCKS: usize = 4500;
+const SLOTS: usize = 288;
+const SEG_BYTES: usize = 16;
+const ITERS: usize = 40;
+
+fn main() {
+    let fixture = QueryFixture::new(BLOCKS, SLOTS, SEG_BYTES);
+    eprintln!(
+        "fixture blocks={BLOCKS} slots={SLOTS} wire_bytes={}; looping encode {ITERS}x",
+        fixture.wire_len()
+    );
+    let t0 = Instant::now();
+    let mut acc = 0usize;
+    for _ in 0..ITERS {
+        acc += black_box(fixture.encode());
+    }
+    let ms = t0.elapsed().as_secs_f64() * 1000.0 / ITERS as f64;
+    eprintln!("mean encode = {ms:.2} ms/iter (acc={acc})");
+}

--- a/pegaflow-core/examples/rebuild_profile.rs
+++ b/pegaflow-core/examples/rebuild_profile.rs
@@ -1,0 +1,35 @@
+//! Isolated profiling driver for `rebuild_sealed_blocks`.
+//!
+//! Builds one vLLM-shaped fixture (slots = layers*tp = 288, split K/V) once,
+//! then rebuilds it in a tight loop so a sampling profiler (samply / perf) sees
+//! essentially only the rebuild hot path -- no criterion, no encode, no
+//! fixture setup in the steady state.
+//!
+//!   cargo build --example rebuild_profile --release --no-default-features \
+//!       --features bench,cuda-13,rdma
+//!   samply record -- target/release/examples/rebuild_profile
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use pegaflow_core::bench_support::RebuildFixture;
+
+const BLOCKS: usize = 4500; // 4 KiB load (the regime where rebuild dominates)
+const SLOTS: usize = 288; // layers(36) * tp(8)
+const SEG_BYTES: usize = 16; // cost is count-driven, not byte-driven
+const ITERS: usize = 40;
+
+fn main() {
+    let fixture = RebuildFixture::new(BLOCKS, SLOTS, SEG_BYTES);
+    let (placements, chunks, cells) = fixture.stats();
+    eprintln!(
+        "fixture blocks={BLOCKS} slots={SLOTS} cells={cells} placements={placements} chunks={chunks}; looping {ITERS}x"
+    );
+    let t0 = Instant::now();
+    let mut acc = 0usize;
+    for _ in 0..ITERS {
+        acc += black_box(fixture.rebuild());
+    }
+    let ms = t0.elapsed().as_secs_f64() * 1000.0 / ITERS as f64;
+    eprintln!("mean rebuild = {ms:.2} ms/iter (acc={acc})");
+}

--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -1,7 +1,5 @@
 // RDMA remote block fetch: MetaServer query -> gRPC QueryBlocksForTransfer -> RDMA READ.
 
-use std::collections::HashMap;
-use std::ptr::NonNull;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -11,19 +9,18 @@ use mea::singleflight::Group;
 use pegaflow_proto::proto::engine::engine_client::EngineClient;
 use pegaflow_proto::proto::engine::{
     QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, RdmaHandshakeRequest,
-    ReleaseTransferLockRequest, TransferBlockInfo,
+    ReleaseTransferLockRequest,
 };
-use pegaflow_transfer::{ConnectionStatus, HandshakeMetadata, TransferDesc, TransferOp};
+use pegaflow_transfer::{ConnectionStatus, HandshakeMetadata, TransferOp};
+use pegaflow_transfer_wire::TransferPlan;
 use tonic::transport::{Channel, Endpoint};
-
-use pegaflow_common::NumaNode;
 
 use opentelemetry::KeyValue;
 
 use super::{AllocateFn, PrefetchResult, RdmaTransport};
-use crate::block::{BlockKey, RawBlock, SealedBlock, Segment};
 use crate::internode::MetaServerClient;
 use crate::metrics::core_metrics;
+use crate::transfer_plan::{materialize_transfer_plan, rebuild_sealed_blocks};
 
 /// Minimum usable transfer timeout. If the server's lock timeout minus the
 /// safety margin falls below this, we use this floor to avoid instant timeouts.
@@ -199,18 +196,23 @@ async fn rdma_fetch_task(
 
     // 3. RDMA READ all blocks + build SealedBlocks
     let transfer_timeout = transfer_timeout_from_server(response.lock_timeout_secs);
-    let blocks = response.blocks;
-    let total_bytes: u64 = blocks
-        .iter()
-        .flat_map(|b| &b.slots)
-        .map(|s| s.k_size + s.v_size)
-        .sum();
+    let plan = match TransferPlan::decode_from_slice(&response.transfer_plan) {
+        Ok(plan) => plan,
+        Err(e) => {
+            warn!("Invalid transfer_plan from {remote_addr}: {e}");
+            core_metrics()
+                .rdma_fetch_total
+                .add(1, &[KeyValue::new("status", "error")]);
+            return Vec::new();
+        }
+    };
+    let total_bytes = plan.total_remote_bytes();
     let (result, transfer_timing) = match fetch_blocks_via_rdma(
         rdma,
         allocate_fn,
         namespace,
         remote_addr,
-        &blocks,
+        &plan,
         transfer_timeout,
     )
     .await
@@ -239,12 +241,13 @@ async fn rdma_fetch_task(
         0.0
     };
     info!(
-        "RDMA fetch summary: req_id={req_id} remote={remote_addr} blocks={}/{} slots={} descs={} slabs={} bytes_mib={mb:.1} total_ms={elapsed_ms:.2} tp_mib_s={throughput_mib_s:.0}",
+        "RDMA fetch summary: req_id={req_id} remote={remote_addr} blocks={}/{} chunks={} placements={} numa_slabs={} descs={} bytes_mib={mb:.1} total_ms={elapsed_ms:.2} tp_mib_s={throughput_mib_s:.0}",
         result.len(),
         block_hashes.len(),
-        transfer_timing.slot_count,
-        transfer_timing.transfer_desc_count,
+        plan.remote_chunks.len(),
+        plan.placements.len(),
         transfer_timing.numa_slab_count,
+        transfer_timing.transfer_desc_count,
     );
     info!(
         "RDMA fetch stages: req_id={req_id} remote={remote_addr} connect_ms={:.2} query_ms={:.2} build_transfer_tasks_ms={:.2} submit_transfer_ms={:.2} rdma_wait_ms={:.2} rebuild_ms={:.2}",
@@ -321,97 +324,32 @@ async fn fetch_blocks_via_rdma(
     allocate_fn: &AllocateFn,
     namespace: &str,
     remote_addr: &str,
-    blocks: &[TransferBlockInfo],
+    plan: &TransferPlan,
     transfer_timeout: Duration,
 ) -> Result<(PrefetchResult, TransferTiming), String> {
-    if blocks.is_empty() {
+    if plan.block_hashes.is_empty() {
         return Ok((Vec::new(), TransferTiming::default()));
     }
 
-    let bytes_per_numa = sum_segment_bytes_by_numa(blocks)?;
-    let mut numa_slabs = allocate_numa_slabs(allocate_fn, bytes_per_numa)?;
-
-    // (block_hash, Vec<(slot_segments)>) — for building SealedBlock afterwards
-    let mut block_allocs: Vec<(Vec<u8>, Vec<Vec<SegmentAlloc>>)> = Vec::new();
-    let mut slot_count = 0usize;
     let build_start = Instant::now();
-
-    // Build TransferDescs and submit RDMA READ inside a sync block so that
-    // all_descs (which contains NonNull<u8>, !Send) is dropped before any .await.
-    let (receivers, mut timing) = {
-        let mut all_descs: Vec<TransferDesc> = Vec::new();
-
-        for block_info in blocks {
-            slot_count += block_info.slots.len();
-            let mut slot_allocs = Vec::with_capacity(block_info.slots.len());
-
-            for slot in &block_info.slots {
-                let mut segments = Vec::new();
-                let numa = NumaNode(slot.numa_node);
-
-                // K segment
-                if slot.k_size > 0 {
-                    let len = usize::try_from(slot.k_size)
-                        .map_err(|_| format!("K size exceeds usize: {}", slot.k_size))?;
-                    let (local_ptr, alloc) =
-                        alloc_segment_from_slab(&mut numa_slabs, numa, len, "K")?;
-                    let remote_ptr = NonNull::new(slot.k_ptr as *mut u8)
-                        .ok_or_else(|| "remote K ptr is null".to_string())?;
-                    all_descs.push(TransferDesc {
-                        local_ptr,
-                        remote_ptr,
-                        len,
-                    });
-                    segments.push(SegmentAlloc {
-                        ptr_addr: local_ptr.as_ptr() as u64,
-                        alloc,
-                        size: len,
-                    });
-                }
-
-                // V segment (split KV)
-                if slot.v_size > 0 && slot.v_ptr != 0 {
-                    let len = usize::try_from(slot.v_size)
-                        .map_err(|_| format!("V size exceeds usize: {}", slot.v_size))?;
-                    let (local_ptr, alloc) =
-                        alloc_segment_from_slab(&mut numa_slabs, numa, len, "V")?;
-                    let remote_ptr = NonNull::new(slot.v_ptr as *mut u8)
-                        .ok_or_else(|| "remote V ptr is null".to_string())?;
-                    all_descs.push(TransferDesc {
-                        local_ptr,
-                        remote_ptr,
-                        len,
-                    });
-                    segments.push(SegmentAlloc {
-                        ptr_addr: local_ptr.as_ptr() as u64,
-                        alloc,
-                        size: len,
-                    });
-                }
-
-                slot_allocs.push(segments);
-            }
-
-            block_allocs.push((block_info.block_hash.clone(), slot_allocs));
-        }
-
-        if all_descs.is_empty() {
+    let (receivers, mut timing, rebuild_ctx) = {
+        let materialized = materialize_transfer_plan(plan, allocate_fn)?;
+        let transfer_desc_count = materialized.rdma_descs.len();
+        let numa_slab_count = materialized.rebuild.slabs.len();
+        if materialized.rdma_descs.is_empty() {
             let timing = TransferTiming {
                 build_transfer_tasks: build_start.elapsed(),
-                slot_count,
-                numa_slab_count: numa_slabs.len(),
+                transfer_desc_count,
+                numa_slab_count,
                 ..TransferTiming::default()
             };
             return Ok((Vec::new(), timing));
         }
 
-        let transfer_desc_count = all_descs.len();
-
-        // Submit RDMA READ; all_descs is dropped at the end of this block.
         let submit_start = Instant::now();
         let receivers = rdma
             .engine()
-            .batch_transfer_async(TransferOp::Read, remote_addr, &all_descs)
+            .batch_transfer_async(TransferOp::Read, remote_addr, &materialized.rdma_descs)
             .map_err(|e| format!("RDMA batch_transfer_async failed: {e}"))?;
         let submit_transfer = submit_start.elapsed();
 
@@ -419,11 +357,11 @@ async fn fetch_blocks_via_rdma(
             build_transfer_tasks: build_start.elapsed().saturating_sub(submit_transfer),
             submit_transfer,
             transfer_desc_count,
-            slot_count,
-            numa_slab_count: numa_slabs.len(),
+            numa_slab_count,
             ..TransferTiming::default()
         };
-        (receivers, timing)
+        let rebuild_ctx = materialized.rebuild;
+        (receivers, timing, rebuild_ctx)
     };
 
     let wait_start = Instant::now();
@@ -439,130 +377,11 @@ async fn fetch_blocks_via_rdma(
     .map_err(|_| "RDMA transfer timed out".to_string())??;
     timing.rdma_wait = wait_start.elapsed();
 
-    // Build SealedBlocks from allocated memory
     let rebuild_start = Instant::now();
-    let mut result: PrefetchResult = Vec::with_capacity(block_allocs.len());
-    for (hash, slot_allocs) in block_allocs {
-        let key = BlockKey::new(namespace.to_string(), hash);
-        let slots: Vec<RawBlock> = slot_allocs
-            .into_iter()
-            .map(|segs| {
-                let segments: Vec<Segment> = segs
-                    .into_iter()
-                    .map(|sa| {
-                        let ptr = NonNull::new(sa.ptr_addr as *mut u8)
-                            .expect("slab segment pointer must be non-null");
-                        Segment::new(ptr, sa.size, sa.alloc)
-                    })
-                    .collect();
-                RawBlock::new(segments)
-            })
-            .collect();
-        let sealed = Arc::new(SealedBlock::from_slots(slots));
-        result.push((key, sealed));
-    }
+    let result = rebuild_sealed_blocks(plan, &rebuild_ctx, namespace)?;
     timing.rebuild = rebuild_start.elapsed();
 
     Ok((result, timing))
-}
-
-fn sum_segment_bytes_by_numa(
-    blocks: &[TransferBlockInfo],
-) -> Result<HashMap<NumaNode, u64>, String> {
-    let mut bytes_per_numa: HashMap<NumaNode, u64> = HashMap::new();
-    for block_info in blocks {
-        for slot in &block_info.slots {
-            let numa = NumaNode(slot.numa_node);
-            if slot.k_size > 0 {
-                let total = bytes_per_numa.entry(numa).or_insert(0);
-                *total = total.checked_add(slot.k_size).ok_or_else(|| {
-                    format!("numa bytes overflow while summing K segments on {numa}")
-                })?;
-            }
-            if slot.v_size > 0 && slot.v_ptr != 0 {
-                let total = bytes_per_numa.entry(numa).or_insert(0);
-                *total = total.checked_add(slot.v_size).ok_or_else(|| {
-                    format!("numa bytes overflow while summing V segments on {numa}")
-                })?;
-            }
-        }
-    }
-    Ok(bytes_per_numa)
-}
-
-fn allocate_numa_slabs(
-    allocate_fn: &AllocateFn,
-    bytes_per_numa: HashMap<NumaNode, u64>,
-) -> Result<HashMap<NumaNode, NumaSlab>, String> {
-    let mut numa_slabs: HashMap<NumaNode, NumaSlab> = HashMap::new();
-    for (numa, total_bytes) in bytes_per_numa {
-        if total_bytes == 0 {
-            continue;
-        }
-        let allocation = allocate_fn(total_bytes, Some(numa))
-            .ok_or_else(|| format!("failed to allocate slab ({total_bytes} bytes) for {numa}"))?;
-        let capacity = usize::try_from(total_bytes)
-            .map_err(|_| format!("slab size exceeds usize for {numa}: {total_bytes}"))?;
-        numa_slabs.insert(
-            numa,
-            NumaSlab {
-                allocation,
-                next_offset: 0,
-                capacity,
-            },
-        );
-    }
-    Ok(numa_slabs)
-}
-
-fn alloc_segment_from_slab(
-    slabs: &mut HashMap<NumaNode, NumaSlab>,
-    numa: NumaNode,
-    len: usize,
-    segment_kind: &str,
-) -> Result<(NonNull<u8>, Arc<crate::pinned_pool::PinnedAllocation>), String> {
-    let slab = slabs
-        .get_mut(&numa)
-        .ok_or_else(|| format!("missing slab for {numa} while allocating {segment_kind}"))?;
-    slab.allocate(len, segment_kind)
-}
-
-struct NumaSlab {
-    allocation: Arc<crate::pinned_pool::PinnedAllocation>,
-    next_offset: usize,
-    capacity: usize,
-}
-
-impl NumaSlab {
-    fn allocate(
-        &mut self,
-        len: usize,
-        segment_kind: &str,
-    ) -> Result<(NonNull<u8>, Arc<crate::pinned_pool::PinnedAllocation>), String> {
-        let end = self.next_offset.checked_add(len).ok_or_else(|| {
-            format!(
-                "slab offset overflow while allocating {segment_kind}: offset={} len={len} capacity={}",
-                self.next_offset, self.capacity
-            )
-        })?;
-        if end > self.capacity {
-            return Err(format!(
-                "slab exhausted while allocating {segment_kind}: offset={} len={len} capacity={}",
-                self.next_offset, self.capacity
-            ));
-        }
-
-        let ptr = unsafe { self.allocation.as_non_null().as_ptr().add(self.next_offset) };
-        self.next_offset = end;
-        let ptr = NonNull::new(ptr).ok_or_else(|| "slab pointer is null".to_string())?;
-        Ok((ptr, Arc::clone(&self.allocation)))
-    }
-}
-
-struct SegmentAlloc {
-    ptr_addr: u64,
-    alloc: Arc<crate::pinned_pool::PinnedAllocation>,
-    size: usize,
 }
 
 #[derive(Default)]
@@ -572,7 +391,6 @@ struct TransferTiming {
     rdma_wait: Duration,
     rebuild: Duration,
     transfer_desc_count: usize,
-    slot_count: usize,
     numa_slab_count: usize,
 }
 
@@ -592,9 +410,7 @@ fn get_or_create_channel(
         .map_err(|e| format!("invalid remote address: {e}"))?
         .connect_timeout(Duration::from_secs(5))
         .connect_lazy();
-    // Match the engine server's 64 MiB message cap: a QueryBlocksForTransfer
-    // response carries per-slot transfer descriptors, so a large block batch
-    // overflows tonic's default 4 MiB decode limit.
+    // Match the engine server's 64 MiB message cap.
     const MAX_GRPC_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
     let client = EngineClient::new(channel)
         .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
@@ -678,87 +494,27 @@ fn spawn_release_lock(mut client: EngineClient<Channel>, transfer_session_id: St
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::collections::HashMap;
-    use std::num::NonZeroU64;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    use pegaflow_proto::proto::engine::TransferSlotInfo;
-
-    fn slot(k_size: u64, v_ptr: u64, v_size: u64, numa: u32) -> TransferSlotInfo {
-        TransferSlotInfo {
-            k_ptr: 0x1000,
-            k_size,
-            v_ptr,
-            v_size,
-            numa_node: numa,
-        }
-    }
-
-    fn test_allocate_fn(calls: Arc<AtomicUsize>) -> AllocateFn {
-        let allocator = Arc::new(crate::pinned_pool::PinnedAllocator::new_global(
-            32 * 1024 * 1024,
-            1,
-            false,
-            false,
-            None,
-        ));
-        Arc::new(move |size, _numa| {
-            calls.fetch_add(1, Ordering::Relaxed);
-            allocator.allocate(NonZeroU64::new(size)?, NumaNode::UNKNOWN)
-        })
-    }
+    use pegaflow_transfer_wire::{RemoteChunk, TransferPlan};
 
     #[test]
-    fn sum_segment_bytes_by_numa_aggregates_k_and_v() {
-        let blocks = vec![
-            TransferBlockInfo {
-                block_hash: vec![1],
-                slots: vec![
-                    slot(100, 0, 0, 0),        // contiguous
-                    slot(200, 0x2000, 300, 0), // split KV
-                ],
-            },
-            TransferBlockInfo {
-                block_hash: vec![2],
-                slots: vec![slot(400, 0x3000, 500, 1)],
-            },
-        ];
-
-        let totals = sum_segment_bytes_by_numa(&blocks).expect("sum bytes");
-        assert_eq!(totals.get(&NumaNode(0)), Some(&600)); // 100 + (200 + 300)
-        assert_eq!(totals.get(&NumaNode(1)), Some(&900)); // 400 + 500
-    }
-
-    #[test]
-    fn allocate_numa_slabs_calls_allocator_once_per_numa() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let allocate_fn = test_allocate_fn(Arc::clone(&calls));
-
-        let bytes_per_numa = HashMap::from([(NumaNode(0), 1024_u64), (NumaNode(1), 2048_u64)]);
-        let slabs = allocate_numa_slabs(&allocate_fn, bytes_per_numa).expect("allocate slabs");
-
-        assert_eq!(slabs.len(), 2);
-        assert_eq!(calls.load(Ordering::Relaxed), 2);
-    }
-
-    #[test]
-    fn slab_allocation_is_contiguous_and_bounded() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let allocate_fn = test_allocate_fn(Arc::clone(&calls));
-
-        let mut slabs = allocate_numa_slabs(&allocate_fn, HashMap::from([(NumaNode(0), 1024_u64)]))
-            .expect("allocate slabs");
-        assert_eq!(calls.load(Ordering::Relaxed), 1);
-
-        let (p1, _a1) =
-            alloc_segment_from_slab(&mut slabs, NumaNode(0), 256, "K").expect("alloc p1");
-        let (p2, _a2) =
-            alloc_segment_from_slab(&mut slabs, NumaNode(0), 128, "V").expect("alloc p2");
-        assert_eq!(p2.as_ptr() as usize - p1.as_ptr() as usize, 256);
-
-        let overflow = alloc_segment_from_slab(&mut slabs, NumaNode(0), 1024, "K");
-        assert!(overflow.is_err());
+    fn transfer_plan_total_remote_bytes_sums_chunks() {
+        let plan = TransferPlan {
+            slot_schemas: vec![],
+            remote_chunks: vec![
+                RemoteChunk {
+                    base_ptr: 0x1000,
+                    length: 100,
+                    numa_node: 0,
+                },
+                RemoteChunk {
+                    base_ptr: 0x2000,
+                    length: 200,
+                    numa_node: 0,
+                },
+            ],
+            placements: vec![],
+            block_hashes: vec![],
+        };
+        assert_eq!(plan.total_remote_bytes(), 300);
     }
 }

--- a/pegaflow-core/src/block.rs
+++ b/pegaflow-core/src/block.rs
@@ -268,18 +268,33 @@ impl SealedBlock {
         &self.slot_numas
     }
 
-    /// Create from a vec of slots (for deserialization / prefetch rebuild)
+    /// Create from a vec of slots (for deserialization / prefetch rebuild).
+    ///
+    /// Leaves `slot_numas` empty on purpose: these blocks carry NUMA in
+    /// `SlotMeta`, and consumers fall back to `UNKNOWN` (see `ssd_cache`). The
+    /// strict per-slot NUMA path is [`Self::from_slots_with_numas`].
     pub(crate) fn from_slots(slots: Vec<RawBlock>) -> Self {
         assert!(
             !slots.is_empty(),
             "sealed block must have at least one slot"
         );
         let footprint = slots.iter().map(|s| s.memory_footprint()).sum();
-        Self {
-            slots: slots.into_boxed_slice(),
-            footprint,
-            slot_numas: Vec::new(),
-        }
+        Self::from_slots_with_footprint(slots.into_boxed_slice(), footprint, Vec::new())
+    }
+
+    /// Rebuild path: preserve per-slot NUMA (e.g. from transfer-plan chunk placement).
+    pub(crate) fn from_slots_with_numas(slots: Vec<RawBlock>, slot_numas: Vec<NumaNode>) -> Self {
+        assert!(
+            !slots.is_empty(),
+            "sealed block must have at least one slot"
+        );
+        assert_eq!(
+            slots.len(),
+            slot_numas.len(),
+            "slot_numas length must match slot count"
+        );
+        let footprint = slots.iter().map(|s| s.memory_footprint()).sum();
+        Self::from_slots_with_footprint(slots.into_boxed_slice(), footprint, slot_numas)
     }
 
     /// Create from slots with pre-computed footprint (internal use)

--- a/pegaflow-core/src/block.rs
+++ b/pegaflow-core/src/block.rs
@@ -270,6 +270,10 @@ impl SealedBlock {
 
     /// Create from a vec of slots (for deserialization / prefetch rebuild)
     pub(crate) fn from_slots(slots: Vec<RawBlock>) -> Self {
+        assert!(
+            !slots.is_empty(),
+            "sealed block must have at least one slot"
+        );
         let footprint = slots.iter().map(|s| s.memory_footprint()).sum();
         Self {
             slots: slots.into_boxed_slice(),
@@ -297,6 +301,7 @@ impl SealedBlock {
         total_slots: usize,
         numa_node: NumaNode,
     ) -> Result<Self, Vec<(usize, RawBlock)>> {
+        assert!(total_slots > 0, "total_slots must be > 0");
         if slots.len() != total_slots
             || slots
                 .iter()
@@ -318,6 +323,23 @@ impl SealedBlock {
             footprint,
             vec![numa_node; total_slots],
         ))
+    }
+}
+
+#[cfg(test)]
+impl SealedBlock {
+    /// Minimal sealed block for unit tests that only need a non-empty slot layout.
+    pub(crate) fn test_dummy() -> Self {
+        use std::num::NonZeroU64;
+
+        let allocator = Arc::new(crate::pinned_pool::PinnedAllocator::new_global(
+            4096, 1, false, false, None,
+        ));
+        let allocation = allocator
+            .allocate(NonZeroU64::new(64).unwrap(), NumaNode::UNKNOWN)
+            .expect("test allocation");
+        let segment = Segment::new(allocation.as_non_null(), 64, allocation);
+        Self::from_slots(vec![RawBlock::single_segment(segment)])
     }
 }
 
@@ -354,6 +376,7 @@ pub(crate) struct InflightBlock {
 
 impl InflightBlock {
     pub(crate) fn new(total_slots: usize) -> Self {
+        assert!(total_slots > 0, "total_slots must be > 0");
         Self {
             slots: (0..total_slots).map(|_| None).collect(),
             remaining: total_slots,

--- a/pegaflow-core/src/cache.rs
+++ b/pegaflow-core/src/cache.rs
@@ -266,7 +266,7 @@ mod tests {
     fn contains_key_does_not_bump_frequency() {
         let mut cache = TinyLfuCache::new_unbounded(1024, true, Some(1));
         let key = BlockKey::new("ns".to_string(), vec![1, 2, 3, 4]);
-        let value = Arc::new(SealedBlock::from_slots(Vec::new()));
+        let value = Arc::new(SealedBlock::test_dummy());
 
         let _ = cache.insert(key.clone(), value);
         let before = cache.freq.as_ref().expect("lfu enabled").get(&key);

--- a/pegaflow-core/src/lease.rs
+++ b/pegaflow-core/src/lease.rs
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn consume_allows_configured_number_of_consumers() {
         let manager = QueryLeaseManager::default();
-        let blocks = vec![Arc::new(SealedBlock::from_slots(Vec::new()))];
+        let blocks = vec![Arc::new(SealedBlock::test_dummy())];
         let lease_id = manager.create("inst-a", blocks, 2);
 
         assert_eq!(manager.consume("inst-a", &lease_id).unwrap().len(), 1);

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -28,6 +28,15 @@ mod seal_offload;
 mod storage;
 pub mod sync_state;
 pub mod transfer;
+#[cfg(feature = "rdma")]
+pub(crate) mod transfer_plan;
+
+#[cfg(feature = "rdma")]
+pub fn encode_transfer_plan_bytes(
+    found_blocks: &[(BlockKey, Arc<SealedBlock>)],
+) -> Result<Vec<u8>, String> {
+    transfer_plan::encode_transfer_plan_bytes(found_blocks)
+}
 
 pub use backing::{
     DEFAULT_SSD_PREFETCH_INFLIGHT, DEFAULT_SSD_PREFETCH_QUEUE_DEPTH, DEFAULT_SSD_WRITE_INFLIGHT,

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -31,6 +31,11 @@ pub mod transfer;
 #[cfg(feature = "rdma")]
 pub(crate) mod transfer_plan;
 
+/// Benchmark-only fixtures for the cross-node rebuild hot path. Gated behind the
+/// `bench` feature; never present in production builds.
+#[cfg(all(feature = "bench", feature = "rdma"))]
+pub use transfer_plan::bench_support;
+
 #[cfg(feature = "rdma")]
 pub fn encode_transfer_plan_bytes(
     found_blocks: &[(BlockKey, Arc<SealedBlock>)],

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -637,8 +637,8 @@ mod tests {
         let storage = make_engine();
         let key1 = BlockKey::new("ns".into(), vec![1]);
         let key2 = BlockKey::new("ns".into(), vec![2]);
-        let block1 = Arc::new(SealedBlock::from_slots(Vec::new()));
-        let block2 = Arc::new(SealedBlock::from_slots(Vec::new()));
+        let block1 = Arc::new(SealedBlock::test_dummy());
+        let block2 = Arc::new(SealedBlock::test_dummy());
 
         storage.test_insert_cache(key1, Arc::clone(&block1));
         storage.test_insert_cache(key2, block2);
@@ -682,7 +682,7 @@ mod tests {
         let storage = make_engine();
         let key1 = BlockKey::new("ns".into(), vec![1]);
         let key2 = BlockKey::new("ns".into(), vec![2]);
-        let block = Arc::new(SealedBlock::from_slots(Vec::new()));
+        let block = Arc::new(SealedBlock::test_dummy());
 
         storage.test_insert_cache(key1, block.clone());
         storage.test_insert_cache(key2, block);
@@ -703,7 +703,7 @@ mod tests {
         let key1 = BlockKey::new("ns".into(), vec![1]);
         let key2 = BlockKey::new("ns".into(), vec![2]);
         let key3 = BlockKey::new("ns".into(), vec![3]);
-        let block = Arc::new(SealedBlock::from_slots(Vec::new()));
+        let block = Arc::new(SealedBlock::test_dummy());
 
         storage.test_insert_cache(key1.clone(), block.clone());
         storage.test_insert_cache(key3.clone(), block.clone());
@@ -741,7 +741,7 @@ mod tests {
     async fn lock_and_release_transfer_when_enabled() {
         let storage = make_engine();
         let key = BlockKey::new("ns".into(), vec![1]);
-        let block = Arc::new(SealedBlock::from_slots(Vec::new()));
+        let block = Arc::new(SealedBlock::test_dummy());
 
         storage.test_insert_cache(key.clone(), block.clone());
 

--- a/pegaflow-core/src/storage/prefetch.rs
+++ b/pegaflow-core/src/storage/prefetch.rs
@@ -569,7 +569,7 @@ mod tests {
     }
 
     fn block() -> Arc<SealedBlock> {
-        Arc::new(SealedBlock::from_slots(Vec::new()))
+        Arc::new(SealedBlock::test_dummy())
     }
 
     #[test]

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -113,7 +113,7 @@ mod tests {
     }
 
     fn make_block() -> Arc<SealedBlock> {
-        Arc::new(SealedBlock::from_slots(Vec::new()))
+        Arc::new(SealedBlock::test_dummy())
     }
 
     #[test]

--- a/pegaflow-core/src/storage/transfer_lock.rs
+++ b/pegaflow-core/src/storage/transfer_lock.rs
@@ -157,7 +157,7 @@ mod tests {
 
     fn make_test_block() -> (BlockKey, Arc<SealedBlock>) {
         let key = BlockKey::new("ns".into(), vec![1, 2, 3]);
-        let block = Arc::new(SealedBlock::from_slots(Vec::new()));
+        let block = Arc::new(SealedBlock::test_dummy());
         (key, block)
     }
 
@@ -203,7 +203,7 @@ mod tests {
         let mgr = TransferLockManager::new(Duration::from_secs(30));
         let (key1, block1) = make_test_block();
         let key2 = BlockKey::new("ns".into(), vec![4, 5, 6]);
-        let block2 = Arc::new(SealedBlock::from_slots(Vec::new()));
+        let block2 = Arc::new(SealedBlock::test_dummy());
 
         let s1 = mgr.lock_blocks("node-a", vec![(key1.clone(), block1.clone())]);
         let s2 = mgr.lock_blocks("node-b", vec![(key1, block1), (key2, block2)]);
@@ -223,7 +223,7 @@ mod tests {
     fn arc_keeps_memory_alive() {
         let mgr = TransferLockManager::new(Duration::from_secs(30));
         let key = BlockKey::new("ns".into(), vec![1]);
-        let block = Arc::new(SealedBlock::from_slots(Vec::new()));
+        let block = Arc::new(SealedBlock::test_dummy());
 
         // Lock holds an Arc clone
         let session_id = mgr.lock_blocks("node-a", vec![(key, block.clone())]);
@@ -285,7 +285,7 @@ mod tests {
             let blocks: Vec<(BlockKey, Arc<SealedBlock>)> = (0..blocks_per_session)
                 .map(|j| {
                     let key = BlockKey::new("ns".into(), vec![i as u8, j as u8]);
-                    let block = Arc::new(SealedBlock::from_slots(Vec::new()));
+                    let block = Arc::new(SealedBlock::test_dummy());
                     (key, block)
                 })
                 .collect();
@@ -339,7 +339,7 @@ mod tests {
 
         // Session 2: fresh, should NOT expire
         let key2 = BlockKey::new("ns".into(), vec![7, 8, 9]);
-        let block2 = Arc::new(SealedBlock::from_slots(Vec::new()));
+        let block2 = Arc::new(SealedBlock::test_dummy());
         let s2 = mgr.lock_blocks("node-b", vec![(key2, block2)]);
 
         assert_eq!(mgr.active_session_count(), 2);

--- a/pegaflow-core/src/storage/transfer_lock.rs
+++ b/pegaflow-core/src/storage/transfer_lock.rs
@@ -281,12 +281,17 @@ mod tests {
         let blocks_per_session = 5;
         let num_sessions = 100;
 
+        // The manager only refcounts opaque Arc<SealedBlock> handles, so every
+        // entry shares one block. Allocating a distinct block per entry would
+        // mean num_sessions * blocks_per_session real cudaHostAlloc pinned pools
+        // (each mapped allocation reserves ~100MB), OOM-killing the test box.
+        let block = Arc::new(SealedBlock::test_dummy());
+
         for i in 0..num_sessions {
             let blocks: Vec<(BlockKey, Arc<SealedBlock>)> = (0..blocks_per_session)
                 .map(|j| {
                     let key = BlockKey::new("ns".into(), vec![i as u8, j as u8]);
-                    let block = Arc::new(SealedBlock::test_dummy());
-                    (key, block)
+                    (key, Arc::clone(&block))
                 })
                 .collect();
             let requester = format!("node-{}", i);

--- a/pegaflow-core/src/transfer_plan/bench_support.rs
+++ b/pegaflow-core/src/transfer_plan/bench_support.rs
@@ -1,0 +1,163 @@
+//! Benchmark-only fixtures for the cross-node `rebuild_sealed_blocks` hot path.
+//!
+//! Builds a vLLM-shaped transfer plan (`slots = layers * tp`, split K/V) through
+//! the real encode -> materialize pipeline, then exposes a single `rebuild()`
+//! call for criterion to time. Gated behind the `bench` feature so it never
+//! ships in production builds.
+
+use std::num::NonZeroU64;
+use std::sync::Arc;
+
+use pegaflow_common::NumaNode;
+use pegaflow_transfer_wire::TransferPlan;
+
+use crate::BlockKey;
+use crate::backing::AllocateFn;
+use crate::block::{RawBlock, SealedBlock, Segment};
+use crate::pinned_pool::PinnedAllocator;
+
+use super::materialize::RebuildContext;
+use super::{
+    encode::encode_transfer_plan, encode_transfer_plan_bytes, materialize_transfer_plan,
+    rebuild_sealed_blocks,
+};
+
+const NAMESPACE: &str = "rebuild-bench";
+const SEGMENTS_PER_SLOT: usize = 2; // split K/V
+
+/// A prepared transfer plan plus its materialized local slab, ready to rebuild
+/// repeatedly. Construction runs the real encode + materialize pipeline; only
+/// [`Self::rebuild`] should be timed.
+pub struct RebuildFixture {
+    plan: TransferPlan,
+    rebuild: RebuildContext,
+    cells: usize,
+}
+
+impl RebuildFixture {
+    /// Build a fixture of `blocks` sealed blocks, each with `slots` slots (one
+    /// per layer*rank) of split K/V segments of `seg_bytes` each.
+    ///
+    /// Rebuild cost is driven by cell count (`blocks * slots * 2`), not segment
+    /// byte size, so `seg_bytes` can stay tiny to keep the slab small.
+    pub fn new(blocks: usize, slots: usize, seg_bytes: usize) -> Self {
+        assert!(blocks > 0 && slots > 0 && seg_bytes > 0);
+        let found = build_source_blocks(blocks, slots, seg_bytes);
+        let plan = encode_transfer_plan(&found).expect("encode transfer plan");
+        // Source blocks only feed encode; drop them so the bench measures
+        // rebuild against the freshly materialized slab alone.
+        drop(found);
+
+        let allocate_fn = bench_allocate_fn(plan.total_remote_bytes());
+        let materialized =
+            materialize_transfer_plan(&plan, &allocate_fn).expect("materialize transfer plan");
+        let cells = blocks * slots * SEGMENTS_PER_SLOT;
+        Self {
+            plan,
+            rebuild: materialized.rebuild,
+            cells,
+        }
+    }
+
+    /// Run the production rebuild once; returns the rebuilt block count.
+    pub fn rebuild(&self) -> usize {
+        rebuild_sealed_blocks(&self.plan, &self.rebuild, NAMESPACE)
+            .expect("rebuild sealed blocks")
+            .len()
+    }
+
+    /// `(placements, remote_chunks, cells)` for reporting.
+    pub fn stats(&self) -> (usize, usize, usize) {
+        (
+            self.plan.placements.len(),
+            self.plan.remote_chunks.len(),
+            self.cells,
+        )
+    }
+}
+
+/// Source blocks plus their encoded wire bytes, for benching the query path:
+/// `encode` is the serving-side hot path behind `QueryBlocksForTransfer`,
+/// `decode` is the requesting side parsing + validating the response.
+pub struct QueryFixture {
+    found: Vec<(BlockKey, Arc<SealedBlock>)>,
+    bytes: Vec<u8>,
+}
+
+impl QueryFixture {
+    pub fn new(blocks: usize, slots: usize, seg_bytes: usize) -> Self {
+        assert!(blocks > 0 && slots > 0 && seg_bytes > 0);
+        let found = build_source_blocks(blocks, slots, seg_bytes);
+        let bytes = encode_transfer_plan_bytes(&found).expect("encode transfer plan bytes");
+        Self { found, bytes }
+    }
+
+    /// Server-side: build the `TransferPlan` from sealed blocks and postcard-encode.
+    pub fn encode(&self) -> usize {
+        encode_transfer_plan_bytes(&self.found)
+            .expect("encode transfer plan bytes")
+            .len()
+    }
+
+    /// Client-side: decode + validate the wire bytes back into a `TransferPlan`.
+    pub fn decode(&self) -> usize {
+        TransferPlan::decode_from_slice(&self.bytes)
+            .expect("decode transfer plan")
+            .block_hashes
+            .len()
+    }
+
+    pub fn wire_len(&self) -> usize {
+        self.bytes.len()
+    }
+}
+
+fn bench_allocate_fn(total_bytes: u64) -> AllocateFn {
+    let capacity = (total_bytes as usize)
+        .next_power_of_two()
+        .max(64 * 1024 * 1024);
+    let allocator = Arc::new(PinnedAllocator::new_global(capacity, 1, false, false, None));
+    Arc::new(move |size, _numa| allocator.allocate(NonZeroU64::new(size)?, NumaNode::UNKNOWN))
+}
+
+fn build_source_blocks(
+    blocks: usize,
+    slots: usize,
+    seg_bytes: usize,
+) -> Vec<(BlockKey, Arc<SealedBlock>)> {
+    // One slab; cell (slot s, segment g, block i) lives at byte offset
+    //   ((s * 2 + g) * blocks + i) * seg_bytes.
+    // For a fixed (slot, segment) the blocks are contiguous with stride ==
+    // seg_bytes, so encode coalesces each (slot, segment) into one run: the
+    // plan ends up with `slots * 2` placements of `blocks` each, mirroring the
+    // real vLLM-shaped layout (layers*tp slots, split K/V).
+    let total = (blocks * slots * SEGMENTS_PER_SLOT * seg_bytes) as u64;
+    let capacity = (total as usize).next_power_of_two().max(64 * 1024 * 1024);
+    let allocator = Arc::new(PinnedAllocator::new_global(capacity, 1, false, false, None));
+    let slab = allocator
+        .allocate(
+            NonZeroU64::new(total).expect("non-zero slab"),
+            NumaNode::UNKNOWN,
+        )
+        .expect("source slab");
+    let base = slab.mapped_ptr();
+
+    let mut found = Vec::with_capacity(blocks);
+    for i in 0..blocks {
+        let mut slot_inserts = Vec::with_capacity(slots);
+        for s in 0..slots {
+            let k_off = ((s * SEGMENTS_PER_SLOT) * blocks + i) * seg_bytes;
+            let v_off = ((s * SEGMENTS_PER_SLOT + 1) * blocks + i) * seg_bytes;
+            let k_seg = Segment::new(base.add(k_off).host(), seg_bytes, Arc::clone(&slab));
+            let v_seg = Segment::new(base.add(v_off).host(), seg_bytes, Arc::clone(&slab));
+            slot_inserts.push((s, RawBlock::two_segments(k_seg, v_seg)));
+        }
+        let mut hash = Vec::with_capacity(4);
+        hash.extend_from_slice(&(i as u32).to_le_bytes());
+        let key = BlockKey::new(NAMESPACE.to_string(), hash);
+        let sealed = SealedBlock::from_ordered_slot_inserts(slot_inserts, slots, NumaNode(0))
+            .unwrap_or_else(|_| panic!("ordered slot inserts for block {i}"));
+        found.push((key, Arc::new(sealed)));
+    }
+    found
+}

--- a/pegaflow-core/src/transfer_plan/encode.rs
+++ b/pegaflow-core/src/transfer_plan/encode.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use pegaflow_transfer_wire::TransferPlan;
+
+use crate::BlockKey;
+use crate::block::SealedBlock;
+
+use super::merge::build_transfer_geometry;
+use super::schema::{TransferPlanError, derive_slot_schemas};
+use super::view::block_views_from_found;
+
+pub(crate) fn encode_transfer_plan(
+    found_blocks: &[(BlockKey, Arc<SealedBlock>)],
+) -> Result<TransferPlan, TransferPlanError> {
+    let views = block_views_from_found(found_blocks);
+    if views.is_empty() {
+        return Ok(TransferPlan {
+            slot_schemas: vec![],
+            remote_chunks: vec![],
+            placements: vec![],
+            block_hashes: vec![],
+        });
+    }
+
+    let slot_schemas = derive_slot_schemas(&views);
+    let (remote_chunks, placements) = build_transfer_geometry(&views, &slot_schemas);
+    let block_hashes = views.into_iter().map(|v| v.hash).collect();
+
+    let plan = TransferPlan {
+        slot_schemas,
+        remote_chunks,
+        placements,
+        block_hashes,
+    };
+    plan.validate()
+        .map_err(|e| TransferPlanError::new(e.to_string()))?;
+    Ok(plan)
+}
+
+pub(crate) fn encode_transfer_plan_bytes(
+    found_blocks: &[(BlockKey, Arc<SealedBlock>)],
+) -> Result<Vec<u8>, String> {
+    let plan = encode_transfer_plan(found_blocks).map_err(|e| e.to_string())?;
+    plan.encode_to_vec().map_err(|e| e.to_string())
+}

--- a/pegaflow-core/src/transfer_plan/encode.rs
+++ b/pegaflow-core/src/transfer_plan/encode.rs
@@ -12,7 +12,7 @@ use super::view::block_views_from_found;
 pub(crate) fn encode_transfer_plan(
     found_blocks: &[(BlockKey, Arc<SealedBlock>)],
 ) -> Result<TransferPlan, TransferPlanError> {
-    let views = block_views_from_found(found_blocks);
+    let views = block_views_from_found(found_blocks)?;
     if views.is_empty() {
         return Ok(TransferPlan {
             slot_schemas: vec![],
@@ -22,7 +22,7 @@ pub(crate) fn encode_transfer_plan(
         });
     }
 
-    let slot_schemas = derive_slot_schemas(&views);
+    let slot_schemas = derive_slot_schemas(&views)?;
     let (remote_chunks, placements) = build_transfer_geometry(&views, &slot_schemas);
     let block_hashes = views.into_iter().map(|v| v.hash).collect();
 

--- a/pegaflow-core/src/transfer_plan/encode.rs
+++ b/pegaflow-core/src/transfer_plan/encode.rs
@@ -7,13 +7,13 @@ use crate::block::SealedBlock;
 
 use super::merge::build_transfer_geometry;
 use super::schema::{TransferPlanError, derive_slot_schemas};
-use super::view::block_views_from_found;
+use super::view::block_matrix_from_found;
 
 pub(crate) fn encode_transfer_plan(
     found_blocks: &[(BlockKey, Arc<SealedBlock>)],
 ) -> Result<TransferPlan, TransferPlanError> {
-    let views = block_views_from_found(found_blocks)?;
-    if views.is_empty() {
+    let matrix = block_matrix_from_found(found_blocks)?;
+    if matrix.block_count() == 0 {
         return Ok(TransferPlan {
             slot_schemas: vec![],
             remote_chunks: vec![],
@@ -22,9 +22,9 @@ pub(crate) fn encode_transfer_plan(
         });
     }
 
-    let slot_schemas = derive_slot_schemas(&views)?;
-    let (remote_chunks, placements) = build_transfer_geometry(&views, &slot_schemas);
-    let block_hashes = views.into_iter().map(|v| v.hash).collect();
+    let slot_schemas = derive_slot_schemas(&matrix)?;
+    let (remote_chunks, placements) = build_transfer_geometry(&matrix, &slot_schemas);
+    let block_hashes = matrix.into_hashes();
 
     let plan = TransferPlan {
         slot_schemas,

--- a/pegaflow-core/src/transfer_plan/materialize.rs
+++ b/pegaflow-core/src/transfer_plan/materialize.rs
@@ -1,0 +1,131 @@
+use std::collections::BTreeMap;
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+use pegaflow_transfer::TransferDesc;
+use pegaflow_transfer_wire::TransferPlan;
+
+use pegaflow_common::NumaNode;
+
+use crate::backing::AllocateFn;
+use crate::pinned_pool::PinnedAllocation;
+
+/// NUMA slabs and per-chunk offsets used after RDMA completes. Safe to hold across `.await`.
+pub(crate) struct RebuildContext {
+    pub slabs: Vec<LocalSlab>,
+    pub chunk_local_offsets: Vec<usize>,
+}
+
+pub(crate) struct MaterializeOutput {
+    pub rebuild: RebuildContext,
+    pub rdma_descs: Vec<TransferDesc>,
+}
+
+pub(crate) struct LocalSlab {
+    pub numa: NumaNode,
+    pub allocation: Arc<PinnedAllocation>,
+    pub length: usize,
+}
+
+pub(crate) fn materialize_transfer_plan(
+    plan: &TransferPlan,
+    allocate_fn: &AllocateFn,
+) -> Result<MaterializeOutput, String> {
+    if plan.block_hashes.is_empty() {
+        return Ok(MaterializeOutput {
+            rebuild: RebuildContext {
+                slabs: vec![],
+                chunk_local_offsets: vec![],
+            },
+            rdma_descs: vec![],
+        });
+    }
+
+    let mut bytes_per_numa: BTreeMap<u32, usize> = BTreeMap::new();
+    for chunk in &plan.remote_chunks {
+        let length = usize::try_from(chunk.length)
+            .map_err(|_| format!("remote chunk length exceeds usize: {}", chunk.length))?;
+        *bytes_per_numa.entry(chunk.numa_node).or_default() += length;
+    }
+
+    let mut slabs = Vec::with_capacity(bytes_per_numa.len());
+    for (&numa_id, &total) in &bytes_per_numa {
+        let numa = NumaNode(numa_id);
+        let allocation = allocate_fn(total as u64, Some(numa))
+            .ok_or_else(|| format!("failed to allocate {total} bytes for NUMA slab on {numa}"))?;
+        slabs.push(LocalSlab {
+            numa,
+            allocation,
+            length: total,
+        });
+    }
+
+    let mut numa_cursor: BTreeMap<u32, usize> = BTreeMap::new();
+    let mut chunk_local_offsets = Vec::with_capacity(plan.remote_chunks.len());
+    let mut rdma_descs = Vec::with_capacity(plan.remote_chunks.len());
+
+    for chunk in &plan.remote_chunks {
+        let length = usize::try_from(chunk.length)
+            .map_err(|_| format!("remote chunk length exceeds usize: {}", chunk.length))?;
+        let local_offset = *numa_cursor.entry(chunk.numa_node).or_default();
+        numa_cursor.insert(chunk.numa_node, local_offset + length);
+        chunk_local_offsets.push(local_offset);
+
+        let slab = slab_for_numa(&slabs, chunk.numa_node)?;
+        let local_ptr = slab_ptr_at(slab, local_offset)?;
+        let remote_ptr = NonNull::new(chunk.base_ptr as *mut u8)
+            .ok_or_else(|| "remote chunk base ptr is null".to_string())?;
+
+        rdma_descs.push(TransferDesc {
+            local_ptr,
+            remote_ptr,
+            len: length,
+        });
+    }
+
+    Ok(MaterializeOutput {
+        rebuild: RebuildContext {
+            slabs,
+            chunk_local_offsets,
+        },
+        rdma_descs,
+    })
+}
+
+fn slab_for_numa(slabs: &[LocalSlab], numa_node: u32) -> Result<&LocalSlab, String> {
+    slabs
+        .iter()
+        .find(|slab| slab.numa.0 == numa_node)
+        .ok_or_else(|| format!("missing local slab for NUMA node {numa_node}"))
+}
+
+fn slab_ptr_at(slab: &LocalSlab, offset: usize) -> Result<NonNull<u8>, String> {
+    if offset > slab.length {
+        return Err(format!(
+            "offset {offset} exceeds NUMA slab length {}",
+            slab.length
+        ));
+    }
+    let ptr = unsafe { slab.allocation.as_non_null().as_ptr().add(offset) };
+    NonNull::new(ptr).ok_or_else(|| "computed slab pointer is null".to_string())
+}
+
+pub(crate) fn chunk_ptr_at(
+    rebuild: &RebuildContext,
+    plan: &TransferPlan,
+    chunk_idx: u32,
+    offset_in_chunk: usize,
+) -> Result<(NonNull<u8>, Arc<PinnedAllocation>), String> {
+    let chunk = plan
+        .remote_chunks
+        .get(chunk_idx as usize)
+        .ok_or_else(|| format!("missing remote chunk {chunk_idx}"))?;
+    let local_chunk_offset = rebuild
+        .chunk_local_offsets
+        .get(chunk_idx as usize)
+        .copied()
+        .ok_or_else(|| format!("missing local offset for chunk {chunk_idx}"))?;
+    let slab = slab_for_numa(&rebuild.slabs, chunk.numa_node)?;
+    let offset = local_chunk_offset + offset_in_chunk;
+    Ok((slab_ptr_at(slab, offset)?, Arc::clone(&slab.allocation)))
+}

--- a/pegaflow-core/src/transfer_plan/materialize.rs
+++ b/pegaflow-core/src/transfer_plan/materialize.rs
@@ -110,6 +110,11 @@ fn slab_ptr_at(slab: &LocalSlab, offset: usize) -> Result<NonNull<u8>, String> {
     NonNull::new(ptr).ok_or_else(|| "computed slab pointer is null".to_string())
 }
 
+/// Resolve a chunk-relative offset to its local host pointer and owning slab.
+///
+/// Only the test transfer simulation needs this now; the production rebuild
+/// path resolves slabs once per chunk (see `rebuild::resolve_chunk_locs`).
+#[cfg(test)]
 pub(crate) fn chunk_ptr_at(
     rebuild: &RebuildContext,
     plan: &TransferPlan,

--- a/pegaflow-core/src/transfer_plan/merge.rs
+++ b/pegaflow-core/src/transfer_plan/merge.rs
@@ -1,10 +1,9 @@
 use pegaflow_transfer_wire::{RemoteChunk, SegmentPlacement, SlotSchema};
 
-use super::view::SegmentPoint;
+use super::view::{BlockMatrix, SegmentPoint};
 
 type TransferGeometry = (Vec<RemoteChunk>, Vec<SegmentPlacement>);
 type PtrInterval = (u64, u64, u32);
-type PartitionOutput = (Vec<PendingRun>, Vec<PendingSingle>, Vec<PtrInterval>);
 
 #[derive(Debug, Clone, Copy)]
 struct Interval {
@@ -30,73 +29,86 @@ struct PendingSingle {
     ptr: u64,
 }
 
+/// Accumulates the per-column partition results across every `(slot, segment)`
+/// before they are resolved into coalesced chunks + placements.
+#[derive(Default)]
+struct PartitionSink {
+    runs: Vec<PendingRun>,
+    singles: Vec<PendingSingle>,
+    intervals: Vec<PtrInterval>,
+}
+
 pub(crate) fn build_transfer_geometry(
-    views: &[super::view::BlockView],
+    matrix: &BlockMatrix,
     slot_schemas: &[SlotSchema],
 ) -> TransferGeometry {
-    if views.is_empty() {
+    let block_count = matrix.block_count();
+    if block_count == 0 {
         return (vec![], vec![]);
     }
 
-    let mut pending_runs = Vec::new();
-    let mut pending_singles = Vec::new();
-    let mut intervals = Vec::new();
+    let mut sink = PartitionSink::default();
+    // One scratch buffer reused across every (slot, segment) column instead of
+    // allocating a fresh point vector per column.
+    let mut points: Vec<SegmentPoint> = Vec::with_capacity(block_count);
 
     for (slot_idx, slot_schema) in slot_schemas.iter().enumerate() {
+        let numas = matrix.numas(slot_idx);
         for (segment_idx, seg_schema) in slot_schema.segments.iter().enumerate() {
-            let points: Vec<SegmentPoint> = views
-                .iter()
-                .enumerate()
-                .map(|(block_idx, view)| {
-                    view.segment_point(block_idx as u32, slot_idx, segment_idx)
-                })
-                .collect();
+            let ptrs = matrix.seg_ptrs(slot_idx, segment_idx);
+            let lens = matrix.seg_lens(slot_idx, segment_idx);
+            points.clear();
+            for block_idx in 0..block_count {
+                points.push(SegmentPoint {
+                    block_idx: block_idx as u32,
+                    ptr: ptrs[block_idx],
+                    len: lens[block_idx],
+                    numa_node: numas[block_idx],
+                });
+            }
 
-            let (runs, singles, seg_intervals) = partition_points(
+            partition_points(
                 slot_idx as u32,
                 segment_idx as u32,
-                points,
+                &mut points,
                 seg_schema.block_stride,
                 seg_schema.bytes,
+                &mut sink,
             );
-            pending_runs.extend(runs);
-            pending_singles.extend(singles);
-            intervals.extend(seg_intervals);
         }
     }
 
-    assign_chunks(intervals, pending_runs, pending_singles)
+    assign_chunks(sink)
 }
 
 fn partition_points(
     slot_idx: u32,
     segment_idx: u32,
-    points: Vec<SegmentPoint>,
+    points: &mut [SegmentPoint],
     expected_stride: usize,
     expected_len: usize,
-) -> PartitionOutput {
+    sink: &mut PartitionSink,
+) {
     if points.is_empty() {
-        return (vec![], vec![], vec![]);
+        return;
     }
 
-    let mut sorted = points;
+    let sorted = points;
     sorted.sort_by_key(|p| p.ptr);
 
-    let mut runs = Vec::new();
-    let mut singles = Vec::new();
-    let mut intervals = Vec::new();
     let mut i = 0;
 
     while i < sorted.len() {
         let start = sorted[i];
         if start.len != expected_len {
-            singles.push(PendingSingle {
+            sink.singles.push(PendingSingle {
                 block_idx: start.block_idx,
                 slot_idx,
                 segment_idx,
                 ptr: start.ptr,
             });
-            intervals.push((start.ptr, start.ptr + start.len as u64, start.numa_node));
+            sink.intervals
+                .push((start.ptr, start.ptr + start.len as u64, start.numa_node));
             i += 1;
             continue;
         }
@@ -128,35 +140,35 @@ fn partition_points(
         if count >= 2 {
             let end =
                 base_ptr + u64::from(count - 1) * expected_stride as u64 + expected_len as u64;
-            runs.push(PendingRun {
+            sink.runs.push(PendingRun {
                 slot_idx,
                 segment_idx,
                 block_start,
                 block_count: count,
                 base_ptr,
             });
-            intervals.push((base_ptr, end, run_numa));
+            sink.intervals.push((base_ptr, end, run_numa));
         } else {
-            singles.push(PendingSingle {
+            sink.singles.push(PendingSingle {
                 block_idx: start.block_idx,
                 slot_idx,
                 segment_idx,
                 ptr: start.ptr,
             });
-            intervals.push((start.ptr, start.ptr + start.len as u64, start.numa_node));
+            sink.intervals
+                .push((start.ptr, start.ptr + start.len as u64, start.numa_node));
         }
 
         i = j;
     }
-
-    (runs, singles, intervals)
 }
 
-fn assign_chunks(
-    mut intervals: Vec<PtrInterval>,
-    pending_runs: Vec<PendingRun>,
-    pending_singles: Vec<PendingSingle>,
-) -> TransferGeometry {
+fn assign_chunks(sink: PartitionSink) -> TransferGeometry {
+    let PartitionSink {
+        runs: pending_runs,
+        singles: pending_singles,
+        mut intervals,
+    } = sink;
     if intervals.is_empty() {
         return (vec![], vec![]);
     }
@@ -236,39 +248,32 @@ mod tests {
     use pegaflow_transfer_wire::SegmentSchema;
 
     use super::*;
-    use crate::transfer_plan::view::{BlockView, SegmentView, SlotView};
-    use pegaflow_common::NumaNode;
 
     use smallvec::smallvec;
 
-    fn contiguous_views(stride: usize, count: usize) -> (Vec<BlockView>, Vec<SlotSchema>) {
-        let base = 0x5000u64;
-        let bytes = 64usize;
-        let views: Vec<BlockView> = (0..count)
-            .map(|i| BlockView {
-                hash: vec![i as u8],
-                slots: vec![SlotView {
-                    numa: NumaNode(0),
-                    segments: vec![SegmentView {
-                        ptr: base + (i as u64) * stride as u64,
-                        len: bytes,
-                    }],
-                }],
-            })
+    const BASE: u64 = 0x5000;
+    const BYTES: usize = 64;
+
+    /// One slot, one segment, `count` blocks at `BASE + i*stride`, all NUMA 0.
+    fn contiguous_matrix(stride: usize, count: usize) -> (BlockMatrix, Vec<SlotSchema>) {
+        let seg_ptr: Vec<u64> = (0..count)
+            .map(|i| BASE + (i as u64) * stride as u64)
             .collect();
+        let matrix =
+            BlockMatrix::from_columns(count, 1, 1, seg_ptr, vec![BYTES; count], vec![0; count]);
         let slot_schemas = vec![SlotSchema {
             segments: smallvec![SegmentSchema {
-                bytes,
+                bytes: BYTES,
                 block_stride: stride,
             }],
         }];
-        (views, slot_schemas)
+        (matrix, slot_schemas)
     }
 
     #[test]
     fn batch_blocks_form_one_placement() {
-        let (views, slot_schemas) = contiguous_views(128, 4);
-        let (remote_chunks, placements) = build_transfer_geometry(&views, &slot_schemas);
+        let (matrix, slot_schemas) = contiguous_matrix(128, 4);
+        let (remote_chunks, placements) = build_transfer_geometry(&matrix, &slot_schemas);
         assert_eq!(remote_chunks.len(), 1);
         assert_eq!(placements.len(), 1);
         assert_eq!(placements[0].block_count, 4);
@@ -276,9 +281,18 @@ mod tests {
 
     #[test]
     fn broken_stride_produces_singleton_placement() {
-        let (mut views, slot_schemas) = contiguous_views(128, 3);
-        views[2].slots[0].segments[0].ptr = 0x8000;
-        let (_, placements) = build_transfer_geometry(&views, &slot_schemas);
+        let stride = 128usize;
+        let mut seg_ptr: Vec<u64> = (0..3).map(|i| BASE + (i as u64) * stride as u64).collect();
+        seg_ptr[2] = 0x8000;
+        let matrix = BlockMatrix::from_columns(3, 1, 1, seg_ptr, vec![BYTES; 3], vec![0; 3]);
+        let slot_schemas = vec![SlotSchema {
+            segments: smallvec![SegmentSchema {
+                bytes: BYTES,
+                block_stride: stride,
+            }],
+        }];
+
+        let (_, placements) = build_transfer_geometry(&matrix, &slot_schemas);
         assert_eq!(placements.len(), 2);
         assert_eq!(placements[0].block_count, 2);
         assert_eq!(placements[1].block_count, 1);
@@ -287,29 +301,18 @@ mod tests {
 
     #[test]
     fn mixed_numa_splits_contiguous_run_into_separate_chunks() {
-        let base = 0x5000u64;
-        let bytes = 64usize;
         let stride = 128usize;
-        let views: Vec<BlockView> = (0..4)
-            .map(|i| BlockView {
-                hash: vec![i as u8],
-                slots: vec![SlotView {
-                    numa: NumaNode(if i < 2 { 0 } else { 1 }),
-                    segments: vec![SegmentView {
-                        ptr: base + (i as u64) * stride as u64,
-                        len: bytes,
-                    }],
-                }],
-            })
-            .collect();
+        let seg_ptr: Vec<u64> = (0..4).map(|i| BASE + (i as u64) * stride as u64).collect();
+        let numa: Vec<u32> = (0..4).map(|i| if i < 2 { 0 } else { 1 }).collect();
+        let matrix = BlockMatrix::from_columns(4, 1, 1, seg_ptr, vec![BYTES; 4], numa);
         let slot_schemas = vec![SlotSchema {
             segments: smallvec![SegmentSchema {
-                bytes,
+                bytes: BYTES,
                 block_stride: stride,
             }],
         }];
 
-        let (remote_chunks, placements) = build_transfer_geometry(&views, &slot_schemas);
+        let (remote_chunks, placements) = build_transfer_geometry(&matrix, &slot_schemas);
         assert_eq!(remote_chunks.len(), 2);
         assert_eq!(remote_chunks[0].numa_node, 0);
         assert_eq!(remote_chunks[1].numa_node, 1);

--- a/pegaflow-core/src/transfer_plan/merge.rs
+++ b/pegaflow-core/src/transfer_plan/merge.rs
@@ -1,0 +1,296 @@
+use pegaflow_transfer_wire::{RemoteChunk, SegmentPlacement, SlotSchema};
+
+use super::view::SegmentPoint;
+
+type TransferGeometry = (Vec<RemoteChunk>, Vec<SegmentPlacement>);
+type PtrInterval = (u64, u64, u32);
+type PartitionOutput = (Vec<PendingRun>, Vec<PendingSingle>, Vec<PtrInterval>);
+
+#[derive(Debug, Clone, Copy)]
+struct Interval {
+    start: u64,
+    end: u64,
+    numa_node: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PendingRun {
+    slot_idx: u32,
+    segment_idx: u32,
+    block_start: u32,
+    block_count: u32,
+    base_ptr: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PendingSingle {
+    block_idx: u32,
+    slot_idx: u32,
+    segment_idx: u32,
+    ptr: u64,
+}
+
+pub(crate) fn build_transfer_geometry(
+    views: &[super::view::BlockView],
+    slot_schemas: &[SlotSchema],
+) -> TransferGeometry {
+    if views.is_empty() {
+        return (vec![], vec![]);
+    }
+
+    let mut pending_runs = Vec::new();
+    let mut pending_singles = Vec::new();
+    let mut intervals = Vec::new();
+
+    for (slot_idx, slot_schema) in slot_schemas.iter().enumerate() {
+        let numa_node = slot_schema.numa_node;
+        for (segment_idx, seg_schema) in slot_schema.segments.iter().enumerate() {
+            let points: Vec<SegmentPoint> = views
+                .iter()
+                .enumerate()
+                .map(|(block_idx, view)| {
+                    view.segment_point(block_idx as u32, slot_idx, segment_idx)
+                })
+                .collect();
+
+            let (runs, singles, seg_intervals) = partition_points(
+                slot_idx as u32,
+                segment_idx as u32,
+                numa_node,
+                points,
+                seg_schema.block_stride,
+                seg_schema.bytes,
+            );
+            pending_runs.extend(runs);
+            pending_singles.extend(singles);
+            intervals.extend(seg_intervals);
+        }
+    }
+
+    assign_chunks(intervals, pending_runs, pending_singles)
+}
+
+fn partition_points(
+    slot_idx: u32,
+    segment_idx: u32,
+    numa_node: u32,
+    points: Vec<SegmentPoint>,
+    expected_stride: usize,
+    expected_len: usize,
+) -> PartitionOutput {
+    if points.is_empty() {
+        return (vec![], vec![], vec![]);
+    }
+
+    let mut sorted = points;
+    sorted.sort_by_key(|p| p.ptr);
+
+    let mut runs = Vec::new();
+    let mut singles = Vec::new();
+    let mut intervals = Vec::new();
+    let mut i = 0;
+
+    while i < sorted.len() {
+        let start = sorted[i];
+        if start.len != expected_len {
+            singles.push(PendingSingle {
+                block_idx: start.block_idx,
+                slot_idx,
+                segment_idx,
+                ptr: start.ptr,
+            });
+            intervals.push((start.ptr, start.ptr + start.len as u64, numa_node));
+            i += 1;
+            continue;
+        }
+
+        let block_start = start.block_idx;
+        let base_ptr = start.ptr;
+        let mut count = 1u32;
+        let mut j = i + 1;
+
+        while j < sorted.len() {
+            let prev = &sorted[j - 1];
+            let next = &sorted[j];
+            if next.len != expected_len {
+                break;
+            }
+            let expected_ptr = prev.ptr + expected_stride as u64;
+            if next.ptr == expected_ptr && next.block_idx == prev.block_idx + 1 {
+                count += 1;
+                j += 1;
+            } else {
+                break;
+            }
+        }
+
+        if count >= 2 {
+            let end =
+                base_ptr + u64::from(count - 1) * expected_stride as u64 + expected_len as u64;
+            runs.push(PendingRun {
+                slot_idx,
+                segment_idx,
+                block_start,
+                block_count: count,
+                base_ptr,
+            });
+            intervals.push((base_ptr, end, numa_node));
+        } else {
+            singles.push(PendingSingle {
+                block_idx: start.block_idx,
+                slot_idx,
+                segment_idx,
+                ptr: start.ptr,
+            });
+            intervals.push((start.ptr, start.ptr + start.len as u64, numa_node));
+        }
+
+        i = j;
+    }
+
+    (runs, singles, intervals)
+}
+
+fn assign_chunks(
+    mut intervals: Vec<PtrInterval>,
+    pending_runs: Vec<PendingRun>,
+    pending_singles: Vec<PendingSingle>,
+) -> TransferGeometry {
+    if intervals.is_empty() {
+        return (vec![], vec![]);
+    }
+
+    intervals.sort_by_key(|(start, _, _)| *start);
+
+    let mut merged: Vec<Interval> = Vec::new();
+    for (start, end, numa) in intervals {
+        if let Some(last) = merged.last_mut()
+            && last.numa_node == numa
+            && start <= last.end
+        {
+            last.end = last.end.max(end);
+            continue;
+        }
+        merged.push(Interval {
+            start,
+            end,
+            numa_node: numa,
+        });
+    }
+
+    let mut coalesced: Vec<Interval> = Vec::new();
+    for interval in merged {
+        if let Some(last) = coalesced.last_mut()
+            && last.numa_node == interval.numa_node
+            && last.end == interval.start
+        {
+            last.end = interval.end;
+        } else {
+            coalesced.push(interval);
+        }
+    }
+
+    let remote_chunks: Vec<RemoteChunk> = coalesced
+        .iter()
+        .map(|iv| RemoteChunk {
+            base_ptr: iv.start,
+            length: iv.end - iv.start,
+            numa_node: iv.numa_node,
+        })
+        .collect();
+
+    let mut placements = Vec::with_capacity(pending_runs.len() + pending_singles.len());
+
+    for pending in pending_runs {
+        let (chunk_idx, offset_in_chunk) = locate_in_chunks(pending.base_ptr, &remote_chunks);
+        placements.push(SegmentPlacement {
+            slot_idx: pending.slot_idx,
+            segment_idx: pending.segment_idx,
+            chunk_idx,
+            offset_in_chunk,
+            block_start: pending.block_start,
+            block_count: pending.block_count,
+        });
+    }
+
+    for pending in pending_singles {
+        let (chunk_idx, offset_in_chunk) = locate_in_chunks(pending.ptr, &remote_chunks);
+        placements.push(SegmentPlacement {
+            slot_idx: pending.slot_idx,
+            segment_idx: pending.segment_idx,
+            chunk_idx,
+            offset_in_chunk,
+            block_start: pending.block_idx,
+            block_count: 1,
+        });
+    }
+
+    (remote_chunks, placements)
+}
+
+fn locate_in_chunks(ptr: u64, chunks: &[RemoteChunk]) -> (u32, usize) {
+    for (idx, chunk) in chunks.iter().enumerate() {
+        let end = chunk.base_ptr + chunk.length;
+        if ptr >= chunk.base_ptr && ptr < end {
+            let offset = (ptr - chunk.base_ptr) as usize;
+            return (idx as u32, offset);
+        }
+    }
+    panic!("pointer 0x{ptr:x} not covered by any remote chunk");
+}
+
+#[cfg(test)]
+mod tests {
+    use pegaflow_transfer_wire::SegmentSchema;
+
+    use super::*;
+    use crate::transfer_plan::view::{BlockView, SegmentView, SlotView};
+    use pegaflow_common::NumaNode;
+
+    use smallvec::smallvec;
+
+    fn contiguous_views(stride: usize, count: usize) -> (Vec<BlockView>, Vec<SlotSchema>) {
+        let base = 0x5000u64;
+        let bytes = 64usize;
+        let views: Vec<BlockView> = (0..count)
+            .map(|i| BlockView {
+                hash: vec![i as u8],
+                slots: vec![SlotView {
+                    numa: NumaNode(0),
+                    segments: vec![SegmentView {
+                        ptr: base + (i as u64) * stride as u64,
+                        len: bytes,
+                    }],
+                }],
+            })
+            .collect();
+        let slot_schemas = vec![SlotSchema {
+            numa_node: 0,
+            segments: smallvec![SegmentSchema {
+                bytes,
+                block_stride: stride,
+            }],
+        }];
+        (views, slot_schemas)
+    }
+
+    #[test]
+    fn batch_blocks_form_one_placement() {
+        let (views, slot_schemas) = contiguous_views(128, 4);
+        let (remote_chunks, placements) = build_transfer_geometry(&views, &slot_schemas);
+        assert_eq!(remote_chunks.len(), 1);
+        assert_eq!(placements.len(), 1);
+        assert_eq!(placements[0].block_count, 4);
+    }
+
+    #[test]
+    fn broken_stride_produces_singleton_placement() {
+        let (mut views, slot_schemas) = contiguous_views(128, 3);
+        views[2].slots[0].segments[0].ptr = 0x8000;
+        let (_, placements) = build_transfer_geometry(&views, &slot_schemas);
+        assert_eq!(placements.len(), 2);
+        assert_eq!(placements[0].block_count, 2);
+        assert_eq!(placements[1].block_count, 1);
+        assert_eq!(placements[1].block_start, 2);
+    }
+}

--- a/pegaflow-core/src/transfer_plan/merge.rs
+++ b/pegaflow-core/src/transfer_plan/merge.rs
@@ -163,6 +163,9 @@ fn assign_chunks(
 
     intervals.sort_by_key(|(start, _, _)| *start);
 
+    // Sorted by start, so a same-NUMA interval whose start touches or overlaps
+    // the previous one (`start <= last.end`, which includes the adjacent
+    // `start == last.end` case) extends it. One pass coalesces fully.
     let mut merged: Vec<Interval> = Vec::new();
     for (start, end, numa) in intervals {
         if let Some(last) = merged.last_mut()
@@ -179,19 +182,7 @@ fn assign_chunks(
         });
     }
 
-    let mut coalesced: Vec<Interval> = Vec::new();
-    for interval in merged {
-        if let Some(last) = coalesced.last_mut()
-            && last.numa_node == interval.numa_node
-            && last.end == interval.start
-        {
-            last.end = interval.end;
-        } else {
-            coalesced.push(interval);
-        }
-    }
-
-    let remote_chunks: Vec<RemoteChunk> = coalesced
+    let remote_chunks: Vec<RemoteChunk> = merged
         .iter()
         .map(|iv| RemoteChunk {
             base_ptr: iv.start,
@@ -266,7 +257,6 @@ mod tests {
             })
             .collect();
         let slot_schemas = vec![SlotSchema {
-            numa_node: 0,
             segments: smallvec![SegmentSchema {
                 bytes,
                 block_stride: stride,
@@ -313,7 +303,6 @@ mod tests {
             })
             .collect();
         let slot_schemas = vec![SlotSchema {
-            numa_node: 0,
             segments: smallvec![SegmentSchema {
                 bytes,
                 block_stride: stride,

--- a/pegaflow-core/src/transfer_plan/merge.rs
+++ b/pegaflow-core/src/transfer_plan/merge.rs
@@ -43,7 +43,6 @@ pub(crate) fn build_transfer_geometry(
     let mut intervals = Vec::new();
 
     for (slot_idx, slot_schema) in slot_schemas.iter().enumerate() {
-        let numa_node = slot_schema.numa_node;
         for (segment_idx, seg_schema) in slot_schema.segments.iter().enumerate() {
             let points: Vec<SegmentPoint> = views
                 .iter()
@@ -56,7 +55,6 @@ pub(crate) fn build_transfer_geometry(
             let (runs, singles, seg_intervals) = partition_points(
                 slot_idx as u32,
                 segment_idx as u32,
-                numa_node,
                 points,
                 seg_schema.block_stride,
                 seg_schema.bytes,
@@ -73,7 +71,6 @@ pub(crate) fn build_transfer_geometry(
 fn partition_points(
     slot_idx: u32,
     segment_idx: u32,
-    numa_node: u32,
     points: Vec<SegmentPoint>,
     expected_stride: usize,
     expected_len: usize,
@@ -99,13 +96,14 @@ fn partition_points(
                 segment_idx,
                 ptr: start.ptr,
             });
-            intervals.push((start.ptr, start.ptr + start.len as u64, numa_node));
+            intervals.push((start.ptr, start.ptr + start.len as u64, start.numa_node));
             i += 1;
             continue;
         }
 
         let block_start = start.block_idx;
         let base_ptr = start.ptr;
+        let run_numa = start.numa_node;
         let mut count = 1u32;
         let mut j = i + 1;
 
@@ -116,7 +114,10 @@ fn partition_points(
                 break;
             }
             let expected_ptr = prev.ptr + expected_stride as u64;
-            if next.ptr == expected_ptr && next.block_idx == prev.block_idx + 1 {
+            if next.ptr == expected_ptr
+                && next.block_idx == prev.block_idx + 1
+                && next.numa_node == run_numa
+            {
                 count += 1;
                 j += 1;
             } else {
@@ -134,7 +135,7 @@ fn partition_points(
                 block_count: count,
                 base_ptr,
             });
-            intervals.push((base_ptr, end, numa_node));
+            intervals.push((base_ptr, end, run_numa));
         } else {
             singles.push(PendingSingle {
                 block_idx: start.block_idx,
@@ -142,7 +143,7 @@ fn partition_points(
                 segment_idx,
                 ptr: start.ptr,
             });
-            intervals.push((start.ptr, start.ptr + start.len as u64, numa_node));
+            intervals.push((start.ptr, start.ptr + start.len as u64, start.numa_node));
         }
 
         i = j;
@@ -291,6 +292,41 @@ mod tests {
         assert_eq!(placements.len(), 2);
         assert_eq!(placements[0].block_count, 2);
         assert_eq!(placements[1].block_count, 1);
+        assert_eq!(placements[1].block_start, 2);
+    }
+
+    #[test]
+    fn mixed_numa_splits_contiguous_run_into_separate_chunks() {
+        let base = 0x5000u64;
+        let bytes = 64usize;
+        let stride = 128usize;
+        let views: Vec<BlockView> = (0..4)
+            .map(|i| BlockView {
+                hash: vec![i as u8],
+                slots: vec![SlotView {
+                    numa: NumaNode(if i < 2 { 0 } else { 1 }),
+                    segments: vec![SegmentView {
+                        ptr: base + (i as u64) * stride as u64,
+                        len: bytes,
+                    }],
+                }],
+            })
+            .collect();
+        let slot_schemas = vec![SlotSchema {
+            numa_node: 0,
+            segments: smallvec![SegmentSchema {
+                bytes,
+                block_stride: stride,
+            }],
+        }];
+
+        let (remote_chunks, placements) = build_transfer_geometry(&views, &slot_schemas);
+        assert_eq!(remote_chunks.len(), 2);
+        assert_eq!(remote_chunks[0].numa_node, 0);
+        assert_eq!(remote_chunks[1].numa_node, 1);
+        assert_eq!(placements.len(), 2);
+        assert_eq!(placements[0].block_count, 2);
+        assert_eq!(placements[1].block_count, 2);
         assert_eq!(placements[1].block_start, 2);
     }
 }

--- a/pegaflow-core/src/transfer_plan/mod.rs
+++ b/pegaflow-core/src/transfer_plan/mod.rs
@@ -220,4 +220,25 @@ mod tests {
             materialize_transfer_plan(&plan, &test_allocate_fn()).expect("materialize");
         assert_eq!(materialized.rebuild.slabs.len(), 2);
     }
+
+    /// A block whose slots carry UNKNOWN NUMA must fail rebuild loudly rather
+    /// than silently materialize on an arbitrary node. This guards the
+    /// crash-early invariant of the per-slot NUMA source map: encode also warns
+    /// (`view.rs`) and the production fetch boundary logs + meters the error
+    /// (`rdma_fetch`), so the degradation is never silent.
+    #[test]
+    fn rebuild_rejects_unknown_numa_loudly() {
+        let (found, _slab) = make_stride_blocks_with_numa(2, 128, 64, |_| NumaNode::UNKNOWN);
+        let plan = encode_transfer_plan(&found).expect("encode");
+        let materialized =
+            materialize_transfer_plan(&plan, &test_allocate_fn()).expect("materialize");
+        let err = match rebuild_sealed_blocks(&plan, &materialized.rebuild, "bench-ns") {
+            Ok(_) => panic!("rebuild must reject unknown NUMA, not silently accept it"),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains("unknown NUMA"),
+            "expected an unknown-NUMA rejection, got: {err}"
+        );
+    }
 }

--- a/pegaflow-core/src/transfer_plan/mod.rs
+++ b/pegaflow-core/src/transfer_plan/mod.rs
@@ -1,5 +1,7 @@
 //! Build a compact [`TransferPlan`] from in-memory sealed blocks.
 
+#[cfg(all(feature = "bench", feature = "rdma"))]
+pub mod bench_support;
 mod encode;
 #[cfg(feature = "rdma")]
 mod materialize;

--- a/pegaflow-core/src/transfer_plan/mod.rs
+++ b/pegaflow-core/src/transfer_plan/mod.rs
@@ -1,0 +1,178 @@
+//! Build a compact [`TransferPlan`] from in-memory sealed blocks.
+
+mod encode;
+#[cfg(feature = "rdma")]
+mod materialize;
+mod merge;
+#[cfg(feature = "rdma")]
+mod rebuild;
+mod schema;
+mod view;
+
+pub(crate) use encode::encode_transfer_plan_bytes;
+#[cfg(feature = "rdma")]
+pub(crate) use materialize::materialize_transfer_plan;
+#[cfg(feature = "rdma")]
+pub(crate) use rebuild::rebuild_sealed_blocks;
+
+#[cfg(all(test, feature = "rdma"))]
+mod tests {
+    use std::num::NonZeroU64;
+    use std::sync::Arc;
+
+    use pegaflow_common::NumaNode;
+
+    use crate::BlockKey;
+    use crate::block::{LayerBlock, RawBlock, SealedBlock, Segment};
+    use crate::pinned_pool::PinnedAllocator;
+
+    use super::encode::encode_transfer_plan;
+    use super::{encode_transfer_plan_bytes, materialize_transfer_plan, rebuild_sealed_blocks};
+    use crate::backing::AllocateFn;
+
+    fn make_stride_blocks(
+        count: usize,
+        stride: usize,
+        seg_bytes: usize,
+    ) -> (
+        Vec<(BlockKey, Arc<SealedBlock>)>,
+        Arc<crate::pinned_pool::PinnedAllocation>,
+    ) {
+        let allocator = Arc::new(PinnedAllocator::new_global(
+            64 * 1024 * 1024,
+            1,
+            false,
+            false,
+            None,
+        ));
+        let total = stride
+            .checked_mul(count)
+            .and_then(|n| NonZeroU64::new(n as u64))
+            .expect("allocation size");
+        let slab = allocator
+            .allocate(total, NumaNode::UNKNOWN)
+            .expect("slab allocation");
+
+        let mut found = Vec::with_capacity(count);
+        for i in 0..count {
+            let offset = i * stride;
+            let host = slab.mapped_ptr().add(offset).host();
+            for b in 0..seg_bytes {
+                unsafe {
+                    *host.as_ptr().add(b) = i as u8;
+                }
+            }
+            let segment = Segment::new(host, seg_bytes, Arc::clone(&slab));
+            let key = BlockKey::new("bench-ns".to_string(), vec![i as u8]);
+            found.push((
+                key,
+                Arc::new(SealedBlock::from_slots(vec![RawBlock::single_segment(
+                    segment,
+                )])),
+            ));
+        }
+        (found, slab)
+    }
+
+    fn test_allocate_fn() -> AllocateFn {
+        let allocator = Arc::new(PinnedAllocator::new_global(
+            64 * 1024 * 1024,
+            1,
+            false,
+            false,
+            None,
+        ));
+        Arc::new(move |size, _numa| allocator.allocate(NonZeroU64::new(size)?, NumaNode::UNKNOWN))
+    }
+
+    fn simulate_transfer(
+        plan: &pegaflow_transfer_wire::TransferPlan,
+        found_blocks: &[(BlockKey, Arc<SealedBlock>)],
+        materialized: &super::materialize::RebuildContext,
+    ) {
+        use super::materialize::chunk_ptr_at;
+
+        for placement in &plan.placements {
+            let seg = &plan.slot_schemas[placement.slot_idx as usize].segments
+                [placement.segment_idx as usize];
+            let seg_len = seg.bytes;
+            let stride = seg.block_stride;
+
+            for i in 0..placement.block_count {
+                let block_idx = (placement.block_start + i) as usize;
+                let raw = &found_blocks[block_idx].1.slots()[placement.slot_idx as usize];
+                let layer = LayerBlock::new(raw);
+                let src = if placement.segment_idx == 0 {
+                    layer.k_ptr()
+                } else {
+                    layer.v_ptr().expect("split segment")
+                };
+                let offset_in_chunk = placement.offset_in_chunk + (i as usize) * stride;
+                let (dst_ptr, _) =
+                    chunk_ptr_at(materialized, plan, placement.chunk_idx, offset_in_chunk)
+                        .expect("chunk ptr");
+                let dst = dst_ptr.as_ptr();
+                unsafe {
+                    std::ptr::copy_nonoverlapping(src, dst, seg_len);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn encode_materialize_rebuild_round_trip() {
+        let (found, _slab) = make_stride_blocks(8, 128, 64);
+        let plan = encode_transfer_plan(&found).expect("encode");
+        assert!(!plan.placements.is_empty());
+
+        let materialized =
+            materialize_transfer_plan(&plan, &test_allocate_fn()).expect("materialize");
+        assert_eq!(materialized.rebuild.slabs.len(), 1);
+        assert_eq!(materialized.rdma_descs.len(), plan.remote_chunks.len());
+        simulate_transfer(&plan, &found, &materialized.rebuild);
+        let rebuilt =
+            rebuild_sealed_blocks(&plan, &materialized.rebuild, "bench-ns").expect("rebuild");
+        assert_eq!(rebuilt.len(), found.len());
+
+        for (orig, (key, sealed)) in found.iter().zip(rebuilt.iter()) {
+            assert_eq!(orig.0.hash, key.hash);
+            let orig_raw = &orig.1.slots()[0];
+            let rebuilt_raw = &sealed.slots()[0];
+            let orig_layer = LayerBlock::new(orig_raw);
+            let rebuilt_layer = LayerBlock::new(rebuilt_raw);
+            assert_eq!(orig_layer.k_size(), rebuilt_layer.k_size());
+            unsafe {
+                assert_eq!(
+                    std::slice::from_raw_parts(orig_layer.k_ptr(), orig_layer.k_size()),
+                    std::slice::from_raw_parts(rebuilt_layer.k_ptr(), rebuilt_layer.k_size()),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn batch_encode_wire_size_scales_with_blocks_not_slots() {
+        let block_count = 512;
+        let (found, _) = make_stride_blocks(block_count, 256, 128);
+        let plan = encode_transfer_plan(&found).expect("encode");
+        assert_eq!(plan.placements.len(), 1);
+        assert_eq!(plan.placements[0].block_count, block_count as u32);
+
+        let wire = encode_transfer_plan_bytes(&found).expect("postcard encode");
+        assert!(wire.len() < 64 * 1024, "wire bytes={}", wire.len());
+        assert!(wire.len() < block_count * 64, "wire bytes={}", wire.len());
+    }
+
+    #[test]
+    fn materialize_allocates_one_slab_per_numa() {
+        let (found, _) = make_stride_blocks(4, 128, 64);
+        let plan = encode_transfer_plan(&found).expect("encode");
+        let materialized =
+            materialize_transfer_plan(&plan, &test_allocate_fn()).expect("materialize");
+        assert_eq!(materialized.rebuild.slabs.len(), 1);
+        assert!(
+            materialized.rebuild.slabs[0].length >= plan.total_remote_bytes() as usize,
+            "slab should cover all chunk bytes on NUMA"
+        );
+    }
+}

--- a/pegaflow-core/src/transfer_plan/mod.rs
+++ b/pegaflow-core/src/transfer_plan/mod.rs
@@ -38,40 +38,9 @@ mod tests {
         Vec<(BlockKey, Arc<SealedBlock>)>,
         Arc<crate::pinned_pool::PinnedAllocation>,
     ) {
-        let allocator = Arc::new(PinnedAllocator::new_global(
-            64 * 1024 * 1024,
-            1,
-            false,
-            false,
-            None,
-        ));
-        let total = stride
-            .checked_mul(count)
-            .and_then(|n| NonZeroU64::new(n as u64))
-            .expect("allocation size");
-        let slab = allocator
-            .allocate(total, NumaNode::UNKNOWN)
-            .expect("slab allocation");
-
-        let mut found = Vec::with_capacity(count);
-        for i in 0..count {
-            let offset = i * stride;
-            let host = slab.mapped_ptr().add(offset).host();
-            for b in 0..seg_bytes {
-                unsafe {
-                    *host.as_ptr().add(b) = i as u8;
-                }
-            }
-            let segment = Segment::new(host, seg_bytes, Arc::clone(&slab));
-            let key = BlockKey::new("bench-ns".to_string(), vec![i as u8]);
-            found.push((
-                key,
-                Arc::new(SealedBlock::from_slots(vec![RawBlock::single_segment(
-                    segment,
-                )])),
-            ));
-        }
-        (found, slab)
+        // Blocks that flow through encode → transfer → rebuild must carry a known
+        // NUMA (rebuild rejects UNKNOWN), so default every fixture block to NUMA 0.
+        make_stride_blocks_with_numa(count, stride, seg_bytes, |_| NumaNode(0))
     }
 
     fn test_allocate_fn() -> AllocateFn {
@@ -163,6 +132,73 @@ mod tests {
         assert!(wire.len() < block_count * 64, "wire bytes={}", wire.len());
     }
 
+    fn make_stride_blocks_with_numa(
+        count: usize,
+        stride: usize,
+        seg_bytes: usize,
+        numa_for_block: impl Fn(usize) -> NumaNode,
+    ) -> (
+        Vec<(BlockKey, Arc<SealedBlock>)>,
+        Arc<crate::pinned_pool::PinnedAllocation>,
+    ) {
+        let allocator = Arc::new(PinnedAllocator::new_global(
+            64 * 1024 * 1024,
+            1,
+            false,
+            false,
+            None,
+        ));
+        let total = stride
+            .checked_mul(count)
+            .and_then(|n| NonZeroU64::new(n as u64))
+            .expect("allocation size");
+        let slab = allocator
+            .allocate(total, NumaNode::UNKNOWN)
+            .expect("slab allocation");
+
+        let mut found = Vec::with_capacity(count);
+        for i in 0..count {
+            let offset = i * stride;
+            let host = slab.mapped_ptr().add(offset).host();
+            for b in 0..seg_bytes {
+                unsafe {
+                    *host.as_ptr().add(b) = i as u8;
+                }
+            }
+            let segment = Segment::new(host, seg_bytes, Arc::clone(&slab));
+            let key = BlockKey::new("bench-ns".to_string(), vec![i as u8]);
+            let sealed = match SealedBlock::from_ordered_slot_inserts(
+                vec![(0, RawBlock::single_segment(segment))],
+                1,
+                numa_for_block(i),
+            ) {
+                Ok(block) => block,
+                Err(_) => panic!("ordered slot inserts"),
+            };
+            found.push((key, Arc::new(sealed)));
+        }
+        (found, slab)
+    }
+
+    #[test]
+    fn rebuild_preserves_per_block_slot_numa_from_remote_chunks() {
+        let (found, _slab) =
+            make_stride_blocks_with_numa(4, 128, 64, |i| NumaNode(u32::from(i >= 2)));
+        let plan = encode_transfer_plan(&found).expect("encode");
+        assert_eq!(plan.remote_chunks.len(), 2);
+
+        let materialized =
+            materialize_transfer_plan(&plan, &test_allocate_fn()).expect("materialize");
+        simulate_transfer(&plan, &found, &materialized.rebuild);
+        let rebuilt =
+            rebuild_sealed_blocks(&plan, &materialized.rebuild, "bench-ns").expect("rebuild");
+
+        assert_eq!(rebuilt[0].1.slot_numas(), &[NumaNode(0)]);
+        assert_eq!(rebuilt[1].1.slot_numas(), &[NumaNode(0)]);
+        assert_eq!(rebuilt[2].1.slot_numas(), &[NumaNode(1)]);
+        assert_eq!(rebuilt[3].1.slot_numas(), &[NumaNode(1)]);
+    }
+
     #[test]
     fn materialize_allocates_one_slab_per_numa() {
         let (found, _) = make_stride_blocks(4, 128, 64);
@@ -174,5 +210,14 @@ mod tests {
             materialized.rebuild.slabs[0].length >= plan.total_remote_bytes() as usize,
             "slab should cover all chunk bytes on NUMA"
         );
+    }
+
+    #[test]
+    fn materialize_allocates_one_slab_per_distinct_chunk_numa() {
+        let (found, _) = make_stride_blocks_with_numa(4, 128, 64, |i| NumaNode(u32::from(i >= 2)));
+        let plan = encode_transfer_plan(&found).expect("encode");
+        let materialized =
+            materialize_transfer_plan(&plan, &test_allocate_fn()).expect("materialize");
+        assert_eq!(materialized.rebuild.slabs.len(), 2);
     }
 }

--- a/pegaflow-core/src/transfer_plan/rebuild.rs
+++ b/pegaflow-core/src/transfer_plan/rebuild.rs
@@ -1,0 +1,73 @@
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+use pegaflow_transfer_wire::TransferPlan;
+
+use crate::backing::PrefetchResult;
+use crate::block::{BlockKey, RawBlock, SealedBlock, Segment};
+use crate::pinned_pool::PinnedAllocation;
+
+use super::materialize::{RebuildContext, chunk_ptr_at};
+
+type SegmentSlot = Option<(NonNull<u8>, usize, Arc<PinnedAllocation>)>;
+
+pub(crate) fn rebuild_sealed_blocks(
+    plan: &TransferPlan,
+    rebuild: &RebuildContext,
+    namespace: &str,
+) -> Result<PrefetchResult, String> {
+    if plan.block_hashes.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let block_count = plan.block_hashes.len();
+    let slot_count = plan.slot_schemas.len();
+    let segment_count = plan.slot_schemas[0].segments.len();
+
+    let mut block_slots: Vec<Vec<Vec<SegmentSlot>>> = (0..block_count)
+        .map(|_| {
+            (0..slot_count)
+                .map(|_| (0..segment_count).map(|_| None).collect())
+                .collect()
+        })
+        .collect();
+
+    for placement in &plan.placements {
+        let seg = &plan.slot_schemas[placement.slot_idx as usize].segments
+            [placement.segment_idx as usize];
+        let seg_len = seg.bytes;
+        let stride = seg.block_stride;
+
+        for i in 0..placement.block_count {
+            let block_idx = (placement.block_start + i) as usize;
+            let offset_in_chunk = placement.offset_in_chunk + (i as usize) * stride;
+            let (ptr, allocation) =
+                chunk_ptr_at(rebuild, plan, placement.chunk_idx, offset_in_chunk)?;
+            block_slots[block_idx][placement.slot_idx as usize][placement.segment_idx as usize] =
+                Some((ptr, seg_len, allocation));
+        }
+    }
+
+    let mut result = Vec::with_capacity(block_count);
+    for (block_idx, hash) in plan.block_hashes.iter().enumerate() {
+        let slots: Vec<RawBlock> = block_slots[block_idx]
+            .iter()
+            .map(|slot_segments| {
+                let segments: Vec<Segment> = slot_segments
+                    .iter()
+                    .map(|entry| {
+                        let (ptr, len, alloc) = entry
+                            .as_ref()
+                            .ok_or_else(|| "missing segment during rebuild".to_string())?;
+                        Ok(Segment::new(*ptr, *len, Arc::clone(alloc)))
+                    })
+                    .collect::<Result<Vec<_>, String>>()?;
+                Ok(RawBlock::new(segments))
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        let key = BlockKey::new(namespace.to_string(), hash.clone());
+        result.push((key, Arc::new(SealedBlock::from_slots(slots))));
+    }
+
+    Ok(result)
+}

--- a/pegaflow-core/src/transfer_plan/rebuild.rs
+++ b/pegaflow-core/src/transfer_plan/rebuild.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 
 use pegaflow_transfer_wire::TransferPlan;
 
+use pegaflow_common::NumaNode;
+
 use crate::backing::PrefetchResult;
 use crate::block::{BlockKey, RawBlock, SealedBlock, Segment};
 use crate::pinned_pool::PinnedAllocation;
@@ -31,8 +33,20 @@ pub(crate) fn rebuild_sealed_blocks(
                 .collect()
         })
         .collect();
+    let mut block_slot_numas: Vec<Vec<Option<NumaNode>>> = (0..block_count)
+        .map(|_| (0..slot_count).map(|_| None).collect())
+        .collect();
 
     for placement in &plan.placements {
+        let chunk = &plan.remote_chunks[placement.chunk_idx as usize];
+        let placement_numa = NumaNode(chunk.numa_node);
+        if placement_numa.is_unknown() {
+            return Err(format!(
+                "remote chunk {} has unknown NUMA for rebuild",
+                placement.chunk_idx
+            ));
+        }
+
         let seg = &plan.slot_schemas[placement.slot_idx as usize].segments
             [placement.segment_idx as usize];
         let seg_len = seg.bytes;
@@ -45,6 +59,19 @@ pub(crate) fn rebuild_sealed_blocks(
                 chunk_ptr_at(rebuild, plan, placement.chunk_idx, offset_in_chunk)?;
             block_slots[block_idx][placement.slot_idx as usize][placement.segment_idx as usize] =
                 Some((ptr, seg_len, allocation));
+
+            match block_slot_numas[block_idx][placement.slot_idx as usize] {
+                Some(existing) if existing != placement_numa => {
+                    return Err(format!(
+                        "block {block_idx} slot {} NUMA mismatch: {existing} vs {placement_numa}",
+                        placement.slot_idx
+                    ));
+                }
+                Some(_) => {}
+                None => {
+                    block_slot_numas[block_idx][placement.slot_idx as usize] = Some(placement_numa);
+                }
+            }
         }
     }
 
@@ -66,7 +93,14 @@ pub(crate) fn rebuild_sealed_blocks(
             })
             .collect::<Result<Vec<_>, String>>()?;
         let key = BlockKey::new(namespace.to_string(), hash.clone());
-        result.push((key, Arc::new(SealedBlock::from_slots(slots))));
+        let slot_numas: Vec<NumaNode> = block_slot_numas[block_idx]
+            .iter()
+            .map(|numa| numa.ok_or_else(|| format!("block {block_idx} missing slot NUMA metadata")))
+            .collect::<Result<Vec<_>, String>>()?;
+        result.push((
+            key,
+            Arc::new(SealedBlock::from_slots_with_numas(slots, slot_numas)),
+        ));
     }
 
     Ok(result)

--- a/pegaflow-core/src/transfer_plan/rebuild.rs
+++ b/pegaflow-core/src/transfer_plan/rebuild.rs
@@ -1,7 +1,7 @@
 use std::ptr::NonNull;
 use std::sync::Arc;
 
-use pegaflow_transfer_wire::TransferPlan;
+use pegaflow_transfer_wire::{SegmentSchema, TransferPlan};
 
 use pegaflow_common::NumaNode;
 
@@ -9,9 +9,42 @@ use crate::backing::PrefetchResult;
 use crate::block::{BlockKey, RawBlock, SealedBlock, Segment};
 use crate::pinned_pool::PinnedAllocation;
 
-use super::materialize::{RebuildContext, chunk_ptr_at};
+use super::materialize::RebuildContext;
 
-type SegmentSlot = Option<(NonNull<u8>, usize, Arc<PinnedAllocation>)>;
+/// Sentinel for "this (block, slot) has no NUMA slab assigned yet".
+const UNSET_SLAB: u32 = u32::MAX;
+
+/// Precomputed landing location of one remote chunk inside the local NUMA
+/// slabs. Resolving NUMA -> slab once per chunk keeps it out of the per-cell
+/// fill loop (millions of iterations for large batches).
+struct ChunkLoc {
+    slab_idx: u32,
+    slab_base: NonNull<u8>,
+    slab_len: usize,
+    base_offset: usize,
+}
+
+impl ChunkLoc {
+    /// Validate that a contiguous run of `span` bytes starting at
+    /// `offset_in_chunk` fits in the slab, and return the run's host base
+    /// pointer. Checking the whole run once keeps the per-cell pointer math in
+    /// the fill loop branch-free (the loop runs `block*slot*segment` times).
+    fn run_base(&self, offset_in_chunk: usize, span: usize) -> Result<*mut u8, String> {
+        let start = self
+            .base_offset
+            .checked_add(offset_in_chunk)
+            .ok_or("chunk offset overflow")?;
+        let end = start.checked_add(span).ok_or("segment span overflow")?;
+        if end > self.slab_len {
+            return Err(format!(
+                "segment run {start}..{end} exceeds slab length {}",
+                self.slab_len
+            ));
+        }
+        // SAFETY: `start <= end <= slab_len`, so the pointer stays within the slab.
+        Ok(unsafe { self.slab_base.as_ptr().add(start) })
+    }
+}
 
 pub(crate) fn rebuild_sealed_blocks(
     plan: &TransferPlan,
@@ -26,77 +59,82 @@ pub(crate) fn rebuild_sealed_blocks(
     let slot_count = plan.slot_schemas.len();
     let segment_count = plan.slot_schemas[0].segments.len();
 
-    let mut block_slots: Vec<Vec<Vec<SegmentSlot>>> = (0..block_count)
-        .map(|_| {
-            (0..slot_count)
-                .map(|_| (0..segment_count).map(|_| None).collect())
-                .collect()
-        })
-        .collect();
-    let mut block_slot_numas: Vec<Vec<Option<NumaNode>>> = (0..block_count)
-        .map(|_| (0..slot_count).map(|_| None).collect())
-        .collect();
+    // Resolve each remote chunk to its local slab up front. Rejects unknown
+    // NUMA loudly: the per-slot NUMA source map must not silently land on an
+    // arbitrary node.
+    let chunk_locs = resolve_chunk_locs(plan, rebuild)?;
+
+    // Two flat scatter buffers replace a block x slot x segment `Vec` tree
+    // (~block*slot allocations). `seg_ptrs` holds each segment's host pointer;
+    // `slot_slab` records the slab backing each (block, slot). The owning `Arc`
+    // is cloned only once per segment, at final construction below.
+    let mut seg_ptrs: Vec<Option<NonNull<u8>>> =
+        vec![None; block_count * slot_count * segment_count];
+    let mut slot_slab: Vec<u32> = vec![UNSET_SLAB; block_count * slot_count];
 
     for placement in &plan.placements {
-        let chunk = &plan.remote_chunks[placement.chunk_idx as usize];
-        let placement_numa = NumaNode(chunk.numa_node);
-        if placement_numa.is_unknown() {
-            return Err(format!(
-                "remote chunk {} has unknown NUMA for rebuild",
-                placement.chunk_idx
-            ));
-        }
-
-        let seg = &plan.slot_schemas[placement.slot_idx as usize].segments
-            [placement.segment_idx as usize];
+        let loc = &chunk_locs[placement.chunk_idx as usize];
+        let slot_idx = placement.slot_idx as usize;
+        let segment_idx = placement.segment_idx as usize;
+        let seg = &plan.slot_schemas[slot_idx].segments[segment_idx];
         let seg_len = seg.bytes;
         let stride = seg.block_stride;
+        let count = placement.block_count as usize;
 
-        for i in 0..placement.block_count {
-            let block_idx = (placement.block_start + i) as usize;
-            let offset_in_chunk = placement.offset_in_chunk + (i as usize) * stride;
-            let (ptr, allocation) =
-                chunk_ptr_at(rebuild, plan, placement.chunk_idx, offset_in_chunk)?;
-            block_slots[block_idx][placement.slot_idx as usize][placement.segment_idx as usize] =
-                Some((ptr, seg_len, allocation));
+        // Bounds-check the whole run once, then step the base pointer per cell.
+        let span = count
+            .saturating_sub(1)
+            .checked_mul(stride)
+            .and_then(|s| s.checked_add(seg_len))
+            .ok_or("segment span overflow")?;
+        let run_base = loc.run_base(placement.offset_in_chunk, span)?;
+        let start_block = placement.block_start as usize;
 
-            match block_slot_numas[block_idx][placement.slot_idx as usize] {
-                Some(existing) if existing != placement_numa => {
+        for i in 0..count {
+            let block_idx = start_block + i;
+            // SAFETY: `i * stride < span` and the run is bounded within the slab
+            // by `run_base` above, so this pointer stays inside the allocation.
+            let ptr = unsafe { NonNull::new_unchecked(run_base.add(i * stride)) };
+            seg_ptrs[(block_idx * slot_count + slot_idx) * segment_count + segment_idx] = Some(ptr);
+
+            let slot_pos = block_idx * slot_count + slot_idx;
+            match slot_slab[slot_pos] {
+                UNSET_SLAB => slot_slab[slot_pos] = loc.slab_idx,
+                existing if existing != loc.slab_idx => {
                     return Err(format!(
-                        "block {block_idx} slot {} NUMA mismatch: {existing} vs {placement_numa}",
-                        placement.slot_idx
+                        "block {block_idx} slot {slot_idx} NUMA mismatch: {} vs {}",
+                        rebuild.slabs[existing as usize].numa,
+                        rebuild.slabs[loc.slab_idx as usize].numa,
                     ));
                 }
-                Some(_) => {}
-                None => {
-                    block_slot_numas[block_idx][placement.slot_idx as usize] = Some(placement_numa);
-                }
+                _ => {}
             }
         }
     }
 
     let mut result = Vec::with_capacity(block_count);
     for (block_idx, hash) in plan.block_hashes.iter().enumerate() {
-        let slots: Vec<RawBlock> = block_slots[block_idx]
-            .iter()
-            .map(|slot_segments| {
-                let segments: Vec<Segment> = slot_segments
-                    .iter()
-                    .map(|entry| {
-                        let (ptr, len, alloc) = entry
-                            .as_ref()
-                            .ok_or_else(|| "missing segment during rebuild".to_string())?;
-                        Ok(Segment::new(*ptr, *len, Arc::clone(alloc)))
-                    })
-                    .collect::<Result<Vec<_>, String>>()?;
-                Ok(RawBlock::new(segments))
-            })
-            .collect::<Result<Vec<_>, String>>()?;
+        let mut slots = Vec::with_capacity(slot_count);
+        let mut slot_numas = Vec::with_capacity(slot_count);
+        for slot_idx in 0..slot_count {
+            let slab_idx = slot_slab[block_idx * slot_count + slot_idx];
+            if slab_idx == UNSET_SLAB {
+                return Err(format!(
+                    "block {block_idx} slot {slot_idx} missing during rebuild"
+                ));
+            }
+            let slab = &rebuild.slabs[slab_idx as usize];
+            let seg_base = (block_idx * slot_count + slot_idx) * segment_count;
+            slots.push(build_raw_block(
+                &seg_ptrs[seg_base..seg_base + segment_count],
+                &plan.slot_schemas[slot_idx].segments,
+                &slab.allocation,
+                block_idx,
+                slot_idx,
+            )?);
+            slot_numas.push(slab.numa);
+        }
         let key = BlockKey::new(namespace.to_string(), hash.clone());
-        let slot_numas: Vec<NumaNode> = block_slot_numas[block_idx]
-            .iter()
-            .map(|numa| numa.ok_or_else(|| format!("block {block_idx} missing slot NUMA metadata")))
-            .collect::<Result<Vec<_>, String>>()?;
         result.push((
             key,
             Arc::new(SealedBlock::from_slots_with_numas(slots, slot_numas)),
@@ -104,4 +142,69 @@ pub(crate) fn rebuild_sealed_blocks(
     }
 
     Ok(result)
+}
+
+fn resolve_chunk_locs(
+    plan: &TransferPlan,
+    rebuild: &RebuildContext,
+) -> Result<Vec<ChunkLoc>, String> {
+    let mut locs = Vec::with_capacity(plan.remote_chunks.len());
+    for (chunk_idx, chunk) in plan.remote_chunks.iter().enumerate() {
+        let numa = NumaNode(chunk.numa_node);
+        if numa.is_unknown() {
+            return Err(format!(
+                "remote chunk {chunk_idx} has unknown NUMA for rebuild"
+            ));
+        }
+        let slab_idx = rebuild
+            .slabs
+            .iter()
+            .position(|slab| slab.numa == numa)
+            .ok_or_else(|| format!("missing local slab for NUMA {numa}"))?;
+        let base_offset = *rebuild
+            .chunk_local_offsets
+            .get(chunk_idx)
+            .ok_or_else(|| format!("missing local offset for chunk {chunk_idx}"))?;
+        let slab = &rebuild.slabs[slab_idx];
+        locs.push(ChunkLoc {
+            slab_idx: slab_idx as u32,
+            slab_base: slab.allocation.as_non_null(),
+            slab_len: slab.length,
+            base_offset,
+        });
+    }
+    Ok(locs)
+}
+
+/// Build one slot's [`RawBlock`] from its segment pointers, cloning the slab's
+/// owning `Arc` once per segment. Split K/V (`segment_count == 2`) is the common
+/// case and avoids a transient `Vec`.
+fn build_raw_block(
+    seg_ptrs: &[Option<NonNull<u8>>],
+    seg_schemas: &[SegmentSchema],
+    allocation: &Arc<PinnedAllocation>,
+    block_idx: usize,
+    slot_idx: usize,
+) -> Result<RawBlock, String> {
+    let make = |g: usize| -> Result<Segment, String> {
+        let ptr = seg_ptrs[g].ok_or_else(|| {
+            format!("block {block_idx} slot {slot_idx} segment {g} missing during rebuild")
+        })?;
+        Ok(Segment::new(
+            ptr,
+            seg_schemas[g].bytes,
+            Arc::clone(allocation),
+        ))
+    };
+    match seg_ptrs.len() {
+        1 => Ok(RawBlock::single_segment(make(0)?)),
+        2 => Ok(RawBlock::two_segments(make(0)?, make(1)?)),
+        n => {
+            let mut segments = Vec::with_capacity(n);
+            for g in 0..n {
+                segments.push(make(g)?);
+            }
+            Ok(RawBlock::new(segments))
+        }
+    }
 }

--- a/pegaflow-core/src/transfer_plan/schema.rs
+++ b/pegaflow-core/src/transfer_plan/schema.rs
@@ -36,7 +36,6 @@ pub(crate) fn derive_slot_schemas(views: &[BlockView]) -> Vec<SlotSchema> {
 
     let mut schemas = Vec::with_capacity(slot_count);
     for slot_idx in 0..slot_count {
-        let numa = views[0].slots[slot_idx].numa.0;
         let mut segment_schemas = SmallVec::<[SegmentSchema; 2]>::new();
 
         for segment_idx in 0..segment_count {
@@ -82,14 +81,11 @@ pub(crate) fn derive_slot_schemas(views: &[BlockView]) -> Vec<SlotSchema> {
                 segment_count,
                 "slot {slot_idx} segment count mismatch"
             );
-            assert_eq!(
-                view.slots[slot_idx].numa.0, numa,
-                "slot {slot_idx} NUMA mismatch across blocks"
-            );
         }
 
+        // NUMA affinity lives on each [`RemoteChunk`]; this field is wire-compat only.
         schemas.push(SlotSchema {
-            numa_node: numa,
+            numa_node: views[0].slots[slot_idx].numa.0,
             segments: segment_schemas,
         });
     }

--- a/pegaflow-core/src/transfer_plan/schema.rs
+++ b/pegaflow-core/src/transfer_plan/schema.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use pegaflow_transfer_wire::{SegmentSchema, SlotSchema};
 use smallvec::SmallVec;
 
-use super::view::BlockView;
+use super::view::BlockMatrix;
 
 #[derive(Debug)]
 pub(crate) struct TransferPlanError(String);
@@ -23,34 +23,26 @@ impl fmt::Display for TransferPlanError {
 impl std::error::Error for TransferPlanError {}
 
 pub(crate) fn derive_slot_schemas(
-    views: &[BlockView],
+    matrix: &BlockMatrix,
 ) -> Result<Vec<SlotSchema>, TransferPlanError> {
-    if views.is_empty() {
+    // No blocks => no schemas. Guard here (not just at the caller) so the
+    // per-column `lens[0]` below is self-evidently in bounds: an empty matrix
+    // has empty columns.
+    let slot_count = matrix.slot_count();
+    if slot_count == 0 || matrix.block_count() == 0 {
         return Ok(Vec::new());
     }
 
-    let slot_count = views[0].slots.len();
-    let segment_count = views[0].slots[0].segments.len();
+    // `block_matrix_from_found` already enforced that every block shares block
+    // 0's slot and segment counts; here we only reject a globally invalid
+    // segment count (the wire format coalesces at most K/V). A mismatch means a
+    // namespace shared by incompatible KV layouts; the load path treats that as
+    // a recoverable error, so encode returns Err rather than panicking.
+    let segment_count = matrix.segment_count();
     if !(1..=2).contains(&segment_count) {
         return Err(TransferPlanError::new(format!(
             "invalid segment count {segment_count}"
         )));
-    }
-
-    // Validate every block shares block 0's segment geometry up front, so the
-    // per-segment indexing below cannot go out of bounds. A mismatch means a
-    // namespace shared by incompatible KV layouts; the load path treats that as
-    // a recoverable error, so encode returns Err rather than panicking.
-    // (Slot-count consistency is already enforced by `block_views_from_found`.)
-    for (block_idx, view) in views.iter().enumerate() {
-        for (slot_idx, slot) in view.slots.iter().enumerate() {
-            if slot.segments.len() != segment_count {
-                return Err(TransferPlanError::new(format!(
-                    "block {block_idx} slot {slot_idx} segment count {} != {segment_count}",
-                    slot.segments.len()
-                )));
-            }
-        }
     }
 
     let mut schemas = Vec::with_capacity(slot_count);
@@ -58,29 +50,32 @@ pub(crate) fn derive_slot_schemas(
         let mut segment_schemas = SmallVec::<[SegmentSchema; 2]>::new();
 
         for segment_idx in 0..segment_count {
-            let expected_len = views[0].slots[slot_idx].segments[segment_idx].len;
-            for (block_idx, view) in views.iter().enumerate() {
-                let seg_len = view.slots[slot_idx].segments[segment_idx].len;
-                if seg_len != expected_len {
+            let ptrs = matrix.seg_ptrs(slot_idx, segment_idx);
+            let lens = matrix.seg_lens(slot_idx, segment_idx);
+            let expected_len = lens[0];
+
+            // Single streaming pass over the block-ordered column: validate
+            // length uniformity and derive the block stride (largest
+            // consecutive-block pointer delta that is at least one segment
+            // wide).
+            let mut stride = expected_len;
+            let mut prev_ptr: Option<u64> = None;
+            for (block_idx, (&ptr, &len)) in ptrs.iter().zip(lens).enumerate() {
+                if len != expected_len {
                     return Err(TransferPlanError::new(format!(
                         "block {block_idx} slot {slot_idx} segment {segment_idx} len \
-                         {seg_len} != {expected_len}"
+                         {len} != {expected_len}"
                     )));
                 }
-            }
-
-            let mut stride = expected_len;
-            let ptrs: Vec<u64> = views
-                .iter()
-                .map(|view| view.slots[slot_idx].segments[segment_idx].ptr)
-                .collect();
-            for window in ptrs.windows(2) {
-                if window[1] > window[0] {
-                    let delta = (window[1] - window[0]) as usize;
+                if let Some(prev) = prev_ptr
+                    && ptr > prev
+                {
+                    let delta = (ptr - prev) as usize;
                     if delta >= expected_len {
                         stride = delta;
                     }
                 }
+                prev_ptr = Some(ptr);
             }
 
             segment_schemas.push(SegmentSchema {

--- a/pegaflow-core/src/transfer_plan/schema.rs
+++ b/pegaflow-core/src/transfer_plan/schema.rs
@@ -22,17 +22,36 @@ impl fmt::Display for TransferPlanError {
 
 impl std::error::Error for TransferPlanError {}
 
-pub(crate) fn derive_slot_schemas(views: &[BlockView]) -> Vec<SlotSchema> {
+pub(crate) fn derive_slot_schemas(
+    views: &[BlockView],
+) -> Result<Vec<SlotSchema>, TransferPlanError> {
     if views.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     let slot_count = views[0].slots.len();
     let segment_count = views[0].slots[0].segments.len();
-    assert!(
-        (1..=2).contains(&segment_count),
-        "invalid segment count {segment_count}"
-    );
+    if !(1..=2).contains(&segment_count) {
+        return Err(TransferPlanError::new(format!(
+            "invalid segment count {segment_count}"
+        )));
+    }
+
+    // Validate every block shares block 0's segment geometry up front, so the
+    // per-segment indexing below cannot go out of bounds. A mismatch means a
+    // namespace shared by incompatible KV layouts; the load path treats that as
+    // a recoverable error, so encode returns Err rather than panicking.
+    // (Slot-count consistency is already enforced by `block_views_from_found`.)
+    for (block_idx, view) in views.iter().enumerate() {
+        for (slot_idx, slot) in view.slots.iter().enumerate() {
+            if slot.segments.len() != segment_count {
+                return Err(TransferPlanError::new(format!(
+                    "block {block_idx} slot {slot_idx} segment count {} != {segment_count}",
+                    slot.segments.len()
+                )));
+            }
+        }
+    }
 
     let mut schemas = Vec::with_capacity(slot_count);
     for slot_idx in 0..slot_count {
@@ -40,21 +59,21 @@ pub(crate) fn derive_slot_schemas(views: &[BlockView]) -> Vec<SlotSchema> {
 
         for segment_idx in 0..segment_count {
             let expected_len = views[0].slots[slot_idx].segments[segment_idx].len;
-            let mut stride = expected_len;
+            for (block_idx, view) in views.iter().enumerate() {
+                let seg_len = view.slots[slot_idx].segments[segment_idx].len;
+                if seg_len != expected_len {
+                    return Err(TransferPlanError::new(format!(
+                        "block {block_idx} slot {slot_idx} segment {segment_idx} len \
+                         {seg_len} != {expected_len}"
+                    )));
+                }
+            }
 
+            let mut stride = expected_len;
             let ptrs: Vec<u64> = views
                 .iter()
                 .map(|view| view.slots[slot_idx].segments[segment_idx].ptr)
                 .collect();
-
-            for (block_idx, view) in views.iter().enumerate() {
-                let seg = &view.slots[slot_idx].segments[segment_idx];
-                assert_eq!(
-                    seg.len, expected_len,
-                    "block {block_idx} slot {slot_idx} segment {segment_idx} len mismatch"
-                );
-            }
-
             for window in ptrs.windows(2) {
                 if window[1] > window[0] {
                     let delta = (window[1] - window[0]) as usize;
@@ -70,25 +89,10 @@ pub(crate) fn derive_slot_schemas(views: &[BlockView]) -> Vec<SlotSchema> {
             });
         }
 
-        for view in views.iter().skip(1) {
-            assert_eq!(
-                view.slots.len(),
-                slot_count,
-                "inconsistent slot count across blocks"
-            );
-            assert_eq!(
-                view.slots[slot_idx].segments.len(),
-                segment_count,
-                "slot {slot_idx} segment count mismatch"
-            );
-        }
-
-        // NUMA affinity lives on each [`RemoteChunk`]; this field is wire-compat only.
         schemas.push(SlotSchema {
-            numa_node: views[0].slots[slot_idx].numa.0,
             segments: segment_schemas,
         });
     }
 
-    schemas
+    Ok(schemas)
 }

--- a/pegaflow-core/src/transfer_plan/schema.rs
+++ b/pegaflow-core/src/transfer_plan/schema.rs
@@ -1,0 +1,98 @@
+use std::fmt;
+
+use pegaflow_transfer_wire::{SegmentSchema, SlotSchema};
+use smallvec::SmallVec;
+
+use super::view::BlockView;
+
+#[derive(Debug)]
+pub(crate) struct TransferPlanError(String);
+
+impl TransferPlanError {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl fmt::Display for TransferPlanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "transfer_plan: {}", self.0)
+    }
+}
+
+impl std::error::Error for TransferPlanError {}
+
+pub(crate) fn derive_slot_schemas(views: &[BlockView]) -> Vec<SlotSchema> {
+    if views.is_empty() {
+        return Vec::new();
+    }
+
+    let slot_count = views[0].slots.len();
+    let segment_count = views[0].slots[0].segments.len();
+    assert!(
+        (1..=2).contains(&segment_count),
+        "invalid segment count {segment_count}"
+    );
+
+    let mut schemas = Vec::with_capacity(slot_count);
+    for slot_idx in 0..slot_count {
+        let numa = views[0].slots[slot_idx].numa.0;
+        let mut segment_schemas = SmallVec::<[SegmentSchema; 2]>::new();
+
+        for segment_idx in 0..segment_count {
+            let expected_len = views[0].slots[slot_idx].segments[segment_idx].len;
+            let mut stride = expected_len;
+
+            let ptrs: Vec<u64> = views
+                .iter()
+                .map(|view| view.slots[slot_idx].segments[segment_idx].ptr)
+                .collect();
+
+            for (block_idx, view) in views.iter().enumerate() {
+                let seg = &view.slots[slot_idx].segments[segment_idx];
+                assert_eq!(
+                    seg.len, expected_len,
+                    "block {block_idx} slot {slot_idx} segment {segment_idx} len mismatch"
+                );
+            }
+
+            for window in ptrs.windows(2) {
+                if window[1] > window[0] {
+                    let delta = (window[1] - window[0]) as usize;
+                    if delta >= expected_len {
+                        stride = delta;
+                    }
+                }
+            }
+
+            segment_schemas.push(SegmentSchema {
+                bytes: expected_len,
+                block_stride: stride,
+            });
+        }
+
+        for view in views.iter().skip(1) {
+            assert_eq!(
+                view.slots.len(),
+                slot_count,
+                "inconsistent slot count across blocks"
+            );
+            assert_eq!(
+                view.slots[slot_idx].segments.len(),
+                segment_count,
+                "slot {slot_idx} segment count mismatch"
+            );
+            assert_eq!(
+                view.slots[slot_idx].numa.0, numa,
+                "slot {slot_idx} NUMA mismatch across blocks"
+            );
+        }
+
+        schemas.push(SlotSchema {
+            numa_node: numa,
+            segments: segment_schemas,
+        });
+    }
+
+    schemas
+}

--- a/pegaflow-core/src/transfer_plan/view.rs
+++ b/pegaflow-core/src/transfer_plan/view.rs
@@ -12,6 +12,8 @@ pub(crate) struct SegmentPoint {
     pub block_idx: u32,
     pub ptr: u64,
     pub len: usize,
+    /// Holder-side NUMA for this block's slot; drives [`RemoteChunk::numa_node`].
+    pub numa_node: u32,
 }
 
 /// One block row in the transfer matrix.
@@ -115,6 +117,7 @@ impl BlockView {
             block_idx,
             ptr: seg.ptr,
             len: seg.len,
+            numa_node: self.slots[slot_idx].numa.0,
         }
     }
 }

--- a/pegaflow-core/src/transfer_plan/view.rs
+++ b/pegaflow-core/src/transfer_plan/view.rs
@@ -6,6 +6,8 @@ use pegaflow_common::NumaNode;
 use crate::BlockKey;
 use crate::block::{LayerBlock, SealedBlock};
 
+use super::schema::TransferPlanError;
+
 /// Per-segment pointer extracted from a sealed block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SegmentPoint {
@@ -37,21 +39,25 @@ pub(crate) struct SegmentView {
 
 pub(crate) fn block_views_from_found(
     found_blocks: &[(BlockKey, Arc<SealedBlock>)],
-) -> Vec<BlockView> {
+) -> Result<Vec<BlockView>, TransferPlanError> {
     if found_blocks.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     let slot_count = found_blocks[0].1.slots().len();
-    assert!(slot_count > 0, "sealed block must have at least one slot");
+    if slot_count == 0 {
+        return Err(TransferPlanError::new("sealed block has no slots"));
+    }
 
     let mut views = Vec::with_capacity(found_blocks.len());
     for (block_idx, (key, block)) in found_blocks.iter().enumerate() {
-        assert_eq!(
-            block.slots().len(),
-            slot_count,
-            "block {block_idx} slot count mismatch"
-        );
+        if block.slots().len() != slot_count {
+            return Err(TransferPlanError::new(format!(
+                "block {block_idx} slot count {} != {slot_count} \
+                 (namespace shared by incompatible KV layouts)",
+                block.slots().len()
+            )));
+        }
 
         let slot_numas = block.slot_numas();
         let mut slots = Vec::with_capacity(slot_count);
@@ -70,23 +76,27 @@ pub(crate) fn block_views_from_found(
             let mut segments = Vec::new();
             let k_ptr = layer.k_ptr() as u64;
             let k_len = layer.k_size();
-            assert!(
-                k_len > 0,
-                "block {block_idx} slot {slot_idx} K size is zero"
-            );
+            if k_len == 0 {
+                return Err(TransferPlanError::new(format!(
+                    "block {block_idx} slot {slot_idx} K size is zero"
+                )));
+            }
             segments.push(SegmentView {
                 ptr: k_ptr,
                 len: k_len,
             });
 
             if let Some(v_ptr) = layer.v_ptr() {
-                let v_len = layer
-                    .v_size()
-                    .expect("split layout has V ptr but missing V size");
-                assert!(
-                    v_len > 0,
-                    "block {block_idx} slot {slot_idx} split layout with zero V size"
-                );
+                let v_len = layer.v_size().ok_or_else(|| {
+                    TransferPlanError::new(format!(
+                        "block {block_idx} slot {slot_idx} split layout has V ptr but missing V size"
+                    ))
+                })?;
+                if v_len == 0 {
+                    return Err(TransferPlanError::new(format!(
+                        "block {block_idx} slot {slot_idx} split layout with zero V size"
+                    )));
+                }
                 segments.push(SegmentView {
                     ptr: v_ptr as u64,
                     len: v_len,
@@ -102,7 +112,7 @@ pub(crate) fn block_views_from_found(
         });
     }
 
-    views
+    Ok(views)
 }
 
 impl BlockView {

--- a/pegaflow-core/src/transfer_plan/view.rs
+++ b/pegaflow-core/src/transfer_plan/view.rs
@@ -4,130 +4,186 @@ use log::warn;
 use pegaflow_common::NumaNode;
 
 use crate::BlockKey;
-use crate::block::{LayerBlock, SealedBlock};
+use crate::block::SealedBlock;
 
 use super::schema::TransferPlanError;
 
-/// Per-segment pointer extracted from a sealed block.
+/// Per-segment pointer extracted from one block slot, used by chunk coalescing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SegmentPoint {
     pub block_idx: u32,
     pub ptr: u64,
     pub len: usize,
     /// Holder-side NUMA for this block's slot; drives [`RemoteChunk::numa_node`].
+    ///
+    /// [`RemoteChunk::numa_node`]: pegaflow_transfer_wire::RemoteChunk::numa_node
     pub numa_node: u32,
 }
 
-/// One block row in the transfer matrix.
-#[derive(Debug)]
-pub(crate) struct BlockView {
-    pub hash: Vec<u8>,
-    pub slots: Vec<SlotView>,
+/// Column-major view of a batch of sealed blocks: segment pointers and lengths
+/// laid out as `[slot][segment][block]`, NUMA as `[slot][block]`.
+///
+/// Both encode passes (schema derivation and chunk coalescing) scan one
+/// `(slot, segment)` at a time across all blocks, so this layout hands each pass
+/// a contiguous block-ordered slice and replaces the per-cell `Vec` allocations
+/// of a nested block/slot/segment tree with three flat buffers.
+pub(crate) struct BlockMatrix {
+    block_count: usize,
+    slot_count: usize,
+    segment_count: usize,
+    hashes: Vec<Vec<u8>>,
+    seg_ptr: Vec<u64>,
+    seg_len: Vec<usize>,
+    numa: Vec<u32>,
 }
 
-#[derive(Debug)]
-pub(crate) struct SlotView {
-    pub numa: NumaNode,
-    pub segments: Vec<SegmentView>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct SegmentView {
-    pub ptr: u64,
-    pub len: usize,
-}
-
-pub(crate) fn block_views_from_found(
-    found_blocks: &[(BlockKey, Arc<SealedBlock>)],
-) -> Result<Vec<BlockView>, TransferPlanError> {
-    if found_blocks.is_empty() {
-        return Ok(Vec::new());
+impl BlockMatrix {
+    pub(crate) fn block_count(&self) -> usize {
+        self.block_count
+    }
+    pub(crate) fn slot_count(&self) -> usize {
+        self.slot_count
+    }
+    pub(crate) fn segment_count(&self) -> usize {
+        self.segment_count
     }
 
-    let slot_count = found_blocks[0].1.slots().len();
+    fn seg_base(&self, slot: usize, segment: usize) -> usize {
+        (slot * self.segment_count + segment) * self.block_count
+    }
+
+    /// Block-ordered segment pointers for one `(slot, segment)` column.
+    pub(crate) fn seg_ptrs(&self, slot: usize, segment: usize) -> &[u64] {
+        let base = self.seg_base(slot, segment);
+        &self.seg_ptr[base..base + self.block_count]
+    }
+
+    /// Block-ordered segment lengths for one `(slot, segment)` column.
+    pub(crate) fn seg_lens(&self, slot: usize, segment: usize) -> &[usize] {
+        let base = self.seg_base(slot, segment);
+        &self.seg_len[base..base + self.block_count]
+    }
+
+    /// Block-ordered NUMA nodes for one slot.
+    pub(crate) fn numas(&self, slot: usize) -> &[u32] {
+        let base = slot * self.block_count;
+        &self.numa[base..base + self.block_count]
+    }
+
+    pub(crate) fn into_hashes(self) -> Vec<Vec<u8>> {
+        self.hashes
+    }
+}
+
+/// Build the column-major matrix from found sealed blocks. Validates slot- and
+/// segment-count consistency against block 0 up front, so the per-column encode
+/// passes can index without re-checking shape.
+pub(crate) fn block_matrix_from_found(
+    found_blocks: &[(BlockKey, Arc<SealedBlock>)],
+) -> Result<BlockMatrix, TransferPlanError> {
+    let block_count = found_blocks.len();
+    if block_count == 0 {
+        return Ok(BlockMatrix {
+            block_count: 0,
+            slot_count: 0,
+            segment_count: 0,
+            hashes: Vec::new(),
+            seg_ptr: Vec::new(),
+            seg_len: Vec::new(),
+            numa: Vec::new(),
+        });
+    }
+
+    let first = found_blocks[0].1.slots();
+    let slot_count = first.len();
     if slot_count == 0 {
         return Err(TransferPlanError::new("sealed block has no slots"));
     }
+    let segment_count = first[0].num_segments();
 
-    let mut views = Vec::with_capacity(found_blocks.len());
+    let mut seg_ptr = vec![0u64; block_count * slot_count * segment_count];
+    let mut seg_len = vec![0usize; block_count * slot_count * segment_count];
+    let mut numa = vec![NumaNode::UNKNOWN.0; block_count * slot_count];
+    let mut hashes = Vec::with_capacity(block_count);
+
     for (block_idx, (key, block)) in found_blocks.iter().enumerate() {
-        if block.slots().len() != slot_count {
+        let slots = block.slots();
+        if slots.len() != slot_count {
             return Err(TransferPlanError::new(format!(
                 "block {block_idx} slot count {} != {slot_count} \
                  (namespace shared by incompatible KV layouts)",
-                block.slots().len()
+                slots.len()
             )));
         }
-
         let slot_numas = block.slot_numas();
-        let mut slots = Vec::with_capacity(slot_count);
-        for (slot_idx, raw) in block.slots().iter().enumerate() {
-            let numa = slot_numas
+        for (slot_idx, raw) in slots.iter().enumerate() {
+            if raw.num_segments() != segment_count {
+                return Err(TransferPlanError::new(format!(
+                    "block {block_idx} slot {slot_idx} segment count {} != {segment_count}",
+                    raw.num_segments()
+                )));
+            }
+            let slot_numa = slot_numas
                 .get(slot_idx)
                 .copied()
                 .unwrap_or(NumaNode::UNKNOWN);
-            if numa.is_unknown() {
+            if slot_numa.is_unknown() {
                 warn!(
                     "transfer_plan: block {block_idx} slot {slot_idx} NUMA unknown (slot_numas len={})",
                     slot_numas.len()
                 );
             }
-            let layer = LayerBlock::new(raw);
-            let mut segments = Vec::new();
-            let k_ptr = layer.k_ptr() as u64;
-            let k_len = layer.k_size();
-            if k_len == 0 {
-                return Err(TransferPlanError::new(format!(
-                    "block {block_idx} slot {slot_idx} K size is zero"
-                )));
-            }
-            segments.push(SegmentView {
-                ptr: k_ptr,
-                len: k_len,
-            });
+            numa[slot_idx * block_count + block_idx] = slot_numa.0;
 
-            if let Some(v_ptr) = layer.v_ptr() {
-                let v_len = layer.v_size().ok_or_else(|| {
-                    TransferPlanError::new(format!(
-                        "block {block_idx} slot {slot_idx} split layout has V ptr but missing V size"
-                    ))
-                })?;
-                if v_len == 0 {
+            // One enum-match + tight loop over this slot's inline segment array,
+            // rather than re-dispatching `segment_ptr`/`segment_size` per segment.
+            for (seg, (ptr, len)) in raw.segment_iovecs().enumerate() {
+                if len == 0 {
                     return Err(TransferPlanError::new(format!(
-                        "block {block_idx} slot {slot_idx} split layout with zero V size"
+                        "block {block_idx} slot {slot_idx} segment {seg} size is zero"
                     )));
                 }
-                segments.push(SegmentView {
-                    ptr: v_ptr as u64,
-                    len: v_len,
-                });
+                let idx = (slot_idx * segment_count + seg) * block_count + block_idx;
+                seg_ptr[idx] = ptr.as_ptr() as u64;
+                seg_len[idx] = len;
             }
-
-            slots.push(SlotView { numa, segments });
         }
-
-        views.push(BlockView {
-            hash: key.hash.clone(),
-            slots,
-        });
+        hashes.push(key.hash.clone());
     }
 
-    Ok(views)
+    Ok(BlockMatrix {
+        block_count,
+        slot_count,
+        segment_count,
+        hashes,
+        seg_ptr,
+        seg_len,
+        numa,
+    })
 }
 
-impl BlockView {
-    pub(crate) fn segment_point(
-        &self,
-        block_idx: u32,
-        slot_idx: usize,
-        segment_idx: usize,
-    ) -> SegmentPoint {
-        let seg = &self.slots[slot_idx].segments[segment_idx];
-        SegmentPoint {
-            block_idx,
-            ptr: seg.ptr,
-            len: seg.len,
-            numa_node: self.slots[slot_idx].numa.0,
+#[cfg(test)]
+impl BlockMatrix {
+    /// Construct a matrix directly from column-major arrays for unit tests.
+    pub(crate) fn from_columns(
+        block_count: usize,
+        slot_count: usize,
+        segment_count: usize,
+        seg_ptr: Vec<u64>,
+        seg_len: Vec<usize>,
+        numa: Vec<u32>,
+    ) -> Self {
+        assert_eq!(seg_ptr.len(), block_count * slot_count * segment_count);
+        assert_eq!(seg_len.len(), seg_ptr.len());
+        assert_eq!(numa.len(), block_count * slot_count);
+        Self {
+            block_count,
+            slot_count,
+            segment_count,
+            hashes: (0..block_count).map(|i| vec![i as u8]).collect(),
+            seg_ptr,
+            seg_len,
+            numa,
         }
     }
 }

--- a/pegaflow-core/src/transfer_plan/view.rs
+++ b/pegaflow-core/src/transfer_plan/view.rs
@@ -1,0 +1,120 @@
+use std::sync::Arc;
+
+use log::warn;
+use pegaflow_common::NumaNode;
+
+use crate::BlockKey;
+use crate::block::{LayerBlock, SealedBlock};
+
+/// Per-segment pointer extracted from a sealed block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SegmentPoint {
+    pub block_idx: u32,
+    pub ptr: u64,
+    pub len: usize,
+}
+
+/// One block row in the transfer matrix.
+#[derive(Debug)]
+pub(crate) struct BlockView {
+    pub hash: Vec<u8>,
+    pub slots: Vec<SlotView>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SlotView {
+    pub numa: NumaNode,
+    pub segments: Vec<SegmentView>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SegmentView {
+    pub ptr: u64,
+    pub len: usize,
+}
+
+pub(crate) fn block_views_from_found(
+    found_blocks: &[(BlockKey, Arc<SealedBlock>)],
+) -> Vec<BlockView> {
+    if found_blocks.is_empty() {
+        return Vec::new();
+    }
+
+    let slot_count = found_blocks[0].1.slots().len();
+    assert!(slot_count > 0, "sealed block must have at least one slot");
+
+    let mut views = Vec::with_capacity(found_blocks.len());
+    for (block_idx, (key, block)) in found_blocks.iter().enumerate() {
+        assert_eq!(
+            block.slots().len(),
+            slot_count,
+            "block {block_idx} slot count mismatch"
+        );
+
+        let slot_numas = block.slot_numas();
+        let mut slots = Vec::with_capacity(slot_count);
+        for (slot_idx, raw) in block.slots().iter().enumerate() {
+            let numa = slot_numas
+                .get(slot_idx)
+                .copied()
+                .unwrap_or(NumaNode::UNKNOWN);
+            if numa.is_unknown() {
+                warn!(
+                    "transfer_plan: block {block_idx} slot {slot_idx} NUMA unknown (slot_numas len={})",
+                    slot_numas.len()
+                );
+            }
+            let layer = LayerBlock::new(raw);
+            let mut segments = Vec::new();
+            let k_ptr = layer.k_ptr() as u64;
+            let k_len = layer.k_size();
+            assert!(
+                k_len > 0,
+                "block {block_idx} slot {slot_idx} K size is zero"
+            );
+            segments.push(SegmentView {
+                ptr: k_ptr,
+                len: k_len,
+            });
+
+            if let Some(v_ptr) = layer.v_ptr() {
+                let v_len = layer
+                    .v_size()
+                    .expect("split layout has V ptr but missing V size");
+                assert!(
+                    v_len > 0,
+                    "block {block_idx} slot {slot_idx} split layout with zero V size"
+                );
+                segments.push(SegmentView {
+                    ptr: v_ptr as u64,
+                    len: v_len,
+                });
+            }
+
+            slots.push(SlotView { numa, segments });
+        }
+
+        views.push(BlockView {
+            hash: key.hash.clone(),
+            slots,
+        });
+    }
+
+    views
+}
+
+impl BlockView {
+    pub(crate) fn segment_point(
+        &self,
+        block_idx: u32,
+        slot_idx: usize,
+        segment_idx: usize,
+    ) -> SegmentPoint {
+        let seg = &self.slots[slot_idx].segments[segment_idx];
+        SegmentPoint {
+            block_idx,
+            ptr: seg.ptr,
+            len: seg.len,
+        }
+    }
+}

--- a/pegaflow-core/tests/common/harness.rs
+++ b/pegaflow-core/tests/common/harness.rs
@@ -21,6 +21,15 @@ pub fn has_cuda_devices(n: usize) -> bool {
     (0..n).all(|device_id| CudaContext::new(device_id).is_ok())
 }
 
+/// True when the kernel transfer backend can JIT-load its PTX on this driver.
+/// A driver older than the build's CUDA toolkit rejects the PTX
+/// (`UNSUPPORTED_PTX_VERSION`), so kernel-backend tests skip instead of failing;
+/// they still run wherever the driver supports the kernel.
+pub fn kernel_backend_available() -> bool {
+    let ctx = test_cuda_context();
+    pegaflow_core::transfer::KernelBackend::new(&ctx).is_ok()
+}
+
 // ---------------------------------------------------------------------------
 // TestGpuData: GPU buffer + expected content
 // ---------------------------------------------------------------------------

--- a/pegaflow-core/tests/engine_basic.rs
+++ b/pegaflow-core/tests/engine_basic.rs
@@ -106,6 +106,14 @@ async fn save_query_load_roundtrip_split_storage() {
 /// `CopyDesc.host_device` for save and load.
 #[tokio::test]
 async fn kernel_backend_roundtrip_split_storage() {
+    if !kernel_backend_available() {
+        eprintln!(
+            "skip kernel_backend_roundtrip_split_storage: kernel backend unavailable on this \
+             driver (PTX newer than the driver supports)"
+        );
+        return;
+    }
+
     let env = TestEnvBuilder::new("test-kernel-split", "test-ns")
         .split_layer("layer_0", 2, 4096, 16384)
         .storage(StorageConfig {

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -134,21 +134,6 @@ message SessionRequest {
 message SessionEvent {
 }
 
-// Cross-node transfer: per-slot RDMA metadata
-message TransferSlotInfo {
-  uint64 k_ptr = 1;      // Remote pinned memory address for K segment
-  uint64 k_size = 2;     // Size of the K segment in bytes (per-segment, not total slot size)
-  uint64 v_ptr = 3;      // Remote pinned memory address for V segment (0 if contiguous)
-  uint64 v_size = 4;     // Size of the V segment in bytes (0 if contiguous)
-  uint32 numa_node = 5;  // NUMA node where this slot's memory resides (for RDMA NIC affinity)
-}
-
-// Cross-node transfer: per-block RDMA metadata
-message TransferBlockInfo {
-  bytes block_hash = 1;
-  repeated TransferSlotInfo slots = 2;  // One per TP slot
-}
-
 message QueryBlocksForTransferRequest {
   string namespace = 1;
   repeated bytes block_hashes = 2;
@@ -157,9 +142,9 @@ message QueryBlocksForTransferRequest {
 
 message QueryBlocksForTransferResponse {
   ResponseStatus status = 1;
-  repeated TransferBlockInfo blocks = 2;
-  string transfer_session_id = 3;       // Opaque session ID for ReleaseTransferLock
-  uint32 lock_timeout_secs = 4;         // Server's transfer lock timeout — client must finish before this
+  string transfer_session_id = 2;       // Opaque session ID for ReleaseTransferLock
+  uint32 lock_timeout_secs = 3;         // Server's transfer lock timeout — client must finish before this
+  bytes transfer_plan = 4;              // postcard(pegaflow-transfer-wire::TransferPlan)
 }
 
 // RDMA handshake: establish a new RDMA connection between two peers.

--- a/pegaflow-server/Cargo.toml
+++ b/pegaflow-server/Cargo.toml
@@ -50,6 +50,7 @@ fastrace = { workspace = true, features = ["enable"], optional = true }
 
 [dev-dependencies]
 pegaflow-metaserver = { path = "../pegaflow-metaserver", default-features = false }
+pegaflow-transfer-wire = { path = "../pegaflow-transfer-wire" }
 
 [build-dependencies]
 pyo3-build-config.workspace = true

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -744,8 +744,17 @@ impl Engine for GrpcEngineService {
                 &req.requester_id,
             );
 
-            let transfer_plan = pegaflow_core::encode_transfer_plan_bytes(&found_blocks)
-                .map_err(Status::invalid_argument)?;
+            // The engine already took the transfer lock on `found_blocks`. If
+            // encoding fails, the requester never learns the session id, so it
+            // can never release it — drop the lock here instead of leaking it
+            // until the lock GC sweep.
+            let transfer_plan = match pegaflow_core::encode_transfer_plan_bytes(&found_blocks) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    self.engine.release_transfer_lock(&session_id);
+                    return Err(Status::invalid_argument(e));
+                }
+            };
 
             Ok(Response::new(QueryBlocksForTransferResponse {
                 status: Some(Self::build_simple_response()),

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -8,8 +8,7 @@ use crate::proto::engine::{
     RdmaHandshakeRequest, RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse,
     ReleaseRequest, ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse,
     ResponseStatus, SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest,
-    ShutdownResponse, TransferBlockInfo, TransferSlotInfo, UnregisterRequest, UnregisterResponse,
-    query_response,
+    ShutdownResponse, UnregisterRequest, UnregisterResponse, query_response,
 };
 use crate::registry::RegistryHandle;
 use crate::session::SessionRegistry;
@@ -174,30 +173,6 @@ impl GrpcEngineService {
 
     fn build_simple_response() -> ResponseStatus {
         Self::ok_status()
-    }
-
-    fn build_transfer_slot_info(
-        raw_block: &pegaflow_core::RawBlock,
-        numa_node: pegaflow_common::NumaNode,
-    ) -> TransferSlotInfo {
-        let layer_block = pegaflow_core::LayerBlock::new(raw_block);
-        if let Some(v_ptr) = layer_block.v_ptr() {
-            TransferSlotInfo {
-                k_ptr: layer_block.k_ptr() as u64,
-                k_size: layer_block.k_size() as u64,
-                v_ptr: v_ptr as u64,
-                v_size: layer_block.v_size().unwrap_or(0) as u64,
-                numa_node: numa_node.0,
-            }
-        } else {
-            TransferSlotInfo {
-                k_ptr: layer_block.k_ptr() as u64,
-                k_size: layer_block.k_size() as u64,
-                v_ptr: 0,
-                v_size: 0,
-                numa_node: numa_node.0,
-            }
-        }
     }
 
     fn save_numa_hint(
@@ -769,27 +744,14 @@ impl Engine for GrpcEngineService {
                 &req.requester_id,
             );
 
-            let blocks: Vec<TransferBlockInfo> = found_blocks
-                .iter()
-                .map(|(key, block)| {
-                    let slots: Vec<TransferSlotInfo> = block
-                        .slots()
-                        .iter()
-                        .zip(block.slot_numas())
-                        .map(|(raw, &numa)| Self::build_transfer_slot_info(raw, numa))
-                        .collect();
-                    TransferBlockInfo {
-                        block_hash: key.hash.clone(),
-                        slots,
-                    }
-                })
-                .collect();
+            let transfer_plan = pegaflow_core::encode_transfer_plan_bytes(&found_blocks)
+                .map_err(Status::invalid_argument)?;
 
             Ok(Response::new(QueryBlocksForTransferResponse {
                 status: Some(Self::build_simple_response()),
-                blocks,
                 transfer_session_id: session_id,
                 lock_timeout_secs: self.engine.transfer_lock_timeout().as_secs() as u32,
+                transfer_plan,
             }))
         }
         .await;
@@ -797,8 +759,8 @@ impl Engine for GrpcEngineService {
         let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
         match &result {
             Ok(response) => debug!(
-                "RPC [query_blocks_for_transfer] completed: ok found={} session={} elapsed_ms={:.2}",
-                response.get_ref().blocks.len(),
+                "RPC [query_blocks_for_transfer] completed: ok plan_bytes={} session={} elapsed_ms={:.2}",
+                response.get_ref().transfer_plan.len(),
                 response.get_ref().transfer_session_id,
                 elapsed_ms
             ),

--- a/pegaflow-server/tests/common/p2p_harness.rs
+++ b/pegaflow-server/tests/common/p2p_harness.rs
@@ -1,0 +1,692 @@
+//! Shared harness for pegaflow-server `p2p_rdma` integration tests.
+
+use std::collections::BTreeSet;
+use std::ffi::c_void;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use cudarc::driver::CudaContext;
+use cudarc::driver::sys;
+use pegaflow_common::NumaNode;
+use pegaflow_core::{LayerSave, LoadState, PegaEngine, PrefetchStatus, QueryLeaseId, SealedBlock};
+use pegaflow_metaserver::{BlockHashStore, GrpcMetaService};
+use pegaflow_proto::proto::engine::meta_server_server::MetaServerServer;
+use pegaflow_server::proto::engine::engine_server::EngineServer;
+use pegaflow_server::{CudaTensorRegistry, GrpcEngineService, RegistryHandle};
+use pegaflow_transfer_wire::TransferPlan;
+use tokio::sync::Notify;
+use tonic::transport::Server;
+
+pub(crate) const P2P_NAMESPACE: &str = "test-p2p";
+
+/// Model / workload shape for a p2p RDMA case.
+#[derive(Debug, Clone)]
+pub(crate) struct P2pShape {
+    pub layers: usize,
+    pub blocks: usize,
+    pub block_size: usize,
+    pub tp_size: usize,
+    pub world_size: usize,
+}
+
+impl P2pShape {
+    pub(crate) fn layer_bytes(&self) -> usize {
+        self.blocks * self.block_size * 2
+    }
+
+    pub(crate) fn rank_bytes(&self) -> usize {
+        self.layers * self.layer_bytes()
+    }
+
+    pub(crate) fn layer_names(&self) -> Vec<String> {
+        (0..self.layers).map(|l| format!("layer_{l}")).collect()
+    }
+}
+
+/// Class A cases: a single worker, every slot on one NUMA node. Multi-worker
+/// NUMA shapes (TP, MLA replica) are driven directly in `p2p_rdma.rs` because
+/// each needs its own register/save/load fan-out.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum P2pCase {
+    SingleLayer,
+    MultiLayerMultiBlock,
+}
+
+impl P2pCase {
+    pub(crate) fn default_shape(self) -> P2pShape {
+        match self {
+            Self::SingleLayer => P2pShape {
+                layers: 1,
+                blocks: 4,
+                block_size: 1024,
+                tp_size: 1,
+                world_size: 1,
+            },
+            Self::MultiLayerMultiBlock => P2pShape {
+                layers: 8,
+                blocks: 64,
+                block_size: 512,
+                tp_size: 1,
+                world_size: 1,
+            },
+        }
+    }
+}
+
+pub(crate) fn rdma_nic_names() -> Vec<String> {
+    std::env::var("PEGAFLOW_P2P_NICS")
+        .map(|s| {
+            s.split(',')
+                .map(|n| n.trim().to_string())
+                .filter(|n| !n.is_empty())
+                .collect()
+        })
+        .unwrap_or_else(|_| vec!["mlx5_1".into()])
+}
+
+pub(crate) fn cuda_device_count() -> usize {
+    let mut count = 0i32;
+    check_cuda(unsafe { sys::cuInit(0) }, "cuInit");
+    check_cuda(
+        unsafe { sys::cuDeviceGetCount(&raw mut count) },
+        "cuDeviceGetCount",
+    );
+    count.max(0) as usize
+}
+
+pub(crate) fn make_block_hashes(blocks: usize, salt: u8) -> Vec<Vec<u8>> {
+    (0..blocks)
+        .map(|idx| {
+            let mut hash = Vec::with_capacity(5);
+            hash.push(salt);
+            hash.extend_from_slice(&(idx as u32).to_le_bytes());
+            hash
+        })
+        .collect()
+}
+
+pub(crate) fn fill_test_pattern(host_data: &mut [u8], block_size: usize) {
+    fill_test_pattern_salted(host_data, block_size, 0);
+}
+
+/// Like [`fill_test_pattern`] but offsets the per-block byte by `salt`, so each
+/// TP rank / replica gets a distinct, verifiable payload under the same hashes.
+pub(crate) fn fill_test_pattern_salted(host_data: &mut [u8], block_size: usize, salt: usize) {
+    for (i, block) in host_data.chunks_exact_mut(block_size).enumerate() {
+        let fill = (((i + salt) % 251) + 1) as u8;
+        block.fill(fill);
+    }
+}
+
+pub(crate) fn get_free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+pub(crate) async fn wait_for_grpc_ready(port: u16) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for gRPC on port {port}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+pub(crate) async fn spawn_metaserver(port: u16) -> Arc<BlockHashStore> {
+    let store = Arc::new(BlockHashStore::new());
+    let service = GrpcMetaService::new(Arc::clone(&store));
+    let addr: SocketAddr = ([127, 0, 0, 1], port).into();
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(MetaServerServer::new(service))
+            .serve(addr)
+            .await
+            .expect("MetaServer gRPC serve");
+    });
+    wait_for_grpc_ready(port).await;
+    store
+}
+
+pub(crate) async fn spawn_engine_server(engine: Arc<PegaEngine>, port: u16) {
+    let registry = RegistryHandle::spawn(CudaTensorRegistry::empty());
+    let shutdown = Arc::new(Notify::new());
+    let hll_tracker = Arc::new(std::sync::Mutex::new(
+        pegaflow_common::hll::MultiWindowHllTracker::new(
+            vec![("24h".into(), Duration::from_secs(86400))],
+            14,
+        ),
+    ));
+    let service = GrpcEngineService::new(engine, registry, shutdown, hll_tracker);
+    let addr: SocketAddr = ([127, 0, 0, 1], port).into();
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(EngineServer::new(service))
+            .serve(addr)
+            .await
+            .expect("Engine gRPC serve");
+    });
+    wait_for_grpc_ready(port).await;
+}
+
+pub(crate) struct GpuBuffer {
+    ptr: sys::CUdeviceptr,
+    len: usize,
+}
+
+impl GpuBuffer {
+    pub(crate) fn alloc(len: usize) -> Self {
+        assert!(len > 0);
+        let mut ptr: sys::CUdeviceptr = 0;
+        check_cuda(
+            unsafe { sys::cuMemAlloc_v2(&raw mut ptr, len) },
+            "cuMemAlloc_v2",
+        );
+        Self { ptr, len }
+    }
+
+    pub(crate) fn as_u64(&self) -> u64 {
+        self.ptr
+    }
+
+    pub(crate) fn copy_from_host(&self, data: &[u8]) {
+        assert_eq!(data.len(), self.len);
+        check_cuda(
+            unsafe { sys::cuMemcpyHtoD_v2(self.ptr, data.as_ptr() as *const c_void, self.len) },
+            "cuMemcpyHtoD_v2",
+        );
+    }
+
+    pub(crate) fn copy_to_host(&self) -> Vec<u8> {
+        let mut output = vec![0u8; self.len];
+        check_cuda(
+            unsafe { sys::cuMemcpyDtoH_v2(output.as_mut_ptr() as *mut c_void, self.ptr, self.len) },
+            "cuMemcpyDtoH_v2",
+        );
+        output
+    }
+
+    pub(crate) fn zero(&self) {
+        check_cuda(
+            unsafe { sys::cuMemsetD8_v2(self.ptr, 0, self.len) },
+            "cuMemsetD8_v2",
+        );
+    }
+}
+
+impl Drop for GpuBuffer {
+    fn drop(&mut self) {
+        if self.ptr != 0 {
+            check_cuda(unsafe { sys::cuMemFree_v2(self.ptr) }, "cuMemFree_v2");
+            self.ptr = 0;
+        }
+    }
+}
+
+pub(crate) fn check_cuda(result: sys::CUresult, op: &str) {
+    assert!(
+        result == sys::CUresult::CUDA_SUCCESS,
+        "{op} failed with {result:?}"
+    );
+}
+
+/// A [`GpuBuffer`] pinned to a specific CUDA device.
+///
+/// Multi-worker (TP / replica) cases place each worker on its own device, so
+/// every device-touching op must bind that device's context first — otherwise
+/// alloc/copy/free run against whatever context happens to be current. The
+/// `Drop` impl rebinds before the inner [`GpuBuffer`] frees, mirroring the
+/// single-GPU harness in `common/mod.rs`.
+pub(crate) struct DeviceGpu {
+    ctx: Arc<CudaContext>,
+    gpu: GpuBuffer,
+}
+
+impl DeviceGpu {
+    pub(crate) fn alloc(device_id: i32, len: usize) -> Self {
+        let ctx = CudaContext::new(device_id as usize).expect("CUDA context for device");
+        ctx.bind_to_thread().expect("bind CUDA context");
+        let gpu = GpuBuffer::alloc(len);
+        Self { ctx, gpu }
+    }
+
+    fn bind(&self) {
+        self.ctx.bind_to_thread().expect("bind CUDA context");
+    }
+
+    pub(crate) fn as_u64(&self) -> u64 {
+        self.gpu.as_u64()
+    }
+
+    pub(crate) fn copy_from_host(&self, data: &[u8]) {
+        self.bind();
+        self.gpu.copy_from_host(data);
+    }
+
+    pub(crate) fn copy_to_host(&self) -> Vec<u8> {
+        self.bind();
+        self.gpu.copy_to_host()
+    }
+
+    pub(crate) fn zero(&self) {
+        self.bind();
+        self.gpu.zero();
+    }
+}
+
+impl Drop for DeviceGpu {
+    fn drop(&mut self) {
+        // Bind before the inner GpuBuffer's Drop frees on this device.
+        let _ = self.ctx.bind_to_thread();
+    }
+}
+
+pub(crate) async fn wait_for_cache(
+    engine: &PegaEngine,
+    instance_id: &str,
+    block_hashes: &[Vec<u8>],
+    expected_hit: usize,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let status = engine
+            .count_prefix_hit_blocks_with_prefetch(instance_id, "wait-for-cache", block_hashes)
+            .await
+            .expect("count_prefix_hit_blocks_with_prefetch");
+        let hit = match status {
+            PrefetchStatus::Ready { blocks, .. } => blocks.len(),
+            PrefetchStatus::Loading => 0,
+        };
+        if hit >= expected_hit {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {expected_hit} cached blocks (got {hit})"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+pub(crate) async fn wait_for_metaserver_registration(
+    store: &BlockHashStore,
+    namespace: &str,
+    hashes: &[Vec<u8>],
+    expected: usize,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let found = store.query_prefix(namespace, hashes);
+        if found.len() >= expected {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for MetaServer registration ({} / {})",
+            found.len(),
+            expected
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+pub(crate) async fn wait_for_prefetch_done(
+    engine: &PegaEngine,
+    instance_id: &str,
+    req_id: &str,
+    block_hashes: &[Vec<u8>],
+    expected_hit: usize,
+    timeout: Duration,
+) -> QueryLeaseId {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let status = engine
+            .count_prefix_hit_blocks_with_prefetch(instance_id, req_id, block_hashes)
+            .await
+            .expect("count_prefix_hit_blocks_with_prefetch");
+        match status {
+            PrefetchStatus::Ready { blocks, .. } if blocks.len() >= expected_hit => {
+                return engine
+                    .create_query_lease(instance_id, blocks)
+                    .expect("create query lease");
+            }
+            PrefetchStatus::Ready { blocks, missing } => {
+                assert!(
+                    Instant::now() < deadline,
+                    "prefetch done but hit={} missing={missing}, expected hit>={expected_hit}",
+                    blocks.len()
+                );
+            }
+            PrefetchStatus::Loading => {}
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for prefetch done"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+pub(crate) fn decode_transfer_plan(bytes: &[u8]) -> TransferPlan {
+    TransferPlan::decode_from_slice(bytes).expect("decode transfer plan")
+}
+
+pub(crate) fn assert_transfer_plan_numa(plan: &TransferPlan) {
+    assert!(!plan.block_hashes.is_empty(), "plan must list blocks");
+    assert!(
+        !plan.remote_chunks.is_empty(),
+        "plan must have remote chunks"
+    );
+    for chunk in &plan.remote_chunks {
+        assert!(chunk.length > 0, "remote chunk length must be > 0");
+        assert!(
+            chunk.numa_node != NumaNode::UNKNOWN.0,
+            "remote chunk must carry a valid NUMA node"
+        );
+    }
+}
+
+pub(crate) fn unique_chunk_numa_nodes(plan: &TransferPlan) -> BTreeSet<u32> {
+    plan.remote_chunks.iter().map(|c| c.numa_node).collect()
+}
+
+pub(crate) fn holder_slot_numas_per_block(
+    found: &[(pegaflow_core::BlockKey, Arc<pegaflow_core::SealedBlock>)],
+) -> Vec<Vec<NumaNode>> {
+    found
+        .iter()
+        .map(|(_, block)| block.slot_numas().to_vec())
+        .collect()
+}
+
+/// Register one worker's KV layers at `(tp_rank, pp_rank)`. The engine seals the
+/// instance topology once `world_size` workers have registered, so for
+/// multi-worker cases every worker must register *before* the first save.
+///
+/// `tp_size` / `world_size` are the values the engine sees: for normal TP they
+/// equal the deployment's TP size; for MLA they are the *effective* topology
+/// (eff_tp_size = 1, world_size = replica count).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "mirrors the engine's batched per-worker registration API"
+)]
+pub(crate) fn register_worker(
+    engine: &PegaEngine,
+    instance_id: &str,
+    shape: &P2pShape,
+    device_id: i32,
+    tp_rank: usize,
+    pp_rank: usize,
+    tp_size: usize,
+    world_size: usize,
+    gpu_ptr: u64,
+) {
+    let layer_bytes = shape.layer_bytes();
+    let ptrs: Vec<u64> = (0..shape.layers)
+        .map(|l| gpu_ptr + (l * layer_bytes) as u64)
+        .collect();
+
+    engine
+        .register_context_layer_batch(
+            instance_id,
+            P2P_NAMESPACE,
+            device_id,
+            tp_rank,
+            pp_rank,
+            tp_size,
+            world_size,
+            &shape.layer_names(),
+            &ptrs,
+            &vec![layer_bytes; shape.layers],
+            &vec![shape.blocks; shape.layers],
+            &vec![shape.block_size; shape.layers],
+            &vec![shape.blocks * shape.block_size; shape.layers],
+            &vec![2; shape.layers],
+        )
+        .expect("register_context_layer_batch");
+}
+
+/// Save every layer of `block_ids` from one worker, with an optional NUMA hint.
+///
+/// `numa_hint = None` reproduces the engine-direct path (slot NUMA = the GPU's
+/// preferred NUMA), which is exactly how normal-TP saves land. `Some(node)`
+/// reproduces the server's per-RPC NUMA round-robin used for MLA replicas.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one save RPC's worth of routing + payload fields"
+)]
+pub(crate) async fn save_worker_blocks(
+    engine: &PegaEngine,
+    instance_id: &str,
+    shape: &P2pShape,
+    device_id: i32,
+    tp_rank: usize,
+    pp_rank: usize,
+    block_ids: &[usize],
+    block_hashes: &[Vec<u8>],
+    numa_hint: Option<NumaNode>,
+) {
+    let saves: Vec<LayerSave> = shape
+        .layer_names()
+        .into_iter()
+        .map(|layer_name| LayerSave {
+            layer_name,
+            block_ids: block_ids.to_vec(),
+            block_hashes: block_hashes.to_vec(),
+        })
+        .collect();
+
+    engine
+        .batch_save_kv_blocks_from_ipc_with_numa_hint(
+            instance_id,
+            tp_rank,
+            pp_rank,
+            device_id,
+            saves,
+            numa_hint,
+        )
+        .await
+        .expect("batch_save_kv_blocks_from_ipc_with_numa_hint");
+}
+
+pub(crate) async fn holder_save_blocks(
+    engine: &PegaEngine,
+    instance_id: &str,
+    shape: &P2pShape,
+    device_id: i32,
+    tp_rank: u32,
+    block_hashes: &[Vec<u8>],
+    gpu: &GpuBuffer,
+) -> Vec<u8> {
+    let rank_bytes = shape.rank_bytes();
+    let mut host_data = vec![0u8; rank_bytes];
+    fill_test_pattern(&mut host_data, shape.block_size);
+    gpu.copy_from_host(&host_data);
+
+    register_worker(
+        engine,
+        instance_id,
+        shape,
+        device_id,
+        tp_rank as usize,
+        0,
+        shape.tp_size,
+        shape.world_size,
+        gpu.as_u64(),
+    );
+
+    let block_ids: Vec<usize> = (0..shape.blocks).collect();
+    save_worker_blocks(
+        engine,
+        instance_id,
+        shape,
+        device_id,
+        tp_rank as usize,
+        0,
+        &block_ids,
+        block_hashes,
+        None,
+    )
+    .await;
+
+    host_data
+}
+
+pub(crate) async fn query_holder_transfer_plan(
+    engine: &PegaEngine,
+    block_hashes: &[Vec<u8>],
+    requester_id: &str,
+) -> TransferPlan {
+    let (_, found) = engine.query_blocks_for_transfer(P2P_NAMESPACE, block_hashes, requester_id);
+    assert!(
+        !found.is_empty(),
+        "holder must have blocks for transfer plan query"
+    );
+    let bytes = pegaflow_core::encode_transfer_plan_bytes(&found).expect("encode transfer plan");
+    decode_transfer_plan(&bytes)
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "single-worker load target + its expected payload"
+)]
+pub(crate) async fn requester_load_and_verify(
+    engine: &PegaEngine,
+    instance_id: &str,
+    shape: &P2pShape,
+    device_id: i32,
+    tp_rank: usize,
+    lease: QueryLeaseId,
+    block_ids: &[usize],
+    expected_host: &[u8],
+    gpu: &GpuBuffer,
+) {
+    let load_state = LoadState::new().expect("create LoadState");
+    let layer_names = shape.layer_names();
+    let layer_name_refs: Vec<&str> = layer_names.iter().map(String::as_str).collect();
+
+    engine
+        .batch_load_kv_blocks_multi_layer(
+            instance_id,
+            tp_rank,
+            device_id,
+            load_state.shm_name(),
+            &layer_name_refs,
+            &[(lease, block_ids.to_vec())],
+        )
+        .expect("batch_load_kv_blocks_multi_layer");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let state = load_state.get();
+        if state == pegaflow_core::sync_state::LOAD_STATE_SUCCESS {
+            break;
+        }
+        assert!(
+            state != pegaflow_core::sync_state::LOAD_STATE_ERROR,
+            "load reported ERROR"
+        );
+        assert!(Instant::now() < deadline, "timed out waiting for load");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let loaded = gpu.copy_to_host();
+    assert_eq!(
+        loaded, expected_host,
+        "GPU data mismatch after remote fetch + load"
+    );
+}
+
+/// Load one worker's slice into its own device and verify it against the data
+/// that worker's holder counterpart saved. The single `lease` is shared across
+/// all workers — it is created with `refcount == world_size`, so each worker
+/// consumes it exactly once (see `create_query_lease`).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one worker's load target + its expected payload"
+)]
+pub(crate) async fn requester_load_worker_and_verify(
+    engine: &PegaEngine,
+    instance_id: &str,
+    shape: &P2pShape,
+    device_id: i32,
+    tp_rank: usize,
+    lease: QueryLeaseId,
+    block_ids: &[usize],
+    expected_host: &[u8],
+    gpu: &DeviceGpu,
+) {
+    let load_state = LoadState::new().expect("create LoadState");
+    let layer_names = shape.layer_names();
+    let layer_name_refs: Vec<&str> = layer_names.iter().map(String::as_str).collect();
+
+    engine
+        .batch_load_kv_blocks_multi_layer(
+            instance_id,
+            tp_rank,
+            device_id,
+            load_state.shm_name(),
+            &layer_name_refs,
+            &[(lease, block_ids.to_vec())],
+        )
+        .expect("batch_load_kv_blocks_multi_layer");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let state = load_state.get();
+        if state == pegaflow_core::sync_state::LOAD_STATE_SUCCESS {
+            break;
+        }
+        assert!(
+            state != pegaflow_core::sync_state::LOAD_STATE_ERROR,
+            "load reported ERROR (tp_rank={tp_rank})"
+        );
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for load (tp_rank={tp_rank})"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let loaded = gpu.copy_to_host();
+    assert_eq!(
+        loaded, expected_host,
+        "GPU data mismatch after remote fetch + load (tp_rank={tp_rank})"
+    );
+}
+
+/// Distinct NUMA nodes actually recorded across every slot of every block.
+/// On a single-NUMA box this is `{0}`; on a 2-socket box spanning workers it is
+/// the set the transfer plan's remote chunks must reproduce exactly.
+pub(crate) fn distinct_slot_numas(
+    found: &[(pegaflow_core::BlockKey, Arc<SealedBlock>)],
+) -> BTreeSet<u32> {
+    found
+        .iter()
+        .flat_map(|(_, block)| block.slot_numas().iter().map(|n| n.0))
+        .collect()
+}
+
+/// True if any single block carries slots on more than one NUMA node (the
+/// cross-slot shape produced by TP / layer-split across sockets).
+pub(crate) fn any_block_spans_multiple_numa(
+    found: &[(pegaflow_core::BlockKey, Arc<SealedBlock>)],
+) -> bool {
+    found.iter().any(|(_, block)| {
+        let nodes: BTreeSet<u32> = block.slot_numas().iter().map(|n| n.0).collect();
+        nodes.len() > 1
+    })
+}

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -1,440 +1,579 @@
-//! P2P RDMA remote fetch integration test.
+//! P2P RDMA integration tests: production cross-node fetch + transfer-plan NUMA.
 //!
-//! Verifies the end-to-end flow:
-//! Engine A saves blocks → MetaServer discovers them → Engine B fetches via RDMA READ
-//! → data integrity verified.
+//! ```bash
+//! cargo test -p pegaflow-server --test p2p_rdma -- --ignored --nocapture
+//! ```
 //!
-//! Run with: `cargo test -p pegaflow-server --test p2p_rdma -- --ignored`
+//! The cases here enumerate how a stored block's slots map onto NUMA nodes,
+//! because that mapping is what the transfer plan must reproduce and the
+//! requester must rebuild:
+//!
+//! - **A (single writer)** — `SingleLayer` / `MultiLayerMultiBlock`: one worker,
+//!   every slot on one NUMA. Baseline encode/fetch/load.
+//! - **B (cross-slot NUMA)** — normal MHA TP>1: each rank owns a distinct slot
+//!   column and saves with its own GPU's NUMA, so a *single block* spans NUMA
+//!   when ranks land on different sockets. No server NUMA hint (eff tp_size>1).
+//! - **C (cross-block NUMA)** — MLA replica without DCP: only effective rank 0
+//!   saves, but the server round-robins each save RPC's NUMA across the replica
+//!   candidates, so each block is single-NUMA while the *batch* spans NUMA.
+//!
+//! Multi-NUMA assertions self-adapt: on a single-NUMA box the distinct-NUMA set
+//! collapses to one and the cross-NUMA shape is logged as not exercised, but the
+//! multi-worker topology and the data roundtrip are still verified.
 
-use std::ffi::c_void;
-use std::net::SocketAddr;
+// The p2p harness is standalone: include it directly so this binary does not
+// drag in the unrelated mock-vLLM helpers under `common/` (and vice versa).
+#[path = "common/p2p_harness.rs"]
+mod p2p_harness;
+
+use std::collections::BTreeSet;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use cudarc::driver::CudaContext;
-use cudarc::driver::sys;
-use pegaflow_core::sync_state::{LOAD_STATE_ERROR, LOAD_STATE_SUCCESS};
-use pegaflow_core::*;
-use pegaflow_metaserver::{BlockHashStore, GrpcMetaService};
-use pegaflow_proto::proto::engine::meta_server_server::MetaServerServer;
-use pegaflow_server::proto::engine::engine_server::EngineServer;
-use pegaflow_server::{CudaTensorRegistry, GrpcEngineService, RegistryHandle};
-use tokio::sync::Notify;
-use tonic::transport::Server;
+use pegaflow_common::NumaNode;
+use pegaflow_core::{PegaEngine, StorageConfig};
+use pegaflow_server::session::SessionRegistry;
 
-// ── GPU buffer (from pegaflow-core/tests/common/gpu_buffer.rs) ──────────────
+use p2p_harness::{
+    DeviceGpu, GpuBuffer, P2P_NAMESPACE, P2pCase, P2pShape, any_block_spans_multiple_numa,
+    assert_transfer_plan_numa, cuda_device_count, distinct_slot_numas, fill_test_pattern_salted,
+    get_free_port, holder_save_blocks, holder_slot_numas_per_block, make_block_hashes,
+    query_holder_transfer_plan, register_worker, requester_load_and_verify,
+    requester_load_worker_and_verify, save_worker_blocks, spawn_engine_server, spawn_metaserver,
+    unique_chunk_numa_nodes, wait_for_cache, wait_for_metaserver_registration,
+    wait_for_prefetch_done,
+};
 
-struct GpuBuffer {
-    ptr: sys::CUdeviceptr,
-    len: usize,
-}
+/// Cap multi-GPU fan-out: enough to span both sockets on a 2-NUMA box without
+/// registering an absurd number of CUDA contexts.
+const MAX_TEST_GPUS: usize = 8;
 
-impl GpuBuffer {
-    fn alloc(len: usize) -> Self {
-        assert!(len > 0);
-        let mut ptr: sys::CUdeviceptr = 0;
-        check_cuda(
-            unsafe { sys::cuMemAlloc_v2(&raw mut ptr, len) },
-            "cuMemAlloc_v2",
-        );
-        Self { ptr, len }
-    }
-
-    fn as_u64(&self) -> u64 {
-        self.ptr
-    }
-
-    fn copy_from_host(&self, data: &[u8]) {
-        assert_eq!(data.len(), self.len);
-        check_cuda(
-            unsafe { sys::cuMemcpyHtoD_v2(self.ptr, data.as_ptr() as *const c_void, self.len) },
-            "cuMemcpyHtoD_v2",
-        );
-    }
-
-    fn copy_to_host(&self) -> Vec<u8> {
-        let mut output = vec![0u8; self.len];
-        check_cuda(
-            unsafe { sys::cuMemcpyDtoH_v2(output.as_mut_ptr() as *mut c_void, self.ptr, self.len) },
-            "cuMemcpyDtoH_v2",
-        );
-        output
-    }
-
-    fn zero(&self) {
-        check_cuda(
-            unsafe { sys::cuMemsetD8_v2(self.ptr, 0, self.len) },
-            "cuMemsetD8_v2",
-        );
+fn case_salt(case: P2pCase) -> u8 {
+    match case {
+        P2pCase::SingleLayer => 42,
+        P2pCase::MultiLayerMultiBlock => 43,
     }
 }
 
-impl Drop for GpuBuffer {
-    fn drop(&mut self) {
-        if self.ptr != 0 {
-            check_cuda(unsafe { sys::cuMemFree_v2(self.ptr) }, "cuMemFree_v2");
-            self.ptr = 0;
+struct P2pCluster {
+    meta_port: u16,
+    port_holder: u16,
+    port_requester: u16,
+}
+
+impl P2pCluster {
+    fn new() -> Self {
+        Self {
+            meta_port: get_free_port(),
+            port_holder: get_free_port(),
+            port_requester: get_free_port(),
+        }
+    }
+
+    fn holder_config(&self) -> StorageConfig {
+        StorageConfig {
+            metaserver_addr: Some(format!("http://127.0.0.1:{}", self.meta_port)),
+            advertise_addr: Some(format!("127.0.0.1:{}", self.port_holder)),
+            rdma_nic_names: Some(p2p_harness::rdma_nic_names()),
+            ..StorageConfig::default()
+        }
+    }
+
+    fn requester_config(&self) -> StorageConfig {
+        StorageConfig {
+            metaserver_addr: Some(format!("http://127.0.0.1:{}", self.meta_port)),
+            advertise_addr: Some(format!("127.0.0.1:{}", self.port_requester)),
+            rdma_nic_names: Some(p2p_harness::rdma_nic_names()),
+            ..StorageConfig::default()
         }
     }
 }
 
-fn check_cuda(result: sys::CUresult, op: &str) {
-    assert!(
-        result == sys::CUresult::CUDA_SUCCESS,
-        "{op} failed with {result:?}"
-    );
-}
+// =============================================================================
+// Class A: single writer, single NUMA
+// =============================================================================
 
-// ── Helpers (from pegaflow-core/tests/common/helpers.rs) ────────────────────
-
-fn fill_test_pattern(host_data: &mut [u8], block_size: usize) {
-    for (i, block) in host_data.chunks_exact_mut(block_size).enumerate() {
-        let fill = ((i % 251) + 1) as u8;
-        block.fill(fill);
-    }
-}
-
-fn make_block_ids(num_blocks: usize) -> Vec<usize> {
-    (0..num_blocks).collect()
-}
-
-fn make_block_hashes(num_blocks: usize, salt: u8) -> Vec<Vec<u8>> {
-    (0..num_blocks)
-        .map(|idx| {
-            let mut hash = Vec::with_capacity(5);
-            hash.push(salt);
-            hash.extend_from_slice(&(idx as u32).to_le_bytes());
-            hash
-        })
-        .collect()
-}
-
-// ── Infrastructure ──────────────────────────────────────────────────────────
-
-fn get_free_port() -> u16 {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .expect("bind ephemeral port")
-        .local_addr()
-        .expect("local_addr")
-        .port()
-}
-
-async fn wait_for_grpc_ready(port: u16) {
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        if tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
-            .await
-            .is_ok()
-        {
-            return;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for gRPC on port {port}"
-        );
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
-}
-
-async fn spawn_metaserver(port: u16) -> Arc<BlockHashStore> {
-    let store = Arc::new(BlockHashStore::new());
-    let service = GrpcMetaService::new(Arc::clone(&store));
-    let addr: SocketAddr = ([127, 0, 0, 1], port).into();
-    tokio::spawn(async move {
-        Server::builder()
-            .add_service(MetaServerServer::new(service))
-            .serve(addr)
-            .await
-            .expect("MetaServer gRPC serve");
-    });
-    wait_for_grpc_ready(port).await;
-    store
-}
-
-async fn spawn_engine_server(engine: Arc<PegaEngine>, port: u16) {
-    let registry = CudaTensorRegistry::new().expect("CudaTensorRegistry::new");
-    let registry = RegistryHandle::spawn(registry);
-    let shutdown = Arc::new(Notify::new());
-    let hll_tracker = Arc::new(std::sync::Mutex::new(
-        pegaflow_common::hll::MultiWindowHllTracker::new(
-            vec![("24h".into(), Duration::from_secs(86400))],
-            14,
-        ),
-    ));
-    let service = GrpcEngineService::new(engine, registry, shutdown, hll_tracker);
-    let addr: SocketAddr = ([127, 0, 0, 1], port).into();
-    tokio::spawn(async move {
-        Server::builder()
-            .add_service(EngineServer::new(service))
-            .serve(addr)
-            .await
-            .expect("Engine gRPC serve");
-    });
-    wait_for_grpc_ready(port).await;
-}
-
-async fn wait_for_cache(
-    engine: &PegaEngine,
-    instance_id: &str,
-    block_hashes: &[Vec<u8>],
-    expected_hit: usize,
-    timeout: Duration,
-) {
-    let deadline = Instant::now() + timeout;
-    loop {
-        let status = engine
-            .count_prefix_hit_blocks_with_prefetch(instance_id, "wait-for-cache", block_hashes)
-            .await
-            .expect("count_prefix_hit_blocks_with_prefetch");
-        let hit = match status {
-            PrefetchStatus::Ready { blocks, .. } => blocks.len(),
-            PrefetchStatus::Loading => 0,
-        };
-        if hit >= expected_hit {
-            return;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for {expected_hit} cached blocks (got {hit})"
-        );
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
-}
-
-async fn wait_for_metaserver_registration(
-    store: &BlockHashStore,
-    namespace: &str,
-    hashes: &[Vec<u8>],
-    expected: usize,
-    timeout: Duration,
-) {
-    let deadline = Instant::now() + timeout;
-    loop {
-        let found = store.query_prefix(namespace, hashes);
-        if found.len() >= expected {
-            return;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for MetaServer registration ({} / {})",
-            found.len(),
-            expected
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-}
-
-async fn wait_for_prefetch_done(
-    engine: &PegaEngine,
-    instance_id: &str,
-    req_id: &str,
-    block_hashes: &[Vec<u8>],
-    expected_hit: usize,
-    timeout: Duration,
-) -> QueryLeaseId {
-    let deadline = Instant::now() + timeout;
-    loop {
-        let status = engine
-            .count_prefix_hit_blocks_with_prefetch(instance_id, req_id, block_hashes)
-            .await
-            .expect("count_prefix_hit_blocks_with_prefetch");
-        match status {
-            PrefetchStatus::Ready { blocks, .. } if blocks.len() >= expected_hit => {
-                return engine
-                    .create_query_lease(instance_id, blocks)
-                    .expect("create query lease");
-            }
-            PrefetchStatus::Ready { blocks, missing } => {
-                assert!(
-                    Instant::now() < deadline,
-                    "prefetch done but hit={} missing={missing}, \
-                     expected hit>={expected_hit}",
-                    blocks.len()
-                );
-            }
-            PrefetchStatus::Loading => {}
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for prefetch done"
-        );
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-}
-
-// ── Test ────────────────────────────────────────────────────────────────────
-
-const NUM_BLOCKS: usize = 4;
-const BLOCK_SIZE: usize = 1024;
-const TOTAL_SIZE: usize = NUM_BLOCKS * BLOCK_SIZE;
-const NAMESPACE: &str = "test-p2p";
-const LAYER: &str = "layer_0";
-const DEVICE_ID: i32 = 0;
-
-#[tokio::test]
-#[ignore] // Requires RDMA hardware (mlx5_1), CUDA GPU, and Python+torch
-async fn p2p_rdma_remote_fetch_roundtrip() {
+async fn run_roundtrip(case: P2pCase) {
     pegaflow_common::logging::init_stdout_colored("debug");
-    let _cuda_ctx = CudaContext::new(0).expect("CUDA init");
+    let shape = case.default_shape();
+    let _ = CudaContext::new(0).expect("CUDA init");
 
-    // Allocate ephemeral ports
-    let meta_port = get_free_port();
-    let port_a = get_free_port();
+    let cluster = P2pCluster::new();
+    let meta_store = spawn_metaserver(cluster.meta_port).await;
 
-    // ── 1. Start MetaServer ──
-    let meta_store = spawn_metaserver(meta_port).await;
-
-    // ── 2. Create Engine A (source of blocks) ──
-    let config_a = StorageConfig {
-        metaserver_addr: Some(format!("http://127.0.0.1:{meta_port}")),
-        advertise_addr: Some(format!("127.0.0.1:{port_a}")),
-        rdma_nic_names: Some(vec!["mlx5_1".into()]),
-        ..StorageConfig::default()
-    };
     let engine_a = Arc::new(
-        PegaEngine::new_with_config(16 << 20, false, config_a).expect("engine A should start"),
+        PegaEngine::new_with_config(256 << 20, false, cluster.holder_config())
+            .expect("holder engine"),
     );
+    spawn_engine_server(Arc::clone(&engine_a), cluster.port_holder).await;
 
-    // ── 3. Start Engine A gRPC server ──
-    spawn_engine_server(Arc::clone(&engine_a), port_a).await;
+    let block_hashes = make_block_hashes(shape.blocks, case_salt(case));
+    let gpu_holder = GpuBuffer::alloc(shape.rank_bytes());
+    let holder_host = holder_save_blocks(
+        &engine_a,
+        "inst-a",
+        &shape,
+        0,
+        0,
+        &block_hashes,
+        &gpu_holder,
+    )
+    .await;
 
-    // ── 4. Save blocks on Engine A ──
-    let gpu_a = GpuBuffer::alloc(TOTAL_SIZE);
-    let mut host_data = vec![0u8; TOTAL_SIZE];
-    fill_test_pattern(&mut host_data, BLOCK_SIZE);
-    gpu_a.copy_from_host(&host_data);
-
-    engine_a
-        .register_context_layer_batch(
-            "inst-a",
-            NAMESPACE,
-            DEVICE_ID,
-            0, // tp_rank
-            0, // pp_rank
-            1, // tp_size
-            1, // world_size
-            &[LAYER.to_string()],
-            &[gpu_a.as_u64()],
-            &[TOTAL_SIZE],
-            &[NUM_BLOCKS],
-            &[BLOCK_SIZE],
-            &[0], // kv_strides
-            &[1], // segments
-        )
-        .expect("register layer on engine A");
-
-    let block_ids = make_block_ids(NUM_BLOCKS);
-    let block_hashes = make_block_hashes(NUM_BLOCKS, 42);
-
-    engine_a
-        .batch_save_kv_blocks_from_ipc(
-            "inst-a",
-            0,
-            0,
-            DEVICE_ID,
-            vec![LayerSave {
-                layer_name: LAYER.to_string(),
-                block_ids: block_ids.clone(),
-                block_hashes: block_hashes.clone(),
-            }],
-        )
-        .await
-        .expect("save blocks on engine A");
-
-    // ── 5. Wait for Engine A cache ──
     wait_for_cache(
         &engine_a,
         "inst-a",
         &block_hashes,
-        NUM_BLOCKS,
-        Duration::from_secs(5),
+        shape.blocks,
+        Duration::from_secs(60),
     )
     .await;
-
-    // ── 6. Wait for MetaServer registration (fire-and-forget async) ──
     wait_for_metaserver_registration(
         &meta_store,
-        NAMESPACE,
+        P2P_NAMESPACE,
         &block_hashes,
-        NUM_BLOCKS,
-        Duration::from_secs(10),
-    )
-    .await;
-
-    // ── 7. Create Engine B (fetcher) ──
-    let port_b = get_free_port();
-    let config_b = StorageConfig {
-        metaserver_addr: Some(format!("http://127.0.0.1:{meta_port}")),
-        advertise_addr: Some(format!("127.0.0.1:{port_b}")),
-        rdma_nic_names: Some(vec!["mlx5_1".into()]),
-        ..StorageConfig::default()
-    };
-    let engine_b =
-        PegaEngine::new_with_config(16 << 20, false, config_b).expect("engine B should start");
-
-    let gpu_b = GpuBuffer::alloc(TOTAL_SIZE);
-    gpu_b.zero();
-
-    engine_b
-        .register_context_layer_batch(
-            "inst-b",
-            NAMESPACE,
-            DEVICE_ID,
-            0, // tp_rank
-            0, // pp_rank
-            1, // tp_size
-            1, // world_size
-            &[LAYER.to_string()],
-            &[gpu_b.as_u64()],
-            &[TOTAL_SIZE],
-            &[NUM_BLOCKS],
-            &[BLOCK_SIZE],
-            &[0],
-            &[1],
-        )
-        .expect("register layer on engine B");
-
-    // ── 8. Remote fetch: Engine B discovers blocks via MetaServer → RDMA READ ──
-    let lease = wait_for_prefetch_done(
-        &engine_b,
-        "inst-b",
-        "req-1",
-        &block_hashes,
-        NUM_BLOCKS,
+        shape.blocks,
         Duration::from_secs(30),
     )
     .await;
 
-    // ── 9. Load from Engine B cache → GPU ──
-    let load_state = LoadState::new().expect("create LoadState");
-    let shm_name = load_state.shm_name().to_string();
+    let plan = query_holder_transfer_plan(&engine_a, &block_hashes, "p2p-it-requester").await;
+    assert_transfer_plan_numa(&plan);
+    let (_, found) =
+        engine_a.query_blocks_for_transfer(P2P_NAMESPACE, &block_hashes, "p2p-it-check");
+    let holder_numas = holder_slot_numas_per_block(&found);
+    assert_eq!(holder_numas.len(), shape.blocks);
+    for slot_numas in &holder_numas {
+        assert!(!slot_numas.is_empty());
+        assert!(slot_numas.iter().all(|n| n.is_valid()));
+    }
+    let distinct = unique_chunk_numa_nodes(&plan);
+    eprintln!(
+        "{case:?}: plan blocks={} chunks={} distinct_chunk_numa={distinct:?}",
+        plan.block_hashes.len(),
+        plan.remote_chunks.len()
+    );
 
-    engine_b
-        .batch_load_kv_blocks_multi_layer(
-            "inst-b",
-            0,
-            DEVICE_ID,
-            &shm_name,
-            &[LAYER],
-            &[(lease, block_ids.clone())],
-        )
-        .expect("batch_load on engine B");
+    let engine_b = Arc::new(
+        PegaEngine::new_with_config(256 << 20, false, cluster.requester_config())
+            .expect("requester engine"),
+    );
 
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        let state = load_state.get();
-        if state == LOAD_STATE_SUCCESS {
-            break;
-        }
-        assert!(state != LOAD_STATE_ERROR, "load reported ERROR");
-        assert!(Instant::now() < deadline, "timed out waiting for load");
-        tokio::time::sleep(Duration::from_millis(10)).await;
+    let gpu_req = GpuBuffer::alloc(shape.rank_bytes());
+    gpu_req.zero();
+    register_worker(
+        &engine_b,
+        "inst-b",
+        &shape,
+        0,
+        0,
+        0,
+        shape.tp_size,
+        shape.world_size,
+        gpu_req.as_u64(),
+    );
+
+    let lease = wait_for_prefetch_done(
+        &engine_b,
+        "inst-b",
+        &format!("p2p-{case:?}"),
+        &block_hashes,
+        shape.blocks,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let block_ids: Vec<usize> = (0..shape.blocks).collect();
+    requester_load_and_verify(
+        &engine_b,
+        "inst-b",
+        &shape,
+        0,
+        0,
+        lease,
+        &block_ids,
+        &holder_host,
+        &gpu_req,
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires RDMA NIC + CUDA GPU"]
+async fn p2p_rdma_single_layer_roundtrip() {
+    run_roundtrip(P2pCase::SingleLayer).await;
+}
+
+#[tokio::test]
+#[ignore = "requires RDMA NIC + CUDA GPU"]
+async fn p2p_rdma_multi_layer_multi_block() {
+    run_roundtrip(P2pCase::MultiLayerMultiBlock).await;
+}
+
+// =============================================================================
+// Class B: normal MHA TP>1 — cross-slot NUMA (each rank owns a slot column)
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires RDMA NIC + multiple CUDA GPUs spanning NUMA"]
+async fn p2p_rdma_normal_tp_cross_numa() {
+    pegaflow_common::logging::init_stdout_colored("debug");
+
+    let tp_size = cuda_device_count().min(MAX_TEST_GPUS);
+    if tp_size < 2 {
+        eprintln!("skip: need >= 2 CUDA devices for normal-TP cross-NUMA case");
+        return;
     }
 
-    // ── 10. Verify data integrity ──
-    let loaded = gpu_b.copy_to_host();
-    assert_eq!(
-        loaded, host_data,
-        "GPU data mismatch: remote-fetched blocks differ from original"
+    let shape = P2pShape {
+        layers: 4,
+        blocks: 16,
+        block_size: 512,
+        tp_size,
+        world_size: tp_size,
+    };
+    let rank_bytes = shape.rank_bytes();
+    let block_ids: Vec<usize> = (0..shape.blocks).collect();
+    let block_hashes = make_block_hashes(shape.blocks, 81);
+
+    let cluster = P2pCluster::new();
+    let meta_store = spawn_metaserver(cluster.meta_port).await;
+    let engine_a = Arc::new(
+        PegaEngine::new_with_config(512 << 20, false, cluster.holder_config())
+            .expect("holder engine"),
     );
+    spawn_engine_server(Arc::clone(&engine_a), cluster.port_holder).await;
+
+    // Each TP rank gets its own device + a distinct payload under the same
+    // hashes (different KV heads = different bytes). Register *all* ranks before
+    // saving — sealing requires the full worker set.
+    let mut holder_gpus: Vec<DeviceGpu> = Vec::with_capacity(tp_size);
+    let mut holder_host: Vec<Vec<u8>> = Vec::with_capacity(tp_size);
+    for rank in 0..tp_size {
+        let gpu = DeviceGpu::alloc(rank as i32, rank_bytes);
+        let mut host = vec![0u8; rank_bytes];
+        fill_test_pattern_salted(&mut host, shape.block_size, rank);
+        gpu.copy_from_host(&host);
+        register_worker(
+            &engine_a,
+            "inst-a",
+            &shape,
+            rank as i32,
+            rank,
+            0,
+            tp_size,
+            tp_size,
+            gpu.as_u64(),
+        );
+        holder_gpus.push(gpu);
+        holder_host.push(host);
+    }
+    for rank in 0..tp_size {
+        save_worker_blocks(
+            &engine_a,
+            "inst-a",
+            &shape,
+            rank as i32,
+            rank,
+            0,
+            &block_ids,
+            &block_hashes,
+            None,
+        )
+        .await;
+    }
+
+    wait_for_cache(
+        &engine_a,
+        "inst-a",
+        &block_hashes,
+        shape.blocks,
+        Duration::from_secs(60),
+    )
+    .await;
+    wait_for_metaserver_registration(
+        &meta_store,
+        P2P_NAMESPACE,
+        &block_hashes,
+        shape.blocks,
+        Duration::from_secs(30),
+    )
+    .await;
+
+    let (_, found) =
+        engine_a.query_blocks_for_transfer(P2P_NAMESPACE, &block_hashes, "p2p-it-check");
+    let holder_numas = holder_slot_numas_per_block(&found);
+    assert_eq!(holder_numas.len(), shape.blocks);
+    for slot_numas in &holder_numas {
+        assert_eq!(
+            slot_numas.len(),
+            shape.layers * tp_size,
+            "each block has one slot per (layer, tp_rank)"
+        );
+        assert!(slot_numas.iter().all(|n| n.is_valid()));
+    }
+
+    let plan = query_holder_transfer_plan(&engine_a, &block_hashes, "p2p-it-requester").await;
+    assert_transfer_plan_numa(&plan);
+    let slot_numa = distinct_slot_numas(&found);
+    assert_eq!(
+        unique_chunk_numa_nodes(&plan),
+        slot_numa,
+        "plan remote-chunk NUMA set must equal the holder's slot NUMA set"
+    );
+    if slot_numa.len() > 1 {
+        assert!(
+            any_block_spans_multiple_numa(&found),
+            "TP across sockets must produce blocks whose slots span >1 NUMA"
+        );
+        eprintln!("normal-TP cross-slot multi-NUMA exercised: distinct={slot_numa:?}");
+    } else {
+        eprintln!("single-NUMA box: cross-slot multi-NUMA not exercised (distinct={slot_numa:?})");
+    }
+
+    // Requester mirrors the TP topology; each rank loads its own column.
+    let engine_b = Arc::new(
+        PegaEngine::new_with_config(512 << 20, false, cluster.requester_config())
+            .expect("requester engine"),
+    );
+    let mut req_gpus: Vec<DeviceGpu> = Vec::with_capacity(tp_size);
+    for rank in 0..tp_size {
+        let gpu = DeviceGpu::alloc(rank as i32, rank_bytes);
+        gpu.zero();
+        register_worker(
+            &engine_b,
+            "inst-b",
+            &shape,
+            rank as i32,
+            rank,
+            0,
+            tp_size,
+            tp_size,
+            gpu.as_u64(),
+        );
+        req_gpus.push(gpu);
+    }
+
+    let lease = wait_for_prefetch_done(
+        &engine_b,
+        "inst-b",
+        "p2p-normal-tp",
+        &block_hashes,
+        shape.blocks,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    for rank in 0..tp_size {
+        requester_load_worker_and_verify(
+            &engine_b,
+            "inst-b",
+            &shape,
+            rank as i32,
+            rank,
+            lease,
+            &block_ids,
+            &holder_host[rank],
+            &req_gpus[rank],
+        )
+        .await;
+    }
+}
+
+// =============================================================================
+// Class C: MLA replica (no DCP) — cross-block NUMA via server round-robin
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires RDMA NIC + multiple CUDA GPUs spanning NUMA"]
+async fn p2p_rdma_mla_replica_round_robin_numa() {
+    pegaflow_common::logging::init_stdout_colored("debug");
+
+    let replicas = cuda_device_count().min(MAX_TEST_GPUS);
+    if replicas < 2 {
+        eprintln!("skip: need >= 2 CUDA devices for MLA-replica round-robin case");
+        return;
+    }
+
+    // MLA without DCP: effective tp_size == 1 (one slot column), world_size ==
+    // replica count. KV is identical across replicas, so the latent layout is a
+    // single contiguous segment per slot.
+    let shape = P2pShape {
+        layers: 4,
+        blocks: 16,
+        block_size: 512,
+        tp_size: 1,
+        world_size: replicas,
+    };
+    let rank_bytes = shape.rank_bytes();
+    let block_ids: Vec<usize> = (0..shape.blocks).collect();
+    let block_hashes = make_block_hashes(shape.blocks, 82);
+
+    let cluster = P2pCluster::new();
+    let meta_store = spawn_metaserver(cluster.meta_port).await;
+    let engine_a = Arc::new(
+        PegaEngine::new_with_config(512 << 20, false, cluster.holder_config())
+            .expect("holder engine"),
+    );
+    spawn_engine_server(Arc::clone(&engine_a), cluster.port_holder).await;
+
+    // Register every replica (so the save group's NUMA candidates span both
+    // sockets), but only effective rank 0 (device 0) carries and writes data.
+    let mut host = vec![0u8; rank_bytes];
+    fill_test_pattern_salted(&mut host, shape.block_size, 0);
+    let mut holder_gpus: Vec<DeviceGpu> = Vec::with_capacity(replicas);
+    for device in 0..replicas {
+        let gpu = DeviceGpu::alloc(device as i32, rank_bytes);
+        if device == 0 {
+            gpu.copy_from_host(&host);
+        }
+        register_worker(
+            &engine_a,
+            "inst-a",
+            &shape,
+            device as i32,
+            0,
+            0,
+            shape.tp_size,
+            shape.world_size,
+            gpu.as_u64(),
+        );
+        holder_gpus.push(gpu);
+    }
+
+    // Drive the real server-side round-robin: one save RPC per block, each with
+    // the next candidate NUMA. On a single-NUMA box candidates.len() < 2 makes
+    // this fall back to the device's NUMA (no rotation).
+    let candidates = engine_a
+        .registered_numa_nodes_for_save_group("inst-a", 0, 0)
+        .expect("save-group NUMA candidates");
+    let session = SessionRegistry::new();
+    session.install(
+        "inst-a".to_string(),
+        P2P_NAMESPACE.to_string(),
+        replicas as u32,
+        replicas as u32,
+    );
+    for &block_id in &block_ids {
+        let hint: Option<NumaNode> = session
+            .next_save_numa_hint("inst-a", 0, 0, &candidates)
+            .map(|h| h.numa_node);
+        save_worker_blocks(
+            &engine_a,
+            "inst-a",
+            &shape,
+            0,
+            0,
+            0,
+            std::slice::from_ref(&block_id),
+            std::slice::from_ref(&block_hashes[block_id]),
+            hint,
+        )
+        .await;
+    }
+
+    wait_for_cache(
+        &engine_a,
+        "inst-a",
+        &block_hashes,
+        shape.blocks,
+        Duration::from_secs(60),
+    )
+    .await;
+    wait_for_metaserver_registration(
+        &meta_store,
+        P2P_NAMESPACE,
+        &block_hashes,
+        shape.blocks,
+        Duration::from_secs(30),
+    )
+    .await;
+
+    let (_, found) =
+        engine_a.query_blocks_for_transfer(P2P_NAMESPACE, &block_hashes, "p2p-it-check");
+    let holder_numas = holder_slot_numas_per_block(&found);
+    assert_eq!(holder_numas.len(), shape.blocks);
+    for slot_numas in &holder_numas {
+        assert_eq!(
+            slot_numas.len(),
+            shape.layers,
+            "MLA replica has one slot per layer (effective tp_size == 1)"
+        );
+        assert!(slot_numas.iter().all(|n| n.is_valid()));
+        let block_set: BTreeSet<u32> = slot_numas.iter().map(|n| n.0).collect();
+        assert_eq!(
+            block_set.len(),
+            1,
+            "each replica block is written by one save RPC, so all its slots share one NUMA"
+        );
+    }
+
+    let plan = query_holder_transfer_plan(&engine_a, &block_hashes, "p2p-it-requester").await;
+    assert_transfer_plan_numa(&plan);
+    let slot_numa = distinct_slot_numas(&found);
+    assert_eq!(
+        unique_chunk_numa_nodes(&plan),
+        slot_numa,
+        "plan remote-chunk NUMA set must equal the holder's slot NUMA set"
+    );
+    assert!(
+        !any_block_spans_multiple_numa(&found),
+        "MLA replica blocks must each be single-NUMA (cross-block, not cross-slot)"
+    );
+    if slot_numa.len() > 1 {
+        eprintln!(
+            "MLA-replica round-robin cross-block multi-NUMA exercised: distinct={slot_numa:?}"
+        );
+    } else {
+        eprintln!("single-NUMA box: round-robin not exercised (distinct={slot_numa:?})");
+    }
+
+    // Requester mirrors the replica topology; every replica loads the full block.
+    let engine_b = Arc::new(
+        PegaEngine::new_with_config(512 << 20, false, cluster.requester_config())
+            .expect("requester engine"),
+    );
+    let mut req_gpus: Vec<DeviceGpu> = Vec::with_capacity(replicas);
+    for device in 0..replicas {
+        let gpu = DeviceGpu::alloc(device as i32, rank_bytes);
+        gpu.zero();
+        register_worker(
+            &engine_b,
+            "inst-b",
+            &shape,
+            device as i32,
+            0,
+            0,
+            shape.tp_size,
+            shape.world_size,
+            gpu.as_u64(),
+        );
+        req_gpus.push(gpu);
+    }
+
+    let lease = wait_for_prefetch_done(
+        &engine_b,
+        "inst-b",
+        "p2p-mla-replica",
+        &block_hashes,
+        shape.blocks,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    for (device, gpu) in req_gpus.iter().enumerate() {
+        requester_load_worker_and_verify(
+            &engine_b,
+            "inst-b",
+            &shape,
+            device as i32,
+            0,
+            lease,
+            &block_ids,
+            &host,
+            gpu,
+        )
+        .await;
+    }
 }

--- a/pegaflow-transfer-wire/Cargo.toml
+++ b/pegaflow-transfer-wire/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pegaflow-transfer-wire"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Wire schema for cross-node QueryBlocksForTransfer RDMA fetch"
+
+[lints]
+workspace = true
+
+[dependencies]
+postcard = { version = "1.1", features = ["alloc", "use-std"] }
+serde = { workspace = true, features = ["derive"] }
+smallvec = { workspace = true, features = ["serde"] }

--- a/pegaflow-transfer-wire/src/lib.rs
+++ b/pegaflow-transfer-wire/src/lib.rs
@@ -1,0 +1,264 @@
+//! Wire schema for the serving-side `QueryBlocksForTransfer` response body.
+//!
+//! The gRPC response carries `transfer_plan` as postcard-encoded bytes of
+//! [`TransferPlan`]. Layout is expressed with structs only: contiguous vs
+//! split KV is `SlotSchema.segments.len()` (1 or 2).
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+
+/// Schema violation found while parsing or validating a transfer plan.
+#[derive(Debug)]
+pub struct WireError(String);
+
+impl WireError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl fmt::Display for WireError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "transfer-wire: {}", self.0)
+    }
+}
+
+impl std::error::Error for WireError {}
+
+/// One slot (layer): shared segment shape across every block in the plan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SlotSchema {
+    pub numa_node: u32,
+    pub segments: SmallVec<[SegmentSchema; 2]>,
+}
+
+/// Byte shape of one K or V segment within a slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SegmentSchema {
+    pub bytes: usize,
+    pub block_stride: usize,
+}
+
+/// One coalesced remote pinned-memory interval; requester issues one RDMA READ each.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteChunk {
+    pub base_ptr: u64,
+    pub length: u64,
+    pub numa_node: u32,
+}
+
+/// Maps a slice inside a [`RemoteChunk`] (after NUMA slab packing) back to blocks.
+///
+/// `block_count >= 1`. Stride for `block_count >= 2` comes from
+/// [`SlotSchema::segments`]; singles use `block_start` only.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SegmentPlacement {
+    pub slot_idx: u32,
+    pub segment_idx: u32,
+    pub chunk_idx: u32,
+    pub offset_in_chunk: usize,
+    pub block_start: u32,
+    pub block_count: u32,
+}
+
+/// Compact transfer geometry for a batch of provider-side sealed blocks.
+///
+/// The requester allocates one pinned slab per NUMA node, RDMA-reads each
+/// [`RemoteChunk`] into its slab, then rebuilds blocks from [`SegmentPlacement`]
+/// entries. Block order is [`Self::block_hashes`]; `block_start` indexes into it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferPlan {
+    /// Per-slot (layer) layout shared by every block in the batch.
+    pub slot_schemas: Vec<SlotSchema>,
+    /// Remote intervals to fetch; one RDMA READ per entry.
+    pub remote_chunks: Vec<RemoteChunk>,
+    /// How fetched bytes map back to block slots/segments.
+    pub placements: Vec<SegmentPlacement>,
+    /// Content hashes in transfer order.
+    pub block_hashes: Vec<Vec<u8>>,
+}
+
+impl TransferPlan {
+    pub fn encode_to_vec(&self) -> Result<Vec<u8>, WireError> {
+        postcard::to_allocvec(self).map_err(|e| WireError::new(format!("encode failed: {e}")))
+    }
+
+    pub fn decode_from_slice(bytes: &[u8]) -> Result<Self, WireError> {
+        let plan: Self = postcard::from_bytes(bytes)
+            .map_err(|e| WireError::new(format!("decode failed: {e}")))?;
+        plan.validate()?;
+        Ok(plan)
+    }
+
+    pub fn validate(&self) -> Result<(), WireError> {
+        if self.block_hashes.is_empty() {
+            if !self.slot_schemas.is_empty()
+                || !self.remote_chunks.is_empty()
+                || !self.placements.is_empty()
+            {
+                return Err(WireError::new("empty block_hashes with non-empty geometry"));
+            }
+            return Ok(());
+        }
+
+        if self.slot_schemas.is_empty() {
+            return Err(WireError::new(
+                "block_hashes present but slot_schemas empty",
+            ));
+        }
+
+        let segment_count = self.slot_schemas[0].segments.len();
+        if segment_count == 0 || segment_count > 2 {
+            return Err(WireError::new(format!(
+                "slot 0 has invalid segment count {segment_count}"
+            )));
+        }
+
+        for (slot_idx, slot) in self.slot_schemas.iter().enumerate() {
+            if slot.segments.len() != segment_count {
+                return Err(WireError::new(format!(
+                    "slot {slot_idx} segment count {} != {segment_count}",
+                    slot.segments.len()
+                )));
+            }
+            for (seg_idx, seg) in slot.segments.iter().enumerate() {
+                if seg.bytes == 0 {
+                    return Err(WireError::new(format!(
+                        "slot {slot_idx} segment {seg_idx} bytes is zero"
+                    )));
+                }
+                if seg.block_stride < seg.bytes {
+                    return Err(WireError::new(format!(
+                        "slot {slot_idx} segment {seg_idx} stride {} < bytes {}",
+                        seg.block_stride, seg.bytes
+                    )));
+                }
+            }
+        }
+
+        let block_count = u32::try_from(self.block_hashes.len()).map_err(|_| {
+            WireError::new(format!(
+                "block_hashes length {} exceeds u32::MAX",
+                self.block_hashes.len()
+            ))
+        })?;
+
+        for chunk in &self.remote_chunks {
+            if chunk.length == 0 {
+                return Err(WireError::new("remote chunk length is zero"));
+            }
+        }
+
+        for placement in &self.placements {
+            Self::check_slot_segment(placement.slot_idx, placement.segment_idx, segment_count)?;
+            Self::check_chunk_idx(placement.chunk_idx, self.remote_chunks.len())?;
+            if placement.block_count == 0 {
+                return Err(WireError::new(format!(
+                    "placement slot={} segment={} block_count is zero",
+                    placement.slot_idx, placement.segment_idx
+                )));
+            }
+            if placement.block_start >= block_count {
+                return Err(WireError::new("placement block_start out of bounds"));
+            }
+            let end = placement
+                .block_start
+                .checked_add(placement.block_count)
+                .ok_or_else(|| WireError::new("placement block index overflow"))?;
+            if end > block_count {
+                return Err(WireError::new("placement extends past block_hashes"));
+            }
+            let seg = &self.slot_schemas[placement.slot_idx as usize].segments
+                [placement.segment_idx as usize];
+            let span = if placement.block_count > 1 {
+                (u64::from(placement.block_count - 1) * seg.block_stride as u64) + seg.bytes as u64
+            } else {
+                seg.bytes as u64
+            };
+            let end_offset = placement.offset_in_chunk as u64 + span;
+            if end_offset > self.remote_chunks[placement.chunk_idx as usize].length {
+                return Err(WireError::new("placement extends past remote chunk length"));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_slot_segment(
+        slot_idx: u32,
+        segment_idx: u32,
+        segment_count: usize,
+    ) -> Result<(), WireError> {
+        if segment_idx as usize >= segment_count {
+            return Err(WireError::new(format!(
+                "segment_idx {segment_idx} >= segment_count {segment_count}"
+            )));
+        }
+        let _ = slot_idx;
+        Ok(())
+    }
+
+    fn check_chunk_idx(chunk_idx: u32, chunk_count: usize) -> Result<(), WireError> {
+        if chunk_idx as usize >= chunk_count {
+            return Err(WireError::new(format!(
+                "chunk_idx {chunk_idx} >= chunk_count {chunk_count}"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Total payload bytes referenced by all remote chunks.
+    pub fn total_remote_bytes(&self) -> u64 {
+        self.remote_chunks.iter().map(|c| c.length).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use smallvec::smallvec;
+
+    fn sample_plan() -> TransferPlan {
+        TransferPlan {
+            slot_schemas: vec![SlotSchema {
+                numa_node: 0,
+                segments: smallvec![SegmentSchema {
+                    bytes: 64,
+                    block_stride: 128,
+                }],
+            }],
+            remote_chunks: vec![RemoteChunk {
+                base_ptr: 0x5000,
+                length: 256,
+                numa_node: 0,
+            }],
+            placements: vec![SegmentPlacement {
+                slot_idx: 0,
+                segment_idx: 0,
+                chunk_idx: 0,
+                offset_in_chunk: 0,
+                block_start: 0,
+                block_count: 2,
+            }],
+            block_hashes: vec![vec![1], vec![2]],
+        }
+    }
+
+    #[test]
+    fn postcard_round_trip() {
+        let plan = sample_plan();
+        let bytes = plan.encode_to_vec().expect("encode");
+        let decoded = TransferPlan::decode_from_slice(&bytes).expect("decode");
+        assert_eq!(plan, decoded);
+    }
+
+    #[test]
+    fn rejects_placement_with_block_count_zero() {
+        let mut plan = sample_plan();
+        plan.placements[0].block_count = 0;
+        assert!(plan.validate().is_err());
+    }
+}

--- a/pegaflow-transfer-wire/src/lib.rs
+++ b/pegaflow-transfer-wire/src/lib.rs
@@ -29,11 +29,9 @@ impl std::error::Error for WireError {}
 
 /// One slot (layer): shared segment shape across every block in the plan.
 ///
-/// NUMA placement is expressed on each [`RemoteChunk`]; [`Self::numa_node`] is
-/// retained for wire compatibility and mirrors block 0 only.
+/// NUMA placement is expressed per [`RemoteChunk`], not per slot.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SlotSchema {
-    pub numa_node: u32,
     pub segments: SmallVec<[SegmentSchema; 2]>,
 }
 
@@ -227,7 +225,6 @@ mod tests {
     fn sample_plan() -> TransferPlan {
         TransferPlan {
             slot_schemas: vec![SlotSchema {
-                numa_node: 0,
                 segments: smallvec![SegmentSchema {
                     bytes: 64,
                     block_stride: 128,

--- a/pegaflow-transfer-wire/src/lib.rs
+++ b/pegaflow-transfer-wire/src/lib.rs
@@ -28,6 +28,9 @@ impl fmt::Display for WireError {
 impl std::error::Error for WireError {}
 
 /// One slot (layer): shared segment shape across every block in the plan.
+///
+/// NUMA placement is expressed on each [`RemoteChunk`]; [`Self::numa_node`] is
+/// retained for wire compatibility and mirrors block 0 only.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SlotSchema {
     pub numa_node: u32,

--- a/pegaflow-transfer/src/engine.rs
+++ b/pegaflow-transfer/src/engine.rs
@@ -170,8 +170,10 @@ impl TransferEngine {
 
     /// Submit a batch of RDMA READ or WRITE operations against a connected peer.
     ///
-    /// Ops are NUMA-aware distributed across NICs. Returns one receiver per
-    /// active NIC; each yields the bytes transferred on that NIC.
+    /// Ops are routed NUMA-aware, and each op is striped across all NICs of its
+    /// NUMA node (and their QPs), so a single large op saturates the whole group
+    /// rather than one NIC. Returns one receiver per submitted (NIC, QP) batch;
+    /// await all of them. The caller need not pre-shard to get NIC parallelism.
     ///
     /// The connection must be established via `get_or_prepare` +
     /// `complete_handshake` before calling this method.

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -22,6 +22,9 @@ use crate::engine::{NicHandshake, RegisteredMemoryRegion, TransferDesc, Transfer
 use crate::error::{Result, TransferError};
 use pegaflow_common::NumaNode;
 
+/// Max bytes per RDMA work request; larger `TransferDesc`s are split at the engine entry.
+const MAX_RDMA_TRANSFER_BYTES: usize = 128 * 1024 * 1024;
+
 struct NicGroup {
     nic_indices: Vec<usize>,
     rr_counter: AtomicUsize,
@@ -475,32 +478,45 @@ impl RcBackend {
                     (0..n).map(|_| Vec::with_capacity(per_bucket)).collect();
 
                 for (i, desc) in nic_descs.iter().enumerate() {
-                    let local_ptr = desc.local_ptr.as_ptr() as u64;
-                    let remote_ptr = desc.remote_ptr.as_ptr() as u64;
+                    let base_local = desc.local_ptr.as_ptr() as u64;
+                    let base_remote = desc.remote_ptr.as_ptr() as u64;
                     let len = desc.len;
 
                     if len == 0 {
                         return Err(TransferError::InvalidArgument("len must be non-zero"));
                     }
 
-                    let local_mr = state
-                        .find_local_mr(nic_idx, local_ptr, len)
-                        .ok_or(TransferError::MemoryNotRegistered { ptr: local_ptr })?;
-
-                    let remote_rkey = state.nics[nic_idx]
-                        .find_remote_rkey(remote_first_qpn, remote_ptr, len)
-                        .ok_or(TransferError::InvalidArgument(
-                            "remote memory not found in handshake snapshot",
-                        ))?;
-
                     let bucket = rot.wrapping_add(i) % n;
-                    buckets[bucket].push(RdmaOp {
-                        local_mr,
-                        local_ptr,
-                        remote_ptr,
-                        len,
-                        remote_rkey,
-                    });
+
+                    let mut offset = 0usize;
+                    while offset < len {
+                        let chunk_len = (len - offset).min(MAX_RDMA_TRANSFER_BYTES);
+                        let local_ptr = base_local.checked_add(offset as u64).ok_or(
+                            TransferError::InvalidArgument("local_ptr + offset overflow"),
+                        )?;
+                        let remote_ptr = base_remote.checked_add(offset as u64).ok_or(
+                            TransferError::InvalidArgument("remote_ptr + offset overflow"),
+                        )?;
+
+                        let local_mr = state
+                            .find_local_mr(nic_idx, local_ptr, chunk_len)
+                            .ok_or(TransferError::MemoryNotRegistered { ptr: local_ptr })?;
+
+                        let remote_rkey = state.nics[nic_idx]
+                            .find_remote_rkey(remote_first_qpn, remote_ptr, chunk_len)
+                            .ok_or(TransferError::InvalidArgument(
+                                "remote memory not found in handshake snapshot",
+                            ))?;
+
+                        buckets[bucket].push(RdmaOp {
+                            local_mr,
+                            local_ptr,
+                            remote_ptr,
+                            len: chunk_len,
+                            remote_rkey,
+                        });
+                        offset += chunk_len;
+                    }
                 }
 
                 for (q_idx, prepared) in buckets.into_iter().enumerate() {

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -25,6 +25,15 @@ use pegaflow_common::NumaNode;
 /// Max bytes per RDMA work request; larger `TransferDesc`s are split at the engine entry.
 const MAX_RDMA_TRANSFER_BYTES: usize = 128 * 1024 * 1024;
 
+/// Granularity at which a single `TransferDesc` is striped across the NICs of
+/// its NUMA group. A coalesced read from an upper layer can be one huge desc;
+/// without striping it would land on a single NIC (and, via the per-desc QP
+/// bucket below, a single QP), capping throughput at one NIC's bandwidth. At
+/// 8 MiB a transfer of N MiB fans into N/8 stripes — enough to cover every
+/// (NIC, QP) in a NUMA group for any read large enough to be bandwidth-bound,
+/// while keeping each work request large enough to amortize posting overhead.
+const NIC_STRIPE_BYTES: usize = 8 * 1024 * 1024;
+
 fn mr_access_flags() -> AccessFlags {
     AccessFlags::LocalWrite
         | AccessFlags::RemoteWrite
@@ -42,6 +51,22 @@ impl NicGroup {
         let idx = self.rr_counter.fetch_add(1, Ordering::Relaxed);
         self.nic_indices[idx % self.nic_indices.len()]
     }
+}
+
+/// Split `len` into `<= NIC_STRIPE_BYTES` stripes and assign each, round-robin,
+/// to a NIC in `group`. Returns `(offset, stripe_len, nic_idx)` per stripe.
+///
+/// Pure so the fan-out invariant (a large transfer touches every NIC in its
+/// group) is unit-testable without RDMA hardware.
+fn stripe_plan(len: usize, group: &NicGroup) -> Vec<(usize, usize, usize)> {
+    let mut stripes = Vec::with_capacity(len.div_ceil(NIC_STRIPE_BYTES));
+    let mut offset = 0;
+    while offset < len {
+        let stripe = (len - offset).min(NIC_STRIPE_BYTES);
+        stripes.push((offset, stripe, group.next()));
+        offset += stripe;
+    }
+    stripes
 }
 
 struct NumaRoundRobin {
@@ -92,13 +117,15 @@ impl NumaRoundRobin {
         }
     }
 
-    fn pick(&self, numa: NumaNode) -> usize {
+    /// NIC group for `numa`: its NUMA-local NICs, or all NICs when the node is
+    /// unknown / has no dedicated NICs.
+    fn group_for(&self, numa: NumaNode) -> &NicGroup {
         if numa.is_valid()
             && let Some(group) = self.groups.get(&numa)
         {
-            return group.next();
+            return group;
         }
-        self.fallback.next()
+        &self.fallback
     }
 }
 
@@ -423,24 +450,41 @@ impl RcBackend {
 
         let nic_count = self.nic_count();
 
-        // NUMA-aware NIC assignment: query the NUMA node of each descriptor's
-        // first page and route to a NIC on the same NUMA node.
+        // NUMA-aware NIC assignment: route each descriptor to NICs on its
+        // memory's NUMA node, and stripe a large descriptor across all of that
+        // node's NICs so one coalesced read saturates the whole group instead
+        // of a single NIC.
         let mut per_nic: Vec<Vec<TransferDesc>> = (0..nic_count).map(|_| Vec::new()).collect();
-        if self.numa_rr.single_numa {
-            // All NICs on one NUMA node — skip move_pages, plain round-robin.
-            for &desc in descs {
-                let nic_idx = self.numa_rr.fallback.next();
-                per_nic[nic_idx].push(desc);
-            }
+        // Single NUMA node: every NIC shares it, so skip the move_pages syscall
+        // and stripe across all NICs (the fallback group) via UNKNOWN.
+        let numa_nodes: Vec<NumaNode> = if self.numa_rr.single_numa {
+            Vec::new()
         } else {
             let addrs: Vec<*const u8> = descs
                 .iter()
                 .map(|d| d.local_ptr.as_ptr() as *const u8)
                 .collect();
-            let numa_nodes = pegaflow_common::query_pages_numa(&addrs);
-            for (i, &desc) in descs.iter().enumerate() {
-                let nic_idx = self.numa_rr.pick(numa_nodes[i]);
-                per_nic[nic_idx].push(desc);
+            pegaflow_common::query_pages_numa(&addrs)
+        };
+
+        for (i, desc) in descs.iter().enumerate() {
+            if desc.len == 0 {
+                return Err(TransferError::InvalidArgument("len must be non-zero"));
+            }
+            let numa = numa_nodes.get(i).copied().unwrap_or(NumaNode::UNKNOWN);
+            let group = self.numa_rr.group_for(numa);
+            for (offset, stripe_len, nic_idx) in stripe_plan(desc.len, group) {
+                // SAFETY: offset < desc.len and [ptr, ptr+len) is registered, so
+                // the offset pointers are non-null and within the same region.
+                let local_ptr =
+                    unsafe { NonNull::new_unchecked(desc.local_ptr.as_ptr().add(offset)) };
+                let remote_ptr =
+                    unsafe { NonNull::new_unchecked(desc.remote_ptr.as_ptr().add(offset)) };
+                per_nic[nic_idx].push(TransferDesc {
+                    local_ptr,
+                    remote_ptr,
+                    len: stripe_len,
+                });
             }
         }
 
@@ -545,5 +589,46 @@ impl RcBackend {
             receivers.push(session.transfer_batch_async(prepared, op)?);
         }
         Ok(receivers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn group(nic_indices: Vec<usize>) -> NicGroup {
+        NicGroup {
+            nic_indices,
+            rr_counter: AtomicUsize::new(0),
+        }
+    }
+
+    #[test]
+    fn large_desc_fans_out_across_every_nic_in_group() {
+        let g = group(vec![2, 3, 4, 5]); // a 4-NIC NUMA group
+        let len = 100 * NIC_STRIPE_BYTES + 1; // forces many stripes
+        let stripes = stripe_plan(len, &g);
+
+        // Every NIC in the group gets work — the regression was all bytes
+        // landing on a single NIC.
+        let nics: std::collections::HashSet<usize> = stripes.iter().map(|s| s.2).collect();
+        assert_eq!(nics, [2, 3, 4, 5].into_iter().collect());
+
+        // Stripes tile [0, len) contiguously with no gaps/overlap, none oversized.
+        let mut next = 0;
+        for (offset, stripe_len, _) in &stripes {
+            assert_eq!(*offset, next);
+            assert!(*stripe_len <= NIC_STRIPE_BYTES && *stripe_len > 0);
+            next += stripe_len;
+        }
+        assert_eq!(next, len);
+    }
+
+    #[test]
+    fn small_desc_stays_on_one_nic() {
+        let g = group(vec![0, 1, 2, 3]);
+        let stripes = stripe_plan(NIC_STRIPE_BYTES / 4, &g);
+        assert_eq!(stripes.len(), 1);
+        assert_eq!(stripes[0], (0, NIC_STRIPE_BYTES / 4, 0));
     }
 }

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -25,6 +25,13 @@ use pegaflow_common::NumaNode;
 /// Max bytes per RDMA work request; larger `TransferDesc`s are split at the engine entry.
 const MAX_RDMA_TRANSFER_BYTES: usize = 128 * 1024 * 1024;
 
+fn mr_access_flags() -> AccessFlags {
+    AccessFlags::LocalWrite
+        | AccessFlags::RemoteWrite
+        | AccessFlags::RemoteRead
+        | AccessFlags::RelaxedOrdering
+}
+
 struct NicGroup {
     nic_indices: Vec<usize>,
     rr_counter: AtomicUsize,
@@ -154,14 +161,8 @@ impl RcBackend {
         // Register on every NIC's PD.
         let mut mrs = Vec::with_capacity(self.nic_count());
         for runtime in &self.runtimes {
-            let mr = unsafe {
-                runtime.pd.reg_mr(
-                    raw as usize,
-                    len,
-                    AccessFlags::LocalWrite | AccessFlags::RemoteWrite | AccessFlags::RemoteRead,
-                )
-            }
-            .map_err(|error| TransferError::Backend(error.to_string()))?;
+            let mr = unsafe { runtime.pd.reg_mr(raw as usize, len, mr_access_flags()) }
+                .map_err(|error| TransferError::Backend(error.to_string()))?;
             mrs.push(mr);
         }
 


### PR DESCRIPTION
## What & why

`QueryBlocksForTransfer` previously returned per-block / per-slot RDMA metadata as nested protobuf (`TransferBlockInfo` / `TransferSlotInfo`), with the wire size scaling as `blocks × slots`. This branch replaces that with a compact, run-encoded **`TransferPlan`** (new `pegaflow-transfer-wire` crate, postcard-encoded into a single `bytes transfer_plan` field): the response carries a per-slot **segment schema** plus a per-slot **NUMA source map** once, and the requester rebuilds each block's slabs on the NUMA the holder actually used.

The "schema source map" point: the holder tells the requester not just *where* the bytes live, but *which NUMA* each slot is on, so the cross-node RDMA fetch materializes and rebuilds NUMA-correctly instead of landing everything on one node.

## What's in it (5 commits)

- **feat: TransferPlan wire encoding** — new `pegaflow-transfer-wire` crate + `transfer_plan/{encode,schema}`; `QueryBlocksForTransferResponse` carries `bytes transfer_plan` (postcard) instead of nested messages. Wire size scales with *blocks*, not *blocks × slots*.
- **fix: split oversized RDMA reads at 128MB** + **fix: enable IBV_ACCESS_RELAXED_ORDERING** — RDMA read-path fixes the plan-driven fetch depends on.
- **feat: per-slot NUMA source map** — thread holder-side per-slot NUMA through `transfer_plan/{view,merge,schema,rebuild}` + `materialize`; the requester allocates one slab per distinct chunk NUMA and rebuilds each slot on its source NUMA. Rebuild **rejects UNKNOWN NUMA** (crash-early; encode warns and the fetch boundary logs + meters the error, so the degradation is never silent). Restores `SealedBlock::from_slots` to build with empty `slot_numas` (SSD-prefetch path; was regressed into a guaranteed panic). Adds the p2p RDMA integration coverage.
- **test: assert rebuild rejects unknown NUMA loudly** — locks in the crash-early guard so it can't silently regress.

Also: the kernel-backend integration test now self-skips when the driver can't JIT-load its PTX (older driver vs newer CUDA toolkit) instead of failing the suite — it still runs wherever the driver supports the kernel.

## Breaking change

⚠️ Wire-incompatible: `QueryBlocksForTransferResponse` fields are renumbered and `TransferBlockInfo` / `TransferSlotInfo` are removed in favor of `bytes transfer_plan`. **Holder and requester must be upgraded together.**

## Testing

- Local gate green (cuda-13,rdma): `cargo fmt` / `cargo clippy -D warnings` / `cargo test --release` all pass.
- Unit coverage in `transfer_plan::tests`: per-block NUMA preservation through rebuild, one slab per distinct chunk NUMA, loud UNKNOWN-NUMA rejection, encode→materialize→rebuild byte round-trip, wire-size scaling.
- **p2p RDMA integration tests run on an 8-GPU, 2-NUMA-socket node with 400G InfiniBand** — all 4 pass, byte-exact:
  - normal MHA TP>1 → cross-slot multi-NUMA exercised (`distinct={0,1}`)
  - MLA replica (no DCP) → cross-block multi-NUMA via server save-NUMA round-robin (`distinct={0,1}`)
  - single-writer baseline
  - The multi-NUMA cases self-adapt to single-NUMA boxes (skip the cross-NUMA assertion, still verify topology + data roundtrip).

## Note

Related transfer work is in #350 (run-encode `QueryBlocksForTransfer` addresses) on a separate branch — no shared commits, but both touch the transfer fetch path, so mind merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
