### PR TITLE
feat(connector): 按模型自动选择 KV 传输 backend，server 不再静态指定

### DIFF
--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -56,6 +56,7 @@ impl BenchFixture {
                 enable_numa_affinity: false,
                 ..StorageConfig::default()
             },
+            TransferMode::Direct,
             block_ids(num_blocks),
         )
     }
@@ -72,6 +73,7 @@ impl BenchFixture {
                 advertise_addr: enable_metaserver.then(|| ADVERTISE_ADDR.to_string()),
                 ..StorageConfig::default()
             },
+            TransferMode::Direct,
             block_ids(num_blocks),
         )
     }
@@ -96,9 +98,9 @@ impl BenchFixture {
                 enable_lfu_admission: false,
                 hint_value_size_bytes: Some(bytes_per_block),
                 enable_numa_affinity: false,
-                transfer_mode,
                 ..StorageConfig::default()
             },
+            transfer_mode,
             block_ids,
         )
     }
@@ -107,6 +109,7 @@ impl BenchFixture {
         registered_blocks: usize,
         bytes_per_block: usize,
         config: StorageConfig,
+        transfer_mode: TransferMode,
         block_ids: Vec<usize>,
     ) -> Self {
         let ctx = CudaContext::new(DEVICE_ID as usize).expect("CUDA context");
@@ -142,6 +145,7 @@ impl BenchFixture {
                 &[bytes_per_block],
                 &[0],
                 &[1],
+                transfer_mode,
             )
             .expect("register layer");
 
@@ -328,6 +332,7 @@ impl MultiLayerBenchFixture {
                 &block_sizes,
                 &strides,
                 &segments,
+                TransferMode::Direct,
             )
             .expect("register layers");
 

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -126,8 +126,6 @@ pub struct PegaEngine {
     topology: Arc<NumaTopology>,
     /// Query-ready blocks owned by opaque scheduler leases.
     query_leases: QueryLeaseManager,
-    /// H2D/D2H transfer backend used by GPU worker pools.
-    transfer_mode: TransferMode,
 }
 
 impl PegaEngine {
@@ -144,7 +142,6 @@ impl PegaEngine {
         topology.log_summary();
 
         let config = storage_config;
-        let transfer_mode = config.transfer_mode;
         let numa_nodes: Vec<NumaNode> = if config.enable_numa_affinity && topology.is_multi_numa() {
             let gpu_numa_nodes = topology.gpu_numa_nodes();
             if gpu_numa_nodes.is_empty() {
@@ -173,7 +170,6 @@ impl PegaEngine {
             storage,
             topology,
             query_leases: QueryLeaseManager::default(),
-            transfer_mode,
         })
     }
 
@@ -259,6 +255,7 @@ impl PegaEngine {
         bytes_per_block_list: &[usize],
         kv_stride_bytes_list: &[usize],
         segments_list: &[usize],
+        transfer_mode: TransferMode,
     ) -> Result<(), EngineError> {
         // Dense default: block stride == bytes_per_block (layer-first layout).
         self.register_context_layer_batch_strided(
@@ -277,6 +274,7 @@ impl PegaEngine {
             kv_stride_bytes_list,
             segments_list,
             None,
+            transfer_mode,
         )
     }
 
@@ -284,6 +282,10 @@ impl PegaEngine {
     /// block stride (see [`KVCacheRegistration::with_block_stride`]). When
     /// `block_stride_bytes_list` is `Some` it must match `layer_names` in length;
     /// each entry overrides that layer's stride.
+    ///
+    /// `transfer_mode` selects the GPU worker pools' H2D/D2H backend for this
+    /// instance. The pools are spawned per (instance, GPU) at registration, so
+    /// each instance can run a different backend.
     #[allow(
         clippy::too_many_arguments,
         reason = "public API mirrors one batched registration RPC payload"
@@ -305,6 +307,7 @@ impl PegaEngine {
         kv_stride_bytes_list: &[usize],
         segments_list: &[usize],
         block_stride_bytes_list: Option<&[usize]>,
+        transfer_mode: TransferMode,
     ) -> Result<(), EngineError> {
         // Build all registrations
         let ssd_enabled = self.storage.is_ssd_enabled();
@@ -388,13 +391,14 @@ impl PegaEngine {
             )));
         }
 
-        // Register GPU with all layers
+        // Register GPU with all layers. The connector picks the backend per
+        // model and sends it with the registration.
         instance.register_new_gpu(GpuRegistration {
             device_id,
             tp_rank,
             pp_rank,
             numa_node,
-            transfer_mode: self.transfer_mode,
+            transfer_mode,
             kv_caches,
         })?;
 

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -69,8 +69,6 @@ pub struct StorageConfig {
     pub metaserver_queue_depth: usize,
     /// Number of shards for the pinned memory pool (reduces allocator lock contention).
     pub pool_shards: usize,
-    /// H2D/D2H transfer backend used by the GPU workers.
-    pub transfer_mode: crate::TransferMode,
 }
 
 impl Default for StorageConfig {
@@ -89,7 +87,6 @@ impl Default for StorageConfig {
             advertise_addr: None,
             metaserver_queue_depth: crate::internode::DEFAULT_METASERVER_QUEUE_DEPTH,
             pool_shards: 1,
-            transfer_mode: crate::TransferMode::default(),
         }
     }
 }

--- a/pegaflow-core/src/transfer/mod.rs
+++ b/pegaflow-core/src/transfer/mod.rs
@@ -57,7 +57,10 @@ pub trait TransferBackend: Send {
     fn name(&self) -> &'static str;
 }
 
-/// Which [`TransferBackend`] the GPU workers use, selected once at startup.
+/// Which [`TransferBackend`] an instance's GPU worker pools use. The connector
+/// picks this per model (kernel for MLA, direct otherwise) and sends it with
+/// the registration; the pools are spawned per (instance, GPU), so each
+/// instance can run a different backend.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum TransferMode {
     /// One directional `cuMemcpyAsync` per coalesced range, on the DMA copy
@@ -68,18 +71,4 @@ pub enum TransferMode {
     /// memory directly. Wins when the batch is so fragmented that per-call
     /// launch latency on the direct path dominates.
     Kernel,
-}
-
-impl std::str::FromStr for TransferMode {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
-            "direct" | "memcpy" => Ok(Self::Direct),
-            "kernel" => Ok(Self::Kernel),
-            other => Err(format!(
-                "unknown transfer mode '{other}' (expected 'direct' or 'kernel')"
-            )),
-        }
-    }
 }

