### PR TITLE
feat(connector): distribute MLA TP save across ranks by layer

### DIFF
--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -529,56 +529,9 @@ impl InstanceContext {
         &self.namespace
     }
 
-    /// Access the effective TP size registered with the engine.
-    pub(crate) fn tp_size(&self) -> usize {
-        self.tp_size
-    }
-
     /// Total worker count registered for this instance.
     pub(crate) fn world_size(&self) -> usize {
         self.world_size
-    }
-
-    /// Return unique valid NUMA nodes for registered shards in one save group.
-    pub(crate) fn registered_numa_nodes_for_save_group(
-        &self,
-        tp_rank: usize,
-        pp_rank: usize,
-    ) -> Vec<NumaNode> {
-        let state = self.state.lock();
-        let mut nodes: Vec<NumaNode> = state
-            .gpu_contexts
-            .values()
-            .filter(|gpu| gpu.tp_rank() == tp_rank && gpu.pp_rank() == pp_rank)
-            .map(|gpu| gpu.preferred_numa())
-            .filter(|node| node.is_valid())
-            .collect();
-        nodes.sort_unstable();
-        nodes.dedup();
-        nodes
-    }
-
-    /// Validate that a save placement hint targets a registered shard NUMA node.
-    pub(crate) fn validate_save_numa_hint(
-        &self,
-        tp_rank: usize,
-        pp_rank: usize,
-        numa_node: NumaNode,
-    ) -> Result<NumaNode, EngineError> {
-        if !numa_node.is_valid() {
-            return Err(EngineError::InvalidArgument(format!(
-                "save NUMA hint must be a valid NUMA node, got {numa_node}"
-            )));
-        }
-
-        let candidates = self.registered_numa_nodes_for_save_group(tp_rank, pp_rank);
-        if candidates.contains(&numa_node) {
-            return Ok(numa_node);
-        }
-
-        Err(EngineError::InvalidArgument(format!(
-            "save NUMA hint {numa_node} is not registered for tp_rank {tp_rank}, pp_rank {pp_rank}; candidates={candidates:?}"
-        )))
     }
 
     /// Verify that the topology matches expected values.

--- a/pegaflow-core/src/instance/tests.rs
+++ b/pegaflow-core/src/instance/tests.rs
@@ -293,19 +293,3 @@ fn seal_rejects_inconsistent_layer_geometry() {
         .expect_err("same name with different geometry must fail the seal");
     assert!(err.to_string().contains("inconsistent geometry"));
 }
-
-#[test]
-fn save_numa_hint_validation_rejects_unknown_or_unregistered_nodes() {
-    let instance = InstanceContext::new("hint-instance".to_string(), "hint-ns".to_string(), 1, 1)
-        .expect("create instance");
-
-    let err = instance
-        .validate_save_numa_hint(0, 0, NumaNode::UNKNOWN)
-        .expect_err("unknown NUMA hint should fail");
-    assert!(err.to_string().contains("valid NUMA node"));
-
-    let err = instance
-        .validate_save_numa_hint(0, 0, NumaNode(0))
-        .expect_err("unregistered NUMA hint should fail");
-    assert!(err.to_string().contains("not registered"));
-}

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -453,23 +453,6 @@ impl PegaEngine {
             .collect()
     }
 
-    /// Return the effective TP size registered for this instance.
-    pub fn instance_tp_size(&self, instance_id: &str) -> Result<usize, EngineError> {
-        Ok(self.get_instance(instance_id)?.tp_size())
-    }
-
-    /// Return the unique valid NUMA nodes used by a registered save group.
-    pub fn registered_numa_nodes_for_save_group(
-        &self,
-        instance_id: &str,
-        tp_rank: usize,
-        pp_rank: usize,
-    ) -> Result<Vec<NumaNode>, EngineError> {
-        Ok(self
-            .get_instance(instance_id)?
-            .registered_numa_nodes_for_save_group(tp_rank, pp_rank))
-    }
-
     /// Count prefix hit blocks with SSD prefetch support.
     ///
     /// Argument contract:

