### PR TITLE
fix(metaserver): size removal pipeline for eviction bursts

### DIFF
--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -17,7 +17,9 @@ use uuid::Uuid;
 
 use crate::metrics::core_metrics;
 
-pub const DEFAULT_METASERVER_QUEUE_DEPTH: usize = 256;
+// Shared insert/remove command channel depth. Eviction bursts outrun the single
+// consumer's per-RPC drain, so a shallow queue silently drops removals.
+pub const DEFAULT_METASERVER_QUEUE_DEPTH: usize = 4096;
 
 /// Error type for MetaServer client operations.
 #[cfg(feature = "rdma")]

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -416,10 +416,10 @@ async fn registration_loop(
 
         // Process inserts
         let insert_namespaces: Vec<(String, Vec<Vec<u8>>)> = inserts.into_iter().collect();
-        let mut insert_failed_at = None;
+        let mut insert_failed_at: Option<(usize, usize)> = None;
 
         'insert: for (i, (namespace, hashes)) in insert_namespaces.iter().enumerate() {
-            for chunk in hashes.chunks(MAX_HASHES_PER_RPC) {
+            for (chunk_idx, chunk) in hashes.chunks(MAX_HASHES_PER_RPC).enumerate() {
                 let count = chunk.len();
                 let request = InsertBlockHashesRequest {
                     namespace: namespace.clone(),
@@ -449,15 +449,15 @@ async fn registration_loop(
                             core_metrics().metaserver_session_resets.add(1, &[]);
                             heartbeat.node_registered = false;
                         }
-                        insert_failed_at = Some(i);
+                        insert_failed_at = Some((i, chunk_idx * MAX_HASHES_PER_RPC));
                         break 'insert;
                     }
                 }
             }
         }
 
