### PR TITLE
fix(core): harden MetaServer tonic connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,6 +1953,7 @@ dependencies = [
  "pegaflow-proto",
  "prometheus",
  "tokio",
+ "tokio-stream",
  "tonic",
  "uuid",
 ]

--- a/pegaflow-common/src/grpc.rs
+++ b/pegaflow-common/src/grpc.rs
@@ -1,0 +1,6 @@
+use std::time::Duration;
+
+pub const GRPC_CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
+pub const GRPC_RPC_TIMEOUT: Duration = Duration::from_secs(3);
+pub const GRPC_HTTP2_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
+pub const GRPC_HTTP2_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);

--- a/pegaflow-common/src/lib.rs
+++ b/pegaflow-common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod block;
+pub mod grpc;
 pub mod hll;
 pub mod logging;
 #[cfg(target_os = "linux")]

--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 use dashmap::DashMap;
 use log::{debug, info, warn};
 use mea::singleflight::Group;
+use pegaflow_proto::MAX_GRPC_MESSAGE_SIZE;
 use pegaflow_proto::proto::engine::engine_client::EngineClient;
 use pegaflow_proto::proto::engine::{
     QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, RdmaHandshakeRequest,
@@ -602,7 +603,6 @@ fn get_or_create_channel(
     // Match the engine server's 64 MiB message cap: a QueryBlocksForTransfer
     // response carries per-slot transfer descriptors, so a large block batch
     // overflows tonic's default 4 MiB decode limit.
-    const MAX_GRPC_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
     let client = EngineClient::new(channel)
         .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
         .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE);

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -1,18 +1,25 @@
 use std::collections::HashMap;
 
 use log::{debug, error, info, warn};
+use pegaflow_common::grpc::{
+    GRPC_CONNECT_TIMEOUT, GRPC_HTTP2_KEEPALIVE_INTERVAL, GRPC_HTTP2_KEEPALIVE_TIMEOUT,
+    GRPC_RPC_TIMEOUT,
+};
+use pegaflow_proto::MAX_GRPC_MESSAGE_SIZE;
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
     HeartbeatNodeRequest, InsertBlockHashesRequest, RemoveBlockHashesRequest, UnregisterNodeRequest,
 };
 #[cfg(feature = "rdma")]
 use pegaflow_proto::proto::engine::{NodePrefixResult, QueryPrefixBlocksRequest};
+#[cfg(feature = "rdma")]
+use tokio::sync::Mutex;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Duration, Instant};
-use tonic::Code;
-use tonic::transport::Channel;
 #[cfg(feature = "rdma")]
-use tonic::transport::Endpoint;
+use tonic::Status;
+use tonic::transport::{Channel, Endpoint};
+use tonic::{Code, Request};
 use uuid::Uuid;
 
 use crate::metrics::core_metrics;
@@ -23,8 +30,8 @@ pub const DEFAULT_METASERVER_QUEUE_DEPTH: usize = 4096;
 
 // Cap hashes per insert/remove RPC. The consumer coalesces a whole queue drain
 // per namespace, so without a cap one RPC could reach queue_depth * batch_size
-// hashes and blow past the MetaServer's gRPC decode limit. 32-byte sha256 hashes
-// keep a full chunk near 0.5 MiB, well under tonic's 4 MiB default.
+// hashes. 32-byte sha256 hashes keep a full chunk near 0.5 MiB, so registration
+// bursts stay small even though MetaServer now accepts larger gRPC messages.
 const MAX_HASHES_PER_RPC: usize = 16_384;
 
 /// Error type for MetaServer client operations.
@@ -121,47 +128,94 @@ enum MetaServerCommand {
     Shutdown(oneshot::Sender<()>),
 }
 