--- a/pegaflow-core/src/offload.rs
+++ b/pegaflow-core/src/offload.rs
@@ -148,6 +148,9 @@ impl PegaEngine {
     /// reduces Python-Rust boundary crossings and batches GPU copies + storage
     /// operations across all layers for minimal lock overhead and a single
     /// CUDA stream synchronization.
+    ///
+    /// Pinned memory is allocated on the saving GPU's own NUMA node, keeping
+    /// every D2H copy socket-local.
     pub async fn batch_save_kv_blocks_from_ipc(
         &self,
         instance_id: &str,
@@ -155,36 +158,6 @@ impl PegaEngine {
         pp_rank: usize,
         device_id: i32,
         saves: Vec<LayerSave>,
-    ) -> Result<(), EngineError> {
-        self.batch_save_kv_blocks_from_ipc_with_numa_hint(
-            instance_id,
-            tp_rank,
-            pp_rank,
-            device_id,
-            saves,
-            None,
-        )
-        .await
-    }
-
-    /// Batch save KV blocks with an optional NUMA allocation override.
-    ///
-    /// `numa_hint` only changes the pinned-memory allocation node and the
-    /// recorded slot NUMA metadata. CUDA reads still use the registered GPU
-    /// context identified by `device_id`. Hints are accepted only when they
-    /// target a registered NUMA node for this effective TP/PP group.
-    #[allow(
-        clippy::too_many_arguments,
-        reason = "save requests carry the externally registered KV layout fields"
-    )]
-    pub async fn batch_save_kv_blocks_from_ipc_with_numa_hint(
-        &self,
-        instance_id: &str,
-        tp_rank: usize,
-        pp_rank: usize,
-        device_id: i32,
-        saves: Vec<LayerSave>,
-        numa_hint: Option<NumaNode>,
     ) -> Result<(), EngineError> {
         self.query_leases.sweep_expired();
 
@@ -308,10 +281,7 @@ impl PegaEngine {
         // ── Phase 2: Allocate pinned memory + build SaveBlocks for all layers ──
 
         trace_scope!("save.pinned_alloc", _s);
-        let save_numa_node = match numa_hint {
-            Some(hint) => instance.validate_save_numa_hint(tp_rank, pp_rank, hint)?,
-            None => gpu_context.preferred_numa(),
-        };
+        let save_numa_node = gpu_context.preferred_numa();
         let numa_node = Some(save_numa_node);
         let blockwise = self.storage.blockwise_alloc();
 

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -14,7 +14,6 @@ use crate::proto::engine::{
 use crate::registry::RegistryHandle;
 use crate::session::SessionRegistry;
 use log::{debug, info, warn};
-use pegaflow_common::NumaNode;
 use pegaflow_core::{EngineError, LayerSave, PegaEngine, PrefetchStatus, QueryLeaseId};
 use std::sync::Arc;
 use std::time::Instant;
@@ -198,55 +197,6 @@ impl GrpcEngineService {
                 numa_node: numa_node.0,
             }
         }
-    }
-
-    fn save_numa_hint(
-        &self,
-        instance_id: &str,
-        tp_rank: usize,
-        pp_rank: usize,
-    ) -> Option<NumaNode> {
-        if tp_rank != 0 {
-            return None;
-        }
-
-        match self.engine.instance_tp_size(instance_id) {
-            Ok(1) => {}
-            Ok(_) => return None,
-            Err(err) => {
-                debug!(
-                    "save NUMA hint skipped: instance={} tp_rank={} could not read instance topology: {}",
-                    instance_id, tp_rank, err
-                );
-                return None;
-            }
-        }
-
-        let candidates = match self.engine.registered_numa_nodes_for_save_group(
-            instance_id,
-            tp_rank,
-            pp_rank,
-        ) {
-            Ok(candidates) => candidates,
-            Err(err) => {
-                debug!(
-                    "save NUMA hint skipped: instance={} tp_rank={} pp_rank={} could not read shard NUMA nodes: {}",
-                    instance_id, tp_rank, pp_rank, err
-                );
-                return None;
-            }
-        };
-
-        let hint =
-            self.session_registry
-                .next_save_numa_hint(instance_id, tp_rank, pp_rank, &candidates);
-        if let Some(numa) = hint {
-            debug!(
-                "save NUMA hint selected: instance={} tp_rank={} pp_rank={} session_tp_size={} candidates={:?} hint={}",
-                instance_id, tp_rank, pp_rank, numa.session_tp_size, candidates, numa.numa_node
-            );
-        }
-        hint.map(|hint| hint.numa_node)
     }
 }
 
@@ -446,17 +396,8 @@ impl Engine for GrpcEngineService {
                 instance_id, tp_rank, pp_rank, device_id, layer_count, total_blocks, total_hashes
             );
 
