### PR TITLE
fix(nixl): use vendored connector imports

### DIFF
--- a/python/pegaflow/nixl_connector/__init__.py
+++ b/python/pegaflow/nixl_connector/__init__.py
@@ -2,42 +2,42 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """NIXL KV-cache transfer connector (disaggregated prefill / decode)."""
 
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler import (
+from pegaflow.nixl_connector.base_scheduler import (
     NixlBaseConnectorScheduler,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
+from pegaflow.nixl_connector.base_worker import (
     NixlBaseConnectorWorker,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.connector import (
+from pegaflow.nixl_connector.connector import (
     NixlBaseConnector,
     NixlConnector,
     NixlPullConnector,
     NixlPushConnector,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+from pegaflow.nixl_connector.metadata import (
     NixlAgentMetadata,
     NixlConnectorMetadata,
     NixlHandshakePayload,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.pull_scheduler import (
+from pegaflow.nixl_connector.pull_scheduler import (
     NixlPullConnectorScheduler,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.pull_worker import (
+from pegaflow.nixl_connector.pull_worker import (
     NixlPullConnectorWorker,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_scheduler import (
+from pegaflow.nixl_connector.push_scheduler import (
     NixlPushConnectorScheduler,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
+from pegaflow.nixl_connector.push_worker import (
     NixlPushConnectorWorker,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.scheduler import (
+from pegaflow.nixl_connector.scheduler import (
     NixlConnectorScheduler,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.stats import (
+from pegaflow.nixl_connector.stats import (
     NixlKVConnectorStats,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+from pegaflow.nixl_connector.worker import (
     NixlConnectorWorker,
 )
 

--- a/python/pegaflow/nixl_connector/base_scheduler.py
+++ b/python/pegaflow/nixl_connector/base_scheduler.py
@@ -19,14 +19,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorHandshakeMetadata,
     KVConnectorMetadata,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
-    GET_META_MSG,
-    HeartbeatInfo,
-    NixlConnectorMetadata,
-    NixlHandshakePayload,
-    ReqId,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import zmq_ctx
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv
@@ -37,6 +29,15 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     SlidingWindowSpec,
 )
+
+from pegaflow.nixl_connector.metadata import (
+    GET_META_MSG,
+    HeartbeatInfo,
+    NixlConnectorMetadata,
+    NixlHandshakePayload,
+    ReqId,
+)
+from pegaflow.nixl_connector.utils import zmq_ctx
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig

--- a/python/pegaflow/nixl_connector/base_worker.py
+++ b/python/pegaflow/nixl_connector/base_worker.py
@@ -30,30 +30,6 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import CopyBlocksOp
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
-    GET_META_MSG,
-    NixlAgentMetadata,
-    NixlConnectorMetadata,
-    NixlHandshakePayload,
-    ReqId,
-    ReqMeta,
-    TransferHandle,
-    compute_nixl_compatibility_hash,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.stats import (
-    NixlKVConnectorStats,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
-    TPMapping,
-    _is_attention_spec,
-    _is_ssm_spec,
-    compute_tp_mapping,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import (
-    _NIXL_SUPPORTED_DEVICE,
-    get_representative_spec_type,
-    zmq_ctx,
-)
 from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import (
     MambaConvSplitInfo,
     derive_mamba_conv_split,
@@ -76,6 +52,31 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.worker.block_table import BlockTable
 from vllm.v1.worker.utils import select_common_block_size
+
+from pegaflow.nixl_connector.metadata import (
+    GET_META_MSG,
+    NixlAgentMetadata,
+    NixlConnectorMetadata,
+    NixlHandshakePayload,
+    ReqId,
+    ReqMeta,
+    TransferHandle,
+    compute_nixl_compatibility_hash,
+)
+from pegaflow.nixl_connector.stats import (
+    NixlKVConnectorStats,
+)
+from pegaflow.nixl_connector.tp_mapping import (
+    TPMapping,
+    _is_attention_spec,
+    _is_ssm_spec,
+    compute_tp_mapping,
+)
+from pegaflow.nixl_connector.utils import (
+    _NIXL_SUPPORTED_DEVICE,
+    get_representative_spec_type,
+    zmq_ctx,
+)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig

--- a/python/pegaflow/nixl_connector/connector.py
+++ b/python/pegaflow/nixl_connector/connector.py
@@ -35,25 +35,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
     PromMetric,
     PromMetricT,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
-    NixlConnectorMetadata,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.pull_scheduler import (
-    NixlPullConnectorScheduler,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.pull_worker import (
-    NixlPullConnectorWorker,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_scheduler import (
-    NixlPushConnectorScheduler,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
-    NixlPushConnectorWorker,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.stats import (
-    NixlKVConnectorStats,
-    NixlPromMetrics,
-)
 from vllm.forward_context import ForwardContext
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata
@@ -62,16 +43,37 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import MambaSpec
 from vllm.v1.outputs import KVConnectorOutput
 
+from pegaflow.nixl_connector.metadata import (
+    NixlConnectorMetadata,
+)
+from pegaflow.nixl_connector.pull_scheduler import (
+    NixlPullConnectorScheduler,
+)
+from pegaflow.nixl_connector.pull_worker import (
+    NixlPullConnectorWorker,
+)
+from pegaflow.nixl_connector.push_scheduler import (
+    NixlPushConnectorScheduler,
+)
+from pegaflow.nixl_connector.push_worker import (
+    NixlPushConnectorWorker,
+)
+from pegaflow.nixl_connector.stats import (
+    NixlKVConnectorStats,
+    NixlPromMetrics,
+)
+
 if TYPE_CHECKING:
-    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler import (
-        NixlBaseConnectorScheduler,
-    )
-    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
-        NixlBaseConnectorWorker,
-    )
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
+
+    from pegaflow.nixl_connector.base_scheduler import (
+        NixlBaseConnectorScheduler,
+    )
+    from pegaflow.nixl_connector.base_worker import (
+        NixlBaseConnectorWorker,
+    )
 
 logger = init_logger(__name__)
 

--- a/python/pegaflow/nixl_connector/pull_scheduler.py
+++ b/python/pegaflow/nixl_connector/pull_scheduler.py
@@ -7,10 +7,11 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler import (
+from vllm.logger import init_logger
+
+from pegaflow.nixl_connector.base_scheduler import (
     NixlBaseConnectorScheduler,
 )
-from vllm.logger import init_logger
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig

--- a/python/pegaflow/nixl_connector/pull_worker.py
+++ b/python/pegaflow/nixl_connector/pull_worker.py
@@ -7,17 +7,18 @@ import time
 from typing import TYPE_CHECKING
 
 import numpy as np
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
+from vllm.logger import init_logger
+
+from pegaflow.nixl_connector.base_worker import (
     NixlBaseConnectorWorker,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+from pegaflow.nixl_connector.metadata import (
     NixlConnectorMetadata,
     ReqMeta,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
+from pegaflow.nixl_connector.tp_mapping import (
     ReadSpec,
 )
-from vllm.logger import init_logger
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig

--- a/python/pegaflow/nixl_connector/push_scheduler.py
+++ b/python/pegaflow/nixl_connector/push_scheduler.py
@@ -32,14 +32,15 @@ from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler import (
+from vllm.logger import init_logger
+
+from pegaflow.nixl_connector.base_scheduler import (
     NixlBaseConnectorScheduler,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+from pegaflow.nixl_connector.metadata import (
     NixlConnectorMetadata,
     ReqId,
 )
-from vllm.logger import init_logger
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig

--- a/python/pegaflow/nixl_connector/push_worker.py
+++ b/python/pegaflow/nixl_connector/push_worker.py
@@ -39,10 +39,12 @@ from typing import TYPE_CHECKING, Any
 import msgspec
 import numpy as np
 from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
+from vllm.logger import init_logger
+
+from pegaflow.nixl_connector.base_worker import (
     NixlBaseConnectorWorker,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+from pegaflow.nixl_connector.metadata import (
     PUSH_REG_NOTIF_PREFIX,
     NixlConnectorMetadata,
     RemoteMeta,
@@ -50,9 +52,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     ReqMeta,
     TransferHandle,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import ReadSpec
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import get_base_request_id
-from vllm.logger import init_logger
+from pegaflow.nixl_connector.tp_mapping import ReadSpec
+from pegaflow.nixl_connector.utils import get_base_request_id
 
 if TYPE_CHECKING:
     import torch

--- a/python/pegaflow/nixl_connector/scheduler.py
+++ b/python/pegaflow/nixl_connector/scheduler.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Backward-compatible re-export of NixlPullConnectorScheduler."""
 
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.pull_scheduler import (
+from pegaflow.nixl_connector.pull_scheduler import (
     NixlPullConnectorScheduler,
 )
 

--- a/python/pegaflow/nixl_connector/worker.py
+++ b/python/pegaflow/nixl_connector/worker.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Backward-compatible re-export of NixlPullConnectorWorker."""
 
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl.pull_worker import (
+from pegaflow.nixl_connector.pull_worker import (
     NixlPullConnectorWorker,
 )
 

--- a/python/pegaflow/vllm_plugin.py
+++ b/python/pegaflow/vllm_plugin.py
@@ -49,3 +49,21 @@ def register() -> None:
             "pegaflow.pd_connector",
             "PdPrefillConnector",
         )
+    with contextlib.suppress(ValueError):
+        KVConnectorFactory.register_connector(
+            "NixlConnector",
+            "pegaflow.nixl_connector",
+            "NixlConnector",
+        )
+    with contextlib.suppress(ValueError):
+        KVConnectorFactory.register_connector(
+            "NixlPullConnector",
+            "pegaflow.nixl_connector",
+            "NixlPullConnector",
+        )
+    with contextlib.suppress(ValueError):
+        KVConnectorFactory.register_connector(
+            "NixlPushConnector",
+            "pegaflow.nixl_connector",
+            "NixlPushConnector",
+        )


### PR DESCRIPTION
## Summary

Split out the import/registration cleanup needed by the vendored NIXL connector.

This PR only rewires imports so the copied NIXL connector consistently imports from `pegaflow.nixl_connector` instead of upstream vLLM module paths, and registers the vendored connector classes through the PegaFlow vLLM plugin.

## What Changed

- Update vendored NIXL connector imports to use the local `pegaflow.nixl_connector` package.
- Register `NixlConnector`, `NixlPullConnector`, and `NixlPushConnector` in `vllm_plugin.py`.
- Keep this separate from the Pega RDMA v1 connector work so the latter PR can focus on transport changes.

## Validation

```bash
python -m py_compile python/pegaflow/nixl_connector/*.py python/pegaflow/vllm_plugin.py
ruff check python/pegaflow/nixl_connector python/pegaflow/vllm_plugin.py
git diff --check origin/master...HEAD
cargo check -p pegaflow-py --no-default-features --features cuda-13
```
