### PR TITLE
fix(core): preserve per-slot NUMA on block rebuild to prevent 0-slot re-serve

### DIFF
--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -315,6 +315,12 @@ async fn ensure_connected(
         .await
 }
 
+/// One fetched slot: its RDMA-staged segments plus the NUMA node they sit on.
+/// The NUMA travels with the slot so a re-served block advertises real topology.
+type StagedSlot = (Vec<SegmentAlloc>, NumaNode);
+/// A staged block awaiting SealedBlock rebuild: its hash and per-slot allocations.
+type StagedBlock = (Vec<u8>, Vec<StagedSlot>);
+
 /// Allocate local memory, build TransferDescs, execute RDMA READ, build SealedBlocks.
 async fn fetch_blocks_via_rdma(
     rdma: &RdmaTransport,
@@ -331,8 +337,9 @@ async fn fetch_blocks_via_rdma(
     let bytes_per_numa = sum_segment_bytes_by_numa(blocks)?;
     let mut numa_slabs = allocate_numa_slabs(allocate_fn, bytes_per_numa)?;
 
-    // (block_hash, Vec<(slot_segments)>) — for building SealedBlock afterwards
-    let mut block_allocs: Vec<(Vec<u8>, Vec<Vec<SegmentAlloc>>)> = Vec::new();
+    // (block_hash, Vec<(slot_segments, slot_numa)>) — for building SealedBlock afterwards.
+    // The per-slot NUMA is preserved so a re-served fetched block advertises real topology.
+    let mut block_allocs: Vec<StagedBlock> = Vec::new();
     let mut slot_count = 0usize;
     let build_start = Instant::now();
 
@@ -389,7 +396,7 @@ async fn fetch_blocks_via_rdma(
                     });
                 }
 
-                slot_allocs.push(segments);
+                slot_allocs.push((segments, numa));
             }
 
             block_allocs.push((block_info.block_hash.clone(), slot_allocs));