-            let numa_hint = self.save_numa_hint(&instance_id, tp_rank, pp_rank);
-
             self.engine
-                .batch_save_kv_blocks_from_ipc_with_numa_hint(
-                    &instance_id,
-                    tp_rank,
-                    pp_rank,
-                    device_id,
-                    saves,
-                    numa_hint,
-                )
+                .batch_save_kv_blocks_from_ipc(&instance_id, tp_rank, pp_rank, device_id, saves)
                 .await
                 .map_err(Self::map_engine_error)?;
 

--- a/pegaflow-server/src/session.rs
+++ b/pegaflow-server/src/session.rs
@@ -6,9 +6,6 @@
 //! a no-op.
 
 use dashmap::DashMap;
-use parking_lot::Mutex;
-use pegaflow_common::NumaNode;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -19,22 +16,9 @@ pub struct SessionTopology {
     pub world_size: u32,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct SaveNumaHint {
-    pub session_tp_size: u32,
-    pub numa_node: NumaNode,
-}
-
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-struct SaveNumaGroup {
-    tp_rank: usize,
-    pp_rank: usize,
-}
-
 struct SessionEntry {
     token: u64,
     topology: SessionTopology,
-    save_numa_cursors: Mutex<HashMap<SaveNumaGroup, usize>>,
 }
 
 #[derive(Default)]
@@ -68,7 +52,6 @@ impl SessionRegistry {
                     tp_size,
                     world_size,
                 },
-                save_numa_cursors: Mutex::new(HashMap::new()),
             },
         );
         token
@@ -78,34 +61,6 @@ impl SessionRegistry {
         self.sessions
             .get(instance_id)
             .map(|entry| entry.topology.clone())
-    }
-
-    pub fn next_save_numa_hint(
-        &self,
-        instance_id: &str,
-        tp_rank: usize,
-        pp_rank: usize,
-        candidates: &[NumaNode],
-    ) -> Option<SaveNumaHint> {
-        if tp_rank != 0 || candidates.len() < 2 {
-            return None;
-        }
-        let entry = self.sessions.get(instance_id)?;
-        if entry.topology.tp_size <= 1 {
-            return None;
-        }
-        let group = SaveNumaGroup { tp_rank, pp_rank };
-        let index = {
-            let mut cursors = entry.save_numa_cursors.lock();
-            let cursor = cursors.entry(group).or_insert(0);
-            let index = *cursor % candidates.len();
-            *cursor = cursor.wrapping_add(1);
-            index
-        };
-        Some(SaveNumaHint {
-            session_tp_size: entry.topology.tp_size,
-            numa_node: candidates[index],
-        })
     }
 
     /// CAS-remove: only removes if `token` is still the current one.