--- a/pegaflow-core/tests/common/harness.rs
+++ b/pegaflow-core/tests/common/harness.rs
@@ -135,6 +135,7 @@ pub struct TestEnvBuilder {
     pool_size: usize,
     world_size: usize,
     storage_config: Option<StorageConfig>,
+    transfer_mode: TransferMode,
     layers: Vec<LayerSpec>,
 }
 
@@ -146,6 +147,7 @@ impl TestEnvBuilder {
             pool_size: 16 << 20,
             world_size: 1,
             storage_config: None,
+            transfer_mode: TransferMode::Direct,
             layers: vec![],
         }
     }
@@ -200,6 +202,12 @@ impl TestEnvBuilder {
 
     pub fn storage(mut self, config: StorageConfig) -> Self {
         self.storage_config = Some(config);
+        self
+    }
+
+    /// Select the H2D/D2H backend for this env's GPU worker pools.
+    pub fn transfer_mode(mut self, mode: TransferMode) -> Self {
+        self.transfer_mode = mode;
         self
     }
 
@@ -259,6 +267,7 @@ impl TestEnvBuilder {
                 0,
                 1,
                 self.world_size,
+                self.transfer_mode,
             );
         }
 

--- a/pegaflow-core/tests/common/helpers.rs
+++ b/pegaflow-core/tests/common/helpers.rs
@@ -37,6 +37,7 @@ pub fn register_layers(
     pp_rank: usize,
     tp_size: usize,
     world_size: usize,
+    transfer_mode: TransferMode,
 ) {
     let layer_names: Vec<String> = layers.iter().map(|l| l.name.clone()).collect();
     let gpu_ptrs: Vec<u64> = layers.iter().map(|l| l.gpu_ptr).collect();
@@ -62,6 +63,7 @@ pub fn register_layers(
             &block_sizes,
             &kv_strides,
             &segments,
+            transfer_mode,
         )
         .expect("register_context_layer_batch");
 }

