### PR TITLE
feat(metaserver): add live-owner block redundancy metrics

### DIFF
--- a/pegaflow-metaserver/src/metric.rs
+++ b/pegaflow-metaserver/src/metric.rs
@@ -14,6 +14,8 @@ struct StoreGaugeHandles {
     _entries: ObservableGauge<u64>,
     _owners: ObservableGauge<u64>,
     _nodes: ObservableGauge<u64>,
+    _redundancy: ObservableGauge<u64>,
+    _redundancy_avg: ObservableGauge<f64>,
 }
 
 static STORE_GAUGES: OnceLock<StoreGaugeHandles> = OnceLock::new();
@@ -49,10 +51,42 @@ pub fn register_store_gauges(store: &Arc<BlockHashStore>) {
                 observer.observe(stale, &[KeyValue::new("state", "stale")]);
             })
             .build();
+        let redundancy_store = Arc::clone(&s);
+        let redundancy = meter
+            .u64_observable_gauge("pegaflow_metaserver_block_redundancy")
+            .with_description("Block keys bucketed by live owner count (replication factor)")
+            .with_callback(move |observer| {
+                let snap = redundancy_store.redundancy_snapshot();
+                observer.observe(snap.keys_1, &[KeyValue::new("owners", "1")]);
+                observer.observe(snap.keys_2, &[KeyValue::new("owners", "2")]);
+                observer.observe(snap.keys_3, &[KeyValue::new("owners", "3")]);
+                observer.observe(snap.keys_4plus, &[KeyValue::new("owners", ">=4")]);
+            })
+            .build();
+        let redundancy_avg_store = Arc::clone(&s);
+        let redundancy_avg = meter
+            .f64_observable_gauge("pegaflow_metaserver_block_redundancy_avg")
+            .with_description(
+                "Average live owners per block key with at least one live owner \
+                 (cluster replication factor / cache capacity shrink factor)",
+            )
+            .with_callback(move |observer| {
+                let snap = redundancy_avg_store.redundancy_snapshot();
+                let keys = snap.keys_1 + snap.keys_2 + snap.keys_3 + snap.keys_4plus;
+                let avg = if keys == 0 {
+                    0.0
+                } else {
+                    snap.copies as f64 / keys as f64
+                };
+                observer.observe(avg, &[]);
+            })
+            .build();
         StoreGaugeHandles {
             _entries: entries,
             _owners: owners,
             _nodes: nodes,
+            _redundancy: redundancy,
+            _redundancy_avg: redundancy_avg,
         }
     });
 }

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -2,7 +2,7 @@ use dashmap::{DashMap, mapref::entry::Entry};
 use log::{info, warn};
 use pegaflow_common::BlockKey;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
@@ -44,6 +44,34 @@ impl SweepStats {
     }
 }
 
