### PR TITLE
feat(core): expose prefetch stale GC and quiet load completion logs

### DIFF
--- a/docs/p2p.md
+++ b/docs/p2p.md
@@ -138,6 +138,7 @@ P2P-related Prometheus metrics (on `:9091/metrics` by default):
 | `pegaflow_rdma_qps` | Gauge | Active RDMA queue pairs |
 | `pegaflow_transfer_lock_active` | UpDownCounter | Currently held transfer locks |
 | `pegaflow_transfer_lock_timeouts_total` | Counter | Transfer lock timeout events |
+| `pegaflow_prefetch_stale_gc_total` | Counter | Stale prefetch active entries removed by background GC |
 
 ## Troubleshooting
 

--- a/examples/metric-prometheus/grafana/dashboards/pegaflow.json
+++ b/examples/metric-prometheus/grafana/dashboards/pegaflow.json
@@ -870,9 +870,14 @@
           "expr": "rate(pegaflow_inflight_gc_cleaned_total[1m])",
           "legendFormat": "inflight gc cleaned/sec",
           "refId": "A"
+        },
+        {
+          "expr": "rate(pegaflow_prefetch_stale_gc_total[1m])",
+          "legendFormat": "prefetch stale gc/sec",
+          "refId": "B"
         }
       ],
-      "title": "Inflight GC Cleaned Rate",
+      "title": "Background GC Rates",
       "type": "timeseries"
     }
   ],

--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -454,7 +454,7 @@ fn process_load_task(
             .record(elapsed.as_secs_f64(), &[]);
     }
 
-    info!(
+    debug!(
         "Load task completed: layers={} blocks={} copies={} bytes={} elapsed_ms={:.2} bandwidth_gbps={:.2} backend={}",
         layers.len(),
         total_blocks,

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -32,6 +32,8 @@ pub(crate) struct CoreMetrics {
     // Inflight (write path safety/health)
     pub inflight_bytes: UpDownCounter<i64>,
     pub inflight_gc_cleaned: Counter<u64>,
+    /// Prefetch tasks older than the background GC age threshold (default 5m).
+    pub prefetch_stale_gc_total: Counter<u64>,
 
     // Cache (sealed blocks in memory)
     pub cache_resident_bytes: UpDownCounter<i64>,
@@ -230,6 +232,12 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
             inflight_gc_cleaned: meter
                 .u64_counter("pegaflow_inflight_gc_cleaned")
                 .with_description("Stale inflight blocks cleaned by background GC")
+                .build(),
+            prefetch_stale_gc_total: meter
+                .u64_counter("pegaflow_prefetch_stale_gc_total")
+                .with_description(
+                    "Stale prefetch active entries removed by background GC (potential hang)",
+                )
                 .build(),
 
             // Cache

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -7,7 +7,7 @@ mod write_path;
 use bytesize::ByteSize;
 #[cfg(not(feature = "rdma"))]
 use log::warn;
-use log::{debug, info};
+use log::{debug, info, warn};
 use std::collections::HashSet;
 use std::num::NonZeroU64;
 use std::sync::{Arc, Weak};
@@ -542,7 +542,10 @@ impl StorageEngine {
             .prefetch
             .gc_stale_entries(inflight_max_age, failed_remote_max_age);
         if stale_prefetch > 0 {
-            log::debug!("gc: removed {stale_prefetch} stale prefetch entries");
+            core_metrics()
+                .prefetch_stale_gc_total
+                .add(stale_prefetch as u64, &[]);
+            warn!("Prefetch GC: removed {stale_prefetch} stale active entries (age > threshold)");
         }
         if failed > 0 {
             log::debug!("gc: cleared {failed} stale failed_remote entries");


### PR DESCRIPTION
## Summary

- Promote stale prefetch active-entry GC from debug to **warn** with a clear log line: `Prefetch GC: removed N stale active entries (age > threshold)`.
- Add **`pegaflow_prefetch_stale_gc_total`** counter so hung/stuck prefetch paths are observable in Prometheus (alert on `rate(...) > 0`).
- Demote per-load **`Load task completed`** logs from info to **debug** (load bytes/duration metrics already capture throughput).
- Wire the new metric into the Grafana "Background GC Rates" panel and document it in `docs/p2p.md`.

## Test plan

- [x] `cargo check -p pegaflow-core`
- [x] pre-commit hooks (fmt, clippy, `cargo test --release`)

## Observability

```promql
rate(pegaflow_prefetch_stale_gc_total[5m]) > 0
```

Log grep (default `--log-level info` now sufficient):

```
Prefetch GC: removed
```


Made with [Cursor](https://cursor.com)