### PR TITLE
refactor(pd): restructure pd_connector for maintainability

### DIFF
--- a/python/pegaflow/pd_connector/__init__.py
+++ b/python/pegaflow/pd_connector/__init__.py
@@ -26,29 +26,36 @@ from pegaflow.pd_connector.worker import (
 )
 
 
-class PdDecodeConnector(PdConnectorClassMixin, KVConnectorBase_V1, SupportsHMA):
-    """Decode-side vLLM connector for P/D RDMA push."""
+class _PdSplitConnector(PdConnectorClassMixin, KVConnectorBase_V1, SupportsHMA):
+    """Base for the split decode/prefill connectors.
 
-    @classmethod
-    def requires_piecewise_for_cudagraph(cls, extra_config: dict[str, Any]) -> bool:
-        return False
+    Holds the vLLM callbacks that are identical on both sides. Subclasses set
+    ``_scheduler_cls`` / ``_worker_cls`` and override only the callbacks that
+    actually differ between decode and prefill (load/save side, cudagraph
+    requirement, load-error reporting).
+    """
+
+    _scheduler_cls: type
+    _worker_cls: type
 
     def __init__(self, vllm_config: Any, role: KVConnectorRole, kv_cache_config: Any = None):
         super().__init__(vllm_config, role, kv_cache_config)
         assert_supported_config(vllm_config)
-        self._scheduler: PdDecodeSchedulerConnector | None = None
-        self._worker: PdDecodeWorkerConnector | None = None
+        self._scheduler: Any | None = None
+        self._worker: Any | None = None
         self._metrics = PdMetricsTracker()
         if role == KVConnectorRole.SCHEDULER:
-            self._scheduler = PdDecodeSchedulerConnector(vllm_config, metrics=self._metrics)
+            self._scheduler = self._scheduler_cls(vllm_config, metrics=self._metrics)
         elif role == KVConnectorRole.WORKER:
-            self._worker = PdDecodeWorkerConnector(
+            self._worker = self._worker_cls(
                 vllm_config,
                 kv_cache_config=kv_cache_config,
                 metrics=self._metrics,
             )
         else:
             raise ValueError(f"unsupported KV connector role: {role}")
+
+    # -- worker-side common callbacks --------------------------------------
 
     def register_kv_caches(self, kv_caches: dict[str, Any]) -> None:
         if self._worker is not None:
@@ -61,42 +68,18 @@ class PdDecodeConnector(PdConnectorClassMixin, KVConnectorBase_V1, SupportsHMA):
         assert isinstance(metadata, PdConnectorMetadata)
         self._worker.start_load_kv(metadata, forward_context, **kwargs)
 
-    def wait_for_layer_load(self, layer_name: str) -> None:
-        if self._worker is not None:
-            self._worker.wait_for_layer_load(layer_name)
-
-    def save_kv_layer(
-        self,
-        layer_name: str,
-        kv_layer: Any,
-        attn_metadata: Any,
-        **kwargs: Any,
-    ) -> None:
-        return None
-
-    def wait_for_save(self) -> None:
-        return None
-
     def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str] | None, set[str] | None]:
         if self._worker is None:
             return None, None
         return self._worker.get_finished(finished_req_ids)
-
-    def get_block_ids_with_load_errors(self) -> set[int]:
-        if self._worker is None:
-            return set()
-        return self._worker.get_block_ids_with_load_errors()
-
-    def build_connector_worker_meta(self) -> Any | None:
-        if self._worker is None:
-            return None
-        return self._worker.build_connector_worker_meta()
 
     def shutdown(self) -> None:
         if self._worker is not None:
             self._worker.shutdown()
         if self._scheduler is not None:
             self._scheduler.shutdown()
+
+    # -- scheduler-side common callbacks -----------------------------------
 
     def get_num_new_matched_tokens(
         self,
@@ -140,36 +123,48 @@ class PdDecodeConnector(PdConnectorClassMixin, KVConnectorBase_V1, SupportsHMA):
         return self._scheduler.request_finished(request, block_ids)
 
 
-class PdPrefillConnector(PdConnectorClassMixin, KVConnectorBase_V1, SupportsHMA):
+class PdDecodeConnector(_PdSplitConnector):
+    """Decode-side vLLM connector for P/D RDMA push."""
+
+    _scheduler_cls = PdDecodeSchedulerConnector
+    _worker_cls = PdDecodeWorkerConnector
+
+    @classmethod
+    def requires_piecewise_for_cudagraph(cls, extra_config: dict[str, Any]) -> bool:
+        return False
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        if self._worker is not None:
+            self._worker.wait_for_layer_load(layer_name)
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: Any,
+        attn_metadata: Any,
+        **kwargs: Any,
+    ) -> None:
+        return None
+
+    def wait_for_save(self) -> None:
+        return None
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        if self._worker is None:
+            return set()
+        return self._worker.get_block_ids_with_load_errors()
+
+    def build_connector_worker_meta(self) -> Any | None:
+        if self._worker is None:
+            return None
+        return self._worker.build_connector_worker_meta()
+
+
+class PdPrefillConnector(_PdSplitConnector):
     """Prefill-side vLLM connector for P/D RDMA push."""
 
-    def __init__(self, vllm_config: Any, role: KVConnectorRole, kv_cache_config: Any = None):
-        super().__init__(vllm_config, role, kv_cache_config)
-        assert_supported_config(vllm_config)
-        self._scheduler: PdPrefillSchedulerConnector | None = None
-        self._worker: PdPrefillWorkerConnector | None = None
-        self._metrics = PdMetricsTracker()
-        if role == KVConnectorRole.SCHEDULER:
-            self._scheduler = PdPrefillSchedulerConnector(vllm_config, metrics=self._metrics)
-        elif role == KVConnectorRole.WORKER:
-            self._worker = PdPrefillWorkerConnector(
-                vllm_config,
-                kv_cache_config=kv_cache_config,
-                metrics=self._metrics,
-            )
-        else:
-            raise ValueError(f"unsupported KV connector role: {role}")
-
-    def register_kv_caches(self, kv_caches: dict[str, Any]) -> None:
-        if self._worker is not None:
-            self._worker.register_kv_caches(kv_caches)
-
-    def start_load_kv(self, forward_context: Any, **kwargs: Any) -> None:
-        if self._worker is None:
-            return
-        metadata = self._get_connector_metadata()
-        assert isinstance(metadata, PdConnectorMetadata)
-        self._worker.start_load_kv(metadata, forward_context, **kwargs)
+    _scheduler_cls = PdPrefillSchedulerConnector
+    _worker_cls = PdPrefillWorkerConnector
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         return None
@@ -188,63 +183,11 @@ class PdPrefillConnector(PdConnectorClassMixin, KVConnectorBase_V1, SupportsHMA)
         if self._worker is not None:
             self._worker.wait_for_save()
 
-    def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str] | None, set[str] | None]:
-        if self._worker is None:
-            return None, None
-        return self._worker.get_finished(finished_req_ids)
-
     def get_block_ids_with_load_errors(self) -> set[int]:
         return set()
 
     def build_connector_worker_meta(self) -> Any | None:
         return None
-
-    def shutdown(self) -> None:
-        if self._worker is not None:
-            self._worker.shutdown()
-        if self._scheduler is not None:
-            self._scheduler.shutdown()
-
-    def get_num_new_matched_tokens(
-        self,
-        request: Any,
-        num_computed_tokens: int,
-    ) -> tuple[int | None, bool]:
-        assert self._scheduler is not None
-        return self._scheduler.get_num_new_matched_tokens(request, num_computed_tokens)
-
-    def update_state_after_alloc(
-        self,
-        request: Any,
-        blocks: Any,
-        num_external_tokens: int,
-    ) -> None:
-        assert self._scheduler is not None
-        self._scheduler.update_state_after_alloc(request, blocks, num_external_tokens)
-
-    def build_connector_meta(self, scheduler_output: Any) -> PdConnectorMetadata:
-        assert self._scheduler is not None
-        return self._scheduler.build_connector_meta(scheduler_output)
-
-    def update_connector_output(self, connector_output: Any) -> None:
-        if self._scheduler is not None:
-            self._scheduler.update_connector_output(connector_output)
-
-    def request_finished(
-        self,
-        request: Any,
-        block_ids: list[int],
-    ) -> tuple[bool, dict[str, Any] | None]:
-        assert self._scheduler is not None
-        return self._scheduler.request_finished(request, (block_ids,))
-
-    def request_finished_all_groups(
-        self,
-        request: Any,
-        block_ids: tuple[list[int], ...],
-    ) -> tuple[bool, dict[str, Any] | None]:
-        assert self._scheduler is not None
-        return self._scheduler.request_finished(request, block_ids)
 
 
 class PdConnector(PdConnectorClassMixin, KVConnectorBase_V1, SupportsHMA):