--- a/pegaflow-core/tests/engine_basic.rs
+++ b/pegaflow-core/tests/engine_basic.rs
@@ -108,10 +108,7 @@ async fn save_query_load_roundtrip_split_storage() {
 async fn kernel_backend_roundtrip_split_storage() {
     let env = TestEnvBuilder::new("test-kernel-split", "test-ns")
         .split_layer("layer_0", 2, 4096, 16384)
-        .storage(StorageConfig {
-            transfer_mode: TransferMode::Kernel,
-            ..StorageConfig::default()
-        })
+        .transfer_mode(TransferMode::Kernel)
         .build();
     let hashes = env.hashes(0);
 

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -7,6 +7,12 @@ message ResponseStatus {
   string message = 2;
 }
 
+// H2D/D2H transfer backend the engine uses for an instance's GPU worker pools.
+enum TransferMode {
+  TRANSFER_MODE_DIRECT = 0;
+  TRANSFER_MODE_KERNEL = 1;
+}
+
 // Batch registration request for all layers on a GPU (reduces N RPCs to 1).
 //
 // Workers declare only the layers that actually exist on the device; the
@@ -31,6 +37,10 @@ message RegisterContextRequest {
   repeated uint32 segments = 13;
   uint32 pp_rank = 14;
   string client_version = 15;
+  // Transfer backend the connector chose for this instance (kernel for MLA,
+  // direct otherwise; overridable via pegaflow.transfer_backend). The engine
+  // spawns this instance's GPU worker pools with the requested backend.
+  TransferMode transfer_mode = 17;
 }
 
 message RegisterContextResponse {

--- a/pegaflow-server/examples/p2p_bench.rs
+++ b/pegaflow-server/examples/p2p_bench.rs
@@ -246,6 +246,7 @@ fn register_ranks(engine: &PegaEngine, shape: &Shape) -> Vec<RankBuffers> {
                     &vec![shape.kv_bytes; shape.layers],
                     &vec![shape.blocks * shape.kv_bytes; shape.layers], // kv_stride
                     &vec![2; shape.layers],                             // split K/V
+                    TransferMode::Direct,
                 )
                 .expect("register rank");
             RankBuffers { device: rank, buf }

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -150,12 +150,6 @@ pub struct Cli {
     #[arg(long, default_value_t = false)]
     pub blockwise_alloc: bool,
 
-    /// H2D/D2H transfer backend: "direct" (one cuMemcpyAsync per coalesced
-    /// range, default) or "kernel" (a single copy kernel over mapped pinned
-    /// memory; lower latency when transfers are highly fragmented).
-    #[arg(long, default_value = "direct", value_parser = parse_transfer_mode)]
-    pub transfer_backend: pegaflow_core::TransferMode,
-
     /// RDMA NIC names for inter-node transfer (e.g. --nics mlx5_0,mlx5_1 or --nics mlx5_0 mlx5_1).
     /// When set, pinned memory is registered for RDMA access on these NICs.
     #[arg(long, value_delimiter = ',', value_parser = parse_nic_name, num_args = 1..)]
@@ -207,10 +201,6 @@ fn parse_nic_name(s: &str) -> Result<String, String> {
         return Err("--nics contains an empty NIC name".into());
     }
     Ok(name.to_string())
-}
-
-fn parse_transfer_mode(s: &str) -> Result<pegaflow_core::TransferMode, String> {
-    s.parse()
 }
 
 fn parse_hll_windows_arg(s: &str) -> Result<String, String> {
@@ -560,7 +550,6 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         advertise_addr,
         metaserver_queue_depth: cli.metaserver_queue_depth,
         pool_shards: cli.pool_shards,
-        transfer_mode: cli.transfer_backend,
     };
 
     if cli.pool_shards > 1 {

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -8,8 +8,8 @@ use crate::proto::engine::{
     RdmaHandshakeRequest, RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse,
     ReleaseRequest, ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse,
     ResponseStatus, SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest,
-    ShutdownResponse, TransferBlockInfo, TransferSlotInfo, UnregisterRequest, UnregisterResponse,
-    query_response,
+    ShutdownResponse, TransferBlockInfo, TransferMode as ProtoTransferMode, TransferSlotInfo,
+    UnregisterRequest, UnregisterResponse, query_response,
 };
 use crate::registry::RegistryHandle;
 use crate::session::SessionRegistry;
@@ -278,6 +278,13 @@ impl Engine for GrpcEngineService {
 
             Self::validate_register_context_request(&req)?;
 
+            // The connector picks the H2D/D2H backend per model and sends it
+            // here. Read it before `req` is partially moved below.
+            let transfer_mode = match req.transfer_mode() {
+                ProtoTransferMode::Direct => pegaflow_core::TransferMode::Direct,
+                ProtoTransferMode::Kernel => pegaflow_core::TransferMode::Kernel,
+            };
+
             // Validate array lengths are consistent with each other.
             let batch_len = req.layer_names.len();
             if batch_len == 0
@@ -359,6 +366,7 @@ impl Engine for GrpcEngineService {
                 &bytes_per_block_list,
                 &kv_stride_bytes_list,
                 &segments_list,
+                transfer_mode,
             ) {
                 let status = Self::map_engine_error(err);
                 let removed = self.registry.drop_context(context_key.clone()).await;
@@ -1053,6 +1061,7 @@ mod tests {
             kv_stride_bytes: Vec::new(),
             segments: Vec::new(),
             pp_rank: 0,
+            transfer_mode: ProtoTransferMode::Direct as i32,
         })
         .expect_err("tp_rank outside tp_size must be rejected at RPC boundary");
 
@@ -1077,6 +1086,7 @@ mod tests {
             kv_stride_bytes: Vec::new(),
             segments: Vec::new(),
             pp_rank: 0,
+            transfer_mode: ProtoTransferMode::Direct as i32,
         })
         .expect_err("client/server version mismatch must be rejected before registration");
 

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use cudarc::driver::CudaContext;
 use cudarc::driver::sys;
 use pegaflow_core::sync_state::{LOAD_STATE_ERROR, LOAD_STATE_SUCCESS};
-use pegaflow_core::{LoadState, PegaEngine, PrefetchStatus, StorageConfig};
+use pegaflow_core::{LoadState, PegaEngine, PrefetchStatus, StorageConfig, TransferMode};
 use pegaflow_server::proto::engine::engine_client::EngineClient;
 use pegaflow_server::proto::engine::engine_server::EngineServer;
 use pegaflow_server::proto::engine::{
@@ -533,6 +533,7 @@ fn register_instance_layers(
                 &[BYTES_PER_BLOCK],
                 &[0],
                 &[1],
+                TransferMode::Direct,
             )
             .expect("register_context_layer_batch");
     }

--- a/pegaflow-server/tests/http_cleanup_hang_repro.rs
+++ b/pegaflow-server/tests/http_cleanup_hang_repro.rs
@@ -38,7 +38,7 @@ use pegaflow_core::{PegaEngine, StorageConfig};
 use pegaflow_server::http_server::start_http_server;
 use pegaflow_server::proto::engine::engine_client::EngineClient;
 use pegaflow_server::proto::engine::engine_server::EngineServer;
-use pegaflow_server::proto::engine::{HealthRequest, RegisterContextRequest};
+use pegaflow_server::proto::engine::{HealthRequest, RegisterContextRequest, TransferMode};
 use pegaflow_server::{CudaTensorRegistry, GrpcEngineService, RegistryHandle};
 use prometheus::Registry;
 use pyo3::Python;
@@ -247,6 +247,7 @@ fn wedge_register_request(i: usize) -> RegisterContextRequest {
         kv_stride_bytes: vec![1],
         segments: vec![1],
         pp_rank: 0,
+        transfer_mode: TransferMode::Direct as i32,
     }
 }
 

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -320,6 +320,7 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
             &[BLOCK_SIZE],
             &[0], // kv_strides
             &[1], // segments
+            TransferMode::Direct,
         )
         .expect("register layer on engine A");
 
@@ -391,6 +392,7 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
             &[BLOCK_SIZE],
             &[0],
             &[1],
+            TransferMode::Direct,
         )
         .expect("register layer on engine B");
 

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -25,6 +25,7 @@ from pegaflow.connector.common import (
     detect_mla,
     logger,
     resolve_instance_id,
+    resolve_transfer_backend,
 )
 from pegaflow.connector.scheduler import SchedulerConnector
 from pegaflow.connector.state_manager import ServiceStateManager
@@ -101,6 +102,10 @@ class PegaKVConnector(KVConnectorBase_V1):
                 "pegaflow.mode", PegaConnectorMode.READ_WRITE.value
             )
         )