+/// Live-owner redundancy distribution over block keys, recomputed each sweep and
+/// cached so metric scrapes stay O(1). Keys are bucketed by their number of
+/// query-visible owners (1, 2, 3, >=4); keys with zero visible owners are
+/// excluded from every bucket. `copies` is the exact total of visible owners, so
+/// average redundancy (the cache capacity shrink factor) is
+/// `copies / (keys_1 + keys_2 + keys_3 + keys_4plus)`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RedundancySnapshot {
+    pub keys_1: u64,
+    pub keys_2: u64,
+    pub keys_3: u64,
+    pub keys_4plus: u64,
+    pub copies: u64,
+}
+
+impl RedundancySnapshot {
+    fn record(&mut self, visible_owners: u64) {
+        match visible_owners {
+            0 => {}
+            1 => self.keys_1 += 1,
+            2 => self.keys_2 += 1,
+            3 => self.keys_3 += 1,
+            _ => self.keys_4plus += 1,
+        }
+        self.copies += visible_owners;
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StoreError {
     UnknownNode,
@@ -66,6 +94,15 @@ struct NodeRecord {
     last_seen: Instant,
 }
 
+/// Both lifecycle decisions for one owner record, produced from a single `nodes`
+/// lookup: `keep` (survives the TTL purge) and `visible` (query-visible: current
+/// session and node still fresh). Lets the sweep tally live redundancy without
+/// probing the node map twice per owner.
+struct OwnerEval {
+    keep: bool,
+    visible: bool,
+}
+
 /// Async thread-safe block hash storage using DashMap.
 ///
 /// `blocks` maps each block key to node URL ownership records. `nodes` tracks
@@ -74,6 +111,9 @@ pub struct BlockHashStore {
     blocks: DashMap<BlockKey, HashMap<Arc<str>, OwnerRecord>>,
     nodes: DashMap<Arc<str>, NodeRecord>,
     config: StoreConfig,
+    /// Latest live-owner redundancy distribution, refreshed each sweep and read
+    /// by metric callbacks. Decouples the O(N) scan from the scrape path.
+    redundancy: Mutex<RedundancySnapshot>,
 }
 
 impl BlockHashStore {
@@ -86,6 +126,7 @@ impl BlockHashStore {
             blocks: DashMap::new(),
             nodes: DashMap::new(),
             config,
+            redundancy: Mutex::new(RedundancySnapshot::default()),
         }
     }
 
@@ -244,21 +285,30 @@ impl BlockHashStore {
         result
     }
 
-    /// Sweep owners whose node is missing or whose ownership TTL has expired.
+    /// Sweep owners whose node is missing or whose ownership TTL has expired, and
+    /// refresh the cached live-owner redundancy snapshot in the same walk.
     pub fn sweep_expired(&self) -> SweepStats {
         let now = Instant::now();
         let mut stats = SweepStats::default();
+        let mut snapshot = RedundancySnapshot::default();
 
         self.blocks.retain(|_, owners| {
             let before = owners.len();
-            owners.retain(|node, owner| self.should_keep_owner(node, owner, now));
+            let mut visible = 0u64;
+            owners.retain(|node, owner| {
+                let eval = self.eval_owner(node, owner, now);
+                if eval.keep && eval.visible {
+                    visible += 1;
+                }
+                eval.keep
+            });
             stats.removed_owners += before.saturating_sub(owners.len());
             if owners.is_empty() {
                 stats.removed_keys += 1;
-                false
-            } else {
-                true
+                return false;
             }
+            snapshot.record(visible);
+            true
         });
 
         let node_before = self.nodes.len();
@@ -277,7 +327,20 @@ impl BlockHashStore {
         });
         stats.removed_nodes = node_before.saturating_sub(self.nodes.len());
 
+        *self
+            .redundancy
+            .lock()
+            .expect("redundancy snapshot mutex poisoned") = snapshot;
+
         stats
+    }
+
+    /// Latest cached live-owner redundancy distribution (refreshed each sweep).
+    pub fn redundancy_snapshot(&self) -> RedundancySnapshot {
+        *self
+            .redundancy
+            .lock()
+            .expect("redundancy snapshot mutex poisoned")
     }
 
     pub fn entry_count(&self) -> u64 {
@@ -313,6 +376,10 @@ impl BlockHashStore {
     pub fn invalidate_all(&self) {
         self.blocks.clear();
         self.nodes.clear();
+        *self
+            .redundancy
+            .lock()
+            .expect("redundancy snapshot mutex poisoned") = RedundancySnapshot::default();
     }
 
     fn touch_node_session(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
@@ -349,20 +416,26 @@ impl BlockHashStore {
         removed
     }
 
-    fn is_owner_visible(&self, node: &Arc<str>, owner: &OwnerRecord, now: Instant) -> bool {
+    /// Evaluate one owner against the current node session and clocks with a
+    /// single `nodes` lookup. A missing node means the owner is neither kept nor
+    /// visible.
+    fn eval_owner(&self, node: &Arc<str>, owner: &OwnerRecord, now: Instant) -> OwnerEval {
         let Some(record) = self.nodes.get(node.as_ref()) else {
-            return false;
+            return OwnerEval {
+                keep: false,
+                visible: false,
+            };
         };
-        record.node_id == owner.node_id
-            && now.duration_since(record.last_seen) <= self.config.node_stale_after
+        let node_age = now.duration_since(record.last_seen);
+        OwnerEval {
+            keep: now.duration_since(owner.key_register_time) <= self.config.ttl
+                && node_age <= self.config.ttl,
+            visible: record.node_id == owner.node_id && node_age <= self.config.node_stale_after,
+        }
     }
 
-    fn should_keep_owner(&self, node: &Arc<str>, owner: &OwnerRecord, now: Instant) -> bool {
-        let Some(record) = self.nodes.get(node.as_ref()) else {
-            return false;
-        };
-        now.duration_since(owner.key_register_time) <= self.config.ttl
-            && now.duration_since(record.last_seen) <= self.config.ttl
+    fn is_owner_visible(&self, node: &Arc<str>, owner: &OwnerRecord, now: Instant) -> bool {
+        self.eval_owner(node, owner, now).visible
     }
 }
 
@@ -785,5 +858,56 @@ mod tests {
         assert_eq!(store.entry_count(), 0);
         assert_eq!(store.owner_count(), 0);
         assert_eq!(store.node_counts(), (0, 0));
+    }
+
+    #[test]
+    fn test_redundancy_snapshot_buckets_live_owners() {
+        let store = BlockHashStore::new();
+        let a = heartbeat_node(&store, "n-a");
+        let b = heartbeat_node(&store, "n-b");
+        let c = heartbeat_node(&store, "n-c");
+        let d = heartbeat_node(&store, "n-d");
+
+        // 1 owner, 2 owners, and 4 owners across three distinct keys.
+        store.insert_hashes("ns", &[vec![1]], "n-a", a).unwrap();
+        store.insert_hashes("ns", &[vec![2]], "n-a", a).unwrap();
+        store.insert_hashes("ns", &[vec![2]], "n-b", b).unwrap();
+        for (node, id) in [("n-a", a), ("n-b", b), ("n-c", c), ("n-d", d)] {
+            store.insert_hashes("ns", &[vec![3]], node, id).unwrap();
+        }
+
+        store.sweep_expired();
+
+        assert_eq!(
+            store.redundancy_snapshot(),
+            RedundancySnapshot {
+                keys_1: 1,
+                keys_2: 1,
+                keys_3: 0,
+                keys_4plus: 1,
+                copies: 1 + 2 + 4,
+            }
+        );
+    }
+
+    #[test]
+    fn test_redundancy_snapshot_excludes_superseded_owner() {
+        // A block whose only owner is a superseded session has zero *visible*
+        // owners, so it must not appear in any bucket even though the raw record
+        // survives until the TTL purge.
+        let store = BlockHashStore::new();
+        let old_id = heartbeat_node(&store, "node-a");
+        store
+            .insert_hashes("ns", &[vec![1]], "node-a", old_id)
+            .unwrap();
+        store.nodes.get_mut("node-a").unwrap().last_seen =
+            Instant::now() - Duration::from_secs(DEFAULT_NODE_STALE_SECS + 1);
+        let new_id = heartbeat_node(&store, "node-a");
+        assert_ne!(old_id, new_id);
+
+        store.sweep_expired();
+
+        assert_eq!(store.owner_count(), 1, "raw record still present");
+        assert_eq!(store.redundancy_snapshot(), RedundancySnapshot::default());
     }
 }


### PR DESCRIPTION
## What

Two Prometheus gauges on `pegaflow-metaserver` to monitor cross-node block **redundancy** (replication factor):

- `pegaflow_metaserver_block_redundancy{owners="1"|"2"|"3"|">=4"}` — block keys bucketed by **live owner count**.
- `pegaflow_metaserver_block_redundancy_avg` — average live owners per block key that has ≥1 live owner. This is the alert target.

## Why

Redundancy `r = total_owners / unique_blocks` is the factor by which effective cache capacity shrinks: `r = 3` means the cluster is caching 3× less *unique* content than its raw capacity suggests. Because the KV cache runs near-full, redundancy is a **direct capacity tax**, so it is worth a first-class gauge and an alert.

## Design

- Computed **inside the existing `sweep_expired` O(N) walk** — the snapshot is folded into the loop that already visits every owner, so there is no extra per-scrape scan; the gauge callbacks just read a cached `RedundancySnapshot` (O(1) scrape).
- Counts **visible owners only** (node_id matches the current session and the node is fresh) — superseded/stale zombie records are excluded so the factor reflects real live copies, not registry debris.
- Gauges, not counters (redundancy is current state). No `_max` gauge (the `>=4` bucket already captures the heavy tail). Global, single-model deployment — no namespace split.

## Tests

- `store.rs`: `test_redundancy_snapshot_buckets_live_owners`, `test_redundancy_snapshot_excludes_superseded_owner`.

## E2E validation

Brought up the full topology on a jiuzhang H200 node — **1 metaserver + 8 pegaflow-server (one per GPU/NIC) + 8 vLLM (Qwen3-8B, each pinned to its own server)** — and drove concurrent shared-prefix traffic. Clean run from an empty store:

```
store_entries          = 283
block_owners           = 804
block_redundancy{owners="1"}   = 136   # 8 unique prompts
block_redundancy{owners="2"}   = 48    # prefix fired at 2 instances
block_redundancy{owners="3"}   = 44    # prefix fired at 3 instances
block_redundancy{owners=">=4"} = 55    # prefix fired at all 8 instances (8 owners/block)
block_redundancy_avg           = 2.84
```

Internally consistent: bucket sum `136+48+44+55 = 283 = store_entries`; weighted sum equals `block_owners = 804`; the `>=4` bucket carries 440 owners over 55 keys = 8 owners/block, exactly the prefix fanned out to all 8 instances.

Note: redundancy is only meaningfully formed by **concurrent** independent saves of the same prefix (sequential same-prefix traffic dedups via metaserver-query → remote RDMA load), which mirrors a load balancer fanning identical prefixes across replicas. Requires `PYTHONHASHSEED=0` on the vLLM side (prod already sets it) for cross-process block-hash determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)