@@ -146,102 +101,5 @@ mod tests {
         assert!(!registry.take("inst", first));
         assert!(registry.take("inst", second));
         assert_eq!(registry.topology("inst"), None);
-    }
-
-    #[test]
-    fn save_numa_hint_round_robins_candidates() {
-        let registry = SessionRegistry::default();
-        registry.install("inst".to_string(), "ns".to_string(), 8, 8);
-        let candidates = [NumaNode(0), NumaNode(1), NumaNode(2)];
-
-        assert_eq!(
-            registry.next_save_numa_hint("inst", 0, 0, &candidates),
-            Some(SaveNumaHint {
-                session_tp_size: 8,
-                numa_node: NumaNode(0),
-            })
-        );
-        assert_eq!(
-            registry.next_save_numa_hint("inst", 0, 0, &candidates),
-            Some(SaveNumaHint {
-                session_tp_size: 8,
-                numa_node: NumaNode(1),
-            })
-        );
-        assert_eq!(
-            registry.next_save_numa_hint("inst", 0, 0, &candidates),
-            Some(SaveNumaHint {
-                session_tp_size: 8,
-                numa_node: NumaNode(2),
-            })
-        );
-        assert_eq!(
-            registry.next_save_numa_hint("inst", 0, 0, &candidates),
-            Some(SaveNumaHint {
-                session_tp_size: 8,
-                numa_node: NumaNode(0),
-            })
-        );
-    }
-
-    #[test]
-    fn save_numa_hint_checks_eligibility_without_advancing_cursor() {
-        let registry = SessionRegistry::default();
-        let candidates = [NumaNode(0), NumaNode(1)];
-
-        registry.install("inst".to_string(), "ns".to_string(), 1, 1);
-        assert_eq!(
-            registry.next_save_numa_hint("inst", 0, 0, &candidates),
-            None
-        );
-
-        registry.install("inst".to_string(), "ns".to_string(), 8, 8);
-        assert_eq!(
-            registry.next_save_numa_hint("inst", 1, 0, &candidates),
-            None
-        );
-        assert_eq!(
-            registry.next_save_numa_hint("inst", 0, 0, &candidates),
-            Some(SaveNumaHint {
-                session_tp_size: 8,
-                numa_node: NumaNode(0),
-            })
-        );
-    }
-
-    #[test]
-    fn save_numa_hint_round_robins_pp_groups_independently() {
-        let registry = SessionRegistry::default();
-        registry.install("inst".to_string(), "ns".to_string(), 8, 16);
-        let candidates = [NumaNode(0), NumaNode(1)];
-
-        assert_eq!(
-            registry.next_save_numa_hint("inst", 0, 0, &candidates),
-            Some(SaveNumaHint {
-                session_tp_size: 8,
-                numa_node: NumaNode(0),
-            })
-        );
-        assert_eq!(
-            registry.next_save_numa_hint("inst", 0, 1, &candidates),
-            Some(SaveNumaHint {
-                session_tp_size: 8,
-                numa_node: NumaNode(0),
-            })
-        );
-        assert_eq!(
-            registry.next_save_numa_hint("inst", 0, 0, &candidates),
-            Some(SaveNumaHint {
-                session_tp_size: 8,
-                numa_node: NumaNode(1),
-            })
-        );
-        assert_eq!(
-            registry.next_save_numa_hint("inst", 0, 1, &candidates),
-            Some(SaveNumaHint {
-                session_tp_size: 8,
-                numa_node: NumaNode(1),
-            })
-        );
     }
 }

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -132,6 +132,19 @@ class PegaKVConnector(KVConnectorBase_V1):
             mode=mode,
         )
 
+        # MLA attention backends expose no num-layers stride dimension, so vLLM
+        # cannot build a cross-layer (uniform) KV cache for MLA. Requesting it
+        # is silently ignored upstream and falls back to per-layer — surface
+        # that instead of pretending the request was honored.
+        env_cross_layer = os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
+        self._prefer_cross_layer = env_cross_layer and not is_mla
+        if is_mla and env_cross_layer:
+            logger.warning(
+                "[PegaKVConnector] PEGAFLOW_CROSS_LAYER_BLOCKS=1 is ignored for MLA "
+                "models: cross-layer KV cache is unsupported by MLA attention backends; "
+                "using per-layer registration."
+            )
+
         self._scheduler: SchedulerConnector | None = None
         self._worker: WorkerConnector | None = None
         if role == KVConnectorRole.SCHEDULER:
@@ -312,7 +325,7 @@ class PegaKVConnector(KVConnectorBase_V1):
 
     @property
     def prefer_cross_layer_blocks(self) -> bool:
-        return os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
+        return self._prefer_cross_layer
 
     def register_cross_layers_kv_cache(self, kv_cache, attn_backend):
         if not self._worker:
@@ -339,10 +352,12 @@ class NoopKVConnector(KVConnectorBase_V1):
 
     def __init__(self, vllm_config, role: KVConnectorRole, kv_cache_config=None):
         super().__init__(vllm_config, role, kv_cache_config)
+        self._is_mla = detect_mla(vllm_config)
 
     @property
     def prefer_cross_layer_blocks(self) -> bool:
-        return os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
+        # MLA cannot use cross-layer KV (no num-layers stride); be honest.
+        return not self._is_mla and os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
 
     def start_load_kv(self, forward_context, **kwargs: Any) -> None:
         return

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -198,6 +198,8 @@ class WorkerConnector:
         self._failed_load_reqs: set[str] = set()
 
         self._registered_layers: list[str] = []
+        # Layer subset this rank saves (MLA replica sharding); None = save all.
+        self._save_layer_shard: list[str] | None = None
         self._torch_device: torch.device | None = None
 
         self._cross_layer_mode = False
@@ -265,6 +267,7 @@ class WorkerConnector:
             raise RuntimeError("No KV cache layers were selected for registration")
 
         self._registered_layers = list(kv_caches.keys())
+        self._save_layer_shard = self._compute_save_layer_shard()
         self._torch_device = next(iter(kv_caches.values())).device
 
         layout = "unknown"