-        if let Some(idx) = insert_failed_at {
-            let dropped: usize = insert_namespaces[idx..].iter().map(|(_, h)| h.len()).sum();
+        if let Some((idx, offset)) = insert_failed_at {
+            let dropped = unsent_after_failure(&insert_namespaces, idx, offset);
             core_metrics()
                 .metaserver_registration_failures
                 .add(dropped as u64, &[]);
@@ -473,10 +473,10 @@ async fn registration_loop(
 
         // Process removes
         let remove_namespaces: Vec<(String, Vec<Vec<u8>>)> = removes.into_iter().collect();
-        let mut remove_failed_at = None;
+        let mut remove_failed_at: Option<(usize, usize)> = None;
 
         'remove: for (i, (namespace, hashes)) in remove_namespaces.iter().enumerate() {
-            for chunk in hashes.chunks(MAX_HASHES_PER_RPC) {
+            for (chunk_idx, chunk) in hashes.chunks(MAX_HASHES_PER_RPC).enumerate() {
                 let count = chunk.len();
                 let request = RemoveBlockHashesRequest {
                     namespace: namespace.clone(),
@@ -506,15 +506,15 @@ async fn registration_loop(
                             core_metrics().metaserver_session_resets.add(1, &[]);
                             heartbeat.node_registered = false;
                         }
-                        remove_failed_at = Some(i);
+                        remove_failed_at = Some((i, chunk_idx * MAX_HASHES_PER_RPC));
                         break 'remove;
                     }
                 }
             }
         }
 
-        if let Some(idx) = remove_failed_at {
-            let dropped: usize = remove_namespaces[idx..].iter().map(|(_, h)| h.len()).sum();
+        if let Some((idx, offset)) = remove_failed_at {
+            let dropped = unsent_after_failure(&remove_namespaces, idx, offset);
             core_metrics()
                 .metaserver_removal_failures
                 .add(dropped as u64, &[]);
@@ -523,6 +523,22 @@ async fn registration_loop(
     }
 
     info!("MetaServer registration loop shutting down");
+}
+
+/// Hashes that did not reach the MetaServer after a chunked send failed at
+/// `failed_offset` within namespace `failed_idx`: the unsent tail of that
+/// namespace (earlier chunks already landed) plus every later namespace.
+fn unsent_after_failure(
+    namespaces: &[(String, Vec<Vec<u8>>)],
+    failed_idx: usize,
+    failed_offset: usize,
+) -> usize {
+    let unsent_in_ns = namespaces[failed_idx].1.len().saturating_sub(failed_offset);
+    let later: usize = namespaces[failed_idx + 1..]
+        .iter()
+        .map(|(_, h)| h.len())
+        .sum();
+    unsent_in_ns + later
 }
 
 fn append_groups(target: &mut HashMap<String, Vec<Vec<u8>>>, groups: Vec<(String, Vec<Vec<u8>>)>) {
@@ -936,6 +952,21 @@ mod tests {
 
         client.shutdown().await;
         let _ = shutdown_tx.send(());
+    }
+
+    #[test]
+    fn unsent_after_failure_counts_only_unsent_tail() {
+        let ns = |name: &str, n: usize| (name.to_string(), vec![vec![0u8]; n]);
+        let namespaces = vec![ns("a", 100), ns("b", 50), ns("c", 30)];
+
+        // First chunk of "b" failed (nothing of b sent yet): all of b + c.
+        assert_eq!(unsent_after_failure(&namespaces, 1, 0), 50 + 30);
+        // 40 hashes of "b" already landed before the failing chunk: b's tail + c.
+        assert_eq!(unsent_after_failure(&namespaces, 1, 40), 10 + 30);
+        // Failure in the last namespace: only its unsent tail, no later namespaces.
+        assert_eq!(unsent_after_failure(&namespaces, 2, 20), 10);
+        // Offset past the namespace length saturates to zero unsent.
+        assert_eq!(unsent_after_failure(&namespaces, 2, 999), 0);
     }
 
     #[tokio::test]

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -21,6 +21,12 @@ use crate::metrics::core_metrics;
 // consumer's per-RPC drain, so a shallow queue silently drops removals.
 pub const DEFAULT_METASERVER_QUEUE_DEPTH: usize = 4096;
 
+// Cap hashes per insert/remove RPC. The consumer coalesces a whole queue drain
+// per namespace, so without a cap one RPC could reach queue_depth * batch_size
+// hashes and blow past the MetaServer's gRPC decode limit. 32-byte sha256 hashes
+// keep a full chunk near 0.5 MiB, well under tonic's 4 MiB default.
+const MAX_HASHES_PER_RPC: usize = 16_384;
+
 /// Error type for MetaServer client operations.
 #[cfg(feature = "rdma")]
 #[derive(Debug)]
@@ -412,38 +418,40 @@ async fn registration_loop(
         let insert_namespaces: Vec<(String, Vec<Vec<u8>>)> = inserts.into_iter().collect();
         let mut insert_failed_at = None;
 
-        for (i, (namespace, hashes)) in insert_namespaces.iter().enumerate() {
-            let count = hashes.len();
-            let request = InsertBlockHashesRequest {
-                namespace: namespace.clone(),
-                block_hashes: hashes.clone(),
-                node: advertise_addr.clone(),
-                node_id: node_id.clone(),
-            };
+        'insert: for (i, (namespace, hashes)) in insert_namespaces.iter().enumerate() {
+            for chunk in hashes.chunks(MAX_HASHES_PER_RPC) {
+                let count = chunk.len();
+                let request = InsertBlockHashesRequest {
+                    namespace: namespace.clone(),
+                    block_hashes: chunk.to_vec(),
+                    node: advertise_addr.clone(),
+                    node_id: node_id.clone(),
+                };
 
-            match c.insert_block_hashes(request).await {
-                Ok(resp) => {
-                    let inner = resp.into_inner();
-                    debug!(
-                        "Registered {} block hashes with MetaServer (namespace={}, inserted={})",
-                        count, namespace, inner.inserted_count
-                    );
-                }
-                Err(e) => {
-                    error!(
-                        "MetaServer insert_block_hashes failed (namespace={}, count={}): {e}",
-                        namespace, count
-                    );
-                    if e.code() == Code::FailedPrecondition {
-                        warn!(
-                            "MetaServer insert rejected current session; resetting node registration: node={} node_id={}",
-                            advertise_addr, node_id
+                match c.insert_block_hashes(request).await {
+                    Ok(resp) => {
+                        let inner = resp.into_inner();
+                        debug!(
+                            "Registered {} block hashes with MetaServer (namespace={}, inserted={})",
+                            count, namespace, inner.inserted_count
                         );
-                        core_metrics().metaserver_session_resets.add(1, &[]);
-                        heartbeat.node_registered = false;
                     }
-                    insert_failed_at = Some(i);
-                    break;
+                    Err(e) => {
+                        error!(
+                            "MetaServer insert_block_hashes failed (namespace={}, count={}): {e}",
+                            namespace, count
+                        );
+                        if e.code() == Code::FailedPrecondition {
+                            warn!(
+                                "MetaServer insert rejected current session; resetting node registration: node={} node_id={}",
+                                advertise_addr, node_id
+                            );
+                            core_metrics().metaserver_session_resets.add(1, &[]);
+                            heartbeat.node_registered = false;
+                        }
+                        insert_failed_at = Some(i);
+                        break 'insert;
+                    }
                 }
             }
         }
@@ -467,38 +475,40 @@ async fn registration_loop(
         let remove_namespaces: Vec<(String, Vec<Vec<u8>>)> = removes.into_iter().collect();
         let mut remove_failed_at = None;
 
-        for (i, (namespace, hashes)) in remove_namespaces.iter().enumerate() {
-            let count = hashes.len();
-            let request = RemoveBlockHashesRequest {
-                namespace: namespace.clone(),
-                block_hashes: hashes.clone(),
-                node: advertise_addr.clone(),
-                node_id: node_id.clone(),
-            };
+        'remove: for (i, (namespace, hashes)) in remove_namespaces.iter().enumerate() {
+            for chunk in hashes.chunks(MAX_HASHES_PER_RPC) {
+                let count = chunk.len();
+                let request = RemoveBlockHashesRequest {
+                    namespace: namespace.clone(),
+                    block_hashes: chunk.to_vec(),
+                    node: advertise_addr.clone(),
+                    node_id: node_id.clone(),
+                };
 
-            match c.remove_block_hashes(request).await {
-                Ok(resp) => {
-                    let inner = resp.into_inner();
-                    debug!(
-                        "Removed {} block hashes from MetaServer (namespace={}, removed={})",
-                        count, namespace, inner.removed_count
-                    );
-                }
-                Err(e) => {
-                    error!(
-                        "MetaServer remove_block_hashes failed (namespace={}, count={}): {e}",
-                        namespace, count
-                    );
-                    if e.code() == Code::FailedPrecondition {
-                        warn!(
-                            "MetaServer remove rejected current session; resetting node registration: node={} node_id={}",
-                            advertise_addr, node_id
+                match c.remove_block_hashes(request).await {
+                    Ok(resp) => {
+                        let inner = resp.into_inner();
+                        debug!(
+                            "Removed {} block hashes from MetaServer (namespace={}, removed={})",
+                            count, namespace, inner.removed_count
                         );
-                        core_metrics().metaserver_session_resets.add(1, &[]);
-                        heartbeat.node_registered = false;
                     }
-                    remove_failed_at = Some(i);
-                    break;
+                    Err(e) => {
+                        error!(
+                            "MetaServer remove_block_hashes failed (namespace={}, count={}): {e}",
+                            namespace, count
+                        );
+                        if e.code() == Code::FailedPrecondition {
+                            warn!(
+                                "MetaServer remove rejected current session; resetting node registration: node={} node_id={}",
+                                advertise_addr, node_id
+                            );
+                            core_metrics().metaserver_session_resets.add(1, &[]);
+                            heartbeat.node_registered = false;
+                        }
+                        remove_failed_at = Some(i);
+                        break 'remove;
+                    }
                 }
             }
         }
@@ -923,6 +933,63 @@ mod tests {
         wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
         client.try_register_namespace("ns".to_string(), vec![vec![1]]);
         wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 2).await;
+
+        client.shutdown().await;
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn large_namespace_removal_splits_into_bounded_rpcs() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        let client = MetaServerClient::new(MetaServerClientConfig::new(
+            addr,
+            "node-a:50055".to_string(),
+        ));
+        wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
+
+        // One namespace coalesced past the per-RPC cap. Use sha256-sized (32B)
+        // hashes so the full payload (~5 MiB) exceeds tonic's 4 MiB default
+        // decode limit: without chunking this single RPC would be rejected.
+        // Chunking holds each request to MAX_HASHES_PER_RPC * 32B = 512 KiB.
+        let sha256_hash = |i: u32| {
+            let mut h = vec![0u8; 32];
+            h[..4].copy_from_slice(&i.to_le_bytes());
+            h
+        };
+        let total = MAX_HASHES_PER_RPC * 10 + 1;
+        let expected_chunks = total.div_ceil(MAX_HASHES_PER_RPC);
+        let entries: Vec<(String, Vec<u8>)> = (0..total as u32)
+            .map(|i| ("ns".to_string(), sha256_hash(i)))
+            .collect();
+        client.try_unregister(entries);
+
+        wait_for_count(
+            &service.remove_notify,
+            &service.remove_count,
+            expected_chunks,
+        )
+        .await;
+
+        let logged = service.remove_requests.lock().unwrap().clone();
+        assert_eq!(
+            logged.len(),
+            expected_chunks,
+            "removal split into wrong RPC count"
+        );
+        let mut sent: Vec<Vec<u8>> = Vec::with_capacity(total);
+        for (namespace, hashes) in &logged {
+            assert_eq!(namespace, "ns");
+            assert!(
+                hashes.len() <= MAX_HASHES_PER_RPC,
+                "chunk of {} hashes exceeds cap {MAX_HASHES_PER_RPC}",
+                hashes.len()
+            );
+            sent.extend(hashes.iter().cloned());
+        }
+        sent.sort();
+        let mut expected: Vec<Vec<u8>> = (0..total as u32).map(sha256_hash).collect();
+        expected.sort();
+        assert_eq!(sent, expected, "chunking lost or duplicated hashes");
 
         client.shutdown().await;
         let _ = shutdown_tx.send(());

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -29,7 +29,9 @@ use prefetch::RdmaFetch;
 use read_cache::ReadCache;
 use write_path::{InsertDeps, WritePipeline};
 
-const RECLAIM_BATCH_SIZE: usize = 64;
+// Each reclaim iteration emits one MetaServer removal command; a small batch
+// turns an eviction burst into a command flood that overflows the removal queue.
+const RECLAIM_BATCH_SIZE: usize = 512;
 pub const DEFAULT_RDMA_QPS_PER_PEER: usize = 2;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -164,7 +164,7 @@ pub struct Cli {
     #[arg(long)]
     pub metaserver_addr: Option<String>,
 
-    /// MetaServer registration queue depth (max pending registration batches).
+    /// MetaServer command queue depth (pending insert/remove commands, shared channel).
     #[arg(long, default_value_t = pegaflow_core::DEFAULT_METASERVER_QUEUE_DEPTH)]
     pub metaserver_queue_depth: usize,
 


### PR DESCRIPTION
## Problem

A pegaflow-server deployment was dropping **~56% of its MetaServer block-removal notifications** (44–62% per node, three nodes over ~4.7h). Measured from Prometheus counters, with an exact accounting identity holding on every node:

```
cache_block_evictions == metaserver_removal_blocks (sent) + metaserver_removal_queue_full (dropped)
```

Effect: the MetaServer owner directory carries stale owners, so a peer that queries it gets routed to a node that already evicted the block → wasted cross-node RDMA prefetch (`blocks=0/N`). Correctness is fine (TTL sweep is the fallback), but it's a steady efficiency leak, not an occasional one.

## Mechanism

LRU eviction runs as a synchronous burst inside `StorageEngine::reclaim_until_allocator_can_allocate`: each iteration evicts `RECLAIM_BATCH_SIZE` blocks and fires **one** fire-and-forget removal command into a shared mpsc channel of depth `DEFAULT_METASERVER_QUEUE_DEPTH`. The single async consumer drains + coalesces but does one MetaServer RPC at a time. Page-first save allocates **one page per block in a loop** (`offload.rs:205`), so a long request is hundreds/thousands of `allocate()` calls, each able to trigger a reclaim batch — the producer easily overruns the channel during a burst and `try_send` drops the tail.

This is **not** memory pressure (`pool_alloc_failures = 0`) and **not** insert/remove starvation (`registration_queue_full = 0`, inserts never drop). It is purely removal burstiness.

## Change

- **`RECLAIM_BATCH_SIZE` 64 → 512** (load-bearing): cuts removal command rate ~8×. Over-eviction is bounded by one batch (~512 pages ≈ ~0.15% of a multi-hundred-GB pinned pool); eviction only unlinks LRU entries, in-transfer blocks stay alive via their `Arc`.
- **`DEFAULT_METASERVER_QUEUE_DEPTH` 256 → 4096**: absorbs residual bursts. Also the default for the `--metaserver-queue-depth` CLI flag (stale help text fixed in the same change).

## Trade-offs (honest)

- A reclaim batch now holds the `read_cache` mutex ~8× longer per call — reclaim turns from frequent small pauses into rarer, heavier ones; concurrent prefix lookups/inserts can see a deeper tail-latency spike when a reclaim lands.
- `allocate()` tail latency is concentrated, not removed: 511/512 calls still return on hit, the 1/512 that reclaims pays for 512 evictions at once. Per-request total reclaim cost is unchanged.
- Worst-case channel memory ~100–200 MB when pathologically full (noise vs the pool); near-zero at steady state since the consumer drains the whole channel per wake.

## Validation

No deterministic test — the contract (burst-time `sent + dropped == evictions`, drop → ~0) is async/RPC-timing dependent and would only be reproducible with heavy mocks. Confidence comes from the production drop measurement above. **Merge gate: re-measure `metaserver_removal_queue_full` → ~0 after rollout.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)