+fn metaserver_endpoint(metaserver_addr: String) -> Result<Endpoint, tonic::transport::Error> {
+    Endpoint::from_shared(metaserver_addr).map(|endpoint| {
+        endpoint
+            .connect_timeout(GRPC_CONNECT_TIMEOUT)
+            .timeout(GRPC_RPC_TIMEOUT)
+            .tcp_nodelay(true)
+            .http2_keep_alive_interval(GRPC_HTTP2_KEEPALIVE_INTERVAL)
+            .keep_alive_timeout(GRPC_HTTP2_KEEPALIVE_TIMEOUT)
+            .keep_alive_while_idle(true)
+    })
+}
+
+fn metaserver_grpc_client(channel: Channel) -> MetaServerGrpcClient<Channel> {
+    MetaServerGrpcClient::new(channel)
+        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+}
+
+async fn connect_metaserver_client(
+    endpoint: &Endpoint,
+) -> Result<MetaServerGrpcClient<Channel>, tonic::transport::Error> {
+    endpoint.connect().await.map(metaserver_grpc_client)
+}
+
+fn request_with_timeout<T>(message: T) -> Request<T> {
+    let mut request = Request::new(message);
+    request.set_timeout(GRPC_RPC_TIMEOUT);
+    request
+}
+
+#[cfg(feature = "rdma")]
+fn is_retryable_query_status(status: &Status) -> bool {
+    match status.code() {
+        Code::Unavailable | Code::DeadlineExceeded => true,
+        Code::Cancelled => status.message() == "Timeout expired",
+        Code::Unknown => {
+            let message = status.message();
+            message.starts_with("Service was not ready:")
+                || message.contains("transport error")
+                || message.contains("Connection reset")
+                || message.contains("connection reset")
+        }
+        _ => false,
+    }
+}
+
 /// Unified MetaServer client handling both insert (fire-and-forget) and query (direct RPC).
 pub struct MetaServerClient {
     /// Fire-and-forget command channel for insert/remove operations.
     command_tx: mpsc::Sender<MetaServerCommand>,
-    /// Lazy-connect query client
+    /// Lazy-connect query channel.
     #[cfg(feature = "rdma")]
-    query_client: MetaServerGrpcClient<Channel>,
+    query_endpoint: Endpoint,
+    #[cfg(feature = "rdma")]
+    query_channel: Mutex<Channel>,
 }
 
 impl MetaServerClient {
     /// Create a new client and spawn the background registration loop.
     ///
     /// Must be called from within a tokio runtime context.
-    pub fn new(config: MetaServerClientConfig) -> Self {
+    pub fn new(config: MetaServerClientConfig) -> Result<Self, tonic::transport::Error> {
+        let endpoint = metaserver_endpoint(config.metaserver_addr.clone())?;
         let (command_tx, rx) = mpsc::channel(config.queue_depth);
 
         tokio::spawn(registration_loop(
             rx,
             config.metaserver_addr.clone(),
+            endpoint.clone(),
             config.advertise_addr,
         ));
 
         // Lazy-connect query client: connects on first RPC, not here
         #[cfg(feature = "rdma")]
-        let query_client = {
-            let channel = Endpoint::from_shared(config.metaserver_addr.clone())
-                .expect("valid metaserver_addr URI")
-                .connect_lazy();
-            MetaServerGrpcClient::new(channel)
-        };
+        let query_channel = Mutex::new(endpoint.connect_lazy());
 
         info!(
             "MetaServer client started (queue_depth={}, addr={})",
             config.queue_depth, config.metaserver_addr
         );
 
-        Self {
+        Ok(Self {
             command_tx,
             #[cfg(feature = "rdma")]
-            query_client,
-        }
+            query_endpoint: endpoint,
+            #[cfg(feature = "rdma")]
+            query_channel,
+        })
     }
 
     /// Fire-and-forget registration of block hashes.
@@ -266,33 +320,83 @@ impl MetaServerClient {
         namespace: &str,
         hashes: &[Vec<u8>],
     ) -> Result<Vec<NodePrefixResult>, ClientError> {
-        let request = QueryPrefixBlocksRequest {
+        let make_request = || QueryPrefixBlocksRequest {
             namespace: namespace.to_string(),
             block_hashes: hashes.to_vec(),
         };
 
-        let response = self
-            .query_client
-            .clone()
-            .query_prefix_blocks(request)
-            .await
-            .map_err(|e| ClientError::RpcFailed(format!("MetaServer query failed: {e}")))?;
-
-        let resp = response.into_inner();
+        let response = match self.query_prefix_once(make_request()).await {
+            Ok(response) => response,
+            Err(err) if is_retryable_query_status(&err) => {
+                warn!(
+                    "MetaServer query failed with retryable status, refreshing channel and retrying once: {err}"
+                );
+                self.query_prefix_after_channel_refresh(make_request())
+                    .await
+                    .map_err(|retry_err| {
+                        ClientError::RpcFailed(format!(
+                            "MetaServer query failed after reconnect: {retry_err}"
+                        ))
+                    })?
+            }
+            Err(err) => {
+                return Err(ClientError::RpcFailed(format!(
+                    "MetaServer query failed: {err}"
+                )));
+            }
+        };
 
         debug!(
             "MetaServer query_prefix: namespace={} nodes={}",
             namespace,
-            resp.nodes.len()
+            response.nodes.len()
         );
 
-        Ok(resp.nodes)
+        Ok(response.nodes)
+    }
+
+    #[cfg(feature = "rdma")]
+    async fn query_client(&self) -> MetaServerGrpcClient<Channel> {
+        let channel = self.query_channel.lock().await.clone();
+        metaserver_grpc_client(channel)
+    }
+
+    #[cfg(feature = "rdma")]
+    async fn refresh_query_client(&self) -> MetaServerGrpcClient<Channel> {
+        let channel = self.query_endpoint.connect_lazy();
+        *self.query_channel.lock().await = channel.clone();
+        metaserver_grpc_client(channel)
+    }
+
+    #[cfg(feature = "rdma")]
+    async fn query_prefix_once(
+        &self,
+        request: QueryPrefixBlocksRequest,
+    ) -> Result<pegaflow_proto::proto::engine::QueryPrefixBlocksResponse, Status> {
+        self.query_client()
+            .await
+            .query_prefix_blocks(request_with_timeout(request))
+            .await
+            .map(|response| response.into_inner())
+    }
+
+    #[cfg(feature = "rdma")]
+    async fn query_prefix_after_channel_refresh(
+        &self,
+        request: QueryPrefixBlocksRequest,
+    ) -> Result<pegaflow_proto::proto::engine::QueryPrefixBlocksResponse, Status> {
+        self.refresh_query_client()
+            .await
+            .query_prefix_blocks(request_with_timeout(request))
+            .await
+            .map(|response| response.into_inner())
     }
 }
 
 async fn registration_loop(
     mut rx: mpsc::Receiver<MetaServerCommand>,
     metaserver_addr: String,
+    endpoint: Endpoint,
     advertise_addr: String,
 ) {
     let mut client: Option<MetaServerGrpcClient<Channel>> = None;
@@ -312,6 +416,7 @@ async fn registration_loop(
                     &mut client,
                     &mut heartbeat,
                     &metaserver_addr,
+                    &endpoint,
                     &advertise_addr,
                     &node_id,
                 ).await {
@@ -328,8 +433,14 @@ async fn registration_loop(
         };
 
         if let MetaServerCommand::Shutdown(done) = cmd {
-            unregister_current_session(&mut client, &metaserver_addr, &advertise_addr, &node_id)
-                .await;
+            unregister_current_session(
+                &mut client,
+                &metaserver_addr,
+                &endpoint,
+                &advertise_addr,
+                &node_id,
+            )
+            .await;
             let _ = done.send(());
             break;
         }
@@ -370,6 +481,7 @@ async fn registration_loop(
                     unregister_current_session(
                         &mut client,
                         &metaserver_addr,
+                        &endpoint,
                         &advertise_addr,
                         &node_id,
                     )
@@ -396,6 +508,7 @@ async fn registration_loop(
         if ensure_heartbeat_registered(
             &mut client,
             &metaserver_addr,
+            &endpoint,
             &advertise_addr,
             &node_id,
             &mut heartbeat,
@@ -428,7 +541,7 @@ async fn registration_loop(
                     node_id: node_id.clone(),
                 };
 
-                match c.insert_block_hashes(request).await {
+                match c.insert_block_hashes(request_with_timeout(request)).await {
                     Ok(resp) => {
                         let inner = resp.into_inner();
                         debug!(
@@ -485,7 +598,7 @@ async fn registration_loop(
                     node_id: node_id.clone(),
                 };
 
-                match c.remove_block_hashes(request).await {
+                match c.remove_block_hashes(request_with_timeout(request)).await {
                     Ok(resp) => {
                         let inner = resp.into_inner();
                         debug!(
@@ -582,6 +695,7 @@ fn insert_groups_into_net(
 async fn ensure_heartbeat_registered(
     client: &mut Option<MetaServerGrpcClient<Channel>>,
     metaserver_addr: &str,
+    endpoint: &Endpoint,
     advertise_addr: &str,
     node_id: &str,
     heartbeat: &mut HeartbeatState,
@@ -594,7 +708,16 @@ async fn ensure_heartbeat_registered(
         return Err(());
     }
 
-    match send_heartbeat(client, heartbeat, metaserver_addr, advertise_addr, node_id).await {
+    match send_heartbeat(
+        client,
+        heartbeat,
+        metaserver_addr,
+        endpoint,
+        advertise_addr,
+        node_id,
+    )
+    .await
+    {
         Ok(next_period) => {
             heartbeat.period = next_period;
             heartbeat.next_at = Instant::now() + next_period;
@@ -611,11 +734,12 @@ async fn send_heartbeat(
     client: &mut Option<MetaServerGrpcClient<Channel>>,
     heartbeat: &mut HeartbeatState,
     metaserver_addr: &str,
+    endpoint: &Endpoint,
     advertise_addr: &str,
     node_id: &str,
 ) -> Result<Duration, Duration> {
     if client.is_none() {
-        match MetaServerGrpcClient::connect(metaserver_addr.to_string()).await {
+        match connect_metaserver_client(endpoint).await {
             Ok(c) => {
                 info!("Connected to MetaServer at {}", metaserver_addr);
                 *client = Some(c);
@@ -631,10 +755,10 @@ async fn send_heartbeat(
 
     let c = client.as_mut().expect("client is connected");
     match c
-        .heartbeat_node(HeartbeatNodeRequest {
+        .heartbeat_node(request_with_timeout(HeartbeatNodeRequest {
             node: advertise_addr.to_string(),
             node_id: node_id.to_string(),
-        })
+        }))
         .await
     {
         Ok(resp) => {
@@ -686,14 +810,15 @@ impl HeartbeatState {
 async fn unregister_current_session(
     client: &mut Option<MetaServerGrpcClient<Channel>>,
     metaserver_addr: &str,
+    endpoint: &Endpoint,
     advertise_addr: &str,
     node_id: &str,
 ) {
     if client.is_none() {
-        match MetaServerGrpcClient::connect(metaserver_addr.to_string()).await {
+        match connect_metaserver_client(endpoint).await {
             Ok(c) => *client = Some(c),
             Err(e) => {
-                warn!("Failed to connect to MetaServer for unregister: {e}");
+                warn!("Failed to connect to MetaServer for unregister at {metaserver_addr}: {e}");
                 core_metrics().metaserver_unregister_failures.add(1, &[]);
                 return;
             }
@@ -709,7 +834,7 @@ async fn unregister_current_session(
     };
     match tokio::time::timeout(
         tokio::time::Duration::from_secs(UNREGISTER_TIMEOUT_SECS),
-        c.unregister_node(request),
+        c.unregister_node(request_with_timeout(request)),
     )
     .await
     {
@@ -732,358 +857,4 @@ async fn unregister_current_session(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use pegaflow_proto::proto::engine::meta_server_server::{MetaServer, MetaServerServer};
-    use pegaflow_proto::proto::engine::{
-        HeartbeatNodeResponse, InsertBlockHashesResponse, QueryPrefixBlocksRequest,
-        QueryPrefixBlocksResponse, RemoveBlockHashesResponse, ResponseStatus,
-        UnregisterNodeResponse,
-    };
-    use std::collections::BTreeMap;
-    use std::net::SocketAddr;
-    use std::sync::{
-        Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
-    };
-    use tokio::net::TcpListener;
-    use tokio::sync::{Notify, oneshot};
-    use tokio_stream::wrappers::TcpListenerStream;
-    use tonic::{Request, Response, Status, async_trait};
-
-    type RequestLog = Mutex<Vec<(String, Vec<Vec<u8>>)>>;
-    type RequestSet = BTreeMap<String, Vec<Vec<u8>>>;
-
-    #[derive(Default)]
-    struct FakeMetaServerState {
-        heartbeat_count: AtomicUsize,
-        insert_count: AtomicUsize,
-        remove_count: AtomicUsize,
-        unregister_count: AtomicUsize,
-        fail_insert_with_stale_session: AtomicUsize,
-        insert_requests: RequestLog,
-        remove_requests: RequestLog,
-        heartbeat_notify: Notify,
-        insert_notify: Notify,
-        remove_notify: Notify,
-        unregister_notify: Notify,
-    }
-
-    #[derive(Clone)]
-    struct FakeMetaServer {
-        state: Arc<FakeMetaServerState>,
-    }
-
-    #[async_trait]
-    impl MetaServer for FakeMetaServer {
-        async fn heartbeat_node(
-            &self,
-            _request: Request<HeartbeatNodeRequest>,
-        ) -> Result<Response<HeartbeatNodeResponse>, Status> {
-            self.state.heartbeat_count.fetch_add(1, Ordering::SeqCst);
-            self.state.heartbeat_notify.notify_waiters();
-            Ok(Response::new(HeartbeatNodeResponse {
-                stale_after_secs: 2,
-            }))
-        }
-
-        async fn unregister_node(
-            &self,
-            _request: Request<UnregisterNodeRequest>,
-        ) -> Result<Response<UnregisterNodeResponse>, Status> {
-            self.state.unregister_count.fetch_add(1, Ordering::SeqCst);
-            self.state.unregister_notify.notify_waiters();
-            Ok(Response::new(UnregisterNodeResponse { removed_owners: 0 }))
-        }
-
-        async fn insert_block_hashes(
-            &self,
-            request: Request<InsertBlockHashesRequest>,
-        ) -> Result<Response<InsertBlockHashesResponse>, Status> {
-            let request = request.into_inner();
-            self.state.insert_count.fetch_add(1, Ordering::SeqCst);
-            if self
-                .state
-                .fail_insert_with_stale_session
-                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
-                    (remaining > 0).then(|| remaining - 1)
-                })
-                .is_ok()
-            {
-                return Err(Status::failed_precondition("stale node session"));
-            }
-            let inserted_count = request.block_hashes.len() as u64;
-            self.state
-                .insert_requests
-                .lock()
-                .unwrap()
-                .push((request.namespace, request.block_hashes));
-            self.state.insert_notify.notify_waiters();
-            Ok(Response::new(InsertBlockHashesResponse {
-                status: Some(ResponseStatus {
-                    ok: true,
-                    message: String::new(),
-                }),
-                inserted_count,
-            }))
-        }
-
-        async fn remove_block_hashes(
-            &self,
-            request: Request<RemoveBlockHashesRequest>,
-        ) -> Result<Response<RemoveBlockHashesResponse>, Status> {
-            let request = request.into_inner();
-            self.state.remove_count.fetch_add(1, Ordering::SeqCst);
-            let removed_count = request.block_hashes.len() as u64;
-            self.state
-                .remove_requests
-                .lock()
-                .unwrap()
-                .push((request.namespace, request.block_hashes));
-            self.state.remove_notify.notify_waiters();
-            Ok(Response::new(RemoveBlockHashesResponse {
-                status: Some(ResponseStatus {
-                    ok: true,
-                    message: String::new(),
-                }),
-                removed_count,
-            }))
-        }
-
-        async fn query_prefix_blocks(
-            &self,
-            _request: Request<QueryPrefixBlocksRequest>,
-        ) -> Result<Response<QueryPrefixBlocksResponse>, Status> {
-            Ok(Response::new(QueryPrefixBlocksResponse { nodes: vec![] }))
-        }
-    }
-
-    async fn start_fake_metaserver() -> (String, Arc<FakeMetaServerState>, oneshot::Sender<()>) {
-        let state = Arc::new(FakeMetaServerState::default());
-        let service = FakeMetaServer {
-            state: Arc::clone(&state),
-        };
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr: SocketAddr = listener.local_addr().unwrap();
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let incoming = TcpListenerStream::new(listener);
-        tokio::spawn(async move {
-            tonic::transport::Server::builder()
-                .add_service(MetaServerServer::new(service))
-                .serve_with_incoming_shutdown(incoming, async {
-                    let _ = shutdown_rx.await;
-                })
-                .await
-                .unwrap();
-        });
-        (format!("http://{addr}"), state, shutdown_tx)
-    }
-
-    fn collect_requests(requests: &RequestLog) -> RequestSet {
-        let mut grouped = BTreeMap::new();
-        for (namespace, hashes) in requests.lock().unwrap().iter() {
-            let namespace_hashes: &mut Vec<Vec<u8>> = grouped.entry(namespace.clone()).or_default();
-            namespace_hashes.extend(hashes.iter().cloned());
-        }
-        for hashes in grouped.values_mut() {
-            hashes.sort();
-        }
-        grouped
-    }
-
-    fn expected_requests(entries: &[(&str, Vec<u8>)]) -> RequestSet {
-        let mut grouped: RequestSet = BTreeMap::new();
-        for (namespace, hash) in entries {
-            grouped
-                .entry((*namespace).to_string())
-                .or_default()
-                .push(hash.clone());
-        }
-        for hashes in grouped.values_mut() {
-            hashes.sort();
-        }
-        grouped
-    }
-
-    async fn wait_for_count(notify: &Notify, count: &AtomicUsize, expected: usize) {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
-        loop {
-            if count.load(Ordering::SeqCst) >= expected {
-                return;
-            }
-            tokio::select! {
-                _ = notify.notified() => {}
-                _ = tokio::time::sleep_until(deadline) => {
-                    panic!("timed out waiting for count {expected}");
-                }
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn heartbeat_loop_sends_initial_heartbeat_and_unregisters_on_shutdown() {
-        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
-        let client = MetaServerClient::new(MetaServerClientConfig::new(
-            addr,
-            "node-a:50055".to_string(),
-        ));
-
-        wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
-        client.shutdown().await;
-        wait_for_count(&service.unregister_notify, &service.unregister_count, 1).await;
-
-        let _ = shutdown_tx.send(());
-    }
-
-    #[tokio::test]
-    async fn stale_session_write_error_triggers_new_heartbeat() {
-        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
-        service
-            .fail_insert_with_stale_session
-            .store(1, Ordering::SeqCst);
-        let client = MetaServerClient::new(MetaServerClientConfig::new(
-            addr,
-            "node-a:50055".to_string(),
-        ));
-
-        wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
-        client.try_register_namespace("ns".to_string(), vec![vec![1]]);
-        wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 2).await;
-
-        client.shutdown().await;
-        let _ = shutdown_tx.send(());
-    }
-
-    #[test]
-    fn unsent_after_failure_counts_only_unsent_tail() {
-        let ns = |name: &str, n: usize| (name.to_string(), vec![vec![0u8]; n]);
-        let namespaces = vec![ns("a", 100), ns("b", 50), ns("c", 30)];
-
-        // First chunk of "b" failed (nothing of b sent yet): all of b + c.
-        assert_eq!(unsent_after_failure(&namespaces, 1, 0), 50 + 30);
-        // 40 hashes of "b" already landed before the failing chunk: b's tail + c.
-        assert_eq!(unsent_after_failure(&namespaces, 1, 40), 10 + 30);
-        // Failure in the last namespace: only its unsent tail, no later namespaces.
-        assert_eq!(unsent_after_failure(&namespaces, 2, 20), 10);
-        // Offset past the namespace length saturates to zero unsent.
-        assert_eq!(unsent_after_failure(&namespaces, 2, 999), 0);
-    }
-
-    #[tokio::test]
-    async fn large_namespace_removal_splits_into_bounded_rpcs() {
-        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
-        let client = MetaServerClient::new(MetaServerClientConfig::new(
-            addr,
-            "node-a:50055".to_string(),
-        ));
-        wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
-
-        // One namespace coalesced past the per-RPC cap. Use sha256-sized (32B)
-        // hashes so the full payload (~5 MiB) exceeds tonic's 4 MiB default
-        // decode limit: without chunking this single RPC would be rejected.
-        // Chunking holds each request to MAX_HASHES_PER_RPC * 32B = 512 KiB.
-        let sha256_hash = |i: u32| {
-            let mut h = vec![0u8; 32];
-            h[..4].copy_from_slice(&i.to_le_bytes());
-            h
-        };
-        let total = MAX_HASHES_PER_RPC * 10 + 1;
-        let expected_chunks = total.div_ceil(MAX_HASHES_PER_RPC);
-        let entries: Vec<(String, Vec<u8>)> = (0..total as u32)
-            .map(|i| ("ns".to_string(), sha256_hash(i)))
-            .collect();
-        client.try_unregister(entries);
-
-        wait_for_count(
-            &service.remove_notify,
-            &service.remove_count,
-            expected_chunks,
-        )
-        .await;
-
-        let logged = service.remove_requests.lock().unwrap().clone();
-        assert_eq!(
-            logged.len(),
-            expected_chunks,
-            "removal split into wrong RPC count"
-        );
-        let mut sent: Vec<Vec<u8>> = Vec::with_capacity(total);
-        for (namespace, hashes) in &logged {
-            assert_eq!(namespace, "ns");
-            assert!(
-                hashes.len() <= MAX_HASHES_PER_RPC,
-                "chunk of {} hashes exceeds cap {MAX_HASHES_PER_RPC}",
-                hashes.len()
-            );
-            sent.extend(hashes.iter().cloned());
-        }
-        sent.sort();
-        let mut expected: Vec<Vec<u8>> = (0..total as u32).map(sha256_hash).collect();
-        expected.sort();
-        assert_eq!(sent, expected, "chunking lost or duplicated hashes");
-
-        client.shutdown().await;
-        let _ = shutdown_tx.send(());
-    }
-
-    #[tokio::test]
-    async fn mixed_insert_remove_drain_preserves_last_write_per_namespace() {
-        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
-        let (tx, rx) = mpsc::channel(16);
-
-        let insert_then_remove = vec![0xa0];
-        let remove_then_insert = vec![0xb0];
-        let remove_only = vec![0xc0];
-        let insert_only = vec![0xd0];
-
-        tx.try_send(MetaServerCommand::Insert(BlockHashBatch::single_namespace(
-            "ns-first".to_string(),
-            vec![insert_then_remove.clone()],
-        )))
-        .unwrap();
-        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
-            vec![("ns-first".to_string(), insert_then_remove.clone())],
-        )))
-        .unwrap();
-        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
-            vec![
-                ("ns-second".to_string(), remove_then_insert.clone()),
-                ("ns-remove".to_string(), remove_only.clone()),
-            ],
-        )))
-        .unwrap();
-        tx.try_send(MetaServerCommand::Insert(BlockHashBatch::single_namespace(
-            "ns-second".to_string(),
-            vec![remove_then_insert.clone()],
-        )))
-        .unwrap();
-        tx.try_send(MetaServerCommand::Insert(BlockHashBatch::single_namespace(
-            "ns-insert".to_string(),
-            vec![insert_only.clone()],
-        )))
-        .unwrap();
-
-        let loop_task = tokio::spawn(registration_loop(rx, addr, "node-a:50055".to_string()));
-
-        wait_for_count(&service.insert_notify, &service.insert_count, 2).await;
-        wait_for_count(&service.remove_notify, &service.remove_count, 2).await;
-
-        assert_eq!(
-            collect_requests(&service.insert_requests),
-            expected_requests(&[
-                ("ns-second", remove_then_insert),
-                ("ns-insert", insert_only),
-            ])
-        );
-        assert_eq!(
-            collect_requests(&service.remove_requests),
-            expected_requests(&[("ns-first", insert_then_remove), ("ns-remove", remove_only)])
-        );
-
-        let (done_tx, done_rx) = oneshot::channel();
-        tx.send(MetaServerCommand::Shutdown(done_tx)).await.unwrap();
-        done_rx.await.unwrap();
-        loop_task.await.unwrap();
-        let _ = shutdown_tx.send(());
-    }
-}
+mod tests;

--- a/pegaflow-core/src/internode/metaserver_client/tests.rs
+++ b/pegaflow-core/src/internode/metaserver_client/tests.rs
@@ -1,0 +1,495 @@
+use super::*;
+use pegaflow_proto::proto::engine::meta_server_server::{MetaServer, MetaServerServer};
+use pegaflow_proto::proto::engine::{
+    HeartbeatNodeResponse, InsertBlockHashesResponse, NodePrefixResult, QueryPrefixBlocksRequest,
+    QueryPrefixBlocksResponse, RemoveBlockHashesResponse, ResponseStatus, UnregisterNodeResponse,
+};
+use std::collections::BTreeMap;
+#[cfg(feature = "rdma")]
+use std::collections::BTreeSet;
+use std::net::SocketAddr;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+use tokio::net::TcpListener;
+use tokio::sync::{Notify, oneshot};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status, async_trait};
+
+type RequestLog = Mutex<Vec<(String, Vec<Vec<u8>>)>>;
+type RequestSet = BTreeMap<String, Vec<Vec<u8>>>;
+type TimeoutLog = Mutex<Vec<&'static str>>;
+
+#[derive(Default)]
+struct FakeMetaServerState {
+    heartbeat_count: AtomicUsize,
+    insert_count: AtomicUsize,
+    remove_count: AtomicUsize,
+    query_count: AtomicUsize,
+    unregister_count: AtomicUsize,
+    fail_insert_with_stale_session: AtomicUsize,
+    fail_query_unavailable: AtomicUsize,
+    insert_requests: RequestLog,
+    remove_requests: RequestLog,
+    timeout_methods: TimeoutLog,
+    heartbeat_notify: Notify,
+    insert_notify: Notify,
+    remove_notify: Notify,
+    query_notify: Notify,
+    unregister_notify: Notify,
+}
+
+#[derive(Clone)]
+struct FakeMetaServer {
+    state: Arc<FakeMetaServerState>,
+}
+
+fn record_timeout<T>(state: &FakeMetaServerState, method: &'static str, request: &Request<T>) {
+    if request.metadata().get("grpc-timeout").is_some() {
+        state.timeout_methods.lock().unwrap().push(method);
+    }
+}
+
+#[async_trait]
+impl MetaServer for FakeMetaServer {
+    async fn heartbeat_node(
+        &self,
+        request: Request<HeartbeatNodeRequest>,
+    ) -> Result<Response<HeartbeatNodeResponse>, Status> {
+        record_timeout(&self.state, "heartbeat_node", &request);
+        self.state.heartbeat_count.fetch_add(1, Ordering::SeqCst);
+        self.state.heartbeat_notify.notify_waiters();
+        Ok(Response::new(HeartbeatNodeResponse {
+            stale_after_secs: 2,
+        }))
+    }
+
+    async fn unregister_node(
+        &self,
+        request: Request<UnregisterNodeRequest>,
+    ) -> Result<Response<UnregisterNodeResponse>, Status> {
+        record_timeout(&self.state, "unregister_node", &request);
+        self.state.unregister_count.fetch_add(1, Ordering::SeqCst);
+        self.state.unregister_notify.notify_waiters();
+        Ok(Response::new(UnregisterNodeResponse { removed_owners: 0 }))
+    }
+
+    async fn insert_block_hashes(
+        &self,
+        request: Request<InsertBlockHashesRequest>,
+    ) -> Result<Response<InsertBlockHashesResponse>, Status> {
+        record_timeout(&self.state, "insert_block_hashes", &request);
+        let request = request.into_inner();
+        self.state.insert_count.fetch_add(1, Ordering::SeqCst);
+        if self
+            .state
+            .fail_insert_with_stale_session
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                (remaining > 0).then(|| remaining - 1)
+            })
+            .is_ok()
+        {
+            return Err(Status::failed_precondition("stale node session"));
+        }
+        let inserted_count = request.block_hashes.len() as u64;
+        self.state
+            .insert_requests
+            .lock()
+            .unwrap()
+            .push((request.namespace, request.block_hashes));
+        self.state.insert_notify.notify_waiters();
+        Ok(Response::new(InsertBlockHashesResponse {
+            status: Some(ResponseStatus {
+                ok: true,
+                message: String::new(),
+            }),
+            inserted_count,
+        }))
+    }
+
+    async fn remove_block_hashes(
+        &self,
+        request: Request<RemoveBlockHashesRequest>,
+    ) -> Result<Response<RemoveBlockHashesResponse>, Status> {
+        record_timeout(&self.state, "remove_block_hashes", &request);
+        let request = request.into_inner();
+        self.state.remove_count.fetch_add(1, Ordering::SeqCst);
+        let removed_count = request.block_hashes.len() as u64;
+        self.state
+            .remove_requests
+            .lock()
+            .unwrap()
+            .push((request.namespace, request.block_hashes));
+        self.state.remove_notify.notify_waiters();
+        Ok(Response::new(RemoveBlockHashesResponse {
+            status: Some(ResponseStatus {
+                ok: true,
+                message: String::new(),
+            }),
+            removed_count,
+        }))
+    }
+
+    async fn query_prefix_blocks(
+        &self,
+        request: Request<QueryPrefixBlocksRequest>,
+    ) -> Result<Response<QueryPrefixBlocksResponse>, Status> {
+        record_timeout(&self.state, "query_prefix_blocks", &request);
+        self.state.query_count.fetch_add(1, Ordering::SeqCst);
+        self.state.query_notify.notify_waiters();
+        if self
+            .state
+            .fail_query_unavailable
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                (remaining > 0).then(|| remaining - 1)
+            })
+            .is_ok()
+        {
+            return Err(Status::unavailable("synthetic connection failure"));
+        }
+        Ok(Response::new(QueryPrefixBlocksResponse {
+            nodes: vec![NodePrefixResult {
+                node: "node-b:50055".to_string(),
+                prefix_len: 2,
+            }],
+        }))
+    }
+}
+
+async fn start_fake_metaserver() -> (String, Arc<FakeMetaServerState>, oneshot::Sender<()>) {
+    let state = Arc::new(FakeMetaServerState::default());
+    let service = FakeMetaServer {
+        state: Arc::clone(&state),
+    };
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let incoming = TcpListenerStream::new(listener);
+    tokio::spawn(async move {
+        let service = MetaServerServer::new(service)
+            .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE);
+        tonic::transport::Server::builder()
+            .add_service(service)
+            .serve_with_incoming_shutdown(incoming, async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    (format!("http://{addr}"), state, shutdown_tx)
+}
+
+fn start_client(addr: String) -> MetaServerClient {
+    MetaServerClient::new(MetaServerClientConfig::new(
+        addr,
+        "node-a:50055".to_string(),
+    ))
+    .expect("valid fake MetaServer endpoint")
+}
+
+fn collect_requests(requests: &RequestLog) -> RequestSet {
+    let mut grouped = BTreeMap::new();
+    for (namespace, hashes) in requests.lock().unwrap().iter() {
+        let namespace_hashes: &mut Vec<Vec<u8>> = grouped.entry(namespace.clone()).or_default();
+        namespace_hashes.extend(hashes.iter().cloned());
+    }
+    for hashes in grouped.values_mut() {
+        hashes.sort();
+    }
+    grouped
+}
+
+fn expected_requests(entries: &[(&str, Vec<u8>)]) -> RequestSet {
+    let mut grouped: RequestSet = BTreeMap::new();
+    for (namespace, hash) in entries {
+        grouped
+            .entry((*namespace).to_string())
+            .or_default()
+            .push(hash.clone());
+    }
+    for hashes in grouped.values_mut() {
+        hashes.sort();
+    }
+    grouped
+}
+
+async fn wait_for_count(notify: &Notify, count: &AtomicUsize, expected: usize) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        if count.load(Ordering::SeqCst) >= expected {
+            return;
+        }
+        tokio::select! {
+            _ = notify.notified() => {}
+            _ = tokio::time::sleep_until(deadline) => {
+                panic!("timed out waiting for count {expected}");
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn heartbeat_loop_sends_initial_heartbeat_and_unregisters_on_shutdown() {
+    let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+    let client = start_client(addr);
+
+    wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
+    client.shutdown().await;
+    wait_for_count(&service.unregister_notify, &service.unregister_count, 1).await;
+
+    let _ = shutdown_tx.send(());
+}
+
+#[test]
+fn invalid_metaserver_endpoint_is_returned_as_error() {
+    let result = MetaServerClient::new(MetaServerClientConfig::new(
+        "not a uri".to_string(),
+        "node-a:50055".to_string(),
+    ));
+
+    assert!(result.is_err());
+}
+
+#[cfg(feature = "rdma")]
+#[test]
+fn retryable_query_status_matches_tonic_transport_and_timeout_shapes() {
+    assert!(is_retryable_query_status(&Status::unavailable(
+        "transport error"
+    )));
+    assert!(is_retryable_query_status(&Status::deadline_exceeded(
+        "deadline exceeded"
+    )));
+    assert!(is_retryable_query_status(&Status::cancelled(
+        "Timeout expired"
+    )));
+    assert!(is_retryable_query_status(&Status::unknown(
+        "Service was not ready: transport error"
+    )));
+    assert!(is_retryable_query_status(&Status::unknown(
+        "transport error: Connection reset by peer"
+    )));
+
+    assert!(!is_retryable_query_status(&Status::cancelled(
+        "client cancelled"
+    )));
+    assert!(!is_retryable_query_status(&Status::invalid_argument(
+        "bad request"
+    )));
+}
+
+#[tokio::test]
+async fn stale_session_write_error_triggers_new_heartbeat() {
+    let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+    service
+        .fail_insert_with_stale_session
+        .store(1, Ordering::SeqCst);
+    let client = start_client(addr);
+
+    wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
+    client.try_register_namespace("ns".to_string(), vec![vec![1]]);
+    wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 2).await;
+
+    client.shutdown().await;
+    let _ = shutdown_tx.send(());
+}
+
+#[cfg(feature = "rdma")]
+#[tokio::test]
+async fn metaserver_rpcs_carry_deadline_metadata() {
+    let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+    let client = start_client(addr);
+
+    wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
+    client.try_register_namespace("ns".to_string(), vec![vec![1]]);
+    client.try_unregister(vec![("ns".to_string(), vec![2])]);
+    let nodes = client
+        .query_prefix("ns", &[vec![1], vec![2]])
+        .await
+        .unwrap();
+    assert_eq!(nodes.len(), 1);
+
+    wait_for_count(&service.insert_notify, &service.insert_count, 1).await;
+    wait_for_count(&service.remove_notify, &service.remove_count, 1).await;
+
+    client.shutdown().await;
+    wait_for_count(&service.unregister_notify, &service.unregister_count, 1).await;
+
+    let methods: BTreeSet<&'static str> = service
+        .timeout_methods
+        .lock()
+        .unwrap()
+        .iter()
+        .copied()
+        .collect();
+    assert_eq!(
+        methods,
+        BTreeSet::from([
+            "heartbeat_node",
+            "insert_block_hashes",
+            "remove_block_hashes",
+            "query_prefix_blocks",
+            "unregister_node",
+        ])
+    );
+
+    let _ = shutdown_tx.send(());
+}
+
+#[cfg(feature = "rdma")]
+#[tokio::test]
+async fn query_prefix_refreshes_channel_and_retries_once_on_unavailable() {
+    let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+    service.fail_query_unavailable.store(1, Ordering::SeqCst);
+    let client = start_client(addr);
+
+    let nodes = client
+        .query_prefix("ns", &[vec![1], vec![2]])
+        .await
+        .unwrap();
+
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes[0].node, "node-b:50055");
+    assert_eq!(nodes[0].prefix_len, 2);
+    assert_eq!(service.query_count.load(Ordering::SeqCst), 2);
+
+    client.shutdown().await;
+    let _ = shutdown_tx.send(());
+}
+
+#[test]
+fn unsent_after_failure_counts_only_unsent_tail() {
+    let ns = |name: &str, n: usize| (name.to_string(), vec![vec![0u8]; n]);
+    let namespaces = vec![ns("a", 100), ns("b", 50), ns("c", 30)];
+
+    // First chunk of "b" failed (nothing of b sent yet): all of b + c.
+    assert_eq!(unsent_after_failure(&namespaces, 1, 0), 50 + 30);
+    // 40 hashes of "b" already landed before the failing chunk: b's tail + c.
+    assert_eq!(unsent_after_failure(&namespaces, 1, 40), 10 + 30);
+    // Failure in the last namespace: only its unsent tail, no later namespaces.
+    assert_eq!(unsent_after_failure(&namespaces, 2, 20), 10);
+    // Offset past the namespace length saturates to zero unsent.
+    assert_eq!(unsent_after_failure(&namespaces, 2, 999), 0);
+}
+
+#[tokio::test]
+async fn large_namespace_removal_splits_into_bounded_rpcs() {
+    let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+    let client = start_client(addr);
+    wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
+
+    // One namespace coalesced past the per-RPC cap. Use sha256-sized (32B)
+    // hashes so the total payload is large enough to prove the registration
+    // loop still emits bounded RPCs instead of one burst-sized request.
+    // Chunking holds each request to MAX_HASHES_PER_RPC * 32B = 512 KiB.
+    let sha256_hash = |i: u32| {
+        let mut h = vec![0u8; 32];
+        h[..4].copy_from_slice(&i.to_le_bytes());
+        h
+    };
+    let total = MAX_HASHES_PER_RPC * 10 + 1;
+    let expected_chunks = total.div_ceil(MAX_HASHES_PER_RPC);
+    let entries: Vec<(String, Vec<u8>)> = (0..total as u32)
+        .map(|i| ("ns".to_string(), sha256_hash(i)))
+        .collect();
+    client.try_unregister(entries);
+
+    wait_for_count(
+        &service.remove_notify,
+        &service.remove_count,
+        expected_chunks,
+    )
+    .await;
+
+    let logged = service.remove_requests.lock().unwrap().clone();
+    assert_eq!(
+        logged.len(),
+        expected_chunks,
+        "removal split into wrong RPC count"
+    );
+    let mut sent: Vec<Vec<u8>> = Vec::with_capacity(total);
+    for (namespace, hashes) in &logged {
+        assert_eq!(namespace, "ns");
+        assert!(
+            hashes.len() <= MAX_HASHES_PER_RPC,
+            "chunk of {} hashes exceeds cap {MAX_HASHES_PER_RPC}",
+            hashes.len()
+        );
+        sent.extend(hashes.iter().cloned());
+    }
+    sent.sort();
+    let mut expected: Vec<Vec<u8>> = (0..total as u32).map(sha256_hash).collect();
+    expected.sort();
+    assert_eq!(sent, expected, "chunking lost or duplicated hashes");
+
+    client.shutdown().await;
+    let _ = shutdown_tx.send(());
+}
+
+#[tokio::test]
+async fn mixed_insert_remove_drain_preserves_last_write_per_namespace() {
+    let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+    let (tx, rx) = mpsc::channel(16);
+
+    let insert_then_remove = vec![0xa0];
+    let remove_then_insert = vec![0xb0];
+    let remove_only = vec![0xc0];
+    let insert_only = vec![0xd0];
+
+    tx.try_send(MetaServerCommand::Insert(BlockHashBatch::single_namespace(
+        "ns-first".to_string(),
+        vec![insert_then_remove.clone()],
+    )))
+    .unwrap();
+    tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
+        vec![("ns-first".to_string(), insert_then_remove.clone())],
+    )))
+    .unwrap();
+    tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
+        vec![
+            ("ns-second".to_string(), remove_then_insert.clone()),
+            ("ns-remove".to_string(), remove_only.clone()),
+        ],
+    )))
+    .unwrap();
+    tx.try_send(MetaServerCommand::Insert(BlockHashBatch::single_namespace(
+        "ns-second".to_string(),
+        vec![remove_then_insert.clone()],
+    )))
+    .unwrap();
+    tx.try_send(MetaServerCommand::Insert(BlockHashBatch::single_namespace(
+        "ns-insert".to_string(),
+        vec![insert_only.clone()],
+    )))
+    .unwrap();
+
+    let endpoint = metaserver_endpoint(addr.clone()).expect("valid fake MetaServer endpoint");
+    let loop_task = tokio::spawn(registration_loop(
+        rx,
+        addr,
+        endpoint,
+        "node-a:50055".to_string(),
+    ));
+
+    wait_for_count(&service.insert_notify, &service.insert_count, 2).await;
+    wait_for_count(&service.remove_notify, &service.remove_count, 2).await;
+
+    assert_eq!(
+        collect_requests(&service.insert_requests),
+        expected_requests(&[
+            ("ns-second", remove_then_insert),
+            ("ns-insert", insert_only),
+        ])
+    );
+    assert_eq!(
+        collect_requests(&service.remove_requests),
+        expected_requests(&[("ns-first", insert_then_remove), ("ns-remove", remove_only)])
+    );
+
+    let (done_tx, done_rx) = oneshot::channel();
+    tx.send(MetaServerCommand::Shutdown(done_tx)).await.unwrap();
+    done_rx.await.unwrap();
+    loop_task.await.unwrap();
+    let _ = shutdown_tx.send(());
+}

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -124,7 +124,7 @@ impl StorageEngine {
         let transfer_lock_timeout = config.transfer_lock_timeout;
 
         // Create MetaServer client if configured
-        let metaserver_client = config.metaserver_addr.as_ref().map(|addr| {
+        let metaserver_client = if let Some(addr) = config.metaserver_addr.as_ref() {
             let advertise = config
                 .advertise_addr
                 .clone()
@@ -135,8 +135,12 @@ impl StorageEngine {
             );
             let ms_config = MetaServerClientConfig::new(addr.clone(), advertise)
                 .with_queue_depth(config.metaserver_queue_depth);
-            Arc::new(MetaServerClient::new(ms_config))
-        });
+            Some(Arc::new(MetaServerClient::new(ms_config).map_err(
+                |err| format!("invalid MetaServer endpoint {addr}: {err}"),
+            )?))
+        } else {
+            None
+        };
 
         if blockwise_alloc {
             info!("Blockwise allocation enabled for batch_save");

--- a/pegaflow-metaserver/Cargo.toml
+++ b/pegaflow-metaserver/Cargo.toml
@@ -32,6 +32,7 @@ axum.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+tokio-stream = { workspace = true, features = ["net"] }
 
 [[bench]]
 name = "unregister_node"

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -11,6 +11,8 @@ use clap::Parser;
 use log::{error, info};
 use opentelemetry::global;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
+use pegaflow_common::grpc::{GRPC_HTTP2_KEEPALIVE_INTERVAL, GRPC_HTTP2_KEEPALIVE_TIMEOUT};
+use pegaflow_proto::MAX_GRPC_MESSAGE_SIZE;
 use pegaflow_proto::proto::engine::meta_server_server::MetaServerServer;
 use prometheus::Registry;
 use std::error::Error;
@@ -65,6 +67,12 @@ fn init_metrics() -> Result<(SdkMeterProvider, Registry), Box<dyn Error>> {
     info!("Prometheus metrics exporter enabled");
 
     Ok((meter_provider, registry))
+}
+
+pub fn grpc_meta_server(service: GrpcMetaService) -> MetaServerServer<GrpcMetaService> {
+    MetaServerServer::new(service)
+        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
 }
 
 /// Wait for OS termination signal (Ctrl+C or SIGTERM), then notify dependents.
@@ -181,7 +189,9 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     // Start the gRPC server
     let server_future = Server::builder()
-        .add_service(MetaServerServer::new(service))
+        .http2_keepalive_interval(Some(GRPC_HTTP2_KEEPALIVE_INTERVAL))
+        .http2_keepalive_timeout(Some(GRPC_HTTP2_KEEPALIVE_TIMEOUT))
+        .add_service(grpc_meta_server(service))
         .serve_with_shutdown(cli.addr, shutdown_signal(shutdown.clone()));
 
     if let Err(e) = server_future.await {
@@ -196,4 +206,74 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     info!("MetaServer shut down gracefully");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient;
+    use pegaflow_proto::proto::engine::{HeartbeatNodeRequest, InsertBlockHashesRequest};
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::transport::{Channel, Server};
+
+    async fn start_grpc_metaserver() -> (MetaServerClient<Channel>, oneshot::Sender<()>) {
+        let store = Arc::new(BlockHashStore::new());
+        let service = GrpcMetaService::new(store);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let incoming = TcpListenerStream::new(listener);
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(grpc_meta_server(service))
+                .serve_with_incoming_shutdown(incoming, async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        let channel = Channel::from_shared(format!("http://{addr}"))
+            .unwrap()
+            .connect()
+            .await
+            .unwrap();
+        let client = MetaServerClient::new(channel)
+            .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE);
+        (client, shutdown_tx)
+    }
+
+    #[tokio::test]
+    async fn grpc_meta_server_accepts_insert_payload_above_tonic_default() {
+        let (mut client, shutdown_tx) = start_grpc_metaserver().await;
+        let node_id = uuid::Uuid::new_v4().to_string();
+        client
+            .heartbeat_node(HeartbeatNodeRequest {
+                node: "node-a:50055".to_string(),
+                node_id: node_id.clone(),
+            })
+            .await
+            .unwrap();
+
+        let one_mib = 1024 * 1024;
+        let block_hashes: Vec<Vec<u8>> = (0..5).map(|i| vec![i as u8; one_mib]).collect();
+        let response = client
+            .insert_block_hashes(InsertBlockHashesRequest {
+                namespace: "ns".to_string(),
+                block_hashes,
+                node: "node-a:50055".to_string(),
+                node_id,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.inserted_count, 5);
+        assert!(response.status.unwrap().ok);
+
+        let _ = shutdown_tx.send(());
+    }
 }

--- a/pegaflow-proto/src/lib.rs
+++ b/pegaflow-proto/src/lib.rs
@@ -7,3 +7,5 @@ pub mod proto {
         tonic::include_proto!("pegaflow");
     }
 }
+
+pub const MAX_GRPC_MESSAGE_SIZE: usize = 64 * 1024 * 1024;

--- a/pegaflow-server/examples/p2p_bench.rs
+++ b/pegaflow-server/examples/p2p_bench.rs
@@ -41,8 +41,7 @@ use cudarc::driver::{CudaContext, sys};
 use log::info;
 use pegaflow_core::sync_state::{LOAD_STATE_ERROR, LOAD_STATE_SUCCESS};
 use pegaflow_core::*;
-use pegaflow_metaserver::{BlockHashStore, GrpcMetaService};
-use pegaflow_proto::proto::engine::meta_server_server::MetaServerServer;
+use pegaflow_metaserver::{BlockHashStore, GrpcMetaService, grpc_meta_server};
 use pegaflow_server::proto::engine::engine_server::EngineServer;
 use pegaflow_server::{CudaTensorRegistry, GrpcEngineService, RegistryHandle};
 use tokio::sync::Notify;
@@ -482,7 +481,7 @@ async fn run_holder(cli: &Cli, shape: &Shape, pool_bytes: usize) {
     let meta_service = GrpcMetaService::new(Arc::clone(&meta_store));
     tokio::spawn(async move {
         Server::builder()
-            .add_service(MetaServerServer::new(meta_service))
+            .add_service(grpc_meta_server(meta_service))
             .serve(meta_addr)
             .await
             .expect("MetaServer gRPC serve");

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -24,6 +24,7 @@ use opentelemetry::global;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use pegaflow_core::PegaEngine;
+use pegaflow_proto::MAX_GRPC_MESSAGE_SIZE;
 use prometheus::Registry;
 use proto::engine::engine_server::EngineServer;
 use pyo3::{PyErr, Python, types::PyAnyMethods};
@@ -671,8 +672,6 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         };
 
         info!("PegaEngine gRPC server listening on {}", cli.addr);
-
-        const MAX_GRPC_MESSAGE_SIZE: usize = 64 * 1024 * 1024; // 64 MiB
 
         let grpc_service = EngineServer::new(service)
             .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -15,8 +15,7 @@ use cudarc::driver::CudaContext;
 use cudarc::driver::sys;
 use pegaflow_core::sync_state::{LOAD_STATE_ERROR, LOAD_STATE_SUCCESS};
 use pegaflow_core::*;
-use pegaflow_metaserver::{BlockHashStore, GrpcMetaService};
-use pegaflow_proto::proto::engine::meta_server_server::MetaServerServer;
+use pegaflow_metaserver::{BlockHashStore, GrpcMetaService, grpc_meta_server};
 use pegaflow_server::proto::engine::engine_server::EngineServer;
 use pegaflow_server::{CudaTensorRegistry, GrpcEngineService, RegistryHandle};
 use tokio::sync::Notify;
@@ -142,7 +141,7 @@ async fn spawn_metaserver(port: u16) -> Arc<BlockHashStore> {
     let addr: SocketAddr = ([127, 0, 0, 1], port).into();
     tokio::spawn(async move {
         Server::builder()
-            .add_service(MetaServerServer::new(service))
+            .add_service(grpc_meta_server(service))
             .serve(addr)
             .await
             .expect("MetaServer gRPC serve");

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,4 +1,6 @@
+use pegaflow_common::grpc::{GRPC_CONNECT_TIMEOUT, GRPC_HTTP2_KEEPALIVE_INTERVAL};
 use pegaflow_core::LoadState;
+use pegaflow_proto::MAX_GRPC_MESSAGE_SIZE;
 use pegaflow_proto::proto::engine::{
     HealthRequest, LeaseLoad, LoadRequest, QueryRequest, RegisterContextRequest, ReleaseRequest,
     ResponseStatus, SaveLayer, SaveRequest, SessionEvent, SessionRequest, ShutdownRequest,
@@ -12,7 +14,6 @@ use pyo3::{
 use std::{
     future::Future,
     sync::{Arc, Mutex, OnceLock},
-    time::Duration,
 };
 use tokio::runtime::{Handle, Runtime};
 use tonic::{
@@ -201,16 +202,14 @@ impl EngineRpcClient {
         // Avoid per-RPC overhead by eager-connecting and reusing a warmed client handle.
         let endpoint_cfg = Endpoint::from_shared(endpoint.clone())
             .map_err(|err| transport_connect_error(&endpoint, err))?
-            .connect_timeout(Duration::from_millis(500))
+            .connect_timeout(GRPC_CONNECT_TIMEOUT)
             .tcp_nodelay(true)
-            .http2_keep_alive_interval(Duration::from_secs(30))
+            .http2_keep_alive_interval(GRPC_HTTP2_KEEPALIVE_INTERVAL)
             .keep_alive_while_idle(true);
 
         let channel = rt
             .block_on(endpoint_cfg.connect())
             .map_err(|err| transport_connect_error(&endpoint, err))?;
-        // Match server's 64 MiB limit to avoid Status::resource_exhausted on large payloads
-        const MAX_GRPC_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
         let client = EngineClient::new(channel)
             .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
             .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE);


### PR DESCRIPTION
## Summary

This PR makes the MetaServer gRPC control-plane behavior explicit instead of depending on tonic defaults. The MetaServer path is on the hot correctness boundary for prefix-cache metadata: registration keeps a worker session alive, insert/remove publish block ownership, and query determines whether a request can reuse cached KV blocks. For that path, the transport contract needs to be predictable under bad endpoints, dead idle connections, large metadata batches, and request deadlines.

The change does four things:

- Introduces shared PegaFlow gRPC defaults: 500ms connect timeout, 3s local RPC timeout, 3s propagated gRPC deadline, HTTP/2 keepalive, and a shared 64MiB message limit.
- Builds every internal MetaServer client from the same configured `Endpoint`, and attaches `grpc-timeout` to heartbeat, insert, remove, query, and unregister requests.
- Refreshes the lazy query channel and retries read-only `QueryPrefixBlocks` once when tonic reports a retryable transport/timeout/readiness status.
- Wraps the generated MetaServer server with the same 64MiB encode/decode limit and uses that wrapper in production, p2p bench code, and p2p tests.

No tonic version bump is needed. The workspace already uses `tonic = "0.14"`, Cargo resolves it to 0.14.5, and the behavior this PR relies on is present in that version.

## Change-by-Change Rationale

### Shared gRPC constants

`pegaflow-common` now owns the connect timeout, RPC timeout, HTTP/2 keepalive settings, and `pegaflow-proto` owns the shared 64MiB gRPC message limit.

Why this exists: these values are not independent local choices. A MetaServer client, a generated MetaServer server, and test/bench servers must agree on the same transport contract. Keeping the values in helpers/constants prevents one path from silently using tonic defaults while another path uses PegaFlow limits.

What happens without it: the code can compile while behavior drifts. For example, production can accept a 64MiB MetaServer payload while a p2p test server still rejects it at tonic's default 4MiB decode limit, or one client path can get deadlines while another path waits on default transport behavior.

### `Endpoint::from_shared` error handling

`MetaServerClient::new` now returns a `tonic::transport::Error` for invalid MetaServer endpoint strings instead of panicking.

Why this exists: endpoint parsing is configuration validation. A bad URI should be reported as startup failure with context, not as an internal panic from the client constructor.

What happens without it: a bad `metaserver_addr` crashes the process during setup, which makes the failure look like a programming bug instead of an invalid deployment configuration.

### `connect_timeout(500ms)`

The shared MetaServer `Endpoint` sets a 500ms connect timeout.

Why this exists: tonic's endpoint default has `connect_timeout: None`. For a blackholed or unreachable MetaServer address, connection establishment should be bounded by PegaFlow's control-plane budget, not by the operating system or lower transport stack.

What happens without it: initial registration/query connection attempts can wait far longer than the MetaServer control-plane operation is allowed to matter. The caller sees an unbounded-looking stall rather than a fast, explicit connection failure.

### `Endpoint::timeout(3s)`

The shared MetaServer `Endpoint` sets a local 3s request timeout.

Why this exists: this bounds the client-side RPC future. It is still needed even though the PR also writes `grpc-timeout`, because a propagated server deadline only helps after the request reaches a tonic server that understands the header. The client also needs its own local guard around transport and response wait.

What happens without it: the server may receive a deadline, but the client-side future itself is not bounded by tonic's local endpoint timeout. Failures before the server handles the request, or waits on the response path, can escape the intended local RPC budget.

### `Request::set_timeout(3s)` / `grpc-timeout`

Every MetaServer RPC now wraps the generated request and calls `Request::set_timeout`.

Why this exists: tonic documents that `Endpoint::timeout` does **not** write the `grpc-timeout` metadata header. `Request::set_timeout` is the tonic API that formats the duration and inserts `grpc-timeout`. tonic's server timeout layer reads that header, compares it with any configured server timeout, and uses the shorter value. This is the difference between "the client gives up locally" and "the server is told the caller's deadline".

What happens without it: the client can time out locally while the MetaServer never sees the deadline. In storage terms, the coordinator gave up waiting, but the server-side operation was never given the transaction deadline and can keep running until it finishes or hits some unrelated limit.

### `tcp_nodelay(true)`

The shared MetaServer endpoint sets TCP_NODELAY explicitly.

Why this exists: tonic 0.14.5 already defaults `tcp_nodelay` to `true`, so this is not a behavior change for the current lockfile. It is kept explicit because MetaServer RPCs are small control-plane messages where adding Nagle delay would be the wrong latency tradeoff.

What happens without it: with tonic 0.14.5 specifically, nothing changes because the default is already `true`. If the local endpoint construction changed later, this explicit setting prevents accidental latency regression for small control-plane RPCs.

### HTTP/2 keepalive interval, timeout, and `keep_alive_while_idle(true)`

The shared MetaServer endpoint enables HTTP/2 keepalive with a 30s ping interval, a 10s ping-ack timeout, and idle-channel keepalive.

Why this exists: tonic's endpoint defaults leave HTTP/2 keepalive unset. MetaServer channels can sit idle between control-plane requests. Keepalive lets the transport detect a dead idle connection before the next logical request is the first proof that the channel is broken.

What happens without the interval: tonic does not schedule periodic HTTP/2 pings for this endpoint, so idle connection death is discovered only by later traffic.

What happens without the timeout: a keepalive ping does not have the intended bound for declaring the peer unhealthy after missing the ping ack.

What happens without `keep_alive_while_idle(true)`: the channel can still fail to probe idle periods, which is exactly the period this setting is meant to cover for long-lived MetaServer clients.

### Shared generated-client message size

Generated clients that talk to PegaFlow gRPC services now use the shared `MAX_GRPC_MESSAGE_SIZE` instead of hard-coded `64 * 1024 * 1024` values.

Why this exists: the message-size limit is a protocol contract, not a per-call-site preference. Client and server limits must move together, and the Rust/Python bindings should not carry duplicate literals that can drift.

What happens without it: one generated client can keep accepting/sending 64MiB while another path regresses to tonic's default or a stale local literal. The failure then appears only for larger batches and only through the path that drifted.

### `grpc_meta_server(...)` server wrapper

`pegaflow-metaserver` now exposes a helper that constructs `MetaServerServer<GrpcMetaService>` with the shared 64MiB encode/decode limit.

Why this exists: tonic generated servers default to a 4MiB decoded-message limit. MetaServer insert/query batches can legitimately exceed that when many block hashes are batched. The limit must be applied at every generated-server construction site, not just the production binary.

What happens without it: a valid MetaServer request above 4MiB can be rejected by tonic's codec before `GrpcMetaService` receives it. If only production uses the larger limit but tests/bench code use bare `MetaServerServer::new`, tests stop representing production behavior.

### Production MetaServer HTTP/2 keepalive

The production MetaServer `Server::builder()` now enables HTTP/2 keepalive interval and timeout.

Why this exists: client-side keepalive is only half of the transport contract. The server also needs explicit HTTP/2 keepalive behavior for accepted connections so idle peer health is handled consistently at the server boundary.

What happens without it: production accepted connections continue to rely on tonic/hyper defaults for keepalive behavior, while clients assume a more explicit idle-health policy. That mismatch makes idle connection failures less predictable.

### Query channel refresh and single retry

`QueryPrefixBlocks` now clones the current lazy channel for the first attempt, refreshes the stored channel after a retryable failure, and retries the read-only query once.

Why this exists: `connect_lazy` does not connect until first use. That keeps setup cheap, but a stale or closed HTTP/2 connection is discovered by the query that happens to use it. Since `QueryPrefixBlocks` is read-only, rebuilding the channel and retrying once is a safe bounded recovery.

What happens without it: the first query after an idle transport break can fail even though a fresh channel would succeed. That can turn a transient transport state into a visible cache-query failure.

Why only once: repeated retries would hide a real MetaServer outage and stretch request latency. One retry distinguishes stale-channel recovery from persistent failure.

Why query only: insert/remove/heartbeat/unregister are writes or session lifecycle operations. Retrying them has idempotency/session implications and is already covered by the existing registration loop, backoff, and stale-session reset behavior.

### Retry status classification

The query retry predicate includes `Unavailable`, `DeadlineExceeded`, tonic's local-timeout shape `Cancelled("Timeout expired")`, selected readiness failures, and selected transport-reset messages. It does not treat every `Unknown` as retryable.

Why this exists: tonic and tower expose some channel/readiness/transport failures as status codes and some as `Code::Unknown` with message text. tonic 0.14.5 maps its internal `TimeoutExpired` error to `Status::cancelled("Timeout expired")`, so a retry predicate that only checks `DeadlineExceeded` misses a real tonic timeout shape.

What happens without the `Cancelled("Timeout expired")` case: local tonic timeout expiry is returned directly instead of taking the safe read-only retry path.

What happens without selected `Unknown` handling: readiness and transport-reset failures that tonic reports through `Unknown` are not retried even though refreshing the channel is the right recovery for a read-only query.

What happens if all `Unknown` statuses are retried: application errors that happen to use `Unknown` can be hidden behind a transport retry. This PR only retries the tonic-shaped messages covered by tests.

### Test coverage for the contract

The tests now assert `grpc-timeout` metadata, retry classification, retry count, channel refresh behavior, invalid endpoint handling, chunking/netting behavior, and a real gRPC payload above tonic's default 4MiB decode limit.

Why this exists: most of this bug class lives below application logic. A unit test that only calls the Rust service method would not prove tonic metadata, generated-server codec limits, or generated-client retry behavior.

What happens without it: the code can look correct while missing the actual tonic contract. For example, a future refactor could keep a local timeout but stop writing `grpc-timeout`, or could reintroduce a bare generated server with a 4MiB decode limit.

## Tonic Semantics Used Here

The implementation is based on tonic 0.14.5 source behavior, not on inferred gRPC behavior.

- **Endpoint defaults:** `Endpoint::new_uri` initializes `timeout`, HTTP/2 keepalive fields, and `connect_timeout` to `None`; it does not silently install the deadlines PegaFlow needs. Source: https://github.com/hyperium/tonic/blob/v0.14.5/tonic/src/transport/channel/endpoint.rs#L74-L100

- **Local timeout vs propagated deadline:** `Endpoint::timeout` says it applies a timeout to each request, but its note says it does **not** set `grpc-timeout` and points callers to `Request::set_timeout` for that. So using only `Endpoint::timeout` would bound the local client future but would not tell the MetaServer about the deadline. Source: https://github.com/hyperium/tonic/blob/v0.14.5/tonic/src/transport/channel/endpoint.rs#L220-L236

- **How the deadline reaches the server:** `Request::set_timeout` formats the duration and inserts the `grpc-timeout` metadata header. This is why the PR adds a small helper around outbound MetaServer requests instead of relying on generated-client configuration alone. Source: https://github.com/hyperium/tonic/blob/v0.14.5/tonic/src/request.rs#L266-L297

- **How the server enforces it:** tonic's `GrpcTimeout` service reads the request header, compares it with any configured server timeout, and uses the shorter duration. If the inner future does not complete before the timer fires, tonic returns `TimeoutExpired`. Source: https://github.com/hyperium/tonic/blob/v0.14.5/tonic/src/transport/service/grpc_timeout.rs#L41-L90

- **How local timeout expiry is surfaced:** tonic maps its internal `TimeoutExpired` error to `Status::cancelled("Timeout expired")`. A retry predicate that only treats `DeadlineExceeded` as timeout-like would miss tonic's local timeout shape. Source: https://github.com/hyperium/tonic/blob/v0.14.5/tonic/src/status.rs#L642-L644

- **Lazy connection behavior:** `connect_lazy` returns a channel that does not try to connect until first use. That explains why the query path can hold a channel that only proves whether the transport is usable at RPC time, and why refreshing it before a single read-only retry is useful. Source: https://github.com/hyperium/tonic/blob/v0.14.5/tonic/src/transport/channel/endpoint.rs#L478-L488

- **Message-size default:** tonic's default max decoded message size is 4MiB. PegaFlow's MetaServer batch size expectation is 64MiB, so the limit must be set explicitly anywhere a generated MetaServer client or server is constructed. Source: https://github.com/hyperium/tonic/blob/v0.14.5/tonic/src/codec/mod.rs#L100-L102

## Testing

Commands run:

- `cargo test -p pegaflow-core --no-default-features --features cuda-13,rdma internode::metaserver_client`
- `cargo test -p pegaflow-metaserver`
- `cargo check --workspace --no-default-features --features cuda-13,rdma`
- `cargo check -p pegaflow-server --no-default-features --features cuda-13,rdma --tests --examples`
- `git diff --check`
- `prek run`

Behavior covered by tests:

- invalid MetaServer endpoints return startup errors instead of panicking
- heartbeat, insert, remove, query, and unregister requests carry `grpc-timeout`
- retry classification covers tonic-shaped `Unavailable`, `DeadlineExceeded`, `Cancelled("Timeout expired")`, readiness, and transport-reset statuses
- read-only query refreshes the channel and retries once, with retry count asserted
- insert/remove chunking and netting still produce the expected requests
- a real gRPC MetaServer insert payload above tonic's default 4MiB decoded-message limit succeeds with the shared 64MiB server/client configuration

Refs #353.
