### PR TITLE
feat(core): store MLA KV page-first to collapse per-block metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,11 @@ vLLM Worker <--gRPC--> PegaEngine Server <--CUDA IPC--> GPU Memory
 - Stub and mock tests are allowed only for local contracts and must not shadow real runtime modules during integration/e2e collection.
 - Prefer integration tests when they prove a real boundary that units cannot. Prefer units when they give faster, clearer feedback for local connector state machines.
 
+## Compatibility & Durability
+
+- We have a strict version handshake (`CARGO_PKG_VERSION` exact match at registration), so do NOT design for backward compatibility with older clients or older stored formats — bump the version and break freely.
+- SSD cache is ephemeral: it is wiped on restart. Do NOT add migration, on-disk versioning, or cross-version SSD compatibility handling.
+
 ## Environment Variables
 
 - `PEGAFLOW_ENGINE_ENDPOINT`: gRPC endpoint (default: `127.0.0.1:50055`)

--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -146,6 +146,7 @@ impl BenchFixture {
                 &[0],
                 &[1],
                 transfer_mode,
+                false,
             )
             .expect("register layer");
 
@@ -333,6 +334,7 @@ impl MultiLayerBenchFixture {
                 &strides,
                 &segments,
                 TransferMode::Direct,
+                false,
             )
             .expect("register layers");
 

--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -67,6 +67,10 @@ pub(crate) enum HostBlock {
     Cached {
         sealed: Arc<SealedBlock>,
         slot_id: usize,
+        /// Byte offset into the slot's `RawBlock` where this layer begins.
+        /// Page-first reads every layer from one page slot at distinct
+        /// offsets; layer-first is always 0 (the slot is the layer).
+        offset: usize,
     },
 }
 
@@ -74,9 +78,19 @@ impl HostBlock {
     pub(crate) fn raw(&self) -> &RawBlock {
         match self {
             Self::Owned(block) => block,
-            Self::Cached { sealed, slot_id } => sealed
+            Self::Cached {
+                sealed, slot_id, ..
+            } => sealed
                 .get_slot(*slot_id)
                 .expect("cached slot_id validated at construction"),
+        }
+    }
+
+    /// Byte offset of this layer within its host slot (0 unless page-first).
+    fn host_offset(&self) -> usize {
+        match self {
+            Self::Owned(_) => 0,
+            Self::Cached { offset, .. } => *offset,
         }
     }
 }
@@ -349,14 +363,19 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
                 .block_copies(block.block_idx)
                 .map_err(|e| EngineError::Storage(format!("layer {layer_name}: {e}")))?;
 