@@ -646,19 +649,6 @@ class WorkerConnector:
 
         request_ids = list(metadata.save_intents.keys())
 
-        if self._should_skip_save_submission():
-            logger.debug(
-                "[PegaKVConnector] Skipping save submission on non-zero TP rank for MLA "
-                "without DCP: tp_rank=%s reqs=%s",
-                self._ctx.tp_rank,
-                request_ids,
-            )
-            with self._save_completion_lock:
-                for req_id in request_ids:
-                    self._req_pending_saves.add(req_id)
-            self._complete_save_requests(request_ids)
-            return
-
         with self._save_completion_lock:
             for req_id in request_ids:
                 if req_id not in self._req_pending_saves:
@@ -708,6 +698,9 @@ class WorkerConnector:
 
                 if self._cross_layer_mode:
                     target_layers = (self._cross_layer_key,)
+                elif self._save_layer_shard is not None:
+                    # MLA replica save: this rank only writes its layer slice.
+                    target_layers = tuple(self._save_layer_shard)
                 else:
                     assert self._registered_layers, (
                         "KV caches must be registered before submitting save intents"
@@ -798,13 +791,43 @@ class WorkerConnector:
                 suffix,
             )
 
-    def _should_skip_save_submission(self) -> bool:
+    def _mla_replica_save(self) -> bool:
+        """Whether to shard the save by layer across TP ranks.
+
+        MLA without DCP replicates the full KV on every TP rank's GPU. Instead
+        of TP0 saving every layer (one GPU's copy engine carries all D2H), each
+        rank writes its own layer slice to its NUMA-local pool. Returns False
+        when KV is already unique per rank (non-MLA), per-rank layer-split
+        registration is in effect, or DCP makes each rank store distinct tokens.
+        """
         return (
             self._ctx.is_mla
             and not self._use_mla_layer_split_registration
             and self._ctx.dcp_world_size == 1
-            and (self._ctx.tp_rank or 0) != 0
+            and self._ctx.tp_size > 1
         )
+
+    def _compute_save_layer_shard(self) -> list[str] | None:
+        """Layer subset this rank is responsible for saving, or None for all.
+
+        Ranks sort registered layer names (matching the server's sorted-name
+        layer-id space) and take a strided slice. Striding by tp_rank is a
+        disjoint, complete partition of the layers with no cross-rank
+        coordination, so the union still fills every block's slots.
+
+        Correctness depends on every rank in the save group registering the
+        identical layer set, which holds here by construction: this path runs
+        only when `_mla_replica_save()` is true, i.e. MLA fully replicates the
+        KV cache across TP ranks and each rank registers the same full layer
+        set. The one mode that registers a per-rank layer subset
+        (`mla_layer_split_kv_cache`) is excluded by `_mla_replica_save()` and
+        already distributes the save itself.
+        """
+        if not self._mla_replica_save():
+            return None
+        ordered = sorted(self._registered_layers)
+        tp_rank = self._ctx.tp_rank or 0
+        return [name for idx, name in enumerate(ordered) if idx % self._ctx.tp_size == tp_rank]
 
     def handle_preemptions(self, preempted_req_ids: set[str] | None) -> None:
         """Wait for preempted requests' saves to complete before blocks are reused.

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -12,7 +12,12 @@ from .unit_stubs import install_connector_unit_stubs
 
 install_connector_unit_stubs()
 
-from pegaflow.connector.common import ConnectorContext, PegaConnectorMode  # noqa: E402
+from pegaflow.connector.common import (  # noqa: E402
+    ConnectorContext,
+    PegaConnectorMetadata,
+    PegaConnectorMode,
+    SaveIntent,
+)
 from pegaflow.connector.scheduler import SchedulerConnector  # noqa: E402
 from pegaflow.pegaflow import QueryLoading, QueryReady  # noqa: E402
 
@@ -117,43 +122,43 @@ def test_effective_tp_cases(case: str, kwargs: dict, expected_rank: int, expecte
     ("case", "kwargs", "additional_config", "expected"),
     [
         pytest.param(
-            "ordinary_mla_replica_skips_nonzero_tp_save",
-            {
-                "is_mla": True,
-                "tp_rank": 1,
-                "tp_size": 2,
-            },
+            "ordinary_mla_replica_shards_by_layer",
+            {"is_mla": True, "tp_rank": 1, "tp_size": 2},
             {},
             True,
             id="ordinary_mla_replica",
         ),
         pytest.param(
-            "mla_layer_split_registration_does_not_skip_nonzero_tp_save",
-            {
-                "is_mla": True,
-                "tp_rank": 1,
-                "tp_size": 2,
-            },
+            "mla_layer_split_registration_already_distributes",
+            {"is_mla": True, "tp_rank": 1, "tp_size": 2},
             {"mla_layer_split_kv_cache": True},
             False,
             id="mla_layer_split_registration",
         ),
         pytest.param(
-            "dcp_mla_does_not_skip_save",
-            {
-                "is_mla": True,
-                "tp_rank": 1,
-                "tp_size": 2,
-                "dcp_world_size": 2,
-                "dcp_rank": 1,
-            },
+            "dcp_mla_stores_distinct_tokens",
+            {"is_mla": True, "tp_rank": 1, "tp_size": 2, "dcp_world_size": 2, "dcp_rank": 1},
             {},
             False,
             id="dcp_mla",
         ),
+        pytest.param(
+            "non_mla_already_unique_per_rank",
+            {"is_mla": False, "tp_rank": 1, "tp_size": 2},
+            {},
+            False,
+            id="non_mla",
+        ),
+        pytest.param(
+            "mla_single_gpu_nothing_to_shard",
+            {"is_mla": True, "tp_rank": 0, "tp_size": 1},
+            {},
+            False,
+            id="mla_tp1",
+        ),
     ],
 )
-def test_save_skip_keeps_ordinary_mla_optimization(
+def test_mla_replica_save_detection(
     case: str, kwargs: dict, additional_config: dict, expected: bool
 ):
     from pegaflow.connector.worker import WorkerConnector
@@ -164,9 +169,61 @@ def test_save_skip_keeps_ordinary_mla_optimization(
         vllm_config=SimpleNamespace(additional_config=additional_config),
     )
     try:
-        assert worker._should_skip_save_submission() is expected, case
+        assert worker._mla_replica_save() is expected, case
     finally:
         worker.shutdown()
+
+
+def test_mla_save_layer_shard_is_a_partition():
+    """Across ranks the per-rank layer shards must be disjoint and cover every
+    layer — otherwise blocks never seal (missing slot) or get double-saved."""
+    from pegaflow.connector.worker import WorkerConnector
+
+    layers = [f"model.layers.{i}.self_attn.attn" for i in range(13)]
+    tp_size = 4
+
+    seen: list[str] = []
+    for tp_rank in range(tp_size):
+        ctx = _make_ctx(is_mla=True, tp_rank=tp_rank, tp_size=tp_size)
+        worker = WorkerConnector(ctx, vllm_config=SimpleNamespace(additional_config={}))
+        try:
+            worker._registered_layers = list(layers)
+            shard = worker._compute_save_layer_shard()
+            worker._registered_layers = []  # skip mock unregister on shutdown
+        finally:
+            worker.shutdown()
+        assert shard is not None, tp_rank
+        seen.extend(shard)
+
+    # Equal sorted multisets ⇒ complete coverage and no duplicates across ranks.
+    assert sorted(seen) == sorted(layers)
+
+
+def test_mla_replica_save_submits_only_this_ranks_shard():
+    """A non-zero MLA rank must save its layer slice (not all layers, not
+    nothing) — this is what replaces the old TP0-only save."""
+    from pegaflow.connector.worker import SaveTask, WorkerConnector
+
+    ctx = _make_ctx(is_mla=True, tp_rank=1, tp_size=2, device_id=1)
+    worker = WorkerConnector(ctx, vllm_config=SimpleNamespace(additional_config={}))
+    worker._registered_layers = ["a", "b", "c", "d"]
+    worker._save_layer_shard = worker._compute_save_layer_shard()  # sorted idx%2==1 → b, d
+    worker._torch_device = None
+    ctx.engine_client.save.return_value = (True, "")
+
+    meta = PegaConnectorMetadata(
+        save_intents={"r1": SaveIntent(block_ids=(0, 1), block_hashes=(b"h0", b"h1"))}
+    )
+    try:
+        with patch("torch.cuda.synchronize"):
+            worker._process_save_batch([SaveTask(metadata=meta, request_ids=["r1"])])
+    finally:
+        worker._registered_layers = []  # skip mock unregister on shutdown
+        worker.shutdown()
+
+    ctx.engine_client.save.assert_called_once()
+    saves_list = ctx.engine_client.save.call_args.args[4]
+    assert {name for name, _ids, _hashes in saves_list} == {"b", "d"}
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_mla_replica_registration.py
+++ b/python/tests/test_mla_replica_registration.py
@@ -191,8 +191,9 @@ def test_mla_replica_devices_save_and_load(dual_device_server):
             workers.append(worker)
             worker.register()
 
-        # Only the effective rank-0 worker submits saves for MLA models
-        # (WorkerConnector._should_skip_save_submission); it saves every layer.
+        # Drive the engine directly: rank-0 saves every layer (a valid server
+        # path — replica slots accept any device as owner, see #336). Connector-
+        # level per-rank layer sharding is covered in test_combine_hashes.py.
         block_hashes = [uuid.uuid4().bytes * 2 for _ in SAVED_BLOCK_IDS]
         saves = [(name, SAVED_BLOCK_IDS, block_hashes) for name in layer_names]
         ok, message = engine_client.save(

--- a/python/tests/unit_stubs.py
+++ b/python/tests/unit_stubs.py
@@ -46,6 +46,10 @@ def _install_torch_stub() -> None:
         def empty_cache() -> None:
             return None
 
+        @staticmethod
+        def synchronize(_device=None) -> None:
+            return None
+
     class _Random:
         @staticmethod
         def manual_seed(_seed: int) -> None:


### PR DESCRIPTION
## Problem

MLA replicates the latent KV cache across every TP rank (it is not sharded by head like MHA). On the save path PegaFlow collapsed that to a single writer: only TP0 submitted saves, so the **entire model's KV was streamed to CPU through one GPU's copy engine and one PCIe link**, while the other ranks sat idle. A round-robin NUMA hint then scattered half of TP0's writes to a remote NUMA node, adding cross-socket traffic.

The read path was already N-way parallel (every rank H2D-loads its own full replica), so only the write path had a single-card bottleneck.

## Change

Treat MLA's replicated TP like PP for saving: **split the layer set across ranks**.

- Each rank computes a disjoint layer slice by `sorted_layer_name index % tp_size == tp_rank` and saves only that slice, reading from **its own** GPU into its **NUMA-local** pinned pool. Sorting by name aligns with how the server seals topology, so the partition is exact (no gaps, no double-writes).
- All ranks now run the full save lifecycle (empty trailing slices included) so vLLM's per-rank `finished_sending` aggregation stays correct.
- Load is unchanged — each rank still reads its full replica.
- Stop **silently** downgrading cross-layer blocks for MLA: MLA attention backends don't expose the per-layer stride needed for `use_uniform_kv_cache`, so cross-layer never actually built. We now log it instead of pretending it worked.
- Remove the obsolete round-robin save NUMA hint (and its server/engine plumbing); save now always lands NUMA-local. Net: **+144 / −359**.

Sharding only engages on the MLA-replica path (`is_mla && !mla_layer_split_kv_cache && dcp_world_size == 1 && tp_size > 1`). Non-MLA ranks and the existing `mla_layer_split_kv_cache` feature already store disjoint sets and are untouched.

## Validation

End-to-end on an 8-GPU host with DeepSeek-V2-Lite (27 layers), reading the engine's per-device save/load debug logs:

| Topology | SAVE (layers per device) | LOAD (layers per device) |
| --- | --- | --- |
| TP2 | `14, 13` (Σ27) | `27, 27` |
| PP2 | `14, 13` (Σ27, PP-native; sharding off) | `14, 13` |
| TP2×PP2 | `7, 7, 7, 6` (Σ27) | `14, 14, 13, 13` |
| TP8 | `4,4,4, 3,3,3,3,3` (Σ27) | `27 ×8` |

Save distributes a disjoint 1/N slice across every participating GPU (summing to the full layer set); load stays full-replica within each TP group. `PP2` confirms the non-shard path is a clean no-op. The `cache_metrics`, `no_data_path_rpc_failures`, and `no_kv_load_failures` e2e assertions pass for every topology. The `outputs_match_baseline` assertion flakes under TP only — a known batch-invariance limitation of the MLA attention backend required on this GPU generation (the PP-only run passes it), unrelated to this change.

## Out of scope

- MLA + DCP (`dcp_world_size > 1`): each DCP rank already stores different tokens.
- Localizing the read-side N× fan-out (e.g. NUMA-aware storage redundancy for loads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