+        transfer_backend = resolve_transfer_backend(
+            is_mla,
+            vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.transfer_backend", None),
+        )
         self._engine_endpoint = f"{server_host}:{server_port}"
         engine_client = EngineRpcClient(self._engine_endpoint)
         logger.debug("[PegaKVConnector] Connected to engine server at %s", self._engine_endpoint)
@@ -118,6 +123,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             engine_client=engine_client,
             state_manager=self._state_manager,
             is_mla=is_mla,
+            transfer_backend=transfer_backend,
             dcp_world_size=dcp_world_size,
             pcp_world_size=pcp_world_size,
             dcp_rank=dcp_rank,
@@ -145,7 +151,7 @@ class PegaKVConnector(KVConnectorBase_V1):
         logger.debug(
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
             "tp_rank=%s tp_size=%d pp_rank=%d pp_size=%d world_size=%d namespace=%s "
-            "is_mla=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d mode=%s",
+            "is_mla=%s transfer_backend=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d mode=%s",
             role.name,
             instance_id,
             device_id if device_id is not None else "cpu",
@@ -156,6 +162,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             world_size,
             namespace,
             is_mla,
+            transfer_backend,
             dcp_world_size,
             pcp_world_size,
             dcp_rank,

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -54,6 +54,7 @@ class ConnectorContext:
     engine_client: EngineRpcClient
     state_manager: "ServiceStateManager"
     is_mla: bool = False
+    transfer_backend: str = "direct"
     dcp_world_size: int = 1
     pcp_world_size: int = 1
     dcp_rank: int = 0
@@ -234,6 +235,29 @@ def detect_mla(vllm_config) -> bool:
     return getattr(hf_config, "kv_lora_rank", None) is not None
 
 
+_TRANSFER_BACKENDS = ("direct", "kernel")
+
+
+def resolve_transfer_backend(is_mla: bool, override: str | None) -> str:
+    """Pick the engine's H2D/D2H backend for this model.
+
+    MLA models save/load many small, highly fragmented slots where the kernel
+    backend's single launch beats one cuMemcpyAsync per slot; everything else
+    defaults to direct (best bandwidth for few/large transfers). A non-empty
+    `override` (from `pegaflow.transfer_backend`) wins, and an unknown value is
+    rejected rather than silently falling back.
+    """
+    if override is None:
+        return "kernel" if is_mla else "direct"
+    normalized = override.strip().lower()
+    if normalized not in _TRANSFER_BACKENDS:
+        allowed = ", ".join(_TRANSFER_BACKENDS)
+        raise ValueError(
+            f"Unsupported pegaflow.transfer_backend {override!r}; expected one of: {allowed}"
+        )
+    return normalized
+
+
 __all__ = [
     "ConnectorContext",
     "LoadIntent",
@@ -247,4 +271,5 @@ __all__ = [
     "logger",
     "parse_env_int",
     "resolve_instance_id",
+    "resolve_transfer_backend",
 ]

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -240,8 +240,7 @@ class WorkerConnector:
             kv_cache_tensors = getattr(self._kv_cache_config, "kv_cache_tensors", None)
             if not kv_cache_tensors:
                 raise RuntimeError(
-                    "Layer-split KV cache registration requires "
-                    "kv_cache_config.kv_cache_tensors"
+                    "Layer-split KV cache registration requires kv_cache_config.kv_cache_tensors"
                 )
 
             layer_names = [
@@ -329,6 +328,7 @@ class WorkerConnector:
             layer_bytes_per_block,
             layer_kv_stride_bytes,
             layer_segments,
+            self._ctx.transfer_backend,
         )
 
         if not ok:

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -75,6 +75,7 @@ class EngineRpcClient:
         bytes_per_block_list: list[int],
         kv_stride_bytes_list: list[int],
         segments_list: list[int],
+        transfer_backend: str,
     ) -> tuple[bool, str]:
         """Register all KV cache layers on a GPU with a single RPC call.
 
@@ -100,13 +101,15 @@ class EngineRpcClient:
             bytes_per_block_list: List of block sizes per layer.
             kv_stride_bytes_list: List of K/V strides per layer.
             segments_list: List of segment counts per layer.
+            transfer_backend: H2D/D2H backend for this instance's GPU worker
+                pools, "direct" or "kernel". Chosen by the connector per model.
 
         Returns:
             Tuple of (ok, message) indicating success/failure.
 
         Raises:
             PegaFlowError: If server is unavailable.
-            ValueError: If request is invalid.
+            ValueError: If request is invalid or transfer_backend is unknown.
         """
         ...
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2,7 +2,7 @@ use pegaflow_core::LoadState;
 use pegaflow_proto::proto::engine::{
     HealthRequest, LeaseLoad, LoadRequest, QueryRequest, RegisterContextRequest, ReleaseRequest,
     ResponseStatus, SaveLayer, SaveRequest, SessionEvent, SessionRequest, ShutdownRequest,
-    UnregisterRequest, engine_client::EngineClient, query_response,
+    TransferMode, UnregisterRequest, engine_client::EngineClient, query_response,
 };
 use pyo3::{
     create_exception,
@@ -272,7 +272,7 @@ impl EngineRpcClient {
         clippy::too_many_arguments,
         reason = "PyO3 binding mirrors the public batch registration call shape"
     )]
-    #[pyo3(signature = (instance_id, namespace, tp_rank, pp_rank, tp_size, world_size, device_id, layer_names, wrapper_bytes_list, num_blocks_list, bytes_per_block_list, kv_stride_bytes_list, segments_list))]
+    #[pyo3(signature = (instance_id, namespace, tp_rank, pp_rank, tp_size, world_size, device_id, layer_names, wrapper_bytes_list, num_blocks_list, bytes_per_block_list, kv_stride_bytes_list, segments_list, transfer_backend))]
     fn register_context_batch(
         &self,
         py: Python<'_>,
@@ -289,7 +289,17 @@ impl EngineRpcClient {
         bytes_per_block_list: Vec<u64>,
         kv_stride_bytes_list: Vec<u64>,
         segments_list: Vec<u32>,
+        transfer_backend: &str,
     ) -> PyResult<(bool, String)> {
+        let transfer_mode = match transfer_backend {
+            "direct" => TransferMode::Direct,
+            "kernel" => TransferMode::Kernel,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown transfer_backend '{other}' (expected 'direct' or 'kernel')"
+                )));
+            }
+        };
         self.call(py, "register_context_batch", |mut c| async move {
             let resp = c
                 .register_context_batch(RegisterContextRequest {
@@ -307,6 +317,7 @@ impl EngineRpcClient {
                     kv_stride_bytes: kv_stride_bytes_list,
                     segments: segments_list,
                     pp_rank,
+                    transfer_mode: transfer_mode as i32,
                 })
                 .await?;
             Ok(resp.into_inner())

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -271,6 +271,7 @@ class ClientContext:
             bytes_per_block_list,
             kv_stride_bytes_list,
             segments_list,
+            "direct",
         )
 
         if not ok:

--- a/python/tests/session_crash_helper.py
+++ b/python/tests/session_crash_helper.py
@@ -51,6 +51,7 @@ def main() -> int:
         [bytes_per_block],
         [kv_stride_bytes],
         [segments],
+        "direct",
     )
     if not ok:
         print(f"register_context_batch failed: {msg}", file=sys.stderr)

--- a/python/tests/test_vllm_e2e_correctness.py
+++ b/python/tests/test_vllm_e2e_correctness.py
@@ -229,7 +229,6 @@ class TestE2ECorrectness:
     def pegaflow_server(
         self,
         log_dir: Path,
-        pegaflow_transfer_backend: str,
         pegaflow_use_hugepages: bool,
         pegaflow_pool_size: str,
     ):
@@ -237,7 +236,6 @@ class TestE2ECorrectness:
         with PegaFlowServer(
             log_file=log_dir / "pegaflow-server.log",
             pool_size=pegaflow_pool_size,
-            transfer_backend=pegaflow_transfer_backend,
             use_hugepages=pegaflow_use_hugepages,
         ) as server:
             yield server
@@ -280,6 +278,7 @@ class TestE2ECorrectness:
         model: str,
         base_port: int,
         pegaflow_server: PegaFlowServer,
+        pegaflow_transfer_backend: str,
         log_dir: Path,
         tensor_parallel_size: int,
         pipeline_parallel_size: int,
@@ -299,6 +298,7 @@ class TestE2ECorrectness:
             tensor_parallel_size=tensor_parallel_size,
             pipeline_parallel_size=pipeline_parallel_size,
             max_model_len=max_model_len,
+            transfer_backend=pegaflow_transfer_backend,
         ):
             metrics_port = pegaflow_server.metrics_port
             metrics_start = fetch_pegaflow_metrics(metrics_port)

