### PR TITLE
fix(transfer): clean up failed RDMA handshakes

### DIFF
--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -231,15 +231,16 @@ async fn rdma_fetch_task(
     spawn_release_lock(client, transfer_session_id);
 
     let elapsed = t0.elapsed();
+    let secs = elapsed.as_secs_f64();
     let mb = total_bytes as f64 / (1024.0 * 1024.0);
-    let elapsed_ms = elapsed.as_secs_f64() * 1000.0;
-    let throughput_mib_s = if elapsed.as_secs_f64() > 0.0 {
-        mb / elapsed.as_secs_f64()
+    let elapsed_ms = secs * 1000.0;
+    let bandwidth_gb_s = if secs > 0.0 {
+        (total_bytes as f64 / 1e9) / secs
     } else {
         0.0
     };
     info!(
-        "RDMA fetch summary: req_id={req_id} remote={remote_addr} blocks={}/{} slots={} descs={} slabs={} bytes_mib={mb:.1} total_ms={elapsed_ms:.2} tp_mib_s={throughput_mib_s:.0}",
+        "RDMA fetch summary: req_id={req_id} remote={remote_addr} blocks={}/{} slots={} descs={} slabs={} bytes_mib={mb:.1} total_ms={elapsed_ms:.2} bandwidth_gb_s={bandwidth_gb_s:.2}",
         result.len(),
         block_hashes.len(),
         transfer_timing.slot_count,

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -13,7 +13,7 @@ use sideway::ibverbs::AccessFlags;
 
 use self::runtime::RcRuntime;
 use self::session::{RcSession, RdmaOp};
-use self::state::{AddrConnection, RcBackendState, RegisteredMemoryEntry};
+use self::state::{AddrConnection, PerNicState, RcBackendState, RegisteredMemoryEntry};
 use std::ptr::NonNull;
 
 use mea::oneshot;
@@ -277,7 +277,39 @@ impl RcBackend {
         local_nics: Vec<NicHandshake>,
         remote_nics: &[NicHandshake],
     ) -> Result<()> {
+        let result = self.complete_handshake_for_inner(remote_addr, &local_nics, remote_nics);
+        if let Err(err) = result {
+            let (removed_connecting, removed_pending) =
+                self.cleanup_handshake_attempt(remote_addr, &local_nics);
+            warn!(
+                "handshake completion failed: remote={remote_addr} removed_connecting={removed_connecting} removed_pending={removed_pending}: {err}"
+            );
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    fn complete_handshake_for_inner(
+        &self,
+        remote_addr: &str,
+        local_nics: &[NicHandshake],
+        remote_nics: &[NicHandshake],
+    ) -> Result<()> {
         let nic_count = self.nic_count();
+        if local_nics.len() != nic_count {
+            return Err(TransferError::InvalidArgument(
+                "local NIC count mismatch in handshake",
+            ));
+        }
+        for (nic_idx, nic) in local_nics.iter().enumerate() {
+            if nic.endpoints.len() != self.qps_per_peer {
+                return Err(TransferError::Backend(format!(
+                    "local qps_per_peer mismatch on nic={nic_idx}: local={}, expected={}",
+                    nic.endpoints.len(),
+                    self.qps_per_peer,
+                )));
+            }
+        }
         if remote_nics.len() != nic_count {
             return Err(TransferError::InvalidArgument(
                 "remote NIC count mismatch in handshake",
@@ -292,6 +324,15 @@ impl RcBackend {
                 )));
             }
         }
+        let remote_first_qpns: Vec<u32> = remote_nics
+            .iter()
+            .map(|nic| nic.endpoints[0].qp_num)
+            .collect();
+        let remote_memory: Result<Vec<_>> = remote_nics
+            .iter()
+            .map(|nic| PerNicState::build_remote_memory_cache(&nic.memory_regions))
+            .collect();
+        let remote_memory = remote_memory?;
 
         // Pop pending sessions by matching QPN from local_nics (not blind FIFO).
         // Concurrent prepare/complete for different remote addrs could reorder the
@@ -333,15 +374,12 @@ impl RcBackend {
 
         // Store sessions + addr_connections
         let mut state = self.state.lock();
-        let mut remote_first_qpns = Vec::with_capacity(nic_count);
-        for (nic_idx, sessions) in pending.into_iter().enumerate() {
-            let remote = &remote_nics[nic_idx];
-            let remote_first_qpn = remote.endpoints[0].qp_num;
-            state.nics[nic_idx].cache_remote_memory(remote_first_qpn, &remote.memory_regions)?;
+        for (nic_idx, (sessions, memory)) in pending.into_iter().zip(remote_memory).enumerate() {
+            let remote_first_qpn = remote_first_qpns[nic_idx];
+            state.nics[nic_idx].insert_remote_memory_cache(remote_first_qpn, memory);
             state.nics[nic_idx]
                 .sessions
                 .insert(remote_first_qpn, sessions);
-            remote_first_qpns.push(remote_first_qpn);
         }
         let removed = state.connecting.remove(remote_addr);
         debug_assert!(removed, "connecting set should contain {remote_addr}");
@@ -362,7 +400,7 @@ impl RcBackend {
             remote_addr.to_string(),
             AddrConnection {
                 remote_first_qpns,
-                local_nics,
+                local_nics: local_nics.to_vec(),
                 rr_counters,
             },
         );
@@ -371,15 +409,36 @@ impl RcBackend {
 
     /// Drop pending sessions created by get_or_prepare when handshake failed.
     pub(crate) fn abort_handshake(&self, remote_addr: &str, local_nics: &[NicHandshake]) {
+        let (removed_connecting, removed_pending) =
+            self.cleanup_handshake_attempt(remote_addr, local_nics);
+        if removed_connecting || removed_pending > 0 {
+            warn!(
+                "handshake aborted: remote={remote_addr} removed_connecting={removed_connecting} removed_pending={removed_pending}"
+            );
+        } else {
+            debug!("handshake abort ignored after prior cleanup: remote={remote_addr}");
+        }
+    }
+
+    fn cleanup_handshake_attempt(
+        &self,
+        remote_addr: &str,
+        local_nics: &[NicHandshake],
+    ) -> (bool, usize) {
         let mut state = self.state.lock();
-        let removed = state.connecting.remove(remote_addr);
-        debug_assert!(removed, "connecting set should contain {remote_addr}");
-        for (nic_idx, nic) in local_nics.iter().enumerate() {
+        let removed_connecting = state.connecting.remove(remote_addr);
+        let mut removed_pending = 0usize;
+        for (nic_idx, nic) in local_nics.iter().enumerate().take(state.nics.len()) {
             for ep in &nic.endpoints {
-                state.nics[nic_idx].remove_pending_by_qpn(ep.qp_num);
+                if state.nics[nic_idx]
+                    .remove_pending_by_qpn(ep.qp_num)
+                    .is_some()
+                {
+                    removed_pending += 1;
+                }
             }
         }
-        warn!("handshake aborted: remote={remote_addr}");
+        (removed_connecting, removed_pending)
     }
 
     /// Get local NicHandshake metadata for an established connection.

--- a/pegaflow-transfer/src/rc_backend/session.rs
+++ b/pegaflow-transfer/src/rc_backend/session.rs
@@ -42,6 +42,13 @@ pub(crate) struct RdmaOp {
     pub(crate) remote_rkey: u32,
 }
 
+struct RcSessionIo {
+    qp: Mutex<GenericQueuePair>,
+    send_cq: GenericCompletionQueue,
+    _recv_cq: GenericCompletionQueue,
+    local_endpoint: RcEndpoint,
+}
+
 enum SessionCommand {
     Transfer {
         ops: Vec<RdmaOp>,
@@ -51,9 +58,7 @@ enum SessionCommand {
 }
 
 pub(crate) struct RcSession {
-    qp: Mutex<GenericQueuePair>,
-    send_cq: GenericCompletionQueue,
-    _recv_cq: GenericCompletionQueue,
+    io: Arc<RcSessionIo>,
     pub(crate) local_endpoint: RcEndpoint,
     cmd_tx: std_mpsc::Sender<SessionCommand>,
 }
@@ -107,15 +112,19 @@ impl RcSession {
         };
 
         let (cmd_tx, cmd_rx) = std_mpsc::channel();
-        let session = Arc::new(Self {
+        let io = Arc::new(RcSessionIo {
             qp: Mutex::new(qp),
             send_cq,
             _recv_cq: recv_cq,
             local_endpoint,
+        });
+        let session = Arc::new(Self {
+            io: Arc::clone(&io),
+            local_endpoint,
             cmd_tx,
         });
 
-        Self::spawn_worker(Arc::clone(&session), cmd_rx, runtime.numa_node)?;
+        Self::spawn_worker(io, cmd_rx, runtime.numa_node)?;
         Ok(session)
     }
 
@@ -159,7 +168,7 @@ impl RcSession {
             }
         }
 
-        let mut qp = self.qp.lock();
+        let mut qp = self.io.qp.lock();
         let mut rtr_attr = QueuePairAttribute::new();
         rtr_attr
             .setup_state(QueuePairState::ReadyToReceive)
@@ -205,7 +214,7 @@ impl RcSession {
     }
 
     fn spawn_worker(
-        session: Arc<Self>,
+        io: Arc<RcSessionIo>,
         cmd_rx: std_mpsc::Receiver<SessionCommand>,
         numa_node: NumaNode,
     ) -> Result<()> {
@@ -219,16 +228,16 @@ impl RcSession {
                 }
                 debug!(
                     "session worker started: local_qpn={}, numa={}",
-                    session.local_endpoint.qp_num, numa_node
+                    io.local_endpoint.qp_num, numa_node
                 );
                 while let Ok(command) = cmd_rx.recv() {
                     match command {
                         SessionCommand::Transfer { ops, op, done_tx } => {
-                            let result = Self::execute_batch(&session, ops, op);
+                            let result = Self::execute_batch(&io, ops, op);
                             if done_tx.send(result).is_err() {
                                 debug!(
                                     "session worker reply receiver dropped: local_qpn={}",
-                                    session.local_endpoint.qp_num
+                                    io.local_endpoint.qp_num
                                 );
                             }
                         }
@@ -236,7 +245,7 @@ impl RcSession {
                 }
                 debug!(
                     "session worker stopped: local_qpn={}",
-                    session.local_endpoint.qp_num
+                    io.local_endpoint.qp_num
                 );
             })
             .map_err(|e| TransferError::Backend(format!("failed to spawn session worker: {e}")))?;
@@ -281,7 +290,7 @@ impl RcSession {
         Ok(ops.len())
     }
 
-    fn execute_batch(session: &Self, ops: Vec<RdmaOp>, op: TransferOp) -> Result<usize> {
+    fn execute_batch(io: &RcSessionIo, ops: Vec<RdmaOp>, op: TransferOp) -> Result<usize> {
         let total_ops = ops.len();
         if total_ops == 0 {
             return Ok(0);
@@ -297,7 +306,7 @@ impl RcSession {
                 let available = MAX_SEND_WR as usize - inflight.len();
                 let remaining = total_ops - next_idx;
                 let chain_len = MAX_WR_CHAIN_OPS.min(available).min(remaining);
-                let mut qp = session.qp.lock();
+                let mut qp = io.qp.lock();
                 let posted = Self::post_rdma_wr_chain(
                     &mut qp,
                     &ops[next_idx..next_idx + chain_len],
@@ -315,7 +324,7 @@ impl RcSession {
                 next_idx += posted;
             }
 
-            match session.send_cq.start_poll() {
+            match io.send_cq.start_poll() {
                 Ok(mut poller) => {
                     let mut did_work = false;
                     for wc in &mut poller {
@@ -326,7 +335,7 @@ impl RcSession {
                         if wc.status() != WorkCompletionStatus::Success as u32 {
                             return Err(TransferError::Backend(format!(
                                 "send completion failed: local_qpn={}, status={}, opcode={}, vendor_err={}",
-                                session.local_endpoint.qp_num,
+                                io.local_endpoint.qp_num,
                                 wc.status(),
                                 wc.opcode(),
                                 wc.vendor_err()
@@ -344,7 +353,7 @@ impl RcSession {
                 Err(error) => {
                     return Err(TransferError::Backend(format!(
                         "poll send CQ failed: local_qpn={}, {error}",
-                        session.local_endpoint.qp_num
+                        io.local_endpoint.qp_num
                     )));
                 }
             }

--- a/pegaflow-transfer/src/rc_backend/state.rs
+++ b/pegaflow-transfer/src/rc_backend/state.rs
@@ -15,8 +15,8 @@ pub(super) struct RegisteredMemoryEntry {
     pub(super) mrs: Vec<Arc<MemoryRegion>>,
 }
 
-#[derive(Clone, Copy)]
-struct RemoteMemoryEntry {
+#[derive(Clone, Copy, Debug)]
+pub(super) struct RemoteMemoryEntry {
     base_ptr: u64,
     end_ptr: u64,
     rkey: u32,
@@ -74,12 +74,10 @@ impl PerNicState {
         self.remote_memory.remove(&remote_first_qpn);
     }
 
-    /// Validate and cache the remote memory regions received during handshake.
-    pub(super) fn cache_remote_memory(
-        &mut self,
-        remote_first_qpn: u32,
+    /// Validate the remote memory regions received during handshake.
+    pub(super) fn build_remote_memory_cache(
         remote_memory_regions: &[RegisteredMemoryRegion],
-    ) -> Result<()> {
+    ) -> Result<Vec<RemoteMemoryEntry>> {
         let mut cached = Vec::with_capacity(remote_memory_regions.len());
         for entry in remote_memory_regions.iter().copied() {
             if entry.len == 0 {
@@ -106,8 +104,15 @@ impl PerNicState {
                 ));
             }
         }
+        Ok(cached)
+    }
+
+    pub(super) fn insert_remote_memory_cache(
+        &mut self,
+        remote_first_qpn: u32,
+        cached: Vec<RemoteMemoryEntry>,
+    ) {
         self.remote_memory.insert(remote_first_qpn, cached);
-        Ok(())
     }
 }
 
@@ -169,7 +174,6 @@ mod tests {
 
     #[test]
     fn cache_remote_memory_rejects_overlapping_regions() {
-        let mut nic = PerNicState::default();
         let regions = vec![
             RegisteredMemoryRegion {
                 base_ptr: 0x1000,
@@ -183,9 +187,8 @@ mod tests {
             },
         ];
 
-        let error = nic
-            .cache_remote_memory(1, &regions)
-            .expect_err("overlap should fail");
+        let error =
+            PerNicState::build_remote_memory_cache(&regions).expect_err("overlap should fail");
         assert_eq!(
             error,
             TransferError::Backend(
@@ -215,8 +218,8 @@ mod tests {
                 rkey: 2,
             },
         ];
-        nic.cache_remote_memory(remote_qpn, &regions)
-            .expect("snapshot cache");
+        let cache = PerNicState::build_remote_memory_cache(&regions).expect("snapshot cache");
+        nic.insert_remote_memory_cache(remote_qpn, cache);
 
         let hit = nic.find_remote_rkey(remote_qpn, 0x2080, 0x10);
         assert_eq!(hit, Some(2));


### PR DESCRIPTION
## Summary

- make RC handshake completion roll back connecting state and pending QPs when completion fails
- validate remote memory metadata before committing connection state
- split RcSession worker-owned I/O state from the session handle so failed pending sessions can release worker/QP resources
- report RDMA fetch summary bandwidth as GB/s

Fixes #233.

## Verification

- cargo fmt --check
- cargo test -p pegaflow-transfer
- cargo clippy --workspace --all-targets -- -D warnings
- pre-commit hooks during commit amend, including cargo test --release

## Review

- toxic reviewer pass: ready for review