### PR TITLE
fix(connector): include pp_size and mla_layer_split in namespace

### DIFF
--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -204,17 +204,27 @@ def derive_namespace(
     """
     Derive namespace for storage isolation.
 
-    Different DCP/PCP configurations or cross-layer vs per-layer layouts
-    produce incompatible KV data, so all are included as factors to prevent
-    cross-contamination.
+    Every factor that changes the on-storage KV block layout must be included,
+    otherwise two incompatible layouts share one namespace and a load hits the
+    server-side slot-count guard (`stored block has N slots but instance
+    expects M`). Beyond DCP/PCP and cross-layer, this covers:
+
+    - `pp_size`: the pipeline-parallel degree decides how the model's layers
+      are split across stages, so a given server registers a different layer
+      subset (and slot count) per degree.
+    - `mla_layer_split_kv_cache`: MLA layer-split registration shards each
+      block's slots across ranks, a different per-block layout than the
+      default full-slot registration.
     """
     model_config = vllm_config.model_config
     cache_config = vllm_config.cache_config
+    additional_config = getattr(vllm_config, "additional_config", None) or {}
 
     factors = {
         "model": model_config.model,
         "dtype": str(model_config.dtype),
         "tp_size": tp_size,
+        "pp_size": vllm_config.parallel_config.pipeline_parallel_size,
         "num_kv_heads": model_config.get_total_num_kv_heads(),
         "head_size": model_config.get_head_size(),
         "num_hidden_layers": model_config.get_total_num_hidden_layers(),
@@ -222,6 +232,7 @@ def derive_namespace(
         "dcp_world_size": dcp_world_size,
         "pcp_world_size": pcp_world_size,
         "cross_layer_blocks": cross_layer_blocks,
+        "mla_layer_split_kv_cache": bool(additional_config.get("mla_layer_split_kv_cache", False)),
     }
 
     factor_str = str(sorted(factors.items()))

--- a/python/tests/test_derive_namespace.py
+++ b/python/tests/test_derive_namespace.py
@@ -1,0 +1,62 @@
+"""Unit tests for namespace derivation factors.
+
+The namespace isolates storage by KV layout: any config that changes the
+on-storage block layout must change the namespace, or two incompatible layouts
+collide under one namespace and loads fail the server-side slot-count guard.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from pegaflow.connector.common import derive_namespace  # noqa: E402
+
+
+def _make_vllm_config(
+    *,
+    pp_size: int = 1,
+    mla_layer_split: bool = False,
+) -> SimpleNamespace:
+    model_config = SimpleNamespace(
+        model="/data/models/GLM-5.2-FP8",
+        dtype="bfloat16",
+        get_total_num_kv_heads=lambda: 1,
+        get_head_size=lambda: 576,
+        get_total_num_hidden_layers=lambda: 78,
+    )
+    return SimpleNamespace(
+        model_config=model_config,
+        cache_config=SimpleNamespace(cache_dtype="fp8"),
+        parallel_config=SimpleNamespace(pipeline_parallel_size=pp_size),
+        additional_config={"mla_layer_split_kv_cache": mla_layer_split},
+    )
+
+
+def _ns(**kwargs) -> str:
+    return derive_namespace(_make_vllm_config(**kwargs), tp_size=8)
+
+
+def test_pp_size_isolates_namespace():
+    # Same model, different pipeline-parallel degree -> different layer split
+    # per server -> must not share storage.
+    assert _ns(pp_size=1) != _ns(pp_size=8)
+
+
+def test_mla_layer_split_isolates_namespace():
+    # Layer-split registration shards each block's slots differently from the
+    # default full-slot layout (the haitao GLM-5.2 99-vs-156 collision).
+    assert _ns(mla_layer_split=False) != _ns(mla_layer_split=True)
+
+
+def test_namespace_is_stable_for_same_config():
+    assert _ns(pp_size=4, mla_layer_split=True) == _ns(pp_size=4, mla_layer_split=True)
+
+
+def test_missing_additional_config_defaults_to_no_split():
+    cfg = _make_vllm_config(pp_size=4)
+    cfg.additional_config = None
+    assert derive_namespace(cfg, tp_size=8) == _ns(pp_size=4, mla_layer_split=False)


### PR DESCRIPTION
## Problem

`derive_namespace` only hashed `model / tp_size / num_hidden_layers / dtype / dcp / pcp / cross_layer`. None of these capture the **pipeline-parallel degree** or **MLA layer-split registration**, yet both change the on-storage KV block slot layout. As a result, two incompatible layouts of the *same* model hash to one namespace.

A load then matches a block stored under a foreign layout and trips the server-side slot-count guard (`pegaflow-core/src/lib.rs`):

```
stored block has 99 slots but instance ... expects 156:
namespace is shared by incompatible KV layouts
```

### Observed in production

An MLA model was run with two different builds against a shared metaserver:
- a layer-split build → registered **99** KV slots/block (full MLA latent slots + only the active-indexer slots)
- the default build → registered **156** KV slots/block (full slots)

Same model config → same `num_hidden_layers` → same namespace hash → the stale 99-slot blocks were matched by the 156-slot instances and rejected by the guard, spamming `RPC [load] failed` and losing all external prefix-cache hits.

## Fix

Add `pp_size` and `mla_layer_split_kv_cache` as namespace factors. Both are deployment-level static config read from `vllm_config`, so the scheduler and worker derive the same namespace.

- `pp_size` (`parallel_config.pipeline_parallel_size`): the PP degree decides how layers split across stages, so a server registers a different layer subset / slot count per degree.
- `mla_layer_split_kv_cache` (`additional_config`): layer-split registration shards each block's slots across ranks — a different per-block layout than default full-slot registration.

## Test

`tests/test_derive_namespace.py` (default unit gate, no GPU): asserts `pp_size` and `mla_layer_split_kv_cache` each change the namespace, that the hash is stable for the same config, and that a missing `additional_config` defaults to no-split.

Full default gate: `182 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)