--- a/python/tests/test_vllm_p2p_pp4_e2e.py
+++ b/python/tests/test_vllm_p2p_pp4_e2e.py
@@ -231,7 +231,6 @@ class PegaServer(ManagedProcess):
         devices: str,
         log_dir: Path,
         pool_size: str,
-        transfer_backend: str,
         metaserver: MetaServer,
         nics: str,
         advertise_host: str,
@@ -251,8 +250,6 @@ class PegaServer(ManagedProcess):
                 devices,
                 "--pool-size",
                 pool_size,
-                "--transfer-backend",
-                transfer_backend,
                 "--log-level",
                 os.environ.get("PEGAFLOW_LOG_LEVEL", "debug"),
                 "--disable-numa-affinity",
@@ -290,6 +287,7 @@ class VllmReplica(ManagedProcess):
         pega_server: PegaServer,
         log_dir: Path,
         max_model_len: int,
+        transfer_backend: str,
     ) -> None:
         kv_config = {
             "kv_connector": "PegaKVConnector",
@@ -299,6 +297,7 @@ class VllmReplica(ManagedProcess):
                 "pegaflow.host": f"http://{pega_server.grpc_host}",
                 "pegaflow.port": pega_server.grpc_port,
                 "pegaflow.mode": "read_write",
+                "pegaflow.transfer_backend": transfer_backend,
             },
         }
         env = _env()