@@ -444,9 +451,9 @@ async fn fetch_blocks_via_rdma(
     let mut result: PrefetchResult = Vec::with_capacity(block_allocs.len());
     for (hash, slot_allocs) in block_allocs {
         let key = BlockKey::new(namespace.to_string(), hash);
-        let slots: Vec<RawBlock> = slot_allocs
+        let slots: Vec<(RawBlock, NumaNode)> = slot_allocs
             .into_iter()
-            .map(|segs| {
+            .map(|(segs, numa)| {
                 let segments: Vec<Segment> = segs
                     .into_iter()
                     .map(|sa| {
@@ -455,7 +462,7 @@ async fn fetch_blocks_via_rdma(
                         Segment::new(ptr, sa.size, sa.alloc)
                     })
                     .collect();
-                RawBlock::new(segments)
+                (RawBlock::new(segments), numa)
             })
             .collect();
         let sealed = Arc::new(SealedBlock::from_slots(slots));

--- a/pegaflow-core/src/backing/ssd_cache.rs
+++ b/pegaflow-core/src/backing/ssd_cache.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 use super::ssd::SsdBackingStore;
 use super::uring::UringIoEngine;
-use crate::block::{BlockKey, SealedBlock};
+use crate::block::{BlockKey, RawBlock, SealedBlock};
 use crate::metrics::core_metrics;
 use crate::pinned_pool::PinnedAllocation;
 use crate::seal_offload::{self, SlotMeta};
@@ -314,11 +314,10 @@ impl SsdRingBuffer {
             };
             self.next_shard = (self.next_shard + 1) % self.shards.len();
             let slot_numas = block.slot_numas();
-            debug_assert!(
-                slot_numas.is_empty() || slot_numas.len() == block.slots().len(),
-                "slot_numas length mismatch: {} vs {}",
+            assert_eq!(
                 slot_numas.len(),
                 block.slots().len(),
+                "slot_numas must cover every slot",
             );
             let slots: Vec<SlotMeta> = block
                 .slots()
@@ -328,10 +327,7 @@ impl SsdRingBuffer {
                     let segment_sizes: SmallVec<[u64; 2]> = (0..s.num_segments())
                         .map(|idx| s.segment_size(idx).unwrap() as u64)
                         .collect();
-                    SlotMeta::new(
-                        segment_sizes,
-                        slot_numas.get(i).copied().unwrap_or(NumaNode::UNKNOWN),
-                    )
+                    SlotMeta::new(segment_sizes, slot_numas[i])
                 })
                 .collect();
             let entry = SsdIndexEntry {
@@ -959,15 +955,18 @@ fn rebuild_sealed_block_per_slot(
     slot_allocs: Vec<SlotAlloc>,
     slot_metas: &[SlotMeta],
 ) -> SealedBlock {
-    let raw_blocks: Vec<_> = slot_metas
+    let slots: Vec<(RawBlock, NumaNode)> = slot_metas
         .iter()
         .zip(slot_allocs)
-        .map(|(meta, alloc)| unsafe {
-            seal_offload::reconstruct_raw_block(meta, alloc.allocation, alloc.offset)
+        .map(|(meta, alloc)| {
+            let raw = unsafe {
+                seal_offload::reconstruct_raw_block(meta, alloc.allocation, alloc.offset)
+            };
+            (raw, meta.numa_node)
         })
         .collect();
 
-    SealedBlock::from_slots(raw_blocks)
+    SealedBlock::from_slots(slots)
 }
 
 #[cfg(test)]

--- a/pegaflow-core/src/block.rs
+++ b/pegaflow-core/src/block.rs
@@ -244,8 +244,8 @@ impl<'a> LayerBlock<'a> {
 pub struct SealedBlock {
     slots: Box<[RawBlock]>,
     footprint: u64,
-    /// Per-slot NUMA affinity, carried from InflightBlock for SSD write path.
-    /// Empty when reconstructed from SSD prefetch (NUMA info lives in SlotMeta).
+    /// Per-slot NUMA affinity; always covers every slot (`len == slots.len()`).
+    /// Used by the SSD write path and advertised on cross-node transfer.
     slot_numas: Vec<NumaNode>,
 }
 
@@ -268,13 +268,22 @@ impl SealedBlock {
         &self.slot_numas
     }
 
-    /// Create from a vec of slots (for deserialization / prefetch rebuild)
-    pub(crate) fn from_slots(slots: Vec<RawBlock>) -> Self {
-        let footprint = slots.iter().map(|s| s.memory_footprint()).sum();
+    /// Create from per-slot `(block, NUMA)` pairs (deserialization / prefetch rebuild).
+    /// Pairing keeps each slot and its advertised NUMA affinity in lockstep, so the
+    /// cross-node serve path can never truncate slots against a short `slot_numas`.
+    pub(crate) fn from_slots(slots: Vec<(RawBlock, NumaNode)>) -> Self {
+        let mut blocks = Vec::with_capacity(slots.len());
+        let mut slot_numas = Vec::with_capacity(slots.len());
+        let mut footprint = 0u64;
+        for (block, numa) in slots {
+            footprint = footprint.saturating_add(block.memory_footprint());
+            blocks.push(block);
+            slot_numas.push(numa);
+        }
         Self {
-            slots: slots.into_boxed_slice(),
+            slots: blocks.into_boxed_slice(),
             footprint,
-            slot_numas: Vec::new(),
+            slot_numas,
         }
     }
 


### PR DESCRIPTION
## Problem

A `SealedBlock` rebuilt from an RDMA fetch or SSD prefetch is constructed via
`SealedBlock::from_slots`, which left `slot_numas` empty even though `slots` was
fully populated. When such a block is later served to a peer,
`query_blocks_for_transfer` builds the wire slot list with:

```rust
block.slots().iter().zip(block.slot_numas())
```

`zip` stops at the shorter side, so an empty `slot_numas` truncates the served
slots to **zero**. The peer then rebuilds a 0-slot block and its load fails with:

```
stored block has 0 slots but instance ... expects N: namespace is shared by incompatible KV layouts
```

That message is misleading — the validator only sees `slots().len() == 0` and
blames layout. The real cause is a `slots` / `slot_numas` length desync, not a
namespace/layout collision.

## Root cause

`SealedBlock` kept `slots` and `slot_numas` as two parallel vecs that could
desync, and `from_slots` set `slot_numas = Vec::new()`. Both production rebuild
sites already had the real per-slot NUMA on hand but discarded it through
`from_slots`.

## Fix

Encode the invariant in the type: `from_slots` now takes
`Vec<(RawBlock, NumaNode)>` pairs, so a slot cannot be constructed without its
NUMA and `slot_numas.len() == slots.len()` holds by construction — a length
desync is no longer representable. Both rebuild sites thread the NUMA they
already had:

- RDMA fetch: the node its staging slab was allocated on (the same value already
  used for the local allocation), so a re-served block advertises where its
  bytes physically sit.
- SSD prefetch: `SlotMeta::numa_node`.

The SSD write path's empty-tolerant `debug_assert(slot_numas.is_empty() || ...)`
+ `.get(i).unwrap_or(UNKNOWN)` is tightened to a hard `assert_eq!` + direct
index, now that an empty `slot_numas` is unreachable.

Net effect: re-served fetched/SSD blocks keep all their slots **and** advertise
their true NUMA, so the next hop can stage NUMA-locally.

## Validation

- `cargo check` + `cargo clippy` clean
- 112 `pegaflow-core` lib unit tests pass
- 11 SSD roundtrip integration tests pass (exercise write → evict → rebuild)
- Adversarial review of NUMA correctness, the new `assert_eq!` reachability,
  `saturating_add` footprint behaviour, and `from_slots` callers — no issues

Merge-before P2P correctness E2E on a GPU host is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