+            // Page-first reads/writes every layer from one slot at its byte
+            // offset; layer-first leaves this 0 (slot == layer).
+            let host_offset = block.block.host_offset();
+
             match block_copies {
                 BlockCopies::Split { k, v } => {
                     let raw = block.block.raw();
-                    let k_ptr = raw.segment_mapped_ptr(0).unwrap();
+                    let k_ptr = raw.segment_mapped_ptr(0).unwrap().add(host_offset);
                     // SAFETY: For a contiguous host block (segment 1 absent), the
                     // allocation is 2 * segment size, so k + k.bytes is in bounds.
                     let v_ptr = raw
                         .segment_mapped_ptr(1)
+                        .map(|p| p.add(host_offset))
                         .unwrap_or_else(|| k_ptr.add(k.bytes));
 
                     copies.push(CopyDesc {
@@ -374,7 +393,12 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
                     total_bytes += k.bytes + v.bytes;
                 }
                 BlockCopies::Contiguous(c) => {
-                    let ptr = block.block.raw().segment_mapped_ptr(0).unwrap();
+                    let ptr = block
+                        .block
+                        .raw()
+                        .segment_mapped_ptr(0)
+                        .unwrap()
+                        .add(host_offset);
                     copies.push(CopyDesc {
                         device: c.addr,
                         host: ptr.host().as_ptr(),

--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -51,6 +51,24 @@ struct RegistrationState {
 pub(crate) struct LayerTopology {
     name_to_id: HashMap<String, usize>,
     tp_size: usize,
+    /// Page-first layout when `Some`: all layers of a block collapse into one
+    /// contiguous page per tp_rank, so `total_slots = tp_size`. `None` is the
+    /// legacy layer-first layout (`total_slots = num_layers * tp_size`).
+    page_layout: Option<PageLayout>,
+}
+
+/// Page-first placement: where each layer lives inside one contiguous per-block
+/// page. Built at seal time from the registered per-layer padded block sizes,
+/// in layer-id (sorted-name) order, so save/load and every node agree.
+#[derive(Debug)]
+struct PageLayout {
+    /// Byte offset of each layer within the page, indexed by layer_id.
+    layer_offsets: Vec<usize>,
+    /// Padded byte size of each layer's block, indexed by layer_id.
+    layer_bytes: Vec<usize>,
+    /// Total page size = sum of `layer_bytes` (also each layer's offset is
+    /// SSD-aligned because every `layer_bytes` entry is alignment-padded).
+    page_size: usize,
 }
 
 impl LayerTopology {
@@ -66,12 +84,37 @@ impl LayerTopology {
         self.name_to_id.len()
     }
 
-    /// Total number of storage slots, organized as `[layer][tp_rank]`.
-    pub(crate) fn total_slots(&self) -> usize {
-        self.num_layers() * self.tp_size
+    /// Whether blocks are stored page-first (one page per tp_rank).
+    pub(crate) fn is_page_first(&self) -> bool {
+        self.page_layout.is_some()
     }
 
-    /// Compute the slot index for a specific layer and TP rank.
+    /// Total number of storage slots per block: `tp_size` page-first, else
+    /// `num_layers * tp_size` (layer-first).
+    pub(crate) fn total_slots(&self) -> usize {
+        match self.page_layout {
+            Some(_) => self.tp_size,
+            None => self.num_layers() * self.tp_size,
+        }
+    }
+
+    /// Page-first only: total contiguous page size in bytes (one slot).
+    pub(crate) fn page_size(&self) -> Option<usize> {
+        self.page_layout.as_ref().map(|p| p.page_size)
+    }
+
+    /// Page-first only: `(byte_offset, padded_bytes)` of `layer_id` within a page.
+    pub(crate) fn page_placement(&self, layer_id: usize) -> Option<(usize, usize)> {
+        self.page_layout
+            .as_ref()
+            .map(|p| (p.layer_offsets[layer_id], p.layer_bytes[layer_id]))
+    }
+
+    /// Compute the storage slot index for a specific layer and TP rank.
+    ///
+    /// Page-first collapses the layer dimension into the page, so the slot is
+    /// just `tp_rank`; the layer's position is its page offset
+    /// ([`Self::page_placement`]). Layer-first keeps `[layer][tp_rank]`.
     pub(crate) fn slot_index(&self, layer_id: usize, tp_rank: usize) -> Result<usize, EngineError> {
         if layer_id >= self.num_layers() {
             return Err(EngineError::InvalidArgument(format!(
@@ -86,7 +129,10 @@ impl LayerTopology {
                 tp_rank, self.tp_size
             )));
         }
-        Ok(layer_id * self.tp_size + tp_rank)
+        Ok(match self.page_layout {
+            Some(_) => tp_rank,
+            None => layer_id * self.tp_size + tp_rank,
+        })
     }
 }
 
@@ -211,6 +257,10 @@ pub struct InstanceContext {
     /// devices have registered.
     world_size: usize,
 
+    /// Page-first storage: collapse a block's layers into one contiguous page
+    /// per tp_rank. Fixed by the first registrant; later workers must agree.
+    page_first: bool,
+
     /// Registration state and GPU contexts protected by a single mutex.
     state: Mutex<RegistrationState>,
 }
@@ -225,6 +275,7 @@ impl InstanceContext {
         namespace: String,
         tp_size: usize,
         world_size: usize,
+        page_first: bool,
     ) -> Result<Self, String> {
         if tp_size == 0 || world_size == 0 {
             return Err("tp_size and world_size must be > 0".into());
@@ -235,6 +286,7 @@ impl InstanceContext {
             namespace,
             tp_size,
             world_size,
+            page_first,
             state: Mutex::new(RegistrationState {
                 gpu_contexts: HashMap::new(),
                 topology: None,
@@ -309,20 +361,29 @@ impl InstanceContext {
         };
 
         // Union of layer names with geometry consistency across devices.
-        let mut geometry_by_name: HashMap<&str, (usize, bool)> = HashMap::new();
+        // The third tuple element (padded_block_bytes) is the per-layer page
+        // footprint; it must also agree across devices because the page-first
+        // layout concatenates layers by this size.
+        let mut geometry_by_name: HashMap<&str, (usize, bool, usize)> = HashMap::new();
         for gpu in gpus() {
             for (name, layout) in &gpu.kv_caches {
-                let geometry = (layout.segment_bytes(), layout.is_split());
+                let geometry = (
+                    layout.segment_bytes(),
+                    layout.is_split(),
+                    layout.padded_block_bytes(),
+                );
                 match geometry_by_name.insert(name, geometry) {
                     None => {}
                     Some(existing) if existing == geometry => {}
-                    Some((existing_bytes, existing_split)) => {
+                    Some((existing_bytes, existing_split, existing_padded)) => {
                         return Err(EngineError::InvalidArgument(format!(
                             "layer {name} registered with inconsistent geometry: \
-                             segment_bytes={existing_bytes} split={existing_split} vs \
-                             segment_bytes={} split={} on device {}",
+                             segment_bytes={existing_bytes} split={existing_split} \
+                             padded_block_bytes={existing_padded} vs \
+                             segment_bytes={} split={} padded_block_bytes={} on device {}",
                             layout.segment_bytes(),
                             layout.is_split(),
+                            layout.padded_block_bytes(),
                             gpu.device_id(),
                         )));
                     }
@@ -337,19 +398,17 @@ impl InstanceContext {
             .enumerate()
             .map(|(id, name)| (name.clone(), id))
             .collect();
-        let topology = LayerTopology {
-            name_to_id,
-            tp_size: self.tp_size,
-        };
 
-        // Per slot: (device_id, pp_rank) of the first registered owner.
-        let mut owners: Vec<Option<(i32, usize)>> = vec![None; topology.total_slots()];
+        // Validate registration completeness on the full `[layer][tp_rank]`
+        // grid, independent of how slots are stored: every (layer, tp_rank)
+        // pair needs an owner regardless of page-first collapsing.
+        let mut owners: Vec<Option<(i32, usize)>> = vec![None; names.len() * self.tp_size];
         for gpu in gpus() {
             for layer_name in gpu.kv_caches.keys() {
-                let layer_id = topology.layer_id(layer_name)?;
-                let slot_id = layer_id * self.tp_size + gpu.tp_rank();
-                match owners[slot_id] {
-                    None => owners[slot_id] = Some((gpu.device_id(), gpu.pp_rank())),
+                let layer_id = name_to_id[layer_name];
+                let grid_id = layer_id * self.tp_size + gpu.tp_rank();
+                match owners[grid_id] {
+                    None => owners[grid_id] = Some((gpu.device_id(), gpu.pp_rank())),
                     Some((existing_device, existing_pp_rank)) => {
                         if existing_pp_rank != gpu.pp_rank() {
                             return Err(EngineError::InvalidArgument(format!(
@@ -366,9 +425,9 @@ impl InstanceContext {
             }
         }
 
-        if let Some(missing_slot) = owners.iter().position(Option::is_none) {
-            let layer_id = missing_slot / self.tp_size;
-            let tp_rank = missing_slot % self.tp_size;
+        if let Some(missing) = owners.iter().position(Option::is_none) {
+            let layer_id = missing / self.tp_size;
+            let tp_rank = missing % self.tp_size;
             return Err(EngineError::InvalidArgument(format!(
                 "instance {} has incomplete KV registration: layer {} has no owner \
                  for tp_rank {tp_rank} after all {} workers registered",
@@ -376,7 +435,33 @@ impl InstanceContext {
             )));
         }
 
-        Ok(topology)
+        // Page-first: lay layers out contiguously in layer-id order. Each
+        // layer's padded_block_bytes is already SSD-aligned, so every per-layer
+        // offset (a prefix sum of aligned sizes) stays aligned too.
+        let page_layout = if self.page_first {
+            let mut layer_offsets = Vec::with_capacity(names.len());
+            let mut layer_bytes = Vec::with_capacity(names.len());
+            let mut offset = 0usize;
+            for name in &names {
+                let padded = geometry_by_name[name.as_str()].2;
+                layer_offsets.push(offset);
+                layer_bytes.push(padded);
+                offset += padded;
+            }
+            Some(PageLayout {
+                layer_offsets,
+                layer_bytes,
+                page_size: offset,
+            })
+        } else {
+            None
+        };
+
+        Ok(LayerTopology {
+            name_to_id,
+            tp_size: self.tp_size,
+            page_layout,
+        })
     }
 
     /// Build a GPU context for the specified device.
@@ -537,11 +622,17 @@ impl InstanceContext {
     /// Verify that the topology matches expected values.
     ///
     /// Returns `Ok(())` if matches, or an error message describing the mismatch.
-    pub(crate) fn verify_topology(&self, tp_size: usize, world_size: usize) -> Result<(), String> {
-        if self.tp_size != tp_size || self.world_size != world_size {
+    pub(crate) fn verify_topology(
+        &self,
+        tp_size: usize,
+        world_size: usize,
+        page_first: bool,
+    ) -> Result<(), String> {
+        if self.tp_size != tp_size || self.world_size != world_size || self.page_first != page_first
+        {
             return Err(format!(
-                "exists with tp={}, world={}; requested tp={}, world={}",
-                self.tp_size, self.world_size, tp_size, world_size
+                "exists with tp={}, world={}, page_first={}; requested tp={}, world={}, page_first={}",
+                self.tp_size, self.world_size, self.page_first, tp_size, world_size, page_first
             ));
         }
         Ok(())

--- a/pegaflow-core/src/instance/tests.rs
+++ b/pegaflow-core/src/instance/tests.rs
@@ -50,7 +50,8 @@ fn gpu_registration_with_segment_bytes(
 /// device 0.
 #[test]
 fn single_worker_registration_seals_topology() {
-    let instance = InstanceContext::new("test-instance-1".into(), "model-ns".into(), 1, 1).unwrap();
+    let instance =
+        InstanceContext::new("test-instance-1".into(), "model-ns".into(), 1, 1, false).unwrap();
 
     // Names intentionally out of registration order: ids come from sorted
     // names, not from declaration order.
@@ -73,9 +74,9 @@ fn single_worker_registration_seals_topology() {
     assert_eq!(topology.total_slots(), 4);
 
     // Topology parameters are pinned at creation.
-    assert!(instance.verify_topology(1, 1).is_ok());
-    assert!(instance.verify_topology(2, 1).is_err());
-    assert!(instance.verify_topology(1, 2).is_err());
+    assert!(instance.verify_topology(1, 1, false).is_ok());
+    assert!(instance.verify_topology(2, 1, false).is_err());
+    assert!(instance.verify_topology(1, 2, false).is_err());
 
     // A sealed instance accepts no further devices.
     let err = instance
@@ -93,11 +94,50 @@ fn single_worker_registration_seals_topology() {
     }
 }
 
+/// Page-first folds the layer dimension into one page slot per tp_rank and
+/// lays layers out contiguously in sorted-name (layer-id) order. Commits
+/// device 0.
+#[test]
+fn page_first_collapses_slots_and_lays_out_page() {
+    let instance = InstanceContext::new("page-first".into(), "page-ns".into(), 1, 1, true).unwrap();
+
+    // segment_bytes=1024, single segment, no SSD padding on this path, so each
+    // layer's padded_block_bytes == 1024.
+    instance
+        .register_new_gpu(gpu_registration_with_segment_bytes(
+            0,
+            0,
+            &["layer_b", "layer_a", "layer_c"],
+            1024,
+        ))
+        .expect("register page-first gpu");
+
+    let topology = instance.sealed_topology().expect("sealed");
+    assert!(topology.is_page_first());
+    assert_eq!(topology.num_layers(), 3);
+    // Layer dimension folds away: one slot per tp_rank (here tp_size == 1).
+    assert_eq!(topology.total_slots(), 1);
+    for layer_id in 0..3 {
+        assert_eq!(topology.slot_index(layer_id, 0).unwrap(), 0);
+    }
+    // Page = all layers concatenated in sorted-name order (a<b<c).
+    assert_eq!(topology.page_size(), Some(3 * 1024));
+    assert_eq!(topology.page_placement(0), Some((0, 1024)));
+    assert_eq!(topology.page_placement(1), Some((1024, 1024)));
+    assert_eq!(topology.page_placement(2), Some((2048, 1024)));
+
+    // page_first is part of the topology contract: a mismatched re-registration
+    // intent is rejected.
+    assert!(instance.verify_topology(1, 1, true).is_ok());
+    assert!(instance.verify_topology(1, 1, false).is_err());
+}
+
 /// Until every worker has registered there is no topology: save/load must be
 /// rejected with a registration-progress error. Commits device 0.
 #[test]
 fn unsealed_instance_rejects_topology_access() {
-    let instance = InstanceContext::new("partial".into(), "partial-ns".into(), 2, 2).unwrap();
+    let instance =
+        InstanceContext::new("partial".into(), "partial-ns".into(), 2, 2, false).unwrap();
     instance
         .register_new_gpu(gpu_registration(0, 0, &["layer_0"]))
         .expect("first of two workers");
@@ -118,7 +158,7 @@ fn unsealed_instance_rejects_topology_access() {
 /// sealed topology contract; reject it outright.
 #[test]
 fn registration_without_layers_is_rejected() {
-    let instance = InstanceContext::new("empty".into(), "empty-ns".into(), 1, 1).unwrap();
+    let instance = InstanceContext::new("empty".into(), "empty-ns".into(), 1, 1, false).unwrap();
     let err = instance
         .register_new_gpu(gpu_registration(0, 0, &[]))
         .expect_err("empty registration must fail");
@@ -145,7 +185,7 @@ fn seal_derives_layer_space_from_union_of_workers() {
         return;
     }
 
-    let instance = InstanceContext::new("pp-mtp".into(), "pp-mtp-ns".into(), 1, 2).unwrap();
+    let instance = InstanceContext::new("pp-mtp".into(), "pp-mtp-ns".into(), 1, 2, false).unwrap();
     instance
         .register_new_gpu(gpu_registration(0, 0, &["model.layers.0.self_attn.attn"]))
         .expect("stage 0 registers the main layer");
@@ -192,7 +232,8 @@ fn mla_replica_registration_seals() {
         return;
     }
 
-    let instance = InstanceContext::new("mla-replica".into(), "mla-ns".into(), 1, 2).unwrap();
+    let instance =
+        InstanceContext::new("mla-replica".into(), "mla-ns".into(), 1, 2, false).unwrap();
     instance
         .register_new_gpu(gpu_registration(0, 0, MLA_DSA_LAYERS))
         .expect("register replica on device 0");
@@ -216,7 +257,7 @@ fn seal_rejects_replicas_across_pipeline_stages() {
         return;
     }
 
-    let instance = InstanceContext::new("pp-conflict".into(), "pp-ns".into(), 1, 2).unwrap();
+    let instance = InstanceContext::new("pp-conflict".into(), "pp-ns".into(), 1, 2, false).unwrap();
     let layers = &["model.layers.0.self_attn.attn"];
     instance
         .register_new_gpu(gpu_registration(0, 0, layers))
@@ -246,7 +287,8 @@ fn seal_rejects_missing_slot_owner() {
         return;
     }
 
-    let instance = InstanceContext::new("missing-slot".into(), "missing-ns".into(), 2, 2).unwrap();
+    let instance =
+        InstanceContext::new("missing-slot".into(), "missing-ns".into(), 2, 2, false).unwrap();
     instance
         .register_new_gpu(gpu_registration(0, 0, &["layer_0", "layer_1"]))
         .expect("rank 0 registers both layers");
@@ -273,7 +315,7 @@ fn seal_rejects_inconsistent_layer_geometry() {
         return;
     }
 
-    let instance = InstanceContext::new("geom".into(), "geom-ns".into(), 1, 2).unwrap();
+    let instance = InstanceContext::new("geom".into(), "geom-ns".into(), 1, 2, false).unwrap();
     instance
         .register_new_gpu(gpu_registration_with_segment_bytes(
             0,

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -183,6 +183,7 @@ impl PegaEngine {
         namespace: &str,
         tp_size: usize,
         world_size: usize,
+        page_first: bool,
     ) -> Result<Arc<InstanceContext>, EngineError> {
         let mut instances = self
             .instances
@@ -191,9 +192,11 @@ impl PegaEngine {
 
         if let Some(instance) = instances.get(instance_id) {
             // Already exists, verify topology
-            instance.verify_topology(tp_size, world_size).map_err(|e| {
-                EngineError::TopologyMismatch(format!("instance {instance_id} {e}"))
-            })?;
+            instance
+                .verify_topology(tp_size, world_size, page_first)
+                .map_err(|e| {
+                    EngineError::TopologyMismatch(format!("instance {instance_id} {e}"))
+                })?;
             return Ok(Arc::clone(instance));
         }
 
@@ -203,6 +206,7 @@ impl PegaEngine {
             namespace.to_string(),
             tp_size,
             world_size,
+            page_first,
         )
         .map_err(EngineError::InvalidArgument)?;
 
@@ -256,6 +260,7 @@ impl PegaEngine {
         kv_stride_bytes_list: &[usize],
         segments_list: &[usize],
         transfer_mode: TransferMode,
+        page_first: bool,
     ) -> Result<(), EngineError> {
         // Dense default: block stride == bytes_per_block (layer-first layout).
         self.register_context_layer_batch_strided(
@@ -275,6 +280,7 @@ impl PegaEngine {
             segments_list,
             None,
             transfer_mode,
+            page_first,
         )
     }
 
@@ -308,6 +314,7 @@ impl PegaEngine {
         segments_list: &[usize],
         block_stride_bytes_list: Option<&[usize]>,
         transfer_mode: TransferMode,
+        page_first: bool,
     ) -> Result<(), EngineError> {
         // Build all registrations
         let ssd_enabled = self.storage.is_ssd_enabled();
@@ -376,7 +383,8 @@ impl PegaEngine {
         }
 
         // Get or create instance
-        let instance = self.get_or_create_instance(instance_id, namespace, tp_size, world_size)?;
+        let instance =
+            self.get_or_create_instance(instance_id, namespace, tp_size, world_size, page_first)?;
 
         // Get NUMA affinity for this GPU
         let numa_node = self.topology.numa_for_gpu(device_id);
@@ -663,6 +671,12 @@ impl PegaEngine {
             })?;
 
             let slot_id = topology.slot_index(layer_id, tp_rank)?;
+            // Page-first: every layer reads from the one page slot (tp_rank) at
+            // its sealed byte offset. Layer-first: offset 0 (the whole slot
+            // RawBlock is the layer).
+            let host_offset = topology
+                .page_placement(layer_id)
+                .map_or(0, |(offset, _)| offset);
 
             let mut blocks = Vec::with_capacity(block_ids.len());
             for (block_idx, block_entry) in block_ids.iter().copied().zip(block_cache.iter()) {
@@ -676,6 +690,7 @@ impl PegaEngine {
                     block: HostBlock::Cached {
                         sealed: Arc::clone(block_entry),
                         slot_id,
+                        offset: host_offset,
                     },
                 });
             }

--- a/pegaflow-core/src/offload.rs
+++ b/pegaflow-core/src/offload.rs
@@ -19,6 +19,7 @@ pub(crate) type InsertEntries = Vec<(BlockKey, Vec<(usize, RawBlock)>)>;
 use crate::gpu_worker::{HostBlock, LayerTransferData, TransferBlock};
 use crate::layout::KVCacheLayout;
 use crate::metrics::core_metrics;
+use crate::pinned_pool::PinnedAllocation;
 use crate::{EngineError, PegaEngine};
 use pegaflow_common::NumaNode;
 
@@ -142,6 +143,103 @@ fn build_hashed_insert_entries(namespace: String, layers: Vec<RawSaveLayer>) -> 
 // ============================================================================
 
 impl PegaEngine {
+    /// Page-first allocation: one contiguous pinned page per block, holding
+    /// every layer at its sealed page offset. Each layer's GPU copy targets a
+    /// sub-view into the pages; the pages themselves are sealed as the single
+    /// stored slot (see Phase 4). Fills `pages` and `gpu_save_layers`.
+    fn alloc_page_first_targets(
+        &self,
+        topology: &crate::instance::LayerTopology,
+        layer_contexts: &[LayerContext],
+        numa_node: Option<NumaNode>,
+        pages: &mut Vec<Arc<PinnedAllocation>>,
+        gpu_save_layers: &mut Vec<LayerTransferData>,
+    ) -> Result<(), EngineError> {
+        let page_size = topology
+            .page_size()
+            .expect("page-first topology must have a page size");
+
+        // A page holds all layers of one block, so every layer must save the
+        // same blocks in the same order. Block hashes are content-derived
+        // (identical across layers) and block_idx is the same physical KV slot
+        // across layers, so this invariant holds for MLA saves.
+        let reference = &layer_contexts[0].blocks_to_save;
+        for ctx in layer_contexts {
+            if ctx.layout.is_split() {
+                return Err(EngineError::InvalidArgument(format!(
+                    "page-first save does not support split K/V (layer {})",
+                    ctx.layer_name
+                )));
+            }
+            if ctx.blocks_to_save != *reference {
+                return Err(EngineError::InvalidArgument(
+                    "page-first save requires the same block set across all layers".into(),
+                ));
+            }
+        }
+
+        // A page-first block has a single slot, sealed by the first save, so
+        // that one save must carry EVERY layer of the page. A partial save
+        // (e.g. a pipeline stage that holds only some layers) would seal a page
+        // whose foreign-layer offsets are never written — they stay as stale
+        // pool memory and load returns another block's KV. Reject it loudly.
+        let mut layer_ids: Vec<usize> = layer_contexts
+            .iter()
+            .map(|ctx| topology.layer_id(&ctx.layer_name))
+            .collect::<Result<_, _>>()?;
+        layer_ids.sort_unstable();
+        layer_ids.dedup();
+        if layer_ids.len() != topology.num_layers() {
+            return Err(EngineError::InvalidArgument(format!(
+                "page-first save must cover all {} layers, got {} distinct \
+                 (one worker must write a block's entire page; pipeline \
+                 parallelism is unsupported)",
+                topology.num_layers(),
+                layer_ids.len()
+            )));
+        }
+
+        // One page per block.
+        let page_bytes = NonZeroU64::new(page_size as u64)
+            .ok_or_else(|| EngineError::Storage("page size is zero".into()))?;
+        for _ in 0..reference.len() {
+            let page = self
+                .storage
+                .allocate(page_bytes, numa_node)
+                .ok_or_else(|| {
+                    EngineError::Storage("pinned pool exhausted while allocating page".into())
+                })?;
+            pages.push(page);
+        }
+
+        // Each layer copies its block into its slice of every page.
+        for ctx in layer_contexts {
+            let layer_id = topology.layer_id(&ctx.layer_name)?;
+            let (offset, layer_bytes) = topology
+                .page_placement(layer_id)
+                .expect("page-first layer placement");
+            let save_blocks: Vec<TransferBlock> = ctx
+                .blocks_to_save
+                .iter()
+                .zip(pages.iter())
+                .map(|((block_idx, _), page)| TransferBlock {
+                    block_idx: *block_idx,
+                    block: HostBlock::Owned(RawBlock::single_segment(Segment::new(
+                        page.mapped_ptr().add(offset).host(),
+                        layer_bytes,
+                        Arc::clone(page),
+                    ))),
+                })
+                .collect();
+            gpu_save_layers.push(LayerTransferData {
+                layer_name: ctx.layer_name.clone(),
+                layout: ctx.layout.clone(),
+                blocks: save_blocks,
+            });
+        }
+        Ok(())
+    }
+
     /// Batch save KV blocks from multiple layers.
     ///
     /// More efficient than calling `save_kv_blocks_from_ipc` in a loop as it
@@ -284,83 +382,101 @@ impl PegaEngine {
         let save_numa_node = gpu_context.preferred_numa();
         let numa_node = Some(save_numa_node);
         let blockwise = self.storage.blockwise_alloc();
+        let page_first = topology.is_page_first();
 
         let mut gpu_save_layers: Vec<LayerTransferData> = Vec::with_capacity(layer_contexts.len());
+        // Page-first only: one contiguous page per block holds every layer.
+        // Each layer's GPU copy targets a sub-view into these pages, and the
+        // pages themselves become the single stored slot in Phase 4. Kept alive
+        // across the GPU copy so the segments stay valid.
+        let mut pages: Vec<Arc<PinnedAllocation>> = Vec::new();
 
-        for ctx in &mut layer_contexts {
-            let layout = &ctx.layout;
-            let num_blocks = ctx.blocks_to_save.len();
+        if page_first {
+            self.alloc_page_first_targets(
+                &topology,
+                &layer_contexts,
+                numa_node,
+                &mut pages,
+                &mut gpu_save_layers,
+            )?;
+        } else {
+            for ctx in &mut layer_contexts {
+                let layout = &ctx.layout;
+                let num_blocks = ctx.blocks_to_save.len();
 
-            // Blockwise: allocate once per block; Batch: allocate once for all blocks
-            let alloc_count = if blockwise { num_blocks } else { 1 };
-            let blocks_per_alloc = if blockwise { 1 } else { num_blocks };
+                // Blockwise: allocate once per block; Batch: allocate once for all blocks
+                let alloc_count = if blockwise { num_blocks } else { 1 };
+                let blocks_per_alloc = if blockwise { 1 } else { num_blocks };
 
-            let alloc_pinned = |stride: usize, what: &str| {
-                let alloc_size = (stride as u64)
-                    .checked_mul(blocks_per_alloc as u64)
-                    .and_then(NonZeroU64::new)
-                    .ok_or_else(|| {
-                        EngineError::Storage(format!("allocation size overflow for {what}"))
-                    })?;
-                self.storage.allocate(alloc_size, numa_node).ok_or_else(|| {
-                    EngineError::Storage(format!("pinned pool exhausted while allocating {what}"))
-                })
-            };
+                let alloc_pinned = |stride: usize, what: &str| {
+                    let alloc_size = (stride as u64)
+                        .checked_mul(blocks_per_alloc as u64)
+                        .and_then(NonZeroU64::new)
+                        .ok_or_else(|| {
+                            EngineError::Storage(format!("allocation size overflow for {what}"))
+                        })?;
+                    self.storage.allocate(alloc_size, numa_node).ok_or_else(|| {
+                        EngineError::Storage(format!(
+                            "pinned pool exhausted while allocating {what}"
+                        ))
+                    })
+                };
 
-            // Allocate pinned memory and construct the host-side RawBlocks in
-            // save order. Strides are padded (SSD-aligned); GPU copies later
-            // use actual (unpadded) sizes, leaving the padding tail unused.
-            let mut raw_blocks: Vec<RawBlock> = Vec::with_capacity(num_blocks);
-            for _ in 0..alloc_count {
-                if layout.is_split() {
-                    let stride = layout.padded_segment_bytes();
-                    let k_alloc = alloc_pinned(stride, "K segment buffer")?;
-                    let v_alloc = alloc_pinned(stride, "V segment buffer")?;
-                    for i in 0..blocks_per_alloc {
-                        let offset = i * stride;
-                        // Safety: offsets are within the just-made allocations.
-                        raw_blocks.push(RawBlock::two_segments(
-                            Segment::new(
-                                k_alloc.mapped_ptr().add(offset).host(),
+                // Allocate pinned memory and construct the host-side RawBlocks in
+                // save order. Strides are padded (SSD-aligned); GPU copies later
+                // use actual (unpadded) sizes, leaving the padding tail unused.
+                let mut raw_blocks: Vec<RawBlock> = Vec::with_capacity(num_blocks);
+                for _ in 0..alloc_count {
+                    if layout.is_split() {
+                        let stride = layout.padded_segment_bytes();
+                        let k_alloc = alloc_pinned(stride, "K segment buffer")?;
+                        let v_alloc = alloc_pinned(stride, "V segment buffer")?;
+                        for i in 0..blocks_per_alloc {
+                            let offset = i * stride;
+                            // Safety: offsets are within the just-made allocations.
+                            raw_blocks.push(RawBlock::two_segments(
+                                Segment::new(
+                                    k_alloc.mapped_ptr().add(offset).host(),
+                                    stride,
+                                    Arc::clone(&k_alloc),
+                                ),
+                                Segment::new(
+                                    v_alloc.mapped_ptr().add(offset).host(),
+                                    stride,
+                                    Arc::clone(&v_alloc),
+                                ),
+                            ));
+                        }
+                    } else {
+                        let stride = layout.padded_block_bytes();
+                        let alloc = alloc_pinned(stride, "block buffer")?;
+                        for i in 0..blocks_per_alloc {
+                            // Safety: offset is within the just-made allocation.
+                            raw_blocks.push(RawBlock::single_segment(Segment::new(
+                                alloc.mapped_ptr().add(i * stride).host(),
                                 stride,
-                                Arc::clone(&k_alloc),
-                            ),
-                            Segment::new(
-                                v_alloc.mapped_ptr().add(offset).host(),
-                                stride,
-                                Arc::clone(&v_alloc),
-                            ),
-                        ));
-                    }
-                } else {
-                    let stride = layout.padded_block_bytes();
-                    let alloc = alloc_pinned(stride, "block buffer")?;
-                    for i in 0..blocks_per_alloc {
-                        // Safety: offset is within the just-made allocation.
-                        raw_blocks.push(RawBlock::single_segment(Segment::new(
-                            alloc.mapped_ptr().add(i * stride).host(),
-                            stride,
-                            Arc::clone(&alloc),
-                        )));
+                                Arc::clone(&alloc),
+                            )));
+                        }
                     }
                 }
+
+                let save_blocks: Vec<TransferBlock> = ctx
+                    .blocks_to_save
+                    .iter()
+                    .zip(raw_blocks)
+                    .map(|((block_idx, _), block)| TransferBlock {
+                        block_idx: *block_idx,
+                        block: HostBlock::Owned(block),
+                    })
+                    .collect();
+
+                gpu_save_layers.push(LayerTransferData {
+                    layer_name: ctx.layer_name.clone(),
+                    layout: layout.clone(),
+                    blocks: save_blocks,
+                });
             }
-
-            let save_blocks: Vec<TransferBlock> = ctx
-                .blocks_to_save
-                .iter()
-                .zip(raw_blocks)
-                .map(|((block_idx, _), block)| TransferBlock {
-                    block_idx: *block_idx,
-                    block: HostBlock::Owned(block),
-                })
-                .collect();
-
-            gpu_save_layers.push(LayerTransferData {
-                layer_name: ctx.layer_name.clone(),
-                layout: layout.clone(),
-                blocks: save_blocks,
-            });
         }
         trace_drop!(_s);
 
@@ -372,17 +488,23 @@ impl PegaEngine {
         )
         .await?;
 
-        for (ctx, layer) in layer_contexts.iter_mut().zip(returned_layers) {
-            ctx.raw_blocks = layer
-                .blocks
-                .into_iter()
-                .map(|transfer_block| match transfer_block.block {
-                    HostBlock::Owned(block) => block,
-                    HostBlock::Cached { .. } => {
-                        panic!("save path must return HostBlock::Owned blocks")
-                    }
-                })
-                .collect();
+        if page_first {
+            // The pages already hold the copied data; the returned sub-view
+            // blocks share those pages via Arc and are dropped here.
+            drop(returned_layers);
+        } else {
+            for (ctx, layer) in layer_contexts.iter_mut().zip(returned_layers) {
+                ctx.raw_blocks = layer
+                    .blocks
+                    .into_iter()
+                    .map(|transfer_block| match transfer_block.block {
+                        HostBlock::Owned(block) => block,
+                        HostBlock::Cached { .. } => {
+                            panic!("save path must return HostBlock::Owned blocks")
+                        }
+                    })
+                    .collect();
+            }
         }
 
         // ── Phase 4 (deferred): Build RawBlocks + insert — sent to worker ──
@@ -418,23 +540,48 @@ impl PegaEngine {
             batch_start.elapsed().as_secs_f64() * 1000.0
         );
 
-        // Build RawSaveBatch and send to insert worker (fire-and-forget)
-        let raw_layers: Vec<RawSaveLayer> = layer_contexts
-            .into_iter()
-            .map(|ctx| {
-                let block_hashes: Vec<Vec<u8>> = ctx
-                    .blocks_to_save
-                    .into_iter()
-                    .map(|(_, hash)| hash)
-                    .collect();
-                RawSaveLayer {
-                    slot_id: ctx.slot_id,
-                    padded_block_size: ctx.layout.padded_block_bytes(),
-                    blocks: ctx.raw_blocks,
-                    block_hashes,
-                }
-            })
-            .collect();
+        // Build RawSaveBatch and send to insert worker (fire-and-forget).
+        // Page-first collapses every layer into one page slot per block, so a
+        // whole block is a single RawSaveLayer regardless of num_layers.
+        let raw_layers: Vec<RawSaveLayer> = if page_first {
+            let page_size = topology.page_size().expect("page-first page size");
+            let slot_id = layer_contexts[0].slot_id;
+            let block_hashes: Vec<Vec<u8>> = layer_contexts[0]
+                .blocks_to_save
+                .iter()
+                .map(|(_, hash)| hash.clone())
+                .collect();
+            let blocks: Vec<RawBlock> = pages
+                .into_iter()
+                .map(|page| {
+                    let ptr = page.mapped_ptr().host();
+                    RawBlock::single_segment(Segment::new(ptr, page_size, page))
+                })
+                .collect();
+            vec![RawSaveLayer {
+                slot_id,
+                padded_block_size: page_size,
+                blocks,
+                block_hashes,
+            }]
+        } else {
+            layer_contexts
+                .into_iter()
+                .map(|ctx| {
+                    let block_hashes: Vec<Vec<u8>> = ctx
+                        .blocks_to_save
+                        .into_iter()
+                        .map(|(_, hash)| hash)
+                        .collect();
+                    RawSaveLayer {
+                        slot_id: ctx.slot_id,
+                        padded_block_size: ctx.layout.padded_block_bytes(),
+                        blocks: ctx.raw_blocks,
+                        block_hashes,
+                    }
+                })
+                .collect()
+        };
 
         self.storage.send_raw_insert(RawSaveBatch {
             namespace,

--- a/pegaflow-core/tests/common/harness.rs
+++ b/pegaflow-core/tests/common/harness.rs
@@ -136,6 +136,7 @@ pub struct TestEnvBuilder {
     world_size: usize,
     storage_config: Option<StorageConfig>,
     transfer_mode: TransferMode,
+    page_first: bool,
     layers: Vec<LayerSpec>,
 }
 
@@ -148,8 +149,15 @@ impl TestEnvBuilder {
             world_size: 1,
             storage_config: None,
             transfer_mode: TransferMode::Direct,
+            page_first: false,
             layers: vec![],
         }
+    }
+
+    /// Store blocks page-first (all layers of a block in one host page slot).
+    pub fn page_first(mut self) -> Self {
+        self.page_first = true;
+        self
     }
 
     /// Add a contiguous (single-segment) layer.
@@ -268,6 +276,7 @@ impl TestEnvBuilder {
                 1,
                 self.world_size,
                 self.transfer_mode,
+                self.page_first,
             );
         }
 
@@ -348,6 +357,26 @@ impl TestEnv {
         for i in 0..self.layers.len() {
             self.save_layer(i, hashes).await;
         }
+        self.engine.flush_saves().await;
+    }
+
+    /// Save every layer in ONE batch call, then flush. Page-first requires all
+    /// layers of a block in a single save so the page is complete; this mirrors
+    /// the connector, which submits all layers in one `save` RPC.
+    pub async fn save_all_layers_one_batch(&self, hashes: &[Vec<u8>]) {
+        let saves: Vec<LayerSave> = self
+            .layers
+            .iter()
+            .map(|layer| LayerSave {
+                layer_name: layer.name.clone(),
+                block_ids: (0..hashes.len()).collect(),
+                block_hashes: hashes.to_vec(),
+            })
+            .collect();
+        self.engine
+            .batch_save_kv_blocks_from_ipc(&self.instance_id, 0, 0, 0, saves)
+            .await
+            .expect("save all layers");
         self.engine.flush_saves().await;
     }
 

--- a/pegaflow-core/tests/common/helpers.rs
+++ b/pegaflow-core/tests/common/helpers.rs
@@ -38,6 +38,7 @@ pub fn register_layers(
     tp_size: usize,
     world_size: usize,
     transfer_mode: TransferMode,
+    page_first: bool,
 ) {
     let layer_names: Vec<String> = layers.iter().map(|l| l.name.clone()).collect();
     let gpu_ptrs: Vec<u64> = layers.iter().map(|l| l.gpu_ptr).collect();
@@ -64,6 +65,7 @@ pub fn register_layers(
             &kv_strides,
             &segments,
             transfer_mode,
+            page_first,
         )
         .expect("register_context_layer_batch");
 }

--- a/pegaflow-core/tests/engine_basic.rs
+++ b/pegaflow-core/tests/engine_basic.rs
@@ -6,7 +6,7 @@
 mod common;
 
 use common::*;
-use pegaflow_core::{StorageConfig, TransferMode};
+use pegaflow_core::{LayerSave, StorageConfig, TransferMode};
 
 /// Full save -> query -> load round-trip with data integrity check.
 #[tokio::test]
@@ -22,6 +22,71 @@ async fn save_query_load_roundtrip() {
 
     env.load_to_gpu(lease, hashes.len()).await;
     env.data().assert_gpu_matches_expected();
+}
+
+/// Page-first round-trip: all layers of a block live in one host page slot,
+/// saved in a single batch and loaded back. Each layer is given DISTINCT
+/// content AND a DISTINCT (512-aligned) size, so the page offsets are an
+/// uneven prefix sum (0, 512, 1536). A wrong offset or a mishandled prefix
+/// sum makes a layer read/write another layer's slice and fails the assert.
+#[tokio::test]
+async fn page_first_multi_layer_roundtrip() {
+    let mut env = TestEnvBuilder::new("test-page-first", "test-ns")
+        .page_first()
+        .layer("layer_a", 4, 512)
+        .layer("layer_b", 4, 1024)
+        .layer("layer_c", 4, 1536)
+        .build();
+
+    // Make every layer's content unique so layer offsets are actually checked.
+    env.layers[1].data.overwrite(0x40);
+    env.layers[2].data.overwrite(0x80);
+
+    let hashes = make_block_hashes(4, 0xAB);
+
+    env.save_all_layers_one_batch(&hashes).await;
+    for layer in &env.layers {
+        layer.data.zero_gpu();
+    }
+
+    let lease = env.assert_all_hit_lease(&hashes).await;
+    env.load_to_gpu(lease, hashes.len()).await;
+
+    for layer in &env.layers {
+        layer.data.assert_gpu_matches_expected();
+    }
+}
+
+/// Page-first seals a block's single slot on the first save, so one save must
+/// carry EVERY layer of the page. A save covering only some layers (e.g. a
+/// pipeline stage holding a subset) would seal a page whose other offsets are
+/// never written — stale pool memory that load would return as another block's
+/// KV. The engine must reject such a partial-layer page-first save loudly.
+#[tokio::test]
+async fn page_first_rejects_partial_layer_save() {
+    let env = TestEnvBuilder::new("test-page-first-partial", "test-ns")
+        .page_first()
+        .layer("layer_a", 4, 512)
+        .layer("layer_b", 4, 512)
+        .layer("layer_c", 4, 512)
+        .build();
+    let hashes = make_block_hashes(4, 0xCD);
+
+    // Submit only layer_a — a partial page that must not seal.
+    let partial = vec![LayerSave {
+        layer_name: env.layers[0].name.clone(),
+        block_ids: (0..hashes.len()).collect(),
+        block_hashes: hashes.clone(),
+    }];
+    let err = env
+        .engine
+        .batch_save_kv_blocks_from_ipc(&env.instance_id, 0, 0, 0, partial)
+        .await
+        .expect_err("partial page-first save must be rejected");
+    assert!(
+        err.to_string().contains("must cover all"),
+        "unexpected error: {err}"
+    );
 }
 
 /// Round-trip with NUMA-aware allocation enabled.

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -41,6 +41,11 @@ message RegisterContextRequest {
   // direct otherwise; overridable via pegaflow.transfer_backend). The engine
   // spawns this instance's GPU worker pools with the requested backend.
   TransferMode transfer_mode = 17;
+  // Page-first storage: collapse all layers of a block into one contiguous
+  // page per tp_rank, so total_slots = tp_size instead of num_layers * tp_size.
+  // Set by the connector for MLA; the engine derives per-layer page offsets
+  // from the registered layouts. See spec.md.
+  bool page_first = 18;
 }
 
 message RegisterContextResponse {

--- a/pegaflow-server/examples/p2p_bench.rs
+++ b/pegaflow-server/examples/p2p_bench.rs
@@ -1,13 +1,29 @@
 //! End-to-end p2p RDMA fetch benchmark and integrity test.
 //!
 //! Drives the production cross-node path without vLLM. The holder saves
-//! blocks through the real GPU save path with a vLLM-shaped layout
-//! (`layers x tp_ranks` slots per block, split K/V segments), registers them
-//! in an in-process MetaServer, and serves the production Engine gRPC
-//! service. The requester registers the same layout, then walks the real
-//! prefetch path: MetaServer discovery -> QueryBlocksForTransfer ->
-//! RDMA READ (requester reads holder slabs) -> SealedBlock rebuild, and
-//! optionally loads the blocks to GPU and verifies every byte.
+//! blocks through the real GPU save path, registers them in an in-process
+//! MetaServer, and serves the production Engine gRPC service. The requester
+//! registers the same layout, then walks the real prefetch path: MetaServer
+//! discovery -> QueryBlocksForTransfer -> RDMA READ (requester reads holder
+//! slabs) -> SealedBlock rebuild, and optionally loads to GPU and verifies
+//! every byte.
+//!
+//! Two layouts:
+//!   * `--model uniform` (default): vLLM dense-attention shape, `layers`
+//!     equal-size split-K/V layers (`--segments 2`). One host slot per
+//!     (layer, tp_rank).
+//!   * `--model glm51`: GLM-5.1 (glm_moe_dsa) MLA shape. Each transformer
+//!     layer contributes two single-segment KV layers -- an MLA latent cache
+//!     (kv_lora_rank 512 + qk_rope_head_dim 64 = 576 dims) and a DSA sparse
+//!     indexer k_cache (index_head_dim 128), both bf16. MLA replicates KV
+//!     across TP, so the realistic transfer shape is `--tp 1` (one effective
+//!     copy).
+//!
+//! `--page-first` collapses host slots from (layers x tp) to (tp): one
+//! contiguous page per (block, tp_rank) instead of one slot per
+//! (block, layer, tp_rank). This cuts RDMA descriptors and the
+//! QueryBlocksForTransfer response payload by ~num_layers. Page-first requires
+//! single-segment layers (it rejects split K/V).
 //!
 //! Holder (node A):
 //!   p2p_bench --role holder --advertise-ip <A> --nics mlx5_0,...
@@ -36,6 +52,15 @@ use tonic::transport::Server;
 enum Role {
     Holder,
     Requester,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq)]
+enum Model {
+    /// vLLM dense-attention: `layers` equal-size split-K/V layers.
+    Uniform,
+    /// GLM-5.1 (glm_moe_dsa): per transformer layer, an MLA latent cache +
+    /// a DSA indexer k_cache, both single-segment bf16.
+    Glm51,
 }
 
 #[derive(Parser)]
@@ -67,19 +92,41 @@ struct Cli {
     #[arg(long, value_delimiter = ',', num_args = 1..)]
     nics: Vec<String>,
 
-    /// Model shape: transformer layers (block slots = layers * tp).
+    /// Layout model.
+    #[arg(long, value_enum, default_value_t = Model::Uniform)]
+    model: Model,
+
+    /// `uniform`: transformer layers (block slots = layers * tp).
     #[arg(long, default_value_t = 36)]
     layers: usize,
 
-    /// Model shape: tensor-parallel ranks; rank r uses CUDA device r.
-    #[arg(long, default_value_t = 8)]
-    tp: usize,
+    /// `glm51`: transformer layers incl. MTP; KV layers = 2 * this.
+    #[arg(long, default_value_t = 79)]
+    glm_layers: usize,
 
-    /// K segment bytes per (block, layer, rank); V segment is the same size.
+    /// Tokens per block (KV page size). `glm51` derives per-layer bytes from it.
+    #[arg(long, default_value_t = 64)]
+    block_size: usize,
+
+    /// `uniform`: K segment bytes per (block, layer, rank). V segment matches.
     #[arg(long, default_value_t = 4096)]
     kv_bytes: usize,
 
-    /// Blocks per set (one set ~= one request's KV prefix).
+    /// `uniform`: segments per slot (2 = split K/V, 1 = single). Page-first
+    /// requires 1.
+    #[arg(long, default_value_t = 2)]
+    segments: usize,
+
+    /// Tensor-parallel ranks; rank r uses CUDA device r. MLA uses tp=1.
+    #[arg(long, default_value_t = 8)]
+    tp: usize,
+
+    /// Store one contiguous page per (block, tp_rank) instead of one slot per
+    /// (block, layer, tp_rank). Collapses metadata ~num_layers. Single-segment only.
+    #[arg(long)]
+    page_first: bool,
+
+    /// Blocks per set (one set ~= one request's KV prefix = seq_len / block_size).
     #[arg(long, default_value_t = 1000)]
     blocks: usize,
 
@@ -87,7 +134,7 @@ struct Cli {
     #[arg(long, default_value_t = 4)]
     sets: usize,
 
-    /// Pinned pool size in GiB. 0 = auto (sets * set bytes + 25% slack).
+    /// Pinned pool size in GiB. 0 = auto (sets * set bytes + 50% slack).
     #[arg(long, default_value_t = 0)]
     pool_gib: usize,
 
@@ -155,27 +202,50 @@ impl GpuBuffer {
     }
 }
 
-/// One tp rank's GPU state: a single buffer backing all layers,
-/// layer l at offset `l * layer_bytes`, K run then V run inside a layer.
+/// One tp rank's GPU state: a single buffer backing all layers, layer `i` at
+/// `layer_offset(i)`, segments laid out back to back inside a layer.
 struct RankBuffers {
     device: usize,
     buf: GpuBuffer,
 }
 
-struct Shape {
-    layers: usize,
-    tp: usize,
+/// One KV layer's per-block geometry.
+#[derive(Clone, Copy)]
+struct LayerSpec {
+    /// Bytes per block for ONE segment of this layer.
     kv_bytes: usize,
+    /// Segments per slot: 1 (single latent) or 2 (split K/V).
+    segments: usize,
+}
+
+impl LayerSpec {
+    /// Bytes one rank stores for this layer across all blocks and segments.
+    fn total_bytes(&self, blocks: usize) -> usize {
+        self.segments * blocks * self.kv_bytes
+    }
+}
+
+struct Shape {
+    layers: Vec<LayerSpec>,
+    tp: usize,
     blocks: usize,
 }
 
 impl Shape {
-    fn layer_bytes(&self) -> usize {
-        2 * self.blocks * self.kv_bytes
+    fn num_layers(&self) -> usize {
+        self.layers.len()
+    }
+
+    /// Byte offset of layer `i` inside a rank's buffer (prefix sum).
+    fn layer_offset(&self, i: usize) -> usize {
+        self.layers[..i]
+            .iter()
+            .map(|l| l.total_bytes(self.blocks))
+            .sum()
     }
 
     fn rank_bytes(&self) -> usize {
-        self.layers * self.layer_bytes()
+        self.layers.iter().map(|l| l.total_bytes(self.blocks)).sum()
     }
 
     fn set_bytes(&self) -> usize {
@@ -183,11 +253,61 @@ impl Shape {
     }
 
     fn layer_names(&self) -> Vec<String> {
-        (0..self.layers).map(|l| format!("layer_{l}")).collect()
+        (0..self.num_layers())
+            .map(|l| format!("layer_{l}"))
+            .collect()
+    }
+
+    /// Host slots a single block occupies on the fetch path.
+    fn slots_per_block(&self, page_first: bool) -> usize {
+        if page_first {
+            self.tp
+        } else {
+            self.num_layers() * self.tp
+        }
+    }
+
+    /// RDMA read descriptors the requester issues for one set.
+    fn descriptors(&self, page_first: bool) -> usize {
+        if page_first {
+            // one contiguous page per (block, rank), single segment
+            self.blocks * self.tp
+        } else {
+            let segs_per_rank: usize = self.layers.iter().map(|l| l.segments).sum();
+            self.blocks * segs_per_rank * self.tp
+        }
     }
 }
 
-/// Deterministic content for one (set, rank, layer, block, segment) cell —
+/// Build the per-layer geometry from CLI flags.
+fn build_layers(cli: &Cli) -> Vec<LayerSpec> {
+    match cli.model {
+        Model::Uniform => (0..cli.layers)
+            .map(|_| LayerSpec {
+                kv_bytes: cli.kv_bytes,
+                segments: cli.segments,
+            })
+            .collect(),
+        Model::Glm51 => {
+            // GLM-5.1 (glm_moe_dsa) per-transformer-layer caches, both single
+            // segment, bf16. MTP is counted in glm_layers.
+            const MLA_DIM: usize = 512 + 64; // kv_lora_rank + qk_rope_head_dim
+            const IDX_DIM: usize = 128; // index_head_dim
+            const ELEM: usize = 2; // bf16
+            let attn = LayerSpec {
+                kv_bytes: cli.block_size * MLA_DIM * ELEM,
+                segments: 1,
+            };
+            let idx = LayerSpec {
+                kv_bytes: cli.block_size * IDX_DIM * ELEM,
+                segments: 1,
+            };
+            (0..cli.glm_layers).flat_map(|_| [attn, idx]).collect()
+        }
+    }
+}
+
+/// Deterministic content for one (set, rank, layer, block, segment) cell --
 /// both sides derive it independently, so the requester can verify bytes
 /// without shipping the expected data out of band.
 fn cell_fill(set: usize, rank: usize, layer: usize, block: usize, seg: usize) -> u8 {
@@ -197,10 +317,10 @@ fn cell_fill(set: usize, rank: usize, layer: usize, block: usize, seg: usize) ->
 /// Fill one rank's host image for `set` in the registered GPU layout.
 fn fill_rank_image(shape: &Shape, set: usize, rank: usize, out: &mut [u8]) {
     assert_eq!(out.len(), shape.rank_bytes());
-    let kv = shape.kv_bytes;
-    for layer in 0..shape.layers {
-        let layer_base = layer * shape.layer_bytes();
-        for seg in 0..2 {
+    for (layer, spec) in shape.layers.iter().enumerate() {
+        let layer_base = shape.layer_offset(layer);
+        let kv = spec.kv_bytes;
+        for seg in 0..spec.segments {
             let seg_base = layer_base + seg * shape.blocks * kv;
             for block in 0..shape.blocks {
                 let fill = cell_fill(set, rank, layer, block, seg);
@@ -221,14 +341,28 @@ fn make_block_hashes(blocks: usize, set: usize) -> Vec<Vec<u8>> {
         .collect()
 }
 
-fn register_ranks(engine: &PegaEngine, shape: &Shape) -> Vec<RankBuffers> {
+fn register_ranks(engine: &PegaEngine, shape: &Shape, page_first: bool) -> Vec<RankBuffers> {
     let layer_names = shape.layer_names();
+    let size_bytes: Vec<usize> = shape
+        .layers
+        .iter()
+        .map(|l| l.total_bytes(shape.blocks))
+        .collect();
+    let bytes_per_block: Vec<usize> = shape.layers.iter().map(|l| l.kv_bytes).collect();
+    let kv_stride: Vec<usize> = shape
+        .layers
+        .iter()
+        .map(|l| shape.blocks * l.kv_bytes)
+        .collect();
+    let segments: Vec<usize> = shape.layers.iter().map(|l| l.segments).collect();
+    let num_blocks = vec![shape.blocks; shape.num_layers()];
+
     (0..shape.tp)
         .map(|rank| {
             let ctx = CudaContext::new(rank).expect("CUDA context");
             let buf = GpuBuffer::alloc(ctx, shape.rank_bytes());
-            let ptrs: Vec<u64> = (0..shape.layers)
-                .map(|l| buf.ptr + (l * shape.layer_bytes()) as u64)
+            let ptrs: Vec<u64> = (0..shape.num_layers())
+                .map(|l| buf.ptr + shape.layer_offset(l) as u64)
                 .collect();
             engine
                 .register_context_layer_batch(
@@ -241,13 +375,13 @@ fn register_ranks(engine: &PegaEngine, shape: &Shape) -> Vec<RankBuffers> {
                     shape.tp, // world_size
                     &layer_names,
                     &ptrs,
-                    &vec![shape.layer_bytes(); shape.layers],
-                    &vec![shape.blocks; shape.layers],
-                    &vec![shape.kv_bytes; shape.layers],
-                    &vec![shape.blocks * shape.kv_bytes; shape.layers], // kv_stride
-                    &vec![2; shape.layers],                             // split K/V
+                    &size_bytes,
+                    &num_blocks,
+                    &bytes_per_block,
+                    &kv_stride,
+                    &segments,
                     TransferMode::Direct,
-                    false,
+                    page_first,
                 )
                 .expect("register rank");
             RankBuffers { device: rank, buf }
@@ -287,6 +421,29 @@ async fn cached_blocks(engine: &PegaEngine, req_id: &str, hashes: &[Vec<u8>]) ->
         PrefetchStatus::Ready { blocks, .. } => blocks.len(),
         PrefetchStatus::Loading => 0,
     }
+}
+
+/// Print the layout's metadata footprint -- the quantities page-first shrinks.
+fn report_metadata(shape: &Shape, page_first: bool) {
+    let slots = shape.blocks * shape.slots_per_block(page_first);
+    let descs = shape.descriptors(page_first);
+    // QueryBlocksForTransferResponse carries one TransferSlotInfo per host
+    // slot (5 fields; v_ptr/v_size are 0 for single-segment) plus a per-block
+    // hash. ~25 B/slot + ~12 B/block on the wire is a close estimate.
+    let query_bytes = slots * 25 + shape.blocks * 12;
+    println!(
+        "META page_first={page_first} model_layers={} tp={} blocks={} \
+         set_mib={:.1} slots_per_block={} total_slots={} rdma_descriptors={} \
+         query_resp_kib={:.1}",
+        shape.num_layers(),
+        shape.tp,
+        shape.blocks,
+        shape.set_bytes() as f64 / (1024.0 * 1024.0),
+        shape.slots_per_block(page_first),
+        slots,
+        descs,
+        query_bytes as f64 / 1024.0,
+    );
 }
 
 async fn run_holder(cli: &Cli, shape: &Shape, pool_bytes: usize) {
@@ -333,7 +490,7 @@ async fn run_holder(cli: &Cli, shape: &Shape, pool_bytes: usize) {
             .expect("Engine gRPC serve");
     });
 
-    let ranks = register_ranks(&engine, shape);
+    let ranks = register_ranks(&engine, shape, cli.page_first);
     let block_ids: Vec<usize> = (0..shape.blocks).collect();
     let layer_names = shape.layer_names();
 
@@ -383,6 +540,7 @@ async fn run_holder(cli: &Cli, shape: &Shape, pool_bytes: usize) {
         );
     }
 
+    report_metadata(shape, cli.page_first);
     println!(
         "HOLDER_READY sets={} blocks={} set_mib={:.1}",
         cli.sets,
@@ -408,8 +566,9 @@ async fn run_requester(cli: &Cli, shape: &Shape, pool_bytes: usize) {
         PegaEngine::new_with_config(pool_bytes, cli.use_hugepages, config)
             .expect("requester engine"),
     );
-    let ranks = register_ranks(&engine, shape);
+    let ranks = register_ranks(&engine, shape, cli.page_first);
     let set_mib = shape.set_bytes() as f64 / (1024.0 * 1024.0);
+    report_metadata(shape, cli.page_first);
 
     let mut results: Vec<(usize, f64)> = Vec::new();
     for set in 0..cli.sets {
@@ -432,8 +591,11 @@ async fn run_requester(cli: &Cli, shape: &Shape, pool_bytes: usize) {
         let gib_s = shape.set_bytes() as f64 / (1024.0 * 1024.0 * 1024.0) / elapsed.as_secs_f64();
         let label = if set == 0 { "warmup" } else { "measure" };
         println!(
-            "FETCH {label} set={set} mib={set_mib:.1} ms={:.2} gib_s={gib_s:.2}",
-            elapsed.as_secs_f64() * 1000.0
+            "FETCH {label} page_first={} set={set} mib={set_mib:.1} ms={:.2} \
+             gib_s={gib_s:.2} descriptors={}",
+            cli.page_first,
+            elapsed.as_secs_f64() * 1000.0,
+            shape.descriptors(cli.page_first),
         );
         if set > 0 {
             results.push((set, elapsed.as_secs_f64()));
@@ -449,8 +611,13 @@ async fn run_requester(cli: &Cli, shape: &Shape, pool_bytes: usize) {
         times.sort_by(|a, b| a.partial_cmp(b).unwrap());
         let median = times[times.len() / 2];
         println!(
-            "SUMMARY sets_measured={} set_mib={set_mib:.1} median_ms={:.2} median_gib_s={:.2}",
-            times.len(),
+            "SUMMARY page_first={} model_layers={} tp={} blocks={} set_mib={set_mib:.1} \
+             descriptors={} median_ms={:.2} median_gib_s={:.2}",
+            cli.page_first,
+            shape.num_layers(),
+            shape.tp,
+            shape.blocks,
+            shape.descriptors(cli.page_first),
             median * 1000.0,
             shape.set_bytes() as f64 / (1024.0 * 1024.0 * 1024.0) / median
         );
@@ -534,9 +701,8 @@ async fn main() {
     pegaflow_common::logging::init_stdout_colored("info");
 
     let shape = Shape {
-        layers: cli.layers,
+        layers: build_layers(&cli),
         tp: cli.tp,
-        kv_bytes: cli.kv_bytes,
         blocks: cli.blocks,
     };
     // Generous slack: if the pool runs tight the engine evicts earlier sets
@@ -547,15 +713,17 @@ async fn main() {
         (cli.sets * shape.set_bytes() + shape.set_bytes() / 2).max(1 << 30)
     };
     info!(
-        "p2p_bench role={:?} shape: layers={} tp={} kv_bytes={} blocks={} sets={} set_bytes={:.1}MiB pool={:.1}GiB",
+        "p2p_bench role={:?} model={:?} layers={} tp={} blocks={} sets={} \
+         set_bytes={:.1}MiB pool={:.1}GiB page_first={}",
         cli.role,
-        shape.layers,
+        cli.model,
+        shape.num_layers(),
         shape.tp,
-        shape.kv_bytes,
         shape.blocks,
         cli.sets,
         shape.set_bytes() as f64 / (1024.0 * 1024.0),
         pool_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+        cli.page_first,
     );
 
     match cli.role {

--- a/pegaflow-server/examples/p2p_bench.rs
+++ b/pegaflow-server/examples/p2p_bench.rs
@@ -126,6 +126,15 @@ struct Cli {
     #[arg(long)]
     page_first: bool,
 
+    /// Model the KV as a single MLA replica (effective_tp_size=1): register all
+    /// `--tp` GPUs into one slot space (tp_rank=0, unique device_id) and
+    /// block-stripe the save (GPU r stores blocks where block_id % tp == r, all
+    /// layers). Stores ONE logical copy striped across the GPUs / both NUMA
+    /// nodes -- the real GLM-5.1 MLA-TP transfer shape. Without it, `--tp` is
+    /// dense (N independent full copies).
+    #[arg(long)]
+    mla_replica: bool,
+
     /// Blocks per set (one set ~= one request's KV prefix = seq_len / block_size).
     #[arg(long, default_value_t = 1000)]
     blocks: usize,
@@ -227,13 +236,22 @@ impl LayerSpec {
 
 struct Shape {
     layers: Vec<LayerSpec>,
+    /// Physical GPU / device count.
     tp: usize,
     blocks: usize,
+    /// One MLA replica striped across the `tp` GPUs (effective_tp_size=1).
+    mla_replica: bool,
 }
 
 impl Shape {
     fn num_layers(&self) -> usize {
         self.layers.len()
+    }
+
+    /// Effective tp_size the engine sees: 1 for an MLA replica, else the
+    /// physical GPU count (dense TP).
+    fn eng_tp_size(&self) -> usize {
+        if self.mla_replica { 1 } else { self.tp }
     }
 
     /// Byte offset of layer `i` inside a rank's buffer (prefix sum).
@@ -248,8 +266,14 @@ impl Shape {
         self.layers.iter().map(|l| l.total_bytes(self.blocks)).sum()
     }
 
+    /// Bytes stored and transferred for one set: dense = `tp` independent
+    /// copies; mla-replica = one copy striped across the `tp` GPUs.
     fn set_bytes(&self) -> usize {
-        self.tp * self.rank_bytes()
+        if self.mla_replica {
+            self.rank_bytes()
+        } else {
+            self.tp * self.rank_bytes()
+        }
     }
 
     fn layer_names(&self) -> Vec<String> {
@@ -260,21 +284,23 @@ impl Shape {
 
     /// Host slots a single block occupies on the fetch path.
     fn slots_per_block(&self, page_first: bool) -> usize {
+        let eng_tp = self.eng_tp_size();
         if page_first {
-            self.tp
+            eng_tp
         } else {
-            self.num_layers() * self.tp
+            self.num_layers() * eng_tp
         }
     }
 
     /// RDMA read descriptors the requester issues for one set.
     fn descriptors(&self, page_first: bool) -> usize {
+        let eng_tp = self.eng_tp_size();
         if page_first {
-            // one contiguous page per (block, rank), single segment
-            self.blocks * self.tp
+            // one contiguous page per (block, slot), single segment
+            self.blocks * eng_tp
         } else {
             let segs_per_rank: usize = self.layers.iter().map(|l| l.segments).sum();
-            self.blocks * segs_per_rank * self.tp
+            self.blocks * segs_per_rank * eng_tp
         }
     }
 }
@@ -356,6 +382,9 @@ fn register_ranks(engine: &PegaEngine, shape: &Shape, page_first: bool) -> Vec<R
         .collect();
     let segments: Vec<usize> = shape.layers.iter().map(|l| l.segments).collect();
     let num_blocks = vec![shape.blocks; shape.num_layers()];
+    // MLA replica: every GPU registers tp_rank=0, tp_size=1 (one slot space),
+    // distinguished only by device_id. Dense: tp_rank=device, tp_size=tp.
+    let eng_tp = shape.eng_tp_size();
 
     (0..shape.tp)
         .map(|rank| {
@@ -364,15 +393,16 @@ fn register_ranks(engine: &PegaEngine, shape: &Shape, page_first: bool) -> Vec<R
             let ptrs: Vec<u64> = (0..shape.num_layers())
                 .map(|l| buf.ptr + shape.layer_offset(l) as u64)
                 .collect();
+            let tp_rank = if shape.mla_replica { 0 } else { rank };
             engine
                 .register_context_layer_batch(
                     INSTANCE,
                     NAMESPACE,
-                    rank as i32, // device_id
-                    rank,        // tp_rank
-                    0,           // pp_rank
-                    shape.tp,
-                    shape.tp, // world_size
+                    rank as i32, // device_id (the worker key)
+                    tp_rank,
+                    0, // pp_rank
+                    eng_tp,
+                    shape.tp, // world_size = physical GPU count
                     &layer_names,
                     &ptrs,
                     &size_bytes,
@@ -491,25 +521,37 @@ async fn run_holder(cli: &Cli, shape: &Shape, pool_bytes: usize) {
     });
 
     let ranks = register_ranks(&engine, shape, cli.page_first);
-    let block_ids: Vec<usize> = (0..shape.blocks).collect();
     let layer_names = shape.layer_names();
 
     let mut image = vec![0u8; shape.rank_bytes()];
     for set in 0..cli.sets {
         let hashes = make_block_hashes(shape.blocks, set);
         for (rank, rb) in ranks.iter().enumerate() {
-            fill_rank_image(shape, set, rank, &mut image);
+            // MLA replica: all GPUs hold identical content and each saves only
+            // its block stripe (block_id % tp == rank), so the union is exactly
+            // one copy. Dense: each GPU has distinct content and saves every block.
+            let content_rank = if cli.mla_replica { 0 } else { rank };
+            fill_rank_image(shape, set, content_rank, &mut image);
             rb.buf.copy_from_host(&image);
+            let (block_ids, block_hashes): (Vec<usize>, Vec<Vec<u8>>) = if cli.mla_replica {
+                (0..shape.blocks)
+                    .filter(|b| b % shape.tp == rank)
+                    .map(|b| (b, hashes[b].clone()))
+                    .unzip()
+            } else {
+                ((0..shape.blocks).collect(), hashes.clone())
+            };
+            let tp_rank = if cli.mla_replica { 0 } else { rank };
             let saves = layer_names
                 .iter()
                 .map(|name| LayerSave {
                     layer_name: name.clone(),
                     block_ids: block_ids.clone(),
-                    block_hashes: hashes.clone(),
+                    block_hashes: block_hashes.clone(),
                 })
                 .collect();
             engine
-                .batch_save_kv_blocks_from_ipc(INSTANCE, rank, 0, rb.device as i32, saves)
+                .batch_save_kv_blocks_from_ipc(INSTANCE, tp_rank, 0, rb.device as i32, saves)
                 .await
                 .expect("save");
         }
@@ -646,8 +688,18 @@ async fn verify_set(
     let layer_names = shape.layer_names();
     let layer_name_refs: Vec<&str> = layer_names.iter().map(|s| s.as_str()).collect();
 
+    // MLA replica: one stored copy loadable from any worker (tp_rank=0); verify
+    // it once on device 0. Dense: verify each rank's distinct shard.
+    let targets: Vec<(usize, &RankBuffers)> = if shape.mla_replica {
+        vec![(0usize, &ranks[0])]
+    } else {
+        ranks.iter().enumerate().collect()
+    };
+
     let mut expected = vec![0u8; shape.rank_bytes()];
-    for (rank, rb) in ranks.iter().enumerate() {
+    for (rank, rb) in targets {
+        let tp_rank = if shape.mla_replica { 0 } else { rank };
+        let content_rank = if shape.mla_replica { 0 } else { rank };
         let lease = engine
             .create_query_lease(INSTANCE, blocks.clone())
             .expect("create lease");
@@ -656,7 +708,7 @@ async fn verify_set(
         engine
             .batch_load_kv_blocks_multi_layer(
                 INSTANCE,
-                rank,
+                tp_rank,
                 rb.device as i32,
                 load_state.shm_name(),
                 &layer_name_refs,
@@ -675,16 +727,14 @@ async fn verify_set(
         }
 
         let loaded = rb.buf.copy_to_host();
-        fill_rank_image(shape, set, rank, &mut expected);
+        fill_rank_image(shape, set, content_rank, &mut expected);
         assert!(
             loaded == expected,
             "verify FAILED: set {set} rank {rank} differs from generator pattern"
         );
     }
-    println!(
-        "VERIFY set={set} ok (all {} ranks, every byte)",
-        ranks.len()
-    );
+    let n = if shape.mla_replica { 1 } else { ranks.len() };
+    println!("VERIFY set={set} ok ({n} target(s), every byte)");
 }
 
 fn nic_config(cli: &Cli) -> Option<Vec<String>> {
@@ -704,6 +754,7 @@ async fn main() {
         layers: build_layers(&cli),
         tp: cli.tp,
         blocks: cli.blocks,
+        mla_replica: cli.mla_replica,
     };
     // Generous slack: if the pool runs tight the engine evicts earlier sets
     // (and deregisters them from MetaServer), which breaks the run.
@@ -714,7 +765,7 @@ async fn main() {
     };
     info!(
         "p2p_bench role={:?} model={:?} layers={} tp={} blocks={} sets={} \
-         set_bytes={:.1}MiB pool={:.1}GiB page_first={}",
+         set_bytes={:.1}MiB pool={:.1}GiB page_first={} mla_replica={}",
         cli.role,
         cli.model,
         shape.num_layers(),
@@ -724,6 +775,7 @@ async fn main() {
         shape.set_bytes() as f64 / (1024.0 * 1024.0),
         pool_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
         cli.page_first,
+        cli.mla_replica,
     );
 
     match cli.role {

--- a/pegaflow-server/examples/p2p_bench.rs
+++ b/pegaflow-server/examples/p2p_bench.rs
@@ -247,6 +247,7 @@ fn register_ranks(engine: &PegaEngine, shape: &Shape) -> Vec<RankBuffers> {
                     &vec![shape.blocks * shape.kv_bytes; shape.layers], // kv_stride
                     &vec![2; shape.layers],                             // split K/V
                     TransferMode::Direct,
+                    false,
                 )
                 .expect("register rank");
             RankBuffers { device: rank, buf }

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -317,6 +317,7 @@ impl Engine for GrpcEngineService {
                 &kv_stride_bytes_list,
                 &segments_list,
                 transfer_mode,
+                req.page_first,
             ) {
                 let status = Self::map_engine_error(err);
                 let removed = self.registry.drop_context(context_key.clone()).await;
@@ -1003,6 +1004,7 @@ mod tests {
             segments: Vec::new(),
             pp_rank: 0,
             transfer_mode: ProtoTransferMode::Direct as i32,
+            page_first: false,
         })
         .expect_err("tp_rank outside tp_size must be rejected at RPC boundary");
 
@@ -1028,6 +1030,7 @@ mod tests {
             segments: Vec::new(),
             pp_rank: 0,
             transfer_mode: ProtoTransferMode::Direct as i32,
+            page_first: false,
         })
         .expect_err("client/server version mismatch must be rejected before registration");
 

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -534,6 +534,7 @@ fn register_instance_layers(
                 &[0],
                 &[1],
                 TransferMode::Direct,
+                false,
             )
             .expect("register_context_layer_batch");
     }

--- a/pegaflow-server/tests/http_cleanup_hang_repro.rs
+++ b/pegaflow-server/tests/http_cleanup_hang_repro.rs
@@ -248,6 +248,7 @@ fn wedge_register_request(i: usize) -> RegisterContextRequest {
         segments: vec![1],
         pp_rank: 0,
         transfer_mode: TransferMode::Direct as i32,
+        page_first: false,
     }
 }
 

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -321,6 +321,7 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
             &[0], // kv_strides
             &[1], // segments
             TransferMode::Direct,
+            false,
         )
         .expect("register layer on engine A");
 
@@ -393,6 +394,7 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
             &[0],
             &[1],
             TransferMode::Direct,
+            false,
         )
         .expect("register layer on engine B");
 

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -198,8 +198,9 @@ class WorkerConnector:
         self._failed_load_reqs: set[str] = set()
 
         self._registered_layers: list[str] = []
-        # Layer subset this rank saves (MLA replica sharding); None = save all.
-        self._save_layer_shard: list[str] | None = None
+        # Page-first storage: all layers of a block in one host page, one slot
+        # per tp_rank. Saves distribute by block stripe instead of by layer.
+        self._page_first: bool = False
         self._torch_device: torch.device | None = None
 
         self._cross_layer_mode = False
@@ -267,7 +268,7 @@ class WorkerConnector:
             raise RuntimeError("No KV cache layers were selected for registration")
 
         self._registered_layers = list(kv_caches.keys())
-        self._save_layer_shard = self._compute_save_layer_shard()
+        self._page_first = self._use_page_first()
         self._torch_device = next(iter(kv_caches.values())).device
 
         layout = "unknown"
@@ -332,6 +333,7 @@ class WorkerConnector:
             layer_kv_stride_bytes,
             layer_segments,
             self._ctx.transfer_backend,
+            self._page_first,
         )
 
         if not ok:
@@ -696,23 +698,34 @@ class WorkerConnector:
                 if not save_intent.block_ids:
                     continue
 
+                block_ids = save_intent.block_ids
+                block_hashes = save_intent.block_hashes
+
                 if self._cross_layer_mode:
                     target_layers = (self._cross_layer_key,)
-                elif self._save_layer_shard is not None:
-                    # MLA replica save: this rank only writes its layer slice.
-                    target_layers = tuple(self._save_layer_shard)
+                elif self._page_first:
+                    # Page-first: a block's page holds every layer, so this rank
+                    # writes all layers for its block stripe (not a layer slice).
+                    assert self._registered_layers, (
+                        "KV caches must be registered before submitting save intents"
+                    )
+                    target_layers = tuple(self._registered_layers)
+                    block_ids, block_hashes = self._block_shard(save_intent)
                 else:
                     assert self._registered_layers, (
                         "KV caches must be registered before submitting save intents"
                     )
                     target_layers = tuple(self._registered_layers)
 
+                if not block_ids:
+                    continue
+
                 for layer_name in target_layers:
                     if layer_name not in saves_by_layer:
                         saves_by_layer[layer_name] = ([], [])
 
-                    saves_by_layer[layer_name][0].extend(save_intent.block_ids)
-                    saves_by_layer[layer_name][1].extend(save_intent.block_hashes)
+                    saves_by_layer[layer_name][0].extend(block_ids)
+                    saves_by_layer[layer_name][1].extend(block_hashes)
 
         if saves_by_layer:
             # Ensure all GPU kernels have completed before reading KV cache
@@ -791,43 +804,54 @@ class WorkerConnector:
                 suffix,
             )
 
-    def _mla_replica_save(self) -> bool:
-        """Whether to shard the save by layer across TP ranks.
+    def _use_page_first(self) -> bool:
+        """Whether this instance stores blocks page-first.
 
-        MLA without DCP replicates the full KV on every TP rank's GPU. Instead
-        of TP0 saving every layer (one GPU's copy engine carries all D2H), each
-        rank writes its own layer slice to its NUMA-local pool. Returns False
-        when KV is already unique per rank (non-MLA), per-rank layer-split
-        registration is in effect, or DCP makes each rank store distinct tokens.
+        Page-first packs all layers of a block into one contiguous host page
+        (one slot per tp_rank instead of one per layer), cutting per-block
+        metadata by a factor of num_layers. Phase 1 scope: MLA without DCP and
+        without per-rank layer-split registration — the full-replica case where
+        every rank holds all layers and can assemble a complete page for its
+        block stripe. At tp_size == 1 there is no cross-rank striping, but the
+        per-block metadata collapse still applies.
+
+        Pipeline parallelism is excluded: with pp_size > 1 each stage registers
+        only its own layers, but the engine seals one topology spanning the
+        union of all stages' layers, so a page covers layers no single worker
+        holds. Since total_slots collapses to 1, the first save seals the page
+        with only that stage's layers written — the rest stay stale and the
+        other stages' same-hash saves dedup instead of repairing it. Page-first
+        requires that one worker can write a block's entire page.
         """
         return (
             self._ctx.is_mla
-            and not self._use_mla_layer_split_registration
             and self._ctx.dcp_world_size == 1
-            and self._ctx.tp_size > 1
+            and self._ctx.pp_size == 1
+            and not self._use_mla_layer_split_registration
         )
 
-    def _compute_save_layer_shard(self) -> list[str] | None:
-        """Layer subset this rank is responsible for saving, or None for all.
+    def _block_shard(self, save_intent) -> tuple[list[int], list[bytes]]:
+        """`(block_ids, hashes)` this rank saves under page-first: a block stripe.
 
-        Ranks sort registered layer names (matching the server's sorted-name
-        layer-id space) and take a strided slice. Striding by tp_rank is a
-        disjoint, complete partition of the layers with no cross-rank
-        coordination, so the union still fills every block's slots.
-
-        Correctness depends on every rank in the save group registering the
-        identical layer set, which holds here by construction: this path runs
-        only when `_mla_replica_save()` is true, i.e. MLA fully replicates the
-        KV cache across TP ranks and each rank registers the same full layer
-        set. The one mode that registers a per-rank layer subset
-        (`mla_layer_split_kv_cache`) is excluded by `_mla_replica_save()` and
-        already distributes the save itself.
+        A page needs all layers, so page-first distributes save work by block
+        rather than by layer: rank r saves physical blocks where
+        `block_id % tp_size == r`, writing all their layers. The stripes are
+        disjoint and complete, so every block's page is written exactly once.
+        With tp_size == 1 this is the whole set.
         """
-        if not self._mla_replica_save():
-            return None
-        ordered = sorted(self._registered_layers)
+        tp_size = self._ctx.tp_size
+        if tp_size <= 1:
+            return list(save_intent.block_ids), list(save_intent.block_hashes)
         tp_rank = self._ctx.tp_rank or 0
-        return [name for idx, name in enumerate(ordered) if idx % self._ctx.tp_size == tp_rank]
+        ids: list[int] = []
+        hashes: list[bytes] = []
+        for block_id, block_hash in zip(
+            save_intent.block_ids, save_intent.block_hashes, strict=True
+        ):
+            if block_id % tp_size == tp_rank:
+                ids.append(block_id)
+                hashes.append(block_hash)
+        return ids, hashes
 
     def handle_preemptions(self, preempted_req_ids: set[str] | None) -> None:
         """Wait for preempted requests' saves to complete before blocks are reused.

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -76,6 +76,7 @@ class EngineRpcClient:
         kv_stride_bytes_list: list[int],
         segments_list: list[int],
         transfer_backend: str,
+        page_first: bool,
     ) -> tuple[bool, str]:
         """Register all KV cache layers on a GPU with a single RPC call.
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -272,7 +272,7 @@ impl EngineRpcClient {
         clippy::too_many_arguments,
         reason = "PyO3 binding mirrors the public batch registration call shape"
     )]
-    #[pyo3(signature = (instance_id, namespace, tp_rank, pp_rank, tp_size, world_size, device_id, layer_names, wrapper_bytes_list, num_blocks_list, bytes_per_block_list, kv_stride_bytes_list, segments_list, transfer_backend))]
+    #[pyo3(signature = (instance_id, namespace, tp_rank, pp_rank, tp_size, world_size, device_id, layer_names, wrapper_bytes_list, num_blocks_list, bytes_per_block_list, kv_stride_bytes_list, segments_list, transfer_backend, page_first))]
     fn register_context_batch(
         &self,
         py: Python<'_>,
@@ -290,6 +290,7 @@ impl EngineRpcClient {
         kv_stride_bytes_list: Vec<u64>,
         segments_list: Vec<u32>,
         transfer_backend: &str,
+        page_first: bool,
     ) -> PyResult<(bool, String)> {
         let transfer_mode = match transfer_backend {
             "direct" => TransferMode::Direct,
@@ -318,6 +319,7 @@ impl EngineRpcClient {
                     segments: segments_list,
                     pp_rank,
                     transfer_mode: transfer_mode as i32,
+                    page_first,
                 })
                 .await?;
             Ok(resp.into_inner())

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -118,49 +118,61 @@ def test_effective_tp_cases(case: str, kwargs: dict, expected_rank: int, expecte
     assert ctx.effective_tp_size == expected_size, case
 
 
+# ---------------------------------------------------------------------------
+# Tests — page-first storage (all layers of a block in one page slot)
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.parametrize(
     ("case", "kwargs", "additional_config", "expected"),
     [
         pytest.param(
-            "ordinary_mla_replica_shards_by_layer",
-            {"is_mla": True, "tp_rank": 1, "tp_size": 2},
+            "mla_no_dcp_uses_page_first",
+            {"is_mla": True, "tp_rank": 0, "tp_size": 2},
             {},
             True,
-            id="ordinary_mla_replica",
+            id="mla_no_dcp",
         ),
         pytest.param(
-            "mla_layer_split_registration_already_distributes",
-            {"is_mla": True, "tp_rank": 1, "tp_size": 2},
+            "mla_tp1_still_page_first",
+            {"is_mla": True, "tp_rank": 0, "tp_size": 1},
+            {},
+            True,
+            id="mla_tp1",
+        ),
+        pytest.param(
+            "mla_layer_split_opts_out",
+            {"is_mla": True, "tp_rank": 0, "tp_size": 2},
             {"mla_layer_split_kv_cache": True},
             False,
-            id="mla_layer_split_registration",
+            id="layer_split",
         ),
         pytest.param(
-            "dcp_mla_stores_distinct_tokens",
-            {"is_mla": True, "tp_rank": 1, "tp_size": 2, "dcp_world_size": 2, "dcp_rank": 1},
+            "dcp_mla_opts_out",
+            {"is_mla": True, "tp_rank": 0, "tp_size": 2, "dcp_world_size": 2, "dcp_rank": 1},
             {},
             False,
-            id="dcp_mla",
+            id="dcp",
         ),
         pytest.param(
-            "non_mla_already_unique_per_rank",
-            {"is_mla": False, "tp_rank": 1, "tp_size": 2},
+            # PP stages each hold only their own layers, so no single worker can
+            # write a block's whole page — page-first must opt out.
+            "pp_mla_opts_out",
+            {"is_mla": True, "tp_rank": 0, "tp_size": 2, "pp_size": 2, "pp_rank": 1},
+            {},
+            False,
+            id="pp",
+        ),
+        pytest.param(
+            "non_mla_opts_out",
+            {"is_mla": False, "tp_rank": 0, "tp_size": 2},
             {},
             False,
             id="non_mla",
         ),
-        pytest.param(
-            "mla_single_gpu_nothing_to_shard",
-            {"is_mla": True, "tp_rank": 0, "tp_size": 1},
-            {},
-            False,
-            id="mla_tp1",
-        ),
     ],
 )
-def test_mla_replica_save_detection(
-    case: str, kwargs: dict, additional_config: dict, expected: bool
-):
+def test_use_page_first_detection(case: str, kwargs: dict, additional_config: dict, expected: bool):
     from pegaflow.connector.worker import WorkerConnector
 
     ctx = _make_ctx(**kwargs)
@@ -169,50 +181,57 @@ def test_mla_replica_save_detection(
         vllm_config=SimpleNamespace(additional_config=additional_config),
     )
     try:
-        assert worker._mla_replica_save() is expected, case
+        assert worker._use_page_first() is expected, case
     finally:
         worker.shutdown()
 
 
-def test_mla_save_layer_shard_is_a_partition():
-    """Across ranks the per-rank layer shards must be disjoint and cover every
-    layer — otherwise blocks never seal (missing slot) or get double-saved."""
+def test_page_first_block_shard_is_a_partition():
+    """Page-first distributes saves by block, not by layer. Across ranks the
+    block stripes must be disjoint and cover every block — otherwise a block's
+    page is dropped (never sealed) or saved twice."""
     from pegaflow.connector.worker import WorkerConnector
 
-    layers = [f"model.layers.{i}.self_attn.attn" for i in range(13)]
+    block_ids = tuple(range(13))
+    block_hashes = tuple(bytes([i]) for i in block_ids)
+    intent = SaveIntent(block_ids=block_ids, block_hashes=block_hashes)
     tp_size = 4
 
-    seen: list[str] = []
+    seen: list[int] = []
     for tp_rank in range(tp_size):
         ctx = _make_ctx(is_mla=True, tp_rank=tp_rank, tp_size=tp_size)
         worker = WorkerConnector(ctx, vllm_config=SimpleNamespace(additional_config={}))
         try:
-            worker._registered_layers = list(layers)
-            shard = worker._compute_save_layer_shard()
-            worker._registered_layers = []  # skip mock unregister on shutdown
+            ids, hashes = worker._block_shard(intent)
         finally:
             worker.shutdown()
-        assert shard is not None, tp_rank
-        seen.extend(shard)
+        # block_ids and block_hashes stay aligned after striping.
+        assert [bytes([i]) for i in ids] == hashes, tp_rank
+        seen.extend(ids)
 
     # Equal sorted multisets ⇒ complete coverage and no duplicates across ranks.
-    assert sorted(seen) == sorted(layers)
+    assert sorted(seen) == sorted(block_ids)
 
 
-def test_mla_replica_save_submits_only_this_ranks_shard():
-    """A non-zero MLA rank must save its layer slice (not all layers, not
-    nothing) — this is what replaces the old TP0-only save."""
+def test_page_first_saves_all_layers_for_this_ranks_block_stripe():
+    """A page needs every layer, so a page-first rank saves ALL layers but only
+    its block stripe (block_id % tp_size == tp_rank)."""
     from pegaflow.connector.worker import SaveTask, WorkerConnector
 
     ctx = _make_ctx(is_mla=True, tp_rank=1, tp_size=2, device_id=1)
     worker = WorkerConnector(ctx, vllm_config=SimpleNamespace(additional_config={}))
-    worker._registered_layers = ["a", "b", "c", "d"]
-    worker._save_layer_shard = worker._compute_save_layer_shard()  # sorted idx%2==1 → b, d
+    worker._registered_layers = ["a", "b", "c"]
+    worker._page_first = True
     worker._torch_device = None
     ctx.engine_client.save.return_value = (True, "")
 
     meta = PegaConnectorMetadata(
-        save_intents={"r1": SaveIntent(block_ids=(0, 1), block_hashes=(b"h0", b"h1"))}
+        save_intents={
+            "r1": SaveIntent(
+                block_ids=(0, 1, 2, 3),
+                block_hashes=(b"h0", b"h1", b"h2", b"h3"),
+            )
+        }
     )
     try:
         with patch("torch.cuda.synchronize"):
@@ -223,7 +242,12 @@ def test_mla_replica_save_submits_only_this_ranks_shard():
 
     ctx.engine_client.save.assert_called_once()
     saves_list = ctx.engine_client.save.call_args.args[4]
-    assert {name for name, _ids, _hashes in saves_list} == {"b", "d"}
+    # Every layer is saved (the whole page)...
+    assert {name for name, _ids, _hashes in saves_list} == {"a", "b", "c"}
+    # ...but only rank 1's block stripe (odd block ids), hashes kept aligned.
+    for _name, ids, hashes in saves_list:
+        assert list(ids) == [1, 3]
+        assert list(hashes) == [b"h1", b"h3"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Store MLA KV cache **page-first** on the host: fold all layers of a block into one
contiguous host page — one storage slot per `tp_rank` instead of one per
`(layer, tp_rank)`. This collapses per-block metadata (RDMA descriptors, SSD
`SlotMeta`, pinned allocations) by roughly `num_layers×`.

**Scope (phase 1):** MLA without DCP, without per-rank layer-split registration,
and without pipeline parallelism. The GPU layout is unchanged; only the host
storage layout changes.

## How

**Engine**
- `PageLayout` (per-layer byte offsets — a 512-aligned prefix sum — plus `page_size`)
  is built at seal time from the sorted-name layer order.
- `total_slots` / `slot_index` collapse the layer dimension: page-first → `tp_rank`.
- Save allocates one page per block and writes each layer into its sub-view
  (`page_base + offset(layer)`); load reads each layer back from the same offset.
- A page-first save that does not cover **every** layer is rejected with
  `InvalidArgument` — a single pipeline stage can never fill a whole page, so a
  partial save must fail loudly instead of sealing a page with stale memory.

**Connector**
- Distribute saves by **block stripe** (`block_id % tp_size == tp_rank`, all layers)
  rather than by layer. This supersedes and **removes** the by-layer MLA save
  distribution from #359 (page-first's gate is a strict superset of that path, so
  it was unreachable).

**Why page-first excludes pipeline parallelism**
A block's page now lives in a single slot. Under PP each stage registers only its
own layers, but the engine seals one topology spanning the union of all stages'
layers, so a page covers layers no single worker holds. With `total_slots == 1`
the first save seals the page with only that stage's layers written; the other
stages' same-content-hash saves dedup instead of repairing it, and load returns
stale KV. This is gated off in the connector (`pp_size == 1`) **and** rejected in
the engine as defense-in-depth.

**proto**
- Add `page_first` to `RegisterContextRequest`; it is part of the version-checked
  topology contract (a re-registration that disagrees on the flag is rejected).

## Testing

On a multi-GPU CUDA-13 box (debug + release):
- `pegaflow-core` `engine_basic`: 9/9 — including a page-first round-trip with
  **unequal** layer sizes (512/1024/1536, offsets 0/512/1536) and the partial-layer
  save rejection; the 7 pre-existing round-trips show no regression.
- `pegaflow-core` `instance::tests`: 9/9 — slot-model collapse, page layout, and the
  `page_first` version contract.

Default Python gate (no GPU): 178 passed — page-first gating (mla / dcp / layer-split
/ pp / non-mla / tp1), block-stripe partition (disjoint + complete), and all-layers
per stripe save.

`cargo clippy --features cuda-13,rdma`, `ruff`, `typos`, and `cargo fmt` all clean.

## Compatibility

Per the strict version handshake (exact `CARGO_PKG_VERSION` match at registration)
and ephemeral SSD cache, no backward compatibility / on-disk migration is needed.

## Remaining before merge

- vLLM MLA end-to-end correctness (DeepSeek-V2-Lite) under tp8 / pp4-tp2 / pp8 —
  the merge gate; in progress on the GPU box.