@@ -541,7 +540,6 @@ def test_pp4_p2p_matches_local_cache_load(
                 source_devices,
                 log_dir,
                 pool_size,
-                pegaflow_transfer_backend,
                 metaserver,
                 nics,
                 server_host,
@@ -556,6 +554,7 @@ def test_pp4_p2p_matches_local_cache_load(
                 source_pega,
                 log_dir,
                 server_max_model_len,
+                pegaflow_transfer_backend,
             )
         )
 
@@ -580,6 +579,7 @@ def test_pp4_p2p_matches_local_cache_load(
             source_pega,
             log_dir,
             server_max_model_len,
+            pegaflow_transfer_backend,
         ):
             local_before = fetch_pegaflow_metrics(source_pega.metrics_port)
             local_outputs = _call_batch(local_consumer_port, PROMPTS, request_max_tokens)
@@ -600,7 +600,6 @@ def test_pp4_p2p_matches_local_cache_load(
                 consumer_devices,
                 log_dir,
                 pool_size,
-                pegaflow_transfer_backend,
                 metaserver,
                 nics,
                 server_host,
@@ -614,6 +613,7 @@ def test_pp4_p2p_matches_local_cache_load(
             remote_pega,
             log_dir,
             server_max_model_len,
+            pegaflow_transfer_backend,
         ):
             rdma_before = fetch_pegaflow_metrics(remote_pega.metrics_port)
             rdma_series_before = _snapshot_metrics(

--- a/python/tests/vllm_helpers.py
+++ b/python/tests/vllm_helpers.py
@@ -55,11 +55,13 @@ class VLLMServer:
         kv_transfer_config: dict[str, object] | None = None,
         server_label: str | None = None,
         env_overrides: dict[str, str] | None = None,
+        transfer_backend: str | None = None,
     ):
         self.model = model
         self.port = port
         self.use_pegaflow = use_pegaflow
         self.pegaflow_port = pegaflow_port
+        self.transfer_backend = transfer_backend
         self.log_file = log_file
         self.max_model_len = max_model_len
         self.tensor_parallel_size = tensor_parallel_size
@@ -130,11 +132,18 @@ class VLLMServer:
             cmd.extend(["--kv-transfer-config", json.dumps(self.kv_transfer_config)])
         elif self.use_pegaflow or self.use_noop_connector:
             connector_name = "PegaKVConnector" if self.use_pegaflow else "NoopKVConnector"
-            kv_config = {
+            kv_config: dict[str, object] = {
                 "kv_connector": connector_name,
                 "kv_role": "kv_both",
                 "kv_connector_module_path": "pegaflow.connector",
             }
+            # The server no longer selects a transfer backend; the connector
+            # does. Force it here so --pegaflow-transfer-backend still exercises
+            # the chosen path end-to-end, regardless of the model's MLA default.
+            if self.use_pegaflow and self.transfer_backend is not None:
+                kv_config["kv_connector_extra_config"] = {
+                    "pegaflow.transfer_backend": self.transfer_backend,
+                }
             cmd.extend(["--kv-transfer-config", json.dumps(kv_config)])
 
         cmd.extend(self.extra_args)
@@ -297,14 +306,12 @@ class PegaFlowServer:
         pool_size: str = "30gb",
         log_level: str | None = None,
         cargo_features: list[str] | None = None,
-        transfer_backend: str = "direct",
         use_hugepages: bool = False,
     ):
         self.grpc_port = find_available_port()
         self.http_port = find_available_port()
         self.pool_size = pool_size
         self.log_level = log_level
-        self.transfer_backend = transfer_backend
         self.use_hugepages = use_hugepages
         self.cargo_features = (
             cargo_features if cargo_features is not None else _detect_pegaflow_cargo_features()
@@ -339,8 +346,6 @@ class PegaFlowServer:
                 f"0.0.0.0:{self.http_port}",
                 "--pool-size",
                 self.pool_size,
-                "--transfer-backend",
-                self.transfer_backend,
                 "--enable-prometheus",
             ]
         )
@@ -372,7 +377,6 @@ class PegaFlowServer:
         feature_label = ",".join(self.cargo_features) or "default"
         print(
             f"\n[PegaFlow Server] cargo run -r features={feature_label} "
-            f"transfer_backend={self.transfer_backend} "
             f"on gRPC={self.grpc_port}, HTTP={self.http_port}"
         )
 


### PR DESCRIPTION
## 背景

KV cache 的 H2D/D2H 传输有 `kernel` 和 `direct` 两种 backend：

- `direct`：每个合并后的连续区间一次 `cuMemcpyAsync`，走 DMA copy engine，少而大的传输带宽最好。
- `kernel`：单个 grid-strided copy kernel 扫过映射的 pinned 内存，碎片化的小块传输更划算。

之前这个选择是 **server 启动时静态决定**（`--transfer-backend` flag），对用户是额外的认知负担：用户得自己知道哪个模型该用哪个 backend。

## 改动

让 **connector 在注册时按模型自动选择**，并把选择**随每次注册经 RPC 下发**，server 启动不再静态选 backend。

- **策略下沉到 connector**：MLA 模型默认 `kernel`（save/load 是大量碎片化小 slot，单次 kernel launch 胜过逐 slot 的 `cuMemcpyAsync`），其余默认 `direct`。用户仍可通过 connector extra config 的 `pegaflow.transfer_backend` 按实例 override；非法值直接报错，不静默回退。
- **proto**：`TransferMode` 改为 `DIRECT=0 / KERNEL=1`（去掉 `UNSPECIFIED`），`transfer_mode` 挂在 `RegisterContextRequest` 上。该 mode 在 pegaflow-core 里按注册粒度穿透，每个 (instance, GPU) worker pool 使用 connector 选定的 backend。
- **移除 server 侧静态机制**：`--transfer-backend` CLI flag、`StorageConfig`/engine 上的字段、以及 `FromStr for TransferMode` 全部删除——server 不再挑 backend。
- **PyO3**：`register_context_batch` 增加 `transfer_backend: &str` 入参，映射到 proto enum。

## 验证

- `cargo check` / `clippy` 干净；`cargo test --release`（含 GPU 测试）通过；engine_basic 7/7。
- source-only Python 默认 gate 全绿。
- vLLM e2e correctness（`tests/test_vllm_e2e_correctness.py`）在 `direct` 与 `kernel` 两种 backend 下各 4 passed，server 日志分别确认 `transfer_mode=Direct` / `transfer_mode=Kernel`，证明 connector → RPC → engine 的 backend 选择端到端生效。

测试硬件：单卡消费级 GPU（CUDA 13 / sm_120）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