--- a/python/pegaflow/pd_connector/async_runner.py
+++ b/python/pegaflow/pd_connector/async_runner.py
@@ -1,0 +1,168 @@
+"""Shared async task-execution primitives for the P/D connector.
+
+These factor out the threading skeleton that the prefill push sender, push
+finalizer, and decode RDMA-done waiter previously duplicated:
+
+- ``AsyncTaskPool``: thin owner of a ``ThreadPoolExecutor`` with a shared lock.
+  Used by callback-driven pools that track their own per-request generation
+  state (the decode RDMA-done waiter).
+- ``InflightTaskRunner``: adds an inflight counter, error propagation, and
+  ``wait_all`` / ``is_idle`` semantics on top, for pools whose callers block on
+  completion (the prefill push sender and finalizer).
+
+The runner deliberately keeps only what all in-flight pools share. Per-request
+counting, cancellation, and dedup live in the subclasses because their
+semantics differ.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class AsyncTaskPool:
+    """Owns a ``ThreadPoolExecutor`` guarded by a shared lock.
+
+    Subclasses implement ``_execute(task)`` with the work body and call
+    ``_spawn(task)`` to schedule it. The pool only manages executor lifecycle;
+    all task bookkeeping is the subclass's responsibility.
+    """
+
+    def __init__(self, thread_name_prefix: str, max_workers: int = 16) -> None:
+        self._lock = threading.Lock()
+        self._executor = ThreadPoolExecutor(
+            max_workers=max(1, int(max_workers)),
+            thread_name_prefix=thread_name_prefix,
+        )
+
+    def _spawn(self, task: Any) -> None:
+        self._executor.submit(self._execute, task)
+
+    def _execute(self, task: Any) -> None:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def close(self) -> None:
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+
+class InflightTaskRunner(AsyncTaskPool, Generic[T]):
+    """Task pool that tracks inflight count, errors, and supports ``wait_all``.
+
+    Shared by the prefill push sender and finalizer. Uses a ``Condition`` so
+    callers can block until all (or a subset of) submitted tasks drain. The
+    first task exception is captured and re-raised to the next waiter, matching
+    the original fail-fast behaviour.
+
+    Subclasses implement ``_run(task)`` (the work body) and may override
+    ``_on_submit_locked`` / ``_on_finish_locked`` to maintain per-request state.
+    ``_set_inflight_metric_locked`` is called whenever the inflight count
+    changes so subclasses can publish their own gauge.
+    """
+
+    def __init__(
+        self,
+        thread_name_prefix: str,
+        metrics: Any | None = None,
+        max_workers: int = 16,
+    ) -> None:
+        super().__init__(thread_name_prefix, max_workers=max_workers)
+        self._condition = threading.Condition()
+        self._inflight = 0
+        self._error: BaseException | None = None
+        self._closed = False
+        self._metrics = metrics
+
+    # -- submission ---------------------------------------------------------
+
+    def _submit(self, task: T, closed_message: str) -> bool:
+        """Register and schedule a task.
+
+        Returns False if the subclass's ``_on_submit_locked`` rejected the task
+        (e.g. dedup); raises if the pool is closed or holds a pending error.
+        """
+        with self._condition:
+            if self._closed:
+                raise RuntimeError(closed_message)
+            if self._error is not None:
+                raise self._error
+            if not self._on_submit_locked(task):
+                return False
+            self._inflight += 1
+            self._set_inflight_metric_locked()
+        try:
+            self._spawn(task)
+        except BaseException:
+            with self._condition:
+                self._finish_locked(task)
+            raise
+        return True
+
+    # -- waiting ------------------------------------------------------------
+
+    def wait_all(self) -> None:
+        with self._condition:
+            while self._inflight > 0 and self._error is None:
+                self._condition.wait()
+            self._raise_pending_error_locked()
+
+    def is_idle(self) -> bool:
+        with self._condition:
+            return self._inflight == 0 and self._error is None
+
+    def close(self) -> None:
+        with self._condition:
+            self._closed = True
+            self._condition.notify_all()
+        super().close()
+
+    # -- execution ----------------------------------------------------------
+
+    def _execute(self, task: T) -> None:
+        try:
+            self._run(task)
+        except BaseException as exc:
+            with self._condition:
+                self._error = exc
+                self._condition.notify_all()
+            self._on_error(task, exc)
+        finally:
+            with self._condition:
+                self._finish_locked(task)
+
+    def _finish_locked(self, task: T) -> None:
+        self._inflight -= 1
+        self._on_finish_locked(task)
+        self._set_inflight_metric_locked()
+        self._condition.notify_all()
+
+    def _raise_pending_error_locked(self) -> None:
+        if self._error is not None:
+            error = self._error
+            self._error = None
+            raise error
+
+    # -- hooks for subclasses ----------------------------------------------
+
+    def _run(self, task: T) -> None:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def _on_submit_locked(self, task: T) -> bool:
+        """Update per-request state under the condition lock. Return False to
+        skip scheduling (e.g. duplicate task)."""
+        return True
+
+    def _on_finish_locked(self, task: T) -> None:
+        """Update per-request state when a task completes (lock held)."""
+
+    def _on_error(self, task: T, exc: BaseException) -> None:
+        """Side effects on task failure (e.g. metrics), outside the lock."""
+
+    def _set_inflight_metric_locked(self) -> None:
+        """Publish the inflight gauge. Default no-op."""
+
+
+__all__ = ["AsyncTaskPool", "InflightTaskRunner"]

--- a/python/pegaflow/pd_connector/decode_worker.py
+++ b/python/pegaflow/pd_connector/decode_worker.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 from pegaflow.logging_utils import get_connector_logger
+from pegaflow.pd_connector.async_runner import AsyncTaskPool
 from pegaflow.pd_connector.layout import KvCacheLayout
 from pegaflow.pd_connector.layout_mapping import (
     decode_rank_source_counts,
@@ -540,7 +540,7 @@ class _RdmaWaitTask:
     queued_ts_ns: int
 
 
-class _AsyncRdmaDoneWaiter:
+class _AsyncRdmaDoneWaiter(AsyncTaskPool):
     """Background pool blocking on request RDMA IMM completion."""
 
     def __init__(
@@ -550,17 +550,13 @@ class _AsyncRdmaDoneWaiter:
         success_callback: Any | None = None,
         max_workers: int = 16,
     ) -> None:
+        super().__init__("pd-rdma-done-waiter", max_workers=max_workers)
         self.rdma = rdma
         self._failure_callback = failure_callback
         self._success_callback = success_callback
-        self._executor = ThreadPoolExecutor(
-            max_workers=max(1, int(max_workers)),
-            thread_name_prefix="pd-rdma-done-waiter",
-        )
         self._submitted: dict[str, int] = {}
         self._cancelled: dict[str, set[int]] = {}
         self._next_generation: dict[str, int] = {}
-        self._lock = threading.Lock()
 
     def submit(self, task: _RdmaWaitTask) -> _RdmaWaitTask | None:
         with self._lock:
@@ -580,7 +576,7 @@ class _AsyncRdmaDoneWaiter:
             task.prefill_url or "<oob>",
             len(self._submitted),
         )
-        self._executor.submit(self._run_task, task)
+        self._spawn(task)
         return task
 
     def cancel(self, req_id: str) -> None:
@@ -590,10 +586,7 @@ class _AsyncRdmaDoneWaiter:
                 return
             self._cancelled.setdefault(req_id, set()).add(generation)
 
-    def close(self) -> None:
-        self._executor.shutdown(wait=False, cancel_futures=True)
-
-    def _run_task(self, task: _RdmaWaitTask) -> None:
+    def _execute(self, task: _RdmaWaitTask) -> None:
         try:
             if self._is_cancelled(task.req_id, task.generation):
                 logger.info(

--- a/python/pegaflow/pd_connector/decode_worker.py
+++ b/python/pegaflow/pd_connector/decode_worker.py
@@ -261,7 +261,11 @@ class _DecodePeerState:
     ) -> list[dict[str, Any]]:
         result = []
         block_size = self.block_size
-        for rank in range(self._w.tp_size):
+        # Iterate the ranks actually gathered rather than range(tp_size): in the
+        # all_gather fallback gather() populates only the local rank, and the
+        # warning there promises dispatch is limited to it. range(tp_size) would
+        # KeyError on the missing peers and contradict that promise.
+        for rank in sorted(self.layer_templates):
             layers = []
             for layer in self.layer_templates[rank]:
                 layer_name = str(layer["layer_name"])

--- a/python/pegaflow/pd_connector/decode_worker.py
+++ b/python/pegaflow/pd_connector/decode_worker.py
@@ -188,6 +188,163 @@ class _DecodeWaitState:
             self.finished_rdma_waits.clear()
 
 
+class _DecodePeerState:
+    """Peer tensor-parallel topology and IMM-id allocation for the decode side.
+
+    After ``register_kv_caches`` the decode worker all-gathers every peer rank's
+    KV layouts and memory-region descriptors, then derives per-rank layer
+    templates and the expected IMM completion counts used to build wait
+    handshakes. This groups that topology state plus the monotonic IMM-id
+    allocator, which were previously flat fields on ``DecodeHandler``.
+
+    Single-threaded: populated during registration and read while building
+    handshakes on the forward thread; no locking needed.
+    """
+
+    def __init__(self, worker: PdWorkerBase) -> None:
+        self._w = worker
+        self.layouts: dict[int, dict[str, KvCacheLayout]] = {}
+        self.mr_descs: dict[int, dict[str, Any]] = {}
+        self.layer_templates: dict[int, tuple[dict[str, Any], ...]] = {}
+        self.expected_imm_counts: dict[int, int] = {}
+        self._next_imm_id = 1
+
+    @property
+    def block_size(self) -> int:
+        return next(iter(self._w.layouts.values())).block_size
+
+    def gather(self) -> None:
+        mr_descs = {name: layer.mr_desc for name, layer in self._w._registered_layers.items()}
+        if self._w.tp_size <= 1:
+            self.layouts = {0: self._w.layouts}
+            self.mr_descs = {0: mr_descs}
+            self._refresh_layer_templates()
+            return
+        try:
+            gathered = _all_gather_peer_info(self._w.layouts, mr_descs, self._w.tp_size)
+        except Exception:
+            logger.warning(
+                "[PdConnector] all_gather_object unavailable, rank 0 dispatch limited to local rank",
+            )
+            self.layouts = {self._w.tp_rank: self._w.layouts}
+            self.mr_descs = {self._w.tp_rank: mr_descs}
+            self._refresh_layer_templates()
+            return
+        for rank, (layouts, descs) in enumerate(gathered):
+            self.layouts[rank] = layouts
+            self.mr_descs[rank] = descs
+        self._refresh_layer_templates()
+
+    def alloc_imm_id(self) -> int:
+        imm_id = self._next_imm_id
+        self._next_imm_id += 1
+        # The wire contract (pegaflow-pd-wire) reserves the top two bits of
+        # imm_id for the fail/abort XOR flags, so wrap before reaching them.
+        if self._next_imm_id > 0x3FFF_FFFF:
+            self._next_imm_id = 1
+        return imm_id
+
+    def expected_imm_count(self, rank: int) -> int:
+        if not self.expected_imm_counts:
+            self._refresh_expected_imm_counts()
+        return self.expected_imm_counts.get(rank, 1)
+
+    def local_expected_imm_count(self) -> int:
+        return self.expected_imm_count(self._w.tp_rank)
+
+    def build_all_rank_handshake_dicts(
+        self,
+        req_id: str,
+        block_ids: BlockIds,
+        imm_id: int,
+    ) -> list[dict[str, Any]]:
+        result = []
+        block_size = self.block_size
+        for rank in range(self._w.tp_size):
+            layers = []
+            for layer in self.layer_templates[rank]:
+                layer_name = str(layer["layer_name"])
+                layer_block_ids = self._w.block_ids_for_layer(block_ids, layer_name)
+                if not layer_block_ids:
+                    continue
+                layer_dict = dict(layer)
+                layer_dict["block_ids"] = sorted(layer_block_ids)
+                layers.append(layer_dict)
+            assert layers, f"PdConnector D wait req={req_id} has no local KV blocks"
+            block_ids_by_layer = [tuple(layer["block_ids"]) for layer in layers]
+            shared_block_ids = block_ids_by_layer[0]
+            compact = all(ids == shared_block_ids for ids in block_ids_by_layer)
+            if compact:
+                payload_layers = [
+                    {key: value for key, value in layer.items() if key != "block_ids"}
+                    for layer in layers
+                ]
+            else:
+                payload_layers = layers
+            payload: dict[str, Any] = {
+                "request_id": req_id,
+                "engine_id": self._w.engine_id,
+                "tp_rank": rank,
+                "tp_size": self._w.tp_size,
+                "block_size": block_size,
+                "layers": payload_layers,
+                "imm_id": imm_id,
+                "fail_imm_id": _fail_imm_id(imm_id),
+                "abort_imm_id": _abort_imm_id(imm_id),
+                "expected_imm_count": self.expected_imm_count(rank),
+            }
+            if compact:
+                payload["block_ids"] = list(shared_block_ids)
+            result.append(payload)
+        return result
+
+    def _refresh_layer_templates(self) -> None:
+        self.layer_templates = {}
+        for rank, peer_layouts in self.layouts.items():
+            peer_mr_descs = self.mr_descs[rank]
+            layers = []
+            for layer_idx, name in enumerate(self._w.layer_names):
+                layer = replace(
+                    peer_layouts[name].remote_layout(layer_idx, (0,)),
+                    mr_desc=peer_mr_descs.get(name),
+                )
+                layers.append(layer_layout_to_compact_dict(layer))
+            self.layer_templates[rank] = tuple(layers)
+        self._refresh_expected_imm_counts()
+
+    def _refresh_expected_imm_counts(self) -> None:
+        if self._w.use_mla:
+            self.expected_imm_counts = dict.fromkeys(range(self._w.tp_size), 1)
+            return
+
+        local_layout = self.layouts.get(self._w.tp_rank, self._w.layouts)
+        first_layout = next(iter(local_layout.values()))
+        remote_heads = int(getattr(first_layout, "num_kv_heads", 1))
+        prefill_tp_size = int(
+            extra_config_value(
+                self._w.vllm_config,
+                "pegaflow.pd.prefill_tp_size",
+                self._w.tp_size,
+            )
+            or self._w.tp_size
+        )
+        total_heads = _total_num_kv_heads_from_config(self._w.vllm_config)
+        if total_heads is None:
+            total_heads = remote_heads * self._w.tp_size
+        local_heads = _ceil_div(total_heads, prefill_tp_size)
+        source_counts = decode_rank_source_counts(
+            prefill_tp_size=prefill_tp_size,
+            decode_tp_size=self._w.tp_size,
+            local_num_kv_heads=local_heads,
+            remote_num_kv_heads=remote_heads,
+            total_num_kv_heads=total_heads,
+            use_mla=False,
+        )
+        self.expected_imm_counts = {
+            rank: source_counts.get(rank, 1) for rank in range(self._w.tp_size)
+        }
+
+
 class DecodeHandler:
     """Handles D-side (decode) requests: RDMA receive, handshake, prefill dispatch."""
 
@@ -198,12 +355,7 @@ class DecodeHandler:
     ) -> None:
         self._w = worker
         self._state = _DecodeWaitState(worker.metrics)
-        self._peer_layouts: dict[int, dict[str, KvCacheLayout]] = {}
-        self._peer_mr_descs: dict[int, dict[str, Any]] = {}
-        self._peer_layer_templates: dict[int, tuple[dict[str, Any], ...]] = {}
-        self._expected_imm_counts: dict[int, int] = {}
-        self._peer_block_size: int | None = None
-        self._next_imm_id = 1
+        self._peers = _DecodePeerState(worker)
         self._rdma_waiter: _AsyncRdmaDoneWaiter | None = (
             _AsyncRdmaDoneWaiter(
                 worker.rdma,
@@ -235,26 +387,7 @@ class DecodeHandler:
             )
 
     def gather_peer_info(self) -> None:
-        mr_descs = {name: layer.mr_desc for name, layer in self._w._registered_layers.items()}
-        if self._w.tp_size <= 1:
-            self._peer_layouts = {0: self._w.layouts}
-            self._peer_mr_descs = {0: mr_descs}
-            self._refresh_peer_layer_templates()
-            return
-        try:
-            gathered = _all_gather_peer_info(self._w.layouts, mr_descs, self._w.tp_size)
-        except Exception:
-            logger.warning(
-                "[PdConnector] all_gather_object unavailable, rank 0 dispatch limited to local rank",
-            )
-            self._peer_layouts = {self._w.tp_rank: self._w.layouts}
-            self._peer_mr_descs = {self._w.tp_rank: mr_descs}
-            self._refresh_peer_layer_templates()
-            return
-        for rank, (layouts, descs) in enumerate(gathered):
-            self._peer_layouts[rank] = layouts
-            self._peer_mr_descs[rank] = descs
-        self._refresh_peer_layer_templates()
+        self._peers.gather()
 
     def process_wait_reqs(self, reqs_to_wait: dict[str, WaitReqMeta]) -> None:
         assert self._w.rdma is not None, "PdConnector RDMA port is not initialized"
@@ -266,7 +399,7 @@ class DecodeHandler:
             process_ts_ns = time.time_ns()
             self._state.register_wait(req_id, req)
             block_ids = flatten_block_ids(req.local_block_ids)
-            imm_id = self._alloc_imm_id()
+            imm_id = self._peers.alloc_imm_id()
             wait_handshake = self._build_wait_handshake(
                 req.done_request_id,
                 req.local_block_ids,
@@ -364,6 +497,10 @@ class DecodeHandler:
     @property
     def _finished_rdma_waits(self) -> set[str]:
         return self._state.finished_rdma_waits
+
+    @property
+    def _peer_layouts(self) -> dict[int, dict[str, KvCacheLayout]]:
+        return self._peers.layouts
 
     def is_idle(self) -> bool:
         return self._state.is_idle()
@@ -466,12 +603,12 @@ class DecodeHandler:
             engine_id=self._w.engine_id,
             tp_rank=self._w.tp_rank,
             tp_size=self._w.tp_size,
-            block_size=next(iter(self._w.layouts.values())).block_size,
+            block_size=self._peers.block_size,
             layers=tuple(layers),
             imm_id=imm_id,
             fail_imm_id=_fail_imm_id(imm_id),
             abort_imm_id=_abort_imm_id(imm_id),
-            expected_imm_count=self._expected_imm_count_for_local_rank(),
+            expected_imm_count=self._peers.local_expected_imm_count(),
         )
 
     def _dispatch_prefill(
@@ -481,7 +618,7 @@ class DecodeHandler:
         imm_id: int,
     ) -> None:
         started_ts_ns = time.time_ns()
-        all_handshakes = self._build_all_rank_handshake_dicts(
+        all_handshakes = self._peers.build_all_rank_handshake_dicts(
             req.done_request_id,
             block_ids,
             imm_id,
@@ -520,117 +657,6 @@ class DecodeHandler:
             _elapsed_ms(req.scheduler_wait_ts_ns, submitted_ts_ns),
             submitted_ts_ns,
         )
-
-    def _build_all_rank_handshake_dicts(
-        self,
-        req_id: str,
-        block_ids: BlockIds,
-        imm_id: int,
-    ) -> list[dict[str, Any]]:
-        result = []
-        block_size = self._peer_block_size
-        assert block_size is not None, "peer layer templates are not initialized"
-        for rank in range(self._w.tp_size):
-            layers = []
-            for layer in self._peer_layer_templates[rank]:
-                layer_name = str(layer["layer_name"])
-                layer_block_ids = self._w.block_ids_for_layer(block_ids, layer_name)
-                if not layer_block_ids:
-                    continue
-                layer_dict = dict(layer)
-                layer_dict["block_ids"] = sorted(layer_block_ids)
-                layers.append(layer_dict)
-            assert layers, f"PdConnector D wait req={req_id} has no local KV blocks"
-            block_ids_by_layer = [tuple(layer["block_ids"]) for layer in layers]
-            shared_block_ids = block_ids_by_layer[0]
-            compact = all(ids == shared_block_ids for ids in block_ids_by_layer)
-            if compact:
-                payload_layers = [
-                    {key: value for key, value in layer.items() if key != "block_ids"}
-                    for layer in layers
-                ]
-            else:
-                payload_layers = layers
-            payload: dict[str, Any] = {
-                "request_id": req_id,
-                "engine_id": self._w.engine_id,
-                "tp_rank": rank,
-                "tp_size": self._w.tp_size,
-                "block_size": block_size,
-                "layers": payload_layers,
-                "imm_id": imm_id,
-                "fail_imm_id": _fail_imm_id(imm_id),
-                "abort_imm_id": _abort_imm_id(imm_id),
-                "expected_imm_count": self._expected_imm_count_for_rank(rank),
-            }
-            if compact:
-                payload["block_ids"] = list(shared_block_ids)
-            result.append(payload)
-        return result
-
-    def _expected_imm_count_for_local_rank(self) -> int:
-        return self._expected_imm_count_for_rank(self._w.tp_rank)
-
-    def _expected_imm_count_for_rank(self, rank: int) -> int:
-        if not self._expected_imm_counts:
-            self._refresh_expected_imm_counts()
-        return self._expected_imm_counts.get(rank, 1)
-
-    def _refresh_peer_layer_templates(self) -> None:
-        self._peer_layer_templates = {}
-        self._peer_block_size = next(iter(self._w.layouts.values())).block_size
-        for rank, peer_layouts in self._peer_layouts.items():
-            peer_mr_descs = self._peer_mr_descs[rank]
-            layers = []
-            for layer_idx, name in enumerate(self._w.layer_names):
-                layer = replace(
-                    peer_layouts[name].remote_layout(layer_idx, (0,)),
-                    mr_desc=peer_mr_descs.get(name),
-                )
-                layers.append(layer_layout_to_compact_dict(layer))
-            self._peer_layer_templates[rank] = tuple(layers)
-        self._refresh_expected_imm_counts()
-
-    def _refresh_expected_imm_counts(self) -> None:
-        if self._w.use_mla:
-            self._expected_imm_counts = dict.fromkeys(range(self._w.tp_size), 1)
-            return
-
-        local_layout = self._peer_layouts.get(self._w.tp_rank, self._w.layouts)
-        first_layout = next(iter(local_layout.values()))
-        remote_heads = int(getattr(first_layout, "num_kv_heads", 1))
-        prefill_tp_size = int(
-            extra_config_value(
-                self._w.vllm_config,
-                "pegaflow.pd.prefill_tp_size",
-                self._w.tp_size,
-            )
-            or self._w.tp_size
-        )
-        total_heads = _total_num_kv_heads_from_config(self._w.vllm_config)
-        if total_heads is None:
-            total_heads = remote_heads * self._w.tp_size
-        local_heads = _ceil_div(total_heads, prefill_tp_size)
-        source_counts = decode_rank_source_counts(
-            prefill_tp_size=prefill_tp_size,
-            decode_tp_size=self._w.tp_size,
-            local_num_kv_heads=local_heads,
-            remote_num_kv_heads=remote_heads,
-            total_num_kv_heads=total_heads,
-            use_mla=False,
-        )
-        self._expected_imm_counts = {
-            rank: source_counts.get(rank, 1) for rank in range(self._w.tp_size)
-        }
-
-    def _alloc_imm_id(self) -> int:
-        imm_id = self._next_imm_id
-        self._next_imm_id += 1
-        # The wire contract (pegaflow-pd-wire) reserves the top two bits of
-        # imm_id for the fail/abort XOR flags, so wrap before reaching them.
-        if self._next_imm_id > 0x3FFF_FFFF:
-            self._next_imm_id = 1
-        return imm_id
 
     def _remote_layout_with_mr_desc(
         self,

--- a/python/pegaflow/pd_connector/decode_worker.py
+++ b/python/pegaflow/pd_connector/decode_worker.py
@@ -59,7 +59,8 @@ class _DecodeWaitState:
     # -- registration / completion -----------------------------------------
 
     def has_wait(self, req_id: str) -> bool:
-        return req_id in self.wait_reqs
+        with self._lock:
+            return req_id in self.wait_reqs
 
     def register_wait(self, req_id: str, req: WaitReqMeta) -> None:
         with self._lock:

--- a/python/pegaflow/pd_connector/decode_worker.py
+++ b/python/pegaflow/pd_connector/decode_worker.py
@@ -32,6 +32,162 @@ from pegaflow.pd_connector.config import extra_config_value
 logger = get_connector_logger()
 
 
+class _DecodeWaitState:
+    """Thread-safe bookkeeping for in-flight decode receives.
+
+    Groups the seven request-tracking collections that the RDMA waiter and
+    prefill-sender callbacks mutate concurrently with the vLLM forward thread,
+    behind a single lock (the original ``DecodeHandler._lock``).
+
+    Failure marking writes the three failure channels together, but they are
+    drained by *different* vLLM callbacks (``get_finished`` /
+    ``build_connector_worker_meta`` / ``get_block_ids_with_load_errors``), so
+    they remain separate collections rather than one merged set.
+    """
+
+    def __init__(self, metrics: Any) -> None:
+        self._metrics = metrics
+        self._lock = threading.Lock()
+        self.wait_reqs: dict[str, WaitReqMeta] = {}
+        self.aborted_waits: set[str] = set()
+        self.failed_recving: set[str] = set()
+        self.failed_recving_for_meta: set[str] = set()
+        self.failed_block_ids: set[int] = set()
+        self.finished_aborted_recving: set[str] = set()
+        self.finished_rdma_waits: set[str] = set()
+
+    # -- registration / completion -----------------------------------------
+
+    def has_wait(self, req_id: str) -> bool:
+        return req_id in self.wait_reqs
+
+    def register_wait(self, req_id: str, req: WaitReqMeta) -> None:
+        with self._lock:
+            self.wait_reqs[req_id] = req
+            self._metrics.set_decode_active_waits(len(self.wait_reqs))
+
+    def mark_aborted(self, req_id: str) -> WaitReqMeta | None:
+        with self._lock:
+            req = self.wait_reqs.get(req_id)
+            if req is not None:
+                self.aborted_waits.add(req_id)
+                self._metrics.record_decode_abort()
+            return req
+
+    def finish_recving_one(self, req_id: str) -> tuple[WaitReqMeta | None, bool, bool]:
+        with self._lock:
+            req = self.wait_reqs.pop(req_id, None)
+            was_aborted = req_id in self.aborted_waits
+            self.aborted_waits.discard(req_id)
+            self._metrics.set_decode_active_waits(len(self.wait_reqs))
+            is_failed = req_id in self.failed_recving
+            return req, was_aborted, is_failed
+
+    def record_rdma_done(self, req_id: str) -> WaitReqMeta | None:
+        with self._lock:
+            if req_id not in self.wait_reqs:
+                return None
+            self.finished_rdma_waits.add(req_id)
+            return self.wait_reqs[req_id]
+
+    # -- failure paths ------------------------------------------------------
+
+    def _mark_failed_unlocked(self, req_id: str, req: WaitReqMeta) -> set[int]:
+        failed_blocks = flatten_block_ids(req.local_block_ids)
+        self.failed_recving.add(req_id)
+        self.failed_recving_for_meta.add(req_id)
+        self.failed_block_ids.update(failed_blocks)
+        self.aborted_waits.discard(req_id)
+        self.finished_rdma_waits.discard(req_id)
+        self.finished_aborted_recving.discard(req_id)
+        self.wait_reqs.pop(req_id, None)
+        self._metrics.set_decode_active_waits(len(self.wait_reqs))
+        return failed_blocks
+
+    def mark_prefill_failed(
+        self, remote_request_id: str
+    ) -> tuple[str, WaitReqMeta, set[int]] | None:
+        with self._lock:
+            for req_id, req in list(self.wait_reqs.items()):
+                if req.remote_request_id != remote_request_id:
+                    continue
+                failed_blocks = self._mark_failed_unlocked(req_id, req)
+                return req_id, req, failed_blocks
+        return None
+
+    def mark_wait_failed(
+        self, req_id: str
+    ) -> tuple[str, WaitReqMeta | None, set[int] | None]:
+        """Returns (kind, req, failed_blocks) where kind is one of
+        ``"unknown"`` / ``"aborted_finished"`` / ``"failed"``."""
+        with self._lock:
+            req = self.wait_reqs.get(req_id)
+            if req is None:
+                return "unknown", None, None
+            if req_id in self.aborted_waits:
+                self.wait_reqs.pop(req_id, None)
+                self.aborted_waits.discard(req_id)
+                self.finished_aborted_recving.add(req_id)
+                self._metrics.set_decode_active_waits(len(self.wait_reqs))
+                return "aborted_finished", req, None
+            failed_blocks = self._mark_failed_unlocked(req_id, req)
+            return "failed", req, failed_blocks
+
+    # -- drains (one per consuming vLLM callback) --------------------------
+
+    def drain_finished_aborted_recving(self) -> set[str]:
+        with self._lock:
+            finished = self.finished_aborted_recving
+            self.finished_aborted_recving = set()
+            return finished
+
+    def drain_finished_rdma_waits(self) -> set[str]:
+        with self._lock:
+            finished = self.finished_rdma_waits
+            self.finished_rdma_waits = set()
+            return finished
+
+    def drain_failed_recving(self) -> set[str]:
+        with self._lock:
+            failed = self.failed_recving
+            self.failed_recving = set()
+            return failed
+
+    def drain_failed_recving_for_meta(self) -> set[str]:
+        with self._lock:
+            failed = self.failed_recving_for_meta
+            self.failed_recving_for_meta = set()
+            return failed
+
+    def drain_failed_block_ids(self) -> set[int]:
+        with self._lock:
+            failed = self.failed_block_ids
+            self.failed_block_ids = set()
+            return failed
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def is_idle(self) -> bool:
+        with self._lock:
+            return (
+                not self.wait_reqs
+                and not self.failed_recving
+                and not self.failed_block_ids
+                and not self.finished_aborted_recving
+                and not self.finished_rdma_waits
+            )
+
+    def clear(self) -> None:
+        with self._lock:
+            self.wait_reqs.clear()
+            self.failed_recving.clear()
+            self.failed_recving_for_meta.clear()
+            self.failed_block_ids.clear()
+            self.aborted_waits.clear()
+            self.finished_aborted_recving.clear()
+            self.finished_rdma_waits.clear()
+
+
 class DecodeHandler:
     """Handles D-side (decode) requests: RDMA receive, handshake, prefill dispatch."""
 
@@ -41,19 +197,12 @@ class DecodeHandler:
         prefill_sender: Any | None = None,
     ) -> None:
         self._w = worker
-        self._lock = threading.Lock()
-        self._wait_reqs: dict[str, WaitReqMeta] = {}
+        self._state = _DecodeWaitState(worker.metrics)
         self._peer_layouts: dict[int, dict[str, KvCacheLayout]] = {}
         self._peer_mr_descs: dict[int, dict[str, Any]] = {}
         self._peer_layer_templates: dict[int, tuple[dict[str, Any], ...]] = {}
         self._expected_imm_counts: dict[int, int] = {}
         self._peer_block_size: int | None = None
-        self._failed_recving: set[str] = set()
-        self._failed_recving_for_meta: set[str] = set()
-        self._failed_block_ids: set[int] = set()
-        self._aborted_waits: set[str] = set()
-        self._finished_aborted_recving: set[str] = set()
-        self._finished_rdma_waits: set[str] = set()
         self._next_imm_id = 1
         self._rdma_waiter: _AsyncRdmaDoneWaiter | None = (
             _AsyncRdmaDoneWaiter(
@@ -111,13 +260,11 @@ class DecodeHandler:
         assert self._w.rdma is not None, "PdConnector RDMA port is not initialized"
         assert self._rdma_waiter is not None, "PdConnector RDMA waiter is not initialized"
         for req_id, req in reqs_to_wait.items():
-            if req_id in self._wait_reqs:
+            if self._state.has_wait(req_id):
                 logger.info("[PdConnector] D wait req=%s already registered", req_id)
                 continue
             process_ts_ns = time.time_ns()
-            with self._lock:
-                self._wait_reqs[req_id] = req
-                self._w.metrics.set_decode_active_waits(len(self._wait_reqs))
+            self._state.register_wait(req_id, req)
             block_ids = flatten_block_ids(req.local_block_ids)
             imm_id = self._alloc_imm_id()
             wait_handshake = self._build_wait_handshake(
@@ -160,70 +307,40 @@ class DecodeHandler:
                 self._dispatch_prefill(req, req.local_block_ids, imm_id)
 
     def release(self, req_id: str) -> None:
-        with self._lock:
-            req = self._wait_reqs.get(req_id)
-            if req is not None:
-                self._aborted_waits.add(req_id)
-                self._w.metrics.record_decode_abort()
+        req = self._state.mark_aborted(req_id)
         cancel_prefill = getattr(self._prefill_sender, "cancel", None)
         if req is not None and cancel_prefill is not None:
             cancel_prefill(req.remote_request_id)
 
     def finish_recving(self, finished_recving: set[str]) -> None:
         for req_id in finished_recving:
-            with self._lock:
-                req = self._wait_reqs.pop(req_id, None)
-                was_aborted = req_id in self._aborted_waits
-                self._aborted_waits.discard(req_id)
-                self._w.metrics.set_decode_active_waits(len(self._wait_reqs))
+            req, was_aborted, is_failed = self._state.finish_recving_one(req_id)
             if req is not None and not was_aborted:
                 self._w.metrics.record_decode_wait(
                     duration_s=_elapsed_seconds(req.scheduler_wait_ts_ns, time.time_ns()),
                     rdma_wait_s=None,
                     blocks=len(flatten_block_ids(req.local_block_ids)),
-                    success=req_id not in self._failed_recving,
+                    success=not is_failed,
                 )
             self._w.rdma.close_request(req_id)
 
     def pop_finished_aborted_recving(self) -> set[str]:
-        with self._lock:
-            finished = self._finished_aborted_recving
-            self._finished_aborted_recving = set()
-            return finished
+        return self._state.drain_finished_aborted_recving()
 
     def pop_finished_rdma_waits(self) -> set[str]:
-        with self._lock:
-            finished = self._finished_rdma_waits
-            self._finished_rdma_waits = set()
-            return finished
+        return self._state.drain_finished_rdma_waits()
 
     def pop_failed_recving(self) -> set[str]:
-        with self._lock:
-            failed = self._failed_recving
-            self._failed_recving = set()
-            return failed
+        return self._state.drain_failed_recving()
 
     def pop_failed_recving_for_meta(self) -> set[str]:
-        with self._lock:
-            failed = self._failed_recving_for_meta
-            self._failed_recving_for_meta = set()
-            return failed
+        return self._state.drain_failed_recving_for_meta()
 
     def pop_failed_block_ids(self) -> set[int]:
-        with self._lock:
-            failed = self._failed_block_ids
-            self._failed_block_ids = set()
-            return failed
+        return self._state.drain_failed_block_ids()
 
     def shutdown(self) -> None:
-        with self._lock:
-            self._wait_reqs.clear()
-            self._failed_recving.clear()
-            self._failed_recving_for_meta.clear()
-            self._failed_block_ids.clear()
-            self._aborted_waits.clear()
-            self._finished_aborted_recving.clear()
-            self._finished_rdma_waits.clear()
+        self._state.clear()
         if self._rdma_waiter is not None:
             self._rdma_waiter.close()
         close = getattr(self._prefill_sender, "close", None)
@@ -232,62 +349,63 @@ class DecodeHandler:
 
     @property
     def wait_reqs(self) -> dict[str, WaitReqMeta]:
-        return self._wait_reqs
+        return self._state.wait_reqs
+
+    # Backward-compatible field access for tests / worker.py that reach into
+    # the decode handler's internal collections directly.
+    @property
+    def _wait_reqs(self) -> dict[str, WaitReqMeta]:
+        return self._state.wait_reqs
+
+    @_wait_reqs.setter
+    def _wait_reqs(self, value: dict[str, WaitReqMeta]) -> None:
+        self._state.wait_reqs = value
+
+    @property
+    def _finished_rdma_waits(self) -> set[str]:
+        return self._state.finished_rdma_waits
 
     def is_idle(self) -> bool:
-        with self._lock:
-            return (
-                not self._wait_reqs
-                and not self._failed_recving
-                and not self._failed_block_ids
-                and not self._finished_aborted_recving
-                and not self._finished_rdma_waits
-            )
+        return self._state.is_idle()
 
     def _mark_prefill_failed(self, remote_request_id: str, exc: BaseException) -> None:
-        with self._lock:
-            for req_id, req in list(self._wait_reqs.items()):
-                if req.remote_request_id != remote_request_id:
-                    continue
-                self._mark_failed_locked(req_id, req, exc)
-                return
-        logger.warning(
-            "[PdConnector] D prefill failed for unknown/finished remote_req=%s: %s",
-            remote_request_id,
-            exc,
-        )
+        result = self._state.mark_prefill_failed(remote_request_id)
+        if result is None:
+            logger.warning(
+                "[PdConnector] D prefill failed for unknown/finished remote_req=%s: %s",
+                remote_request_id,
+                exc,
+            )
+            return
+        req_id, req, failed_blocks = result
+        self._after_mark_failed(req_id, req, failed_blocks, exc)
 
     def _mark_wait_failed(self, req_id: str, exc: BaseException) -> None:
-        with self._lock:
-            req = self._wait_reqs.get(req_id)
-            if req is None:
-                logger.warning(
-                    "[PdConnector] D wait failed for unknown/finished req=%s: %s",
-                    req_id,
-                    exc,
-                )
-                return
-            if req_id in self._aborted_waits:
-                self._wait_reqs.pop(req_id, None)
-                self._aborted_waits.discard(req_id)
-                self._finished_aborted_recving.add(req_id)
-                self._w.metrics.set_decode_active_waits(len(self._wait_reqs))
-                logger.info(
-                    "[PdConnector] D treating aborted wait as finished req=%s remote_req=%s error=%s",
-                    req_id,
-                    req.remote_request_id,
-                    exc,
-                )
-                return
-            self._mark_failed_locked(req_id, req, exc)
+        kind, req, failed_blocks = self._state.mark_wait_failed(req_id)
+        if kind == "unknown":
+            logger.warning(
+                "[PdConnector] D wait failed for unknown/finished req=%s: %s",
+                req_id,
+                exc,
+            )
+            return
+        if kind == "aborted_finished":
+            assert req is not None
+            logger.info(
+                "[PdConnector] D treating aborted wait as finished req=%s remote_req=%s error=%s",
+                req_id,
+                req.remote_request_id,
+                exc,
+            )
+            return
+        assert req is not None and failed_blocks is not None
+        self._after_mark_failed(req_id, req, failed_blocks, exc)
 
     def _record_rdma_wait_done(self, req_id: str, wait_s: float) -> None:
         done_ts_ns = time.time_ns()
-        with self._lock:
-            if req_id not in self._wait_reqs:
-                return
-            req = self._wait_reqs[req_id]
-            self._finished_rdma_waits.add(req_id)
+        req = self._state.record_rdma_done(req_id)
+        if req is None:
+            return
         self._w.metrics.record_decode_rdma_wait(wait_s)
         logger.info(
             "[PdConnector] D RDMA wait done req=%s remote_req=%s wait_ms=%.3f proxy_to_rdma_done_ms=%.3f scheduler_wait_to_rdma_done_ms=%.3f ts_ns=%d",
@@ -299,16 +417,15 @@ class DecodeHandler:
             done_ts_ns,
         )
 
-    def _mark_failed_locked(self, req_id: str, req: WaitReqMeta, exc: BaseException) -> None:
-        failed_blocks = flatten_block_ids(req.local_block_ids)
-        self._failed_recving.add(req_id)
-        self._failed_recving_for_meta.add(req_id)
-        self._failed_block_ids.update(failed_blocks)
-        self._aborted_waits.discard(req_id)
-        self._finished_rdma_waits.discard(req_id)
-        self._finished_aborted_recving.discard(req_id)
-        self._wait_reqs.pop(req_id, None)
-        self._w.metrics.set_decode_active_waits(len(self._wait_reqs))
+    def _after_mark_failed(
+        self,
+        req_id: str,
+        req: WaitReqMeta,
+        failed_blocks: set[int],
+        exc: BaseException,
+    ) -> None:
+        """Side effects after a failure is recorded in state: emit the wait
+        metric, log, and cancel the RDMA waiter."""
         self._w.metrics.record_decode_wait(
             duration_s=_elapsed_seconds(req.scheduler_wait_ts_ns, time.time_ns()),
             rdma_wait_s=None,

--- a/python/pegaflow/pd_connector/metadata.py
+++ b/python/pegaflow/pd_connector/metadata.py
@@ -125,6 +125,32 @@ class PdHandshake:
         )
 
 
+# ---------------------------------------------------------------------------
+# Wire (de)serialization codecs
+#
+# Grouped by type so each dict<->dataclass pair sits together. The byte/JSON
+# shape is part of the P/D wire contract — reorder freely, but do not change
+# the emitted keys or value encodings.
+# ---------------------------------------------------------------------------
+
+
+# -- TransferRegionLayout ---------------------------------------------------
+
+
+def _region_layout_to_dict(region: TransferRegionLayout) -> dict[str, Any]:
+    data = {
+        "region_idx": region.region_idx,
+        "base_addr": region.base_addr,
+        "block_len": region.block_len,
+    }
+    if region.block_stride is not None:
+        data["block_stride"] = region.block_stride
+    return data
+
+
+# -- LayerRemoteLayout ------------------------------------------------------
+
+
 def layer_layout_from_dict(
     data: dict[str, Any],
     *,
@@ -157,6 +183,28 @@ def layer_layout_from_dict(
     )
 
 
+def layer_layout_to_dict(layer: LayerRemoteLayout) -> dict[str, Any]:
+    return {
+        "layer_name": layer.layer_name,
+        "layer_idx": layer.layer_idx,
+        "block_ids": list(layer.block_ids),
+        "regions": [_region_layout_to_dict(region) for region in layer.regions],
+        "mr_desc": layer.mr_desc,
+    }
+
+
+def layer_layout_to_compact_dict(layer: LayerRemoteLayout) -> dict[str, Any]:
+    return {
+        "layer_name": layer.layer_name,
+        "layer_idx": layer.layer_idx,
+        "regions": [_region_layout_to_dict(region) for region in layer.regions],
+        "mr_desc": layer.mr_desc,
+    }
+
+
+# -- PdHandshake ------------------------------------------------------------
+
+
 def handshake_from_dict(data: dict[str, Any] | None) -> PdHandshake | None:
     if data is None:
         return None
@@ -187,36 +235,6 @@ def handshakes_from_dicts(data: Any) -> tuple[PdHandshake, ...]:
     handshakes = tuple(handshake_from_dict(item) for item in iterable)
     assert all(handshake is not None for handshake in handshakes)
     return handshakes  # type: ignore[return-value]
-
-
-def layer_layout_to_dict(layer: LayerRemoteLayout) -> dict[str, Any]:
-    return {
-        "layer_name": layer.layer_name,
-        "layer_idx": layer.layer_idx,
-        "block_ids": list(layer.block_ids),
-        "regions": [_region_layout_to_dict(region) for region in layer.regions],
-        "mr_desc": layer.mr_desc,
-    }
-
-
-def layer_layout_to_compact_dict(layer: LayerRemoteLayout) -> dict[str, Any]:
-    return {
-        "layer_name": layer.layer_name,
-        "layer_idx": layer.layer_idx,
-        "regions": [_region_layout_to_dict(region) for region in layer.regions],
-        "mr_desc": layer.mr_desc,
-    }
-
-
-def _region_layout_to_dict(region: TransferRegionLayout) -> dict[str, Any]:
-    data = {
-        "region_idx": region.region_idx,
-        "base_addr": region.base_addr,
-        "block_len": region.block_len,
-    }
-    if region.block_stride is not None:
-        data["block_stride"] = region.block_stride
-    return data
 
 
 def handshake_to_dict(handshake: PdHandshake) -> dict[str, Any]:

--- a/python/pegaflow/pd_connector/prefill_async.py
+++ b/python/pegaflow/pd_connector/prefill_async.py
@@ -1,0 +1,312 @@
+"""Async executors for the P-side (prefill) push pipeline.
+
+``_AsyncLayerPushSender`` runs per-layer RDMA writes off the forward thread;
+``_AsyncPushFinalizer`` waits for those writes to complete and signals the
+remote done IMM. Both build on ``InflightTaskRunner`` (see ``async_runner``).
+The RDMA throughput-stat helpers live here too since the finalizer is their
+main consumer; ``PrefillHandler`` imports them back for its own logging.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from pegaflow.logging_utils import get_connector_logger
+from pegaflow.pd_connector.async_runner import InflightTaskRunner
+from pegaflow.pd_connector.prefill_tasks import _LayerPushTask, _PushFinalizeTask
+from pegaflow.pd_connector.rdma import RdmaPort
+
+logger = get_connector_logger()
+
+
+# ---------------------------------------------------------------------------
+# RDMA throughput stats
+# ---------------------------------------------------------------------------
+
+
+def _elapsed_ms(start_ts_ns: int | None, end_ts_ns: int | None) -> float:
+    if start_ts_ns is None or end_ts_ns is None:
+        return 0.0
+    return (end_ts_ns - start_ts_ns) / 1_000_000
+
+
+def _gbps(bytes_total: int, start_ts_ns: int | None, end_ts_ns: int | None) -> float:
+    if bytes_total <= 0 or start_ts_ns is None or end_ts_ns is None or end_ts_ns <= start_ts_ns:
+        return 0.0
+    return bytes_total * 8 / ((end_ts_ns - start_ts_ns) / 1_000_000_000) / 1e9
+
+
+def _pct(value: float, total: float) -> float:
+    if value <= 0 or total <= 0:
+        return 0.0
+    return value / total * 100
+
+
+def _rdma_link_gbps(rdma: RdmaPort | None) -> float:
+    if rdma is None:
+        return 0.0
+    try:
+        return rdma.aggregated_link_speed() / 1e9
+    except Exception:
+        logger.exception("[PdConnector] failed to read RDMA link speed")
+        return 0.0
+
+
+def _rdma_write_stats(
+    rdma: RdmaPort,
+    req_ids: tuple[str, ...],
+    *,
+    fallback_bytes: int,
+    fallback_start_ts_ns: int | None,
+    fallback_end_ts_ns: int | None,
+) -> dict[str, float | int | bool]:
+    stats_by_req = []
+    for req_id in req_ids:
+        try:
+            stats_by_req.append(rdma.write_stats(req_id))
+        except AttributeError:
+            continue
+        except Exception:
+            logger.exception("[PdConnector] failed to read RDMA write stats req=%s", req_id)
+    if not stats_by_req:
+        return {
+            "submitted": 0,
+            "completed": 0,
+            "errors": 0,
+            "bytes": fallback_bytes,
+            "has_submit": False,
+            "has_complete": False,
+            "submit_span_ms": 0.0,
+            "xfer_window_ms": 0.0,
+            "completion_tail_ms": 0.0,
+            "window_gbps": 0.0,
+            "gbps": _gbps(fallback_bytes, fallback_start_ts_ns, fallback_end_ts_ns),
+        }
+
+    bytes_total = sum(int(stats.get("bytes", 0)) for stats in stats_by_req)
+    xfer_window_ms = max(float(stats.get("xfer_window_ms", 0.0)) for stats in stats_by_req)
+    window_gbps = bytes_total * 8 / (xfer_window_ms / 1000.0) / 1e9 if xfer_window_ms > 0 else 0.0
+    write_latency_sum_ms = sum(float(stats.get("write_latency_sum_ms", 0.0)) for stats in stats_by_req)
+    active_gbps = (
+        bytes_total * 8 / (write_latency_sum_ms / 1000.0) / 1e9
+        if write_latency_sum_ms > 0
+        else window_gbps
+    )
+    return {
+        "submitted": sum(int(stats.get("submitted", 0)) for stats in stats_by_req),
+        "completed": sum(int(stats.get("completed", 0)) for stats in stats_by_req),
+        "errors": sum(int(stats.get("errors", 0)) for stats in stats_by_req),
+        "bytes": bytes_total,
+        "has_submit": any(bool(stats.get("has_submit", False)) for stats in stats_by_req),
+        "has_complete": any(bool(stats.get("has_complete", False)) for stats in stats_by_req),
+        "submit_span_ms": max(float(stats.get("submit_span_ms", 0.0)) for stats in stats_by_req),
+        "first_complete_ms": max(
+            float(stats.get("first_complete_ms", 0.0)) for stats in stats_by_req
+        ),
+        "xfer_window_ms": xfer_window_ms,
+        "completion_tail_ms": max(
+            float(stats.get("completion_tail_ms", 0.0)) for stats in stats_by_req
+        ),
+        "write_latency_sum_ms": write_latency_sum_ms,
+        "write_latency_max_ms": max(
+            float(stats.get("write_latency_max_ms", 0.0)) for stats in stats_by_req
+        ),
+        "window_gbps": window_gbps,
+        "gbps": active_gbps,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Async workers
+# ---------------------------------------------------------------------------
+
+
+class _AsyncLayerPushSender(InflightTaskRunner["_LayerPushTask"]):
+    def __init__(self, metrics: Any | None = None, max_workers: int = 16) -> None:
+        super().__init__("pd-rdma-push", metrics=metrics, max_workers=max_workers)
+        self._inflight_by_req: dict[str, int] = {}
+        self._cancelled: set[str] = set()
+
+    def submit(self, task: _LayerPushTask) -> None:
+        self._submit(task, "PdConnector RDMA push sender is closed")
+
+    def wait_req(self, req_id: str) -> None:
+        with self._condition:
+            while self._inflight_by_req.get(req_id, 0) > 0 and self._error is None:
+                self._condition.wait()
+            self._raise_pending_error_locked()
+
+    def cancel(self, req_id: str) -> None:
+        self.cancel_many((req_id,))
+
+    def cancel_many(self, req_ids: tuple[str, ...]) -> None:
+        with self._condition:
+            self._cancelled.update(
+                req_id for req_id in req_ids if self._inflight_by_req.get(req_id, 0) > 0
+            )
+            self._condition.notify_all()
+
+    def _on_submit_locked(self, task: _LayerPushTask) -> bool:
+        self._inflight_by_req[task.req_id] = self._inflight_by_req.get(task.req_id, 0) + 1
+        return True
+
+    def _run(self, task: _LayerPushTask) -> None:
+        with self._condition:
+            cancelled = task.req_id in self._cancelled
+        if not cancelled:
+            _run_layer_push(task)
+
+    def _on_finish_locked(self, task: _LayerPushTask) -> None:
+        remaining = self._inflight_by_req.get(task.req_id, 0) - 1
+        if remaining > 0:
+            self._inflight_by_req[task.req_id] = remaining
+        else:
+            self._inflight_by_req.pop(task.req_id, None)
+            self._cancelled.discard(task.req_id)
+
+    def _set_inflight_metric_locked(self) -> None:
+        if self._metrics is not None:
+            self._metrics.set_prefill_inflight_push_tasks(self._inflight)
+
+
+def _run_layer_push(task: _LayerPushTask) -> None:
+    if task.event is not None:
+        task.event.synchronize()
+    task.rdma.push_layer(task.req_id, task.layer_idx, task.block_slices)
+
+
+class _AsyncPushFinalizer(InflightTaskRunner["_PushFinalizeTask"]):
+    def __init__(
+        self,
+        push_sender: _AsyncLayerPushSender,
+        metrics: Any | None = None,
+        max_workers: int = 16,
+    ) -> None:
+        super().__init__("pd-rdma-finalize", metrics=metrics, max_workers=max_workers)
+        self._push_sender = push_sender
+        self._submitted: set[tuple[str, ...]] = set()
+        self._cancelled: set[str] = set()
+
+    def submit(self, task: _PushFinalizeTask) -> None:
+        self._submit(task, "PdConnector RDMA push finalizer is closed")
+
+    def cancel_many(self, req_ids: tuple[str, ...]) -> None:
+        with self._condition:
+            submitted_req_ids = {
+                submitted_req_id for submitted in self._submitted for submitted_req_id in submitted
+            }
+            self._cancelled.update(req_id for req_id in req_ids if req_id in submitted_req_ids)
+            self._condition.notify_all()
+
+    def _on_submit_locked(self, task: _PushFinalizeTask) -> bool:
+        if task.req_ids in self._submitted:
+            return False
+        self._submitted.add(task.req_ids)
+        return True
+
+    def _run(self, task: _PushFinalizeTask) -> None:
+        wait_for_pushes_s = 0.0
+        completed = False
+        for req_id in task.req_ids:
+            if self._is_cancelled(req_id):
+                continue
+            self._push_sender.wait_req(req_id)
+            if self._is_cancelled(req_id):
+                continue
+            per_req_wait_start_ts_ns = time.time_ns()
+            task.rdma.wait_for_pushes(req_id)
+            wait_for_pushes_s += (time.time_ns() - per_req_wait_start_ts_ns) / 1_000_000_000
+            if self._is_cancelled(req_id):
+                continue
+            task.rdma.push_done(req_id)
+            completed = True
+        done_ts_ns = time.time_ns()
+        write_stats = _rdma_write_stats(
+            task.rdma,
+            task.req_ids,
+            fallback_bytes=task.rdma_bytes,
+            fallback_start_ts_ns=task.first_save_ts_ns,
+            fallback_end_ts_ns=done_ts_ns,
+        )
+        if completed and self._metrics is not None:
+            push_gbps = float(write_stats.get("gbps", 0.0))
+            self._metrics.record_prefill_push(
+                duration_s=(done_ts_ns - task.schedule_queued_ts_ns) / 1_000_000_000,
+                first_save_to_done_s=(
+                    (done_ts_ns - task.first_save_ts_ns) / 1_000_000_000
+                    if task.first_save_ts_ns is not None
+                    else None
+                ),
+                wait_for_pushes_s=wait_for_pushes_s,
+                blocks=task.num_blocks,
+                bytes_total=task.rdma_bytes,
+                gbps=push_gbps,
+                success=True,
+            )
+        push_gbps = float(write_stats.get("gbps", 0.0))
+        link_gbps = _rdma_link_gbps(task.rdma)
+        logger.info(
+            "[PdConnector] P RDMA done reqs=%s target_req=%s chunks=%d blocks=%d "
+            "rdma_bytes=%d save_to_imm_ms=%.3f schedule_to_imm_ms=%.3f "
+            "submit_span_ms=%.3f xfer_window_ms=%.3f completion_tail_ms=%.3f "
+            "write_latency_sum_ms=%.3f write_latency_max_ms=%.3f "
+            "writes=%d/%d errors=%d gbps=%.2f window_gbps=%.2f "
+            "link_gbps=%.2f link_util_pct=%.2f ts_ns=%d",
+            list(task.req_ids),
+            task.target_request_id,
+            task.chunk_count,
+            task.num_blocks,
+            task.rdma_bytes,
+            _elapsed_ms(task.first_save_ts_ns, done_ts_ns),
+            _elapsed_ms(task.schedule_queued_ts_ns, done_ts_ns),
+            float(write_stats.get("submit_span_ms", 0.0)),
+            float(write_stats.get("xfer_window_ms", 0.0)),
+            float(write_stats.get("completion_tail_ms", 0.0)),
+            float(write_stats.get("write_latency_sum_ms", 0.0)),
+            float(write_stats.get("write_latency_max_ms", 0.0)),
+            int(write_stats.get("completed", 0)),
+            int(write_stats.get("submitted", 0)),
+            int(write_stats.get("errors", 0)),
+            push_gbps,
+            float(write_stats.get("window_gbps", 0.0)),
+            link_gbps,
+            _pct(push_gbps, link_gbps),
+            done_ts_ns,
+        )
+
+    def _on_error(self, task: _PushFinalizeTask, exc: BaseException) -> None:
+        logger.exception(
+            "[PdConnector] P finalize failed reqs=%s target_req=%s chunks=%d blocks=%d bytes=%d",
+            list(task.req_ids),
+            task.target_request_id,
+            task.chunk_count,
+            task.num_blocks,
+            task.rdma_bytes,
+        )
+        if self._metrics is not None:
+            self._metrics.record_prefill_push(
+                duration_s=(time.time_ns() - task.schedule_queued_ts_ns) / 1_000_000_000,
+                first_save_to_done_s=None,
+                wait_for_pushes_s=None,
+                blocks=task.num_blocks,
+                bytes_total=task.rdma_bytes,
+                gbps=None,
+                success=False,
+            )
+
+    def _is_cancelled(self, req_id: str) -> bool:
+        with self._condition:
+            return req_id in self._cancelled
+
+    def _on_finish_locked(self, task: _PushFinalizeTask) -> None:
+        self._submitted.discard(task.req_ids)
+        for req_id in task.req_ids:
+            self._cancelled.discard(req_id)
+
+    def _set_inflight_metric_locked(self) -> None:
+        if self._metrics is not None:
+            self._metrics.set_prefill_inflight_finalize_tasks(self._inflight)
+
+
+__all__ = ["_AsyncLayerPushSender", "_AsyncPushFinalizer", "_run_layer_push"]

--- a/python/pegaflow/pd_connector/prefill_tasks.py
+++ b/python/pegaflow/pd_connector/prefill_tasks.py
@@ -1,0 +1,74 @@
+"""Data carriers for the P-side (prefill) push pipeline.
+
+These are pure value types shared between ``PrefillHandler`` and the async
+push/finalize executors. Kept in their own module so the handler and executor
+files stay focused on behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pegaflow.pd_connector.layout import LayerBlockSlices
+from pegaflow.pd_connector.rdma import RdmaPort
+
+
+class _SkipPushRank(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class _LayerPushTask:
+    rdma: RdmaPort
+    req_id: str
+    layer_idx: int
+    block_slices: list[LayerBlockSlices]
+    event: Any = None
+
+
+@dataclass(frozen=True)
+class _PreparedTargetPush:
+    physical_req_id: str
+    block_slices: list[LayerBlockSlices]
+
+
+@dataclass(frozen=True)
+class _PreparedLayerPush:
+    req_blocks: frozenset[int]
+    pushed_req_blocks: frozenset[int]
+    target_pushes: tuple[_PreparedTargetPush, ...]
+    rdma_bytes: int
+    all_chunks_seen: bool
+
+
+@dataclass
+class _PushTrace:
+    queued_ts_ns: int
+    first_save_ts_ns: int | None = None
+    last_save_ts_ns: int | None = None
+    rdma_bytes: int = 0
+    chunk_count: int = 0
+
+
+@dataclass(frozen=True)
+class _PushFinalizeTask:
+    rdma: RdmaPort
+    req_ids: tuple[str, ...]
+    target_request_id: str
+    num_blocks: int
+    chunk_count: int
+    first_save_ts_ns: int | None
+    finalize_queued_ts_ns: int
+    schedule_queued_ts_ns: int
+    rdma_bytes: int
+
+
+__all__ = [
+    "_SkipPushRank",
+    "_LayerPushTask",
+    "_PreparedTargetPush",
+    "_PreparedLayerPush",
+    "_PushTrace",
+    "_PushFinalizeTask",
+]

--- a/python/pegaflow/pd_connector/prefill_worker.py
+++ b/python/pegaflow/pd_connector/prefill_worker.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import logging
-import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 from pegaflow.logging_utils import get_connector_logger
+from pegaflow.pd_connector.async_runner import InflightTaskRunner
 from pegaflow.pd_connector.chunk_tracker import ChunkTracker
 from pegaflow.pd_connector.config import extra_config_value
 from pegaflow.pd_connector.layout import (
@@ -938,53 +937,20 @@ class _PushFinalizeTask:
 # ---------------------------------------------------------------------------
 
 
-class _AsyncLayerPushSender:
+class _AsyncLayerPushSender(InflightTaskRunner["_LayerPushTask"]):
     def __init__(self, metrics: Any | None = None, max_workers: int = 16) -> None:
-        self._metrics = metrics
-        self._condition = threading.Condition()
-        self._inflight = 0
+        super().__init__("pd-rdma-push", metrics=metrics, max_workers=max_workers)
         self._inflight_by_req: dict[str, int] = {}
         self._cancelled: set[str] = set()
-        self._error: BaseException | None = None
-        self._closed = False
-        self._executor = ThreadPoolExecutor(
-            max_workers=max(1, int(max_workers)),
-            thread_name_prefix="pd-rdma-push",
-        )
 
     def submit(self, task: _LayerPushTask) -> None:
-        with self._condition:
-            if self._closed:
-                raise RuntimeError("PdConnector RDMA push sender is closed")
-            if self._error is not None:
-                raise self._error
-            self._inflight += 1
-            self._inflight_by_req[task.req_id] = self._inflight_by_req.get(task.req_id, 0) + 1
-            self._set_inflight_metric_locked()
-        try:
-            self._executor.submit(self._run_task, task)
-        except BaseException:
-            with self._condition:
-                self._finish_task(task)
-            raise
-
-    def wait_all(self) -> None:
-        with self._condition:
-            while self._inflight > 0 and self._error is None:
-                self._condition.wait()
-            if self._error is not None:
-                error = self._error
-                self._error = None
-                raise error
+        self._submit(task, "PdConnector RDMA push sender is closed")
 
     def wait_req(self, req_id: str) -> None:
         with self._condition:
             while self._inflight_by_req.get(req_id, 0) > 0 and self._error is None:
                 self._condition.wait()
-            if self._error is not None:
-                error = self._error
-                self._error = None
-                raise error
+            self._raise_pending_error_locked()
 
     def cancel(self, req_id: str) -> None:
         self.cancel_many((req_id,))
@@ -996,40 +962,23 @@ class _AsyncLayerPushSender:
             )
             self._condition.notify_all()
 
-    def close(self) -> None:
+    def _on_submit_locked(self, task: _LayerPushTask) -> bool:
+        self._inflight_by_req[task.req_id] = self._inflight_by_req.get(task.req_id, 0) + 1
+        return True
+
+    def _run(self, task: _LayerPushTask) -> None:
         with self._condition:
-            self._closed = True
-            self._condition.notify_all()
-        self._executor.shutdown(wait=False, cancel_futures=True)
+            cancelled = task.req_id in self._cancelled
+        if not cancelled:
+            _run_layer_push(task)
 
-    def is_idle(self) -> bool:
-        with self._condition:
-            return self._inflight == 0 and self._error is None
-
-    def _run_task(self, task: _LayerPushTask) -> None:
-        try:
-            with self._condition:
-                cancelled = task.req_id in self._cancelled
-            if not cancelled:
-                _run_layer_push(task)
-        except BaseException as exc:
-            with self._condition:
-                self._error = exc
-                self._condition.notify_all()
-        finally:
-            with self._condition:
-                self._finish_task(task)
-
-    def _finish_task(self, task: _LayerPushTask) -> None:
-        self._inflight -= 1
+    def _on_finish_locked(self, task: _LayerPushTask) -> None:
         remaining = self._inflight_by_req.get(task.req_id, 0) - 1
         if remaining > 0:
             self._inflight_by_req[task.req_id] = remaining
         else:
             self._inflight_by_req.pop(task.req_id, None)
             self._cancelled.discard(task.req_id)
-        self._set_inflight_metric_locked()
-        self._condition.notify_all()
 
     def _set_inflight_metric_locked(self) -> None:
         if self._metrics is not None:
@@ -1042,43 +991,20 @@ def _run_layer_push(task: _LayerPushTask) -> None:
     task.rdma.push_layer(task.req_id, task.layer_idx, task.block_slices)
 
 
-class _AsyncPushFinalizer:
+class _AsyncPushFinalizer(InflightTaskRunner["_PushFinalizeTask"]):
     def __init__(
         self,
         push_sender: _AsyncLayerPushSender,
         metrics: Any | None = None,
         max_workers: int = 16,
     ) -> None:
+        super().__init__("pd-rdma-finalize", metrics=metrics, max_workers=max_workers)
         self._push_sender = push_sender
-        self._metrics = metrics
-        self._condition = threading.Condition()
         self._submitted: set[tuple[str, ...]] = set()
         self._cancelled: set[str] = set()
-        self._inflight = 0
-        self._error: BaseException | None = None
-        self._closed = False
-        self._executor = ThreadPoolExecutor(
-            max_workers=max(1, int(max_workers)),
-            thread_name_prefix="pd-rdma-finalize",
-        )
 
     def submit(self, task: _PushFinalizeTask) -> None:
-        with self._condition:
-            if self._closed:
-                raise RuntimeError("PdConnector RDMA push finalizer is closed")
-            if self._error is not None:
-                raise self._error
-            if task.req_ids in self._submitted:
-                return
-            self._submitted.add(task.req_ids)
-            self._inflight += 1
-            self._set_inflight_metric_locked()
-        try:
-            self._executor.submit(self._run_task, task)
-        except BaseException:
-            with self._condition:
-                self._finish_task(task)
-            raise
+        self._submit(task, "PdConnector RDMA push finalizer is closed")
 
     def cancel_many(self, req_ids: tuple[str, ...]) -> None:
         with self._condition:
@@ -1088,132 +1014,110 @@ class _AsyncPushFinalizer:
             self._cancelled.update(req_id for req_id in req_ids if req_id in submitted_req_ids)
             self._condition.notify_all()
 
-    def wait_all(self) -> None:
-        with self._condition:
-            while self._inflight > 0 and self._error is None:
-                self._condition.wait()
-            if self._error is not None:
-                error = self._error
-                self._error = None
-                raise error
+    def _on_submit_locked(self, task: _PushFinalizeTask) -> bool:
+        if task.req_ids in self._submitted:
+            return False
+        self._submitted.add(task.req_ids)
+        return True
 
-    def close(self) -> None:
-        with self._condition:
-            self._closed = True
-            self._condition.notify_all()
-        self._executor.shutdown(wait=False, cancel_futures=True)
-
-    def is_idle(self) -> bool:
-        with self._condition:
-            return self._inflight == 0 and self._error is None
-
-    def _run_task(self, task: _PushFinalizeTask) -> None:
-        try:
-            wait_for_pushes_s = 0.0
-            completed = False
-            for req_id in task.req_ids:
-                if self._is_cancelled(req_id):
-                    continue
-                self._push_sender.wait_req(req_id)
-                if self._is_cancelled(req_id):
-                    continue
-                per_req_wait_start_ts_ns = time.time_ns()
-                task.rdma.wait_for_pushes(req_id)
-                wait_for_pushes_s += (time.time_ns() - per_req_wait_start_ts_ns) / 1_000_000_000
-                if self._is_cancelled(req_id):
-                    continue
-                task.rdma.push_done(req_id)
-                completed = True
-            done_ts_ns = time.time_ns()
-            write_stats = _rdma_write_stats(
-                task.rdma,
-                task.req_ids,
-                fallback_bytes=task.rdma_bytes,
-                fallback_start_ts_ns=task.first_save_ts_ns,
-                fallback_end_ts_ns=done_ts_ns,
-            )
-            if completed and self._metrics is not None:
-                push_gbps = float(write_stats.get("gbps", 0.0))
-                self._metrics.record_prefill_push(
-                    duration_s=(done_ts_ns - task.schedule_queued_ts_ns) / 1_000_000_000,
-                    first_save_to_done_s=(
-                        (done_ts_ns - task.first_save_ts_ns) / 1_000_000_000
-                        if task.first_save_ts_ns is not None
-                        else None
-                    ),
-                    wait_for_pushes_s=wait_for_pushes_s,
-                    blocks=task.num_blocks,
-                    bytes_total=task.rdma_bytes,
-                    gbps=push_gbps,
-                    success=True,
-                )
+    def _run(self, task: _PushFinalizeTask) -> None:
+        wait_for_pushes_s = 0.0
+        completed = False
+        for req_id in task.req_ids:
+            if self._is_cancelled(req_id):
+                continue
+            self._push_sender.wait_req(req_id)
+            if self._is_cancelled(req_id):
+                continue
+            per_req_wait_start_ts_ns = time.time_ns()
+            task.rdma.wait_for_pushes(req_id)
+            wait_for_pushes_s += (time.time_ns() - per_req_wait_start_ts_ns) / 1_000_000_000
+            if self._is_cancelled(req_id):
+                continue
+            task.rdma.push_done(req_id)
+            completed = True
+        done_ts_ns = time.time_ns()
+        write_stats = _rdma_write_stats(
+            task.rdma,
+            task.req_ids,
+            fallback_bytes=task.rdma_bytes,
+            fallback_start_ts_ns=task.first_save_ts_ns,
+            fallback_end_ts_ns=done_ts_ns,
+        )
+        if completed and self._metrics is not None:
             push_gbps = float(write_stats.get("gbps", 0.0))
-            link_gbps = _rdma_link_gbps(task.rdma)
-            logger.info(
-                "[PdConnector] P RDMA done reqs=%s target_req=%s chunks=%d blocks=%d "
-                "rdma_bytes=%d save_to_imm_ms=%.3f schedule_to_imm_ms=%.3f "
-                "submit_span_ms=%.3f xfer_window_ms=%.3f completion_tail_ms=%.3f "
-                "write_latency_sum_ms=%.3f write_latency_max_ms=%.3f "
-                "writes=%d/%d errors=%d gbps=%.2f window_gbps=%.2f "
-                "link_gbps=%.2f link_util_pct=%.2f ts_ns=%d",
-                list(task.req_ids),
-                task.target_request_id,
-                task.chunk_count,
-                task.num_blocks,
-                task.rdma_bytes,
-                _elapsed_ms(task.first_save_ts_ns, done_ts_ns),
-                _elapsed_ms(task.schedule_queued_ts_ns, done_ts_ns),
-                float(write_stats.get("submit_span_ms", 0.0)),
-                float(write_stats.get("xfer_window_ms", 0.0)),
-                float(write_stats.get("completion_tail_ms", 0.0)),
-                float(write_stats.get("write_latency_sum_ms", 0.0)),
-                float(write_stats.get("write_latency_max_ms", 0.0)),
-                int(write_stats.get("completed", 0)),
-                int(write_stats.get("submitted", 0)),
-                int(write_stats.get("errors", 0)),
-                push_gbps,
-                float(write_stats.get("window_gbps", 0.0)),
-                link_gbps,
-                _pct(push_gbps, link_gbps),
-                done_ts_ns,
+            self._metrics.record_prefill_push(
+                duration_s=(done_ts_ns - task.schedule_queued_ts_ns) / 1_000_000_000,
+                first_save_to_done_s=(
+                    (done_ts_ns - task.first_save_ts_ns) / 1_000_000_000
+                    if task.first_save_ts_ns is not None
+                    else None
+                ),
+                wait_for_pushes_s=wait_for_pushes_s,
+                blocks=task.num_blocks,
+                bytes_total=task.rdma_bytes,
+                gbps=push_gbps,
+                success=True,
             )
-        except BaseException as exc:
-            logger.exception(
-                "[PdConnector] P finalize failed reqs=%s target_req=%s chunks=%d blocks=%d bytes=%d",
-                list(task.req_ids),
-                task.target_request_id,
-                task.chunk_count,
-                task.num_blocks,
-                task.rdma_bytes,
+        push_gbps = float(write_stats.get("gbps", 0.0))
+        link_gbps = _rdma_link_gbps(task.rdma)
+        logger.info(
+            "[PdConnector] P RDMA done reqs=%s target_req=%s chunks=%d blocks=%d "
+            "rdma_bytes=%d save_to_imm_ms=%.3f schedule_to_imm_ms=%.3f "
+            "submit_span_ms=%.3f xfer_window_ms=%.3f completion_tail_ms=%.3f "
+            "write_latency_sum_ms=%.3f write_latency_max_ms=%.3f "
+            "writes=%d/%d errors=%d gbps=%.2f window_gbps=%.2f "
+            "link_gbps=%.2f link_util_pct=%.2f ts_ns=%d",
+            list(task.req_ids),
+            task.target_request_id,
+            task.chunk_count,
+            task.num_blocks,
+            task.rdma_bytes,
+            _elapsed_ms(task.first_save_ts_ns, done_ts_ns),
+            _elapsed_ms(task.schedule_queued_ts_ns, done_ts_ns),
+            float(write_stats.get("submit_span_ms", 0.0)),
+            float(write_stats.get("xfer_window_ms", 0.0)),
+            float(write_stats.get("completion_tail_ms", 0.0)),
+            float(write_stats.get("write_latency_sum_ms", 0.0)),
+            float(write_stats.get("write_latency_max_ms", 0.0)),
+            int(write_stats.get("completed", 0)),
+            int(write_stats.get("submitted", 0)),
+            int(write_stats.get("errors", 0)),
+            push_gbps,
+            float(write_stats.get("window_gbps", 0.0)),
+            link_gbps,
+            _pct(push_gbps, link_gbps),
+            done_ts_ns,
+        )
+
+    def _on_error(self, task: _PushFinalizeTask, exc: BaseException) -> None:
+        logger.exception(
+            "[PdConnector] P finalize failed reqs=%s target_req=%s chunks=%d blocks=%d bytes=%d",
+            list(task.req_ids),
+            task.target_request_id,
+            task.chunk_count,
+            task.num_blocks,
+            task.rdma_bytes,
+        )
+        if self._metrics is not None:
+            self._metrics.record_prefill_push(
+                duration_s=(time.time_ns() - task.schedule_queued_ts_ns) / 1_000_000_000,
+                first_save_to_done_s=None,
+                wait_for_pushes_s=None,
+                blocks=task.num_blocks,
+                bytes_total=task.rdma_bytes,
+                gbps=None,
+                success=False,
             )
-            with self._condition:
-                self._error = exc
-                self._condition.notify_all()
-            if self._metrics is not None:
-                self._metrics.record_prefill_push(
-                    duration_s=(time.time_ns() - task.schedule_queued_ts_ns) / 1_000_000_000,
-                    first_save_to_done_s=None,
-                    wait_for_pushes_s=None,
-                    blocks=task.num_blocks,
-                    bytes_total=task.rdma_bytes,
-                    gbps=None,
-                    success=False,
-                )
-        finally:
-            with self._condition:
-                self._finish_task(task)
 
     def _is_cancelled(self, req_id: str) -> bool:
         with self._condition:
             return req_id in self._cancelled
 
-    def _finish_task(self, task: _PushFinalizeTask) -> None:
+    def _on_finish_locked(self, task: _PushFinalizeTask) -> None:
         self._submitted.discard(task.req_ids)
         for req_id in task.req_ids:
             self._cancelled.discard(req_id)
-        self._inflight -= 1
-        self._set_inflight_metric_locked()
-        self._condition.notify_all()
 
     def _set_inflight_metric_locked(self) -> None:
         if self._metrics is not None:

--- a/python/pegaflow/pd_connector/prefill_worker.py
+++ b/python/pegaflow/pd_connector/prefill_worker.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from pegaflow.logging_utils import get_connector_logger
-from pegaflow.pd_connector.async_runner import InflightTaskRunner
 from pegaflow.pd_connector.chunk_tracker import ChunkTracker
 from pegaflow.pd_connector.config import extra_config_value
 from pegaflow.pd_connector.layout import (
@@ -33,7 +32,28 @@ from pegaflow.pd_connector.metadata import (
     PushReqMeta,
     flatten_block_ids,
 )
-from pegaflow.pd_connector.rdma import RdmaPort
+
+# Re-exported so PrefillHandler resolves these as module globals (tests
+# monkeypatch prefill_worker_mod._AsyncLayerPushSender / _LayerPushTask / etc.)
+# and so existing import sites keep working after the split.
+from pegaflow.pd_connector.prefill_async import (  # noqa: F401
+    _AsyncLayerPushSender,
+    _AsyncPushFinalizer,
+    _elapsed_ms,
+    _gbps,
+    _pct,
+    _rdma_link_gbps,
+    _rdma_write_stats,
+    _run_layer_push,
+)
+from pegaflow.pd_connector.prefill_tasks import (  # noqa: F401
+    _LayerPushTask,
+    _PreparedLayerPush,
+    _PreparedTargetPush,
+    _PushFinalizeTask,
+    _PushTrace,
+    _SkipPushRank,
+)
 
 if TYPE_CHECKING:
     from pegaflow.pd_connector.worker import PdWorkerBase
@@ -611,98 +631,6 @@ class PrefillHandler:
 # ---------------------------------------------------------------------------
 
 
-def _elapsed_ms(start_ts_ns: int | None, end_ts_ns: int | None) -> float:
-    if start_ts_ns is None or end_ts_ns is None:
-        return 0.0
-    return (end_ts_ns - start_ts_ns) / 1_000_000
-
-
-def _gbps(bytes_total: int, start_ts_ns: int | None, end_ts_ns: int | None) -> float:
-    if bytes_total <= 0 or start_ts_ns is None or end_ts_ns is None or end_ts_ns <= start_ts_ns:
-        return 0.0
-    return bytes_total * 8 / ((end_ts_ns - start_ts_ns) / 1_000_000_000) / 1e9
-
-
-def _pct(value: float, total: float) -> float:
-    if value <= 0 or total <= 0:
-        return 0.0
-    return value / total * 100
-
-
-def _rdma_link_gbps(rdma: RdmaPort | None) -> float:
-    if rdma is None:
-        return 0.0
-    try:
-        return rdma.aggregated_link_speed() / 1e9
-    except Exception:
-        logger.exception("[PdConnector] failed to read RDMA link speed")
-        return 0.0
-
-
-def _rdma_write_stats(
-    rdma: RdmaPort,
-    req_ids: tuple[str, ...],
-    *,
-    fallback_bytes: int,
-    fallback_start_ts_ns: int | None,
-    fallback_end_ts_ns: int | None,
-) -> dict[str, float | int | bool]:
-    stats_by_req = []
-    for req_id in req_ids:
-        try:
-            stats_by_req.append(rdma.write_stats(req_id))
-        except AttributeError:
-            continue
-        except Exception:
-            logger.exception("[PdConnector] failed to read RDMA write stats req=%s", req_id)
-    if not stats_by_req:
-        return {
-            "submitted": 0,
-            "completed": 0,
-            "errors": 0,
-            "bytes": fallback_bytes,
-            "has_submit": False,
-            "has_complete": False,
-            "submit_span_ms": 0.0,
-            "xfer_window_ms": 0.0,
-            "completion_tail_ms": 0.0,
-            "window_gbps": 0.0,
-            "gbps": _gbps(fallback_bytes, fallback_start_ts_ns, fallback_end_ts_ns),
-        }
-
-    bytes_total = sum(int(stats.get("bytes", 0)) for stats in stats_by_req)
-    xfer_window_ms = max(float(stats.get("xfer_window_ms", 0.0)) for stats in stats_by_req)
-    window_gbps = bytes_total * 8 / (xfer_window_ms / 1000.0) / 1e9 if xfer_window_ms > 0 else 0.0
-    write_latency_sum_ms = sum(float(stats.get("write_latency_sum_ms", 0.0)) for stats in stats_by_req)
-    active_gbps = (
-        bytes_total * 8 / (write_latency_sum_ms / 1000.0) / 1e9
-        if write_latency_sum_ms > 0
-        else window_gbps
-    )
-    return {
-        "submitted": sum(int(stats.get("submitted", 0)) for stats in stats_by_req),
-        "completed": sum(int(stats.get("completed", 0)) for stats in stats_by_req),
-        "errors": sum(int(stats.get("errors", 0)) for stats in stats_by_req),
-        "bytes": bytes_total,
-        "has_submit": any(bool(stats.get("has_submit", False)) for stats in stats_by_req),
-        "has_complete": any(bool(stats.get("has_complete", False)) for stats in stats_by_req),
-        "submit_span_ms": max(float(stats.get("submit_span_ms", 0.0)) for stats in stats_by_req),
-        "first_complete_ms": max(
-            float(stats.get("first_complete_ms", 0.0)) for stats in stats_by_req
-        ),
-        "xfer_window_ms": xfer_window_ms,
-        "completion_tail_ms": max(
-            float(stats.get("completion_tail_ms", 0.0)) for stats in stats_by_req
-        ),
-        "write_latency_sum_ms": write_latency_sum_ms,
-        "write_latency_max_ms": max(
-            float(stats.get("write_latency_max_ms", 0.0)) for stats in stats_by_req
-        ),
-        "window_gbps": window_gbps,
-        "gbps": active_gbps,
-    }
-
-
 def _bool_config(value: Any) -> bool:
     if isinstance(value, str):
         return value.lower() in {"1", "true", "yes", "on"}
@@ -877,248 +805,3 @@ def _assert_handshake_tp_consistency(handshakes: tuple[PdHandshake, ...]) -> Non
     )
 
 
-class _SkipPushRank(Exception):
-    pass
-
-
-# ---------------------------------------------------------------------------
-# Dataclasses
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class _LayerPushTask:
-    rdma: RdmaPort
-    req_id: str
-    layer_idx: int
-    block_slices: list[LayerBlockSlices]
-    event: Any = None
-
-
-@dataclass(frozen=True)
-class _PreparedTargetPush:
-    physical_req_id: str
-    block_slices: list[LayerBlockSlices]
-
-
-@dataclass(frozen=True)
-class _PreparedLayerPush:
-    req_blocks: frozenset[int]
-    pushed_req_blocks: frozenset[int]
-    target_pushes: tuple[_PreparedTargetPush, ...]
-    rdma_bytes: int
-    all_chunks_seen: bool
-
-
-@dataclass
-class _PushTrace:
-    queued_ts_ns: int
-    first_save_ts_ns: int | None = None
-    last_save_ts_ns: int | None = None
-    rdma_bytes: int = 0
-    chunk_count: int = 0
-
-
-@dataclass(frozen=True)
-class _PushFinalizeTask:
-    rdma: RdmaPort
-    req_ids: tuple[str, ...]
-    target_request_id: str
-    num_blocks: int
-    chunk_count: int
-    first_save_ts_ns: int | None
-    finalize_queued_ts_ns: int
-    schedule_queued_ts_ns: int
-    rdma_bytes: int
-
-
-# ---------------------------------------------------------------------------
-# Async workers
-# ---------------------------------------------------------------------------
-
-
-class _AsyncLayerPushSender(InflightTaskRunner["_LayerPushTask"]):
-    def __init__(self, metrics: Any | None = None, max_workers: int = 16) -> None:
-        super().__init__("pd-rdma-push", metrics=metrics, max_workers=max_workers)
-        self._inflight_by_req: dict[str, int] = {}
-        self._cancelled: set[str] = set()
-
-    def submit(self, task: _LayerPushTask) -> None:
-        self._submit(task, "PdConnector RDMA push sender is closed")
-
-    def wait_req(self, req_id: str) -> None:
-        with self._condition:
-            while self._inflight_by_req.get(req_id, 0) > 0 and self._error is None:
-                self._condition.wait()
-            self._raise_pending_error_locked()
-
-    def cancel(self, req_id: str) -> None:
-        self.cancel_many((req_id,))
-
-    def cancel_many(self, req_ids: tuple[str, ...]) -> None:
-        with self._condition:
-            self._cancelled.update(
-                req_id for req_id in req_ids if self._inflight_by_req.get(req_id, 0) > 0
-            )
-            self._condition.notify_all()
-
-    def _on_submit_locked(self, task: _LayerPushTask) -> bool:
-        self._inflight_by_req[task.req_id] = self._inflight_by_req.get(task.req_id, 0) + 1
-        return True
-
-    def _run(self, task: _LayerPushTask) -> None:
-        with self._condition:
-            cancelled = task.req_id in self._cancelled
-        if not cancelled:
-            _run_layer_push(task)
-
-    def _on_finish_locked(self, task: _LayerPushTask) -> None:
-        remaining = self._inflight_by_req.get(task.req_id, 0) - 1
-        if remaining > 0:
-            self._inflight_by_req[task.req_id] = remaining
-        else:
-            self._inflight_by_req.pop(task.req_id, None)
-            self._cancelled.discard(task.req_id)
-
-    def _set_inflight_metric_locked(self) -> None:
-        if self._metrics is not None:
-            self._metrics.set_prefill_inflight_push_tasks(self._inflight)
-
-
-def _run_layer_push(task: _LayerPushTask) -> None:
-    if task.event is not None:
-        task.event.synchronize()
-    task.rdma.push_layer(task.req_id, task.layer_idx, task.block_slices)
-
-
-class _AsyncPushFinalizer(InflightTaskRunner["_PushFinalizeTask"]):
-    def __init__(
-        self,
-        push_sender: _AsyncLayerPushSender,
-        metrics: Any | None = None,
-        max_workers: int = 16,
-    ) -> None:
-        super().__init__("pd-rdma-finalize", metrics=metrics, max_workers=max_workers)
-        self._push_sender = push_sender
-        self._submitted: set[tuple[str, ...]] = set()
-        self._cancelled: set[str] = set()
-
-    def submit(self, task: _PushFinalizeTask) -> None:
-        self._submit(task, "PdConnector RDMA push finalizer is closed")
-
-    def cancel_many(self, req_ids: tuple[str, ...]) -> None:
-        with self._condition:
-            submitted_req_ids = {
-                submitted_req_id for submitted in self._submitted for submitted_req_id in submitted
-            }
-            self._cancelled.update(req_id for req_id in req_ids if req_id in submitted_req_ids)
-            self._condition.notify_all()
-
-    def _on_submit_locked(self, task: _PushFinalizeTask) -> bool:
-        if task.req_ids in self._submitted:
-            return False
-        self._submitted.add(task.req_ids)
-        return True
-
-    def _run(self, task: _PushFinalizeTask) -> None:
-        wait_for_pushes_s = 0.0
-        completed = False
-        for req_id in task.req_ids:
-            if self._is_cancelled(req_id):
-                continue
-            self._push_sender.wait_req(req_id)
-            if self._is_cancelled(req_id):
-                continue
-            per_req_wait_start_ts_ns = time.time_ns()
-            task.rdma.wait_for_pushes(req_id)
-            wait_for_pushes_s += (time.time_ns() - per_req_wait_start_ts_ns) / 1_000_000_000
-            if self._is_cancelled(req_id):
-                continue
-            task.rdma.push_done(req_id)
-            completed = True
-        done_ts_ns = time.time_ns()
-        write_stats = _rdma_write_stats(
-            task.rdma,
-            task.req_ids,
-            fallback_bytes=task.rdma_bytes,
-            fallback_start_ts_ns=task.first_save_ts_ns,
-            fallback_end_ts_ns=done_ts_ns,
-        )
-        if completed and self._metrics is not None:
-            push_gbps = float(write_stats.get("gbps", 0.0))
-            self._metrics.record_prefill_push(
-                duration_s=(done_ts_ns - task.schedule_queued_ts_ns) / 1_000_000_000,
-                first_save_to_done_s=(
-                    (done_ts_ns - task.first_save_ts_ns) / 1_000_000_000
-                    if task.first_save_ts_ns is not None
-                    else None
-                ),
-                wait_for_pushes_s=wait_for_pushes_s,
-                blocks=task.num_blocks,
-                bytes_total=task.rdma_bytes,
-                gbps=push_gbps,
-                success=True,
-            )
-        push_gbps = float(write_stats.get("gbps", 0.0))
-        link_gbps = _rdma_link_gbps(task.rdma)
-        logger.info(
-            "[PdConnector] P RDMA done reqs=%s target_req=%s chunks=%d blocks=%d "
-            "rdma_bytes=%d save_to_imm_ms=%.3f schedule_to_imm_ms=%.3f "
-            "submit_span_ms=%.3f xfer_window_ms=%.3f completion_tail_ms=%.3f "
-            "write_latency_sum_ms=%.3f write_latency_max_ms=%.3f "
-            "writes=%d/%d errors=%d gbps=%.2f window_gbps=%.2f "
-            "link_gbps=%.2f link_util_pct=%.2f ts_ns=%d",
-            list(task.req_ids),
-            task.target_request_id,
-            task.chunk_count,
-            task.num_blocks,
-            task.rdma_bytes,
-            _elapsed_ms(task.first_save_ts_ns, done_ts_ns),
-            _elapsed_ms(task.schedule_queued_ts_ns, done_ts_ns),
-            float(write_stats.get("submit_span_ms", 0.0)),
-            float(write_stats.get("xfer_window_ms", 0.0)),
-            float(write_stats.get("completion_tail_ms", 0.0)),
-            float(write_stats.get("write_latency_sum_ms", 0.0)),
-            float(write_stats.get("write_latency_max_ms", 0.0)),
-            int(write_stats.get("completed", 0)),
-            int(write_stats.get("submitted", 0)),
-            int(write_stats.get("errors", 0)),
-            push_gbps,
-            float(write_stats.get("window_gbps", 0.0)),
-            link_gbps,
-            _pct(push_gbps, link_gbps),
-            done_ts_ns,
-        )
-
-    def _on_error(self, task: _PushFinalizeTask, exc: BaseException) -> None:
-        logger.exception(
-            "[PdConnector] P finalize failed reqs=%s target_req=%s chunks=%d blocks=%d bytes=%d",
-            list(task.req_ids),
-            task.target_request_id,
-            task.chunk_count,
-            task.num_blocks,
-            task.rdma_bytes,
-        )
-        if self._metrics is not None:
-            self._metrics.record_prefill_push(
-                duration_s=(time.time_ns() - task.schedule_queued_ts_ns) / 1_000_000_000,
-                first_save_to_done_s=None,
-                wait_for_pushes_s=None,
-                blocks=task.num_blocks,
-                bytes_total=task.rdma_bytes,
-                gbps=None,
-                success=False,
-            )
-
-    def _is_cancelled(self, req_id: str) -> bool:
-        with self._condition:
-            return req_id in self._cancelled
-
-    def _on_finish_locked(self, task: _PushFinalizeTask) -> None:
-        self._submitted.discard(task.req_ids)
-        for req_id in task.req_ids:
-            self._cancelled.discard(req_id)
-
-    def _set_inflight_metric_locked(self) -> None:
-        if self._metrics is not None:
-            self._metrics.set_prefill_inflight_finalize_tasks(self._inflight)


### PR DESCRIPTION
## What

Maintainability refactor of `python/pegaflow/pd_connector/` (the vLLM P/D RDMA-push connector). Behavior-preserving throughout — no change to the vLLM-facing API, the RDMA data flow, or the wire format.

## Why

The package had grown to ~6.4k lines with parallel-but-unshared structure: three near-identical connector facades, duplicated async-executor scaffolding in three places, a 1.2k-line `prefill_worker.py`, and two flat clusters of decode state with transitions scattered across the handler.

## Changes (6 commits, each independently green against the unit gate)

1. **Shared async task runner** — factor the duplicated `ThreadPoolExecutor` + condition/inflight skeleton out of the prefill push sender, push finalizer, and decode RDMA-done waiter into `async_runner.py` (`AsyncTaskPool` / `InflightTaskRunner`). Per-request counting, cancellation, and dedup stay in subclasses where their semantics differ.
2. **Collapse connector facades** — move the ~11 identical vLLM callbacks shared by `PdDecodeConnector` / `PdPrefillConnector` into a `_PdSplitConnector` base; each side overrides only what differs.
3. **Split `prefill_worker.py`** — into `prefill_tasks.py` (data carriers), `prefill_async.py` (executors + RDMA-stat helpers), and `prefill_worker.py` (handler). Moved symbols are re-imported so they still resolve as module globals.
4. **Group metadata codecs** — reorder the wire (de)serialization helpers by type so each encode/decode pair sits together. Pure reordering, no byte-format change.
5. **Encapsulate decode wait/failure state** — the 7 request/failure collections + lock move into `_DecodeWaitState` with named transitions and one drain method per consuming vLLM callback. The three failure channels stay separate (they are drained by different callbacks); this is encapsulation, not a merge.
6. **Extract decode peer topology + IMM allocation** — the peer-layout / MR-desc / layer-template / expected-imm-count / imm-id cluster and its 6 methods move into `_DecodePeerState`; `_peer_block_size` becomes a derived property.

## Testing

- **Unit gate**: `cd python && uv run --extra test pytest tests/pd/test_pd_connector_flow.py tests/pd/test_pd_connector_layout.py` — 117 passed after every commit.
- **Real RDMA bench** (single-node H200, Qwen3-8B, p-tp4/d-tp4, in 8192 / out 128, c8, 128 prompts):
  - PD (this branch): 128/0 completed, mean TTFT 246 ms, mean TPOT 3.40 ms, 95.9k tok/s — decode logs show 1729 RDMA done / prefill 1152 push done, **0 errors**.
  - On par with NIXL (TTFT 244 ms, 97.7k tok/s) and baseline 2×TP4-router; correctness matches NIXL (token-exact on short greedy decode).
- Strict RDMA NIC + CPU pinning preserved throughout.

## Notes

No behavior or performance regression. 
