### PR TITLE
feat(grpc): enable Neon-style HTTP/2 keepalive for internal gRPC

### DIFF
--- a/pegaflow-common/src/grpc.rs
+++ b/pegaflow-common/src/grpc.rs
@@ -1,0 +1,9 @@
+use std::time::Duration;
+
+// Neon storage_broker client defaults.
+pub const GRPC_CONNECT_TIMEOUT: Duration = Duration::from_millis(5000);
+pub const GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL: Duration = Duration::from_millis(5000);
+
+// Neon pageserver gRPC server defaults.
+pub const GRPC_SERVER_HTTP2_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
+pub const GRPC_SERVER_HTTP2_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(20);

--- a/pegaflow-common/src/lib.rs
+++ b/pegaflow-common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod block;
+pub mod grpc;
 pub mod hll;
 pub mod logging;
 #[cfg(target_os = "linux")]

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use log::{debug, error, info, warn};
+use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_TIMEOUT};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
     HeartbeatNodeRequest, InsertBlockHashesRequest, RemoveBlockHashesRequest, UnregisterNodeRequest,
@@ -10,9 +11,7 @@ use pegaflow_proto::proto::engine::{NodePrefixResult, QueryPrefixBlocksRequest};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Duration, Instant};
 use tonic::Code;
-use tonic::transport::Channel;
-#[cfg(feature = "rdma")]
-use tonic::transport::Endpoint;
+use tonic::transport::{Channel, Endpoint};
 use uuid::Uuid;
 
 use crate::metrics::core_metrics;
@@ -121,6 +120,21 @@ enum MetaServerCommand {
     Shutdown(oneshot::Sender<()>),
 }
 
+fn metaserver_endpoint(metaserver_addr: String) -> Endpoint {
+    // keep_alive_timeout is 20s by default on both client and server side (tonic).
+    Endpoint::from_shared(metaserver_addr)
+        .expect("valid metaserver_addr URI")
+        .connect_timeout(GRPC_CONNECT_TIMEOUT)
+        .http2_keep_alive_interval(GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL)
+        .keep_alive_while_idle(true)
+}
+
+async fn connect_metaserver_client(
+    endpoint: &Endpoint,
+) -> Result<MetaServerGrpcClient<Channel>, tonic::transport::Error> {
+    endpoint.connect().await.map(MetaServerGrpcClient::new)
+}
+
 /// Unified MetaServer client handling both insert (fire-and-forget) and query (direct RPC).
 pub struct MetaServerClient {
     /// Fire-and-forget command channel for insert/remove operations.
@@ -135,20 +149,20 @@ impl MetaServerClient {
     ///
     /// Must be called from within a tokio runtime context.
     pub fn new(config: MetaServerClientConfig) -> Self {
+        let endpoint = metaserver_endpoint(config.metaserver_addr.clone());
         let (command_tx, rx) = mpsc::channel(config.queue_depth);
 
         tokio::spawn(registration_loop(
             rx,
             config.metaserver_addr.clone(),
+            endpoint.clone(),
             config.advertise_addr,
         ));
 
         // Lazy-connect query client: connects on first RPC, not here
         #[cfg(feature = "rdma")]
         let query_client = {
-            let channel = Endpoint::from_shared(config.metaserver_addr.clone())
-                .expect("valid metaserver_addr URI")
-                .connect_lazy();
+            let channel = endpoint.connect_lazy();
             MetaServerGrpcClient::new(channel)
         };
 
@@ -293,6 +307,7 @@ impl MetaServerClient {
 async fn registration_loop(
     mut rx: mpsc::Receiver<MetaServerCommand>,
     metaserver_addr: String,
+    endpoint: Endpoint,
     advertise_addr: String,
 ) {
     let mut client: Option<MetaServerGrpcClient<Channel>> = None;
@@ -312,6 +327,7 @@ async fn registration_loop(
                     &mut client,
                     &mut heartbeat,
                     &metaserver_addr,
+                    &endpoint,
                     &advertise_addr,
                     &node_id,
                 ).await {
@@ -328,8 +344,14 @@ async fn registration_loop(
         };
 
         if let MetaServerCommand::Shutdown(done) = cmd {
-            unregister_current_session(&mut client, &metaserver_addr, &advertise_addr, &node_id)
-                .await;
+            unregister_current_session(
+                &mut client,
+                &metaserver_addr,
+                &endpoint,
+                &advertise_addr,
+                &node_id,
+            )
+            .await;
             let _ = done.send(());
             break;
         }
@@ -370,6 +392,7 @@ async fn registration_loop(
                     unregister_current_session(
                         &mut client,
                         &metaserver_addr,
+                        &endpoint,
                         &advertise_addr,
                         &node_id,
                     )
@@ -396,6 +419,7 @@ async fn registration_loop(
         if ensure_heartbeat_registered(
             &mut client,
             &metaserver_addr,
+            &endpoint,
             &advertise_addr,
             &node_id,
             &mut heartbeat,
@@ -582,6 +606,7 @@ fn insert_groups_into_net(
 async fn ensure_heartbeat_registered(
     client: &mut Option<MetaServerGrpcClient<Channel>>,
     metaserver_addr: &str,
+    endpoint: &Endpoint,
     advertise_addr: &str,
     node_id: &str,
     heartbeat: &mut HeartbeatState,
@@ -594,7 +619,16 @@ async fn ensure_heartbeat_registered(
         return Err(());
     }
 
-    match send_heartbeat(client, heartbeat, metaserver_addr, advertise_addr, node_id).await {
+    match send_heartbeat(
+        client,
+        heartbeat,
+        metaserver_addr,
+        endpoint,
+        advertise_addr,
+        node_id,
+    )
+    .await
+    {
         Ok(next_period) => {
             heartbeat.period = next_period;
             heartbeat.next_at = Instant::now() + next_period;
@@ -611,11 +645,12 @@ async fn send_heartbeat(
     client: &mut Option<MetaServerGrpcClient<Channel>>,
     heartbeat: &mut HeartbeatState,
     metaserver_addr: &str,
+    endpoint: &Endpoint,
     advertise_addr: &str,
     node_id: &str,
 ) -> Result<Duration, Duration> {
     if client.is_none() {
-        match MetaServerGrpcClient::connect(metaserver_addr.to_string()).await {
+        match connect_metaserver_client(endpoint).await {
             Ok(c) => {
                 info!("Connected to MetaServer at {}", metaserver_addr);
                 *client = Some(c);
@@ -686,14 +721,15 @@ impl HeartbeatState {
 async fn unregister_current_session(
     client: &mut Option<MetaServerGrpcClient<Channel>>,
     metaserver_addr: &str,
+    endpoint: &Endpoint,
     advertise_addr: &str,
     node_id: &str,
 ) {
     if client.is_none() {
-        match MetaServerGrpcClient::connect(metaserver_addr.to_string()).await {
+        match connect_metaserver_client(endpoint).await {
             Ok(c) => *client = Some(c),
             Err(e) => {
-                warn!("Failed to connect to MetaServer for unregister: {e}");
+                warn!("Failed to connect to MetaServer for unregister at {metaserver_addr}: {e}");
                 core_metrics().metaserver_unregister_failures.add(1, &[]);
                 return;
             }
@@ -1063,7 +1099,13 @@ mod tests {
         )))
         .unwrap();
 
-        let loop_task = tokio::spawn(registration_loop(rx, addr, "node-a:50055".to_string()));
+        let endpoint = metaserver_endpoint(addr.clone());
+        let loop_task = tokio::spawn(registration_loop(
+            rx,
+            addr,
+            endpoint,
+            "node-a:50055".to_string(),
+        ));
 
         wait_for_count(&service.insert_notify, &service.insert_count, 2).await;
         wait_for_count(&service.remove_notify, &service.remove_count, 2).await;

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -11,6 +11,9 @@ use clap::Parser;
 use log::{error, info};
 use opentelemetry::global;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
+use pegaflow_common::grpc::{
+    GRPC_SERVER_HTTP2_KEEPALIVE_INTERVAL, GRPC_SERVER_HTTP2_KEEPALIVE_TIMEOUT,
+};
 use pegaflow_proto::proto::engine::meta_server_server::MetaServerServer;
 use prometheus::Registry;
 use std::error::Error;
@@ -181,6 +184,8 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     // Start the gRPC server
     let server_future = Server::builder()
+        .http2_keepalive_interval(Some(GRPC_SERVER_HTTP2_KEEPALIVE_INTERVAL))
+        .http2_keepalive_timeout(Some(GRPC_SERVER_HTTP2_KEEPALIVE_TIMEOUT))
         .add_service(MetaServerServer::new(service))
         .serve_with_shutdown(cli.addr, shutdown_signal(shutdown.clone()));
 

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -23,6 +23,9 @@ use log::{error, info, warn};
 use opentelemetry::global;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
+use pegaflow_common::grpc::{
+    GRPC_SERVER_HTTP2_KEEPALIVE_INTERVAL, GRPC_SERVER_HTTP2_KEEPALIVE_TIMEOUT,
+};
 use pegaflow_core::PegaEngine;
 use prometheus::Registry;
 use proto::engine::engine_server::EngineServer;
@@ -679,6 +682,8 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE);
 
         if let Err(err) = Server::builder()
+            .http2_keepalive_interval(Some(GRPC_SERVER_HTTP2_KEEPALIVE_INTERVAL))
+            .http2_keepalive_timeout(Some(GRPC_SERVER_HTTP2_KEEPALIVE_TIMEOUT))
             .add_service(grpc_service)
             .serve_with_shutdown(cli.addr, shutdown_signal)
             .await

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,3 +1,4 @@
+use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_TIMEOUT};
 use pegaflow_core::LoadState;
 use pegaflow_proto::proto::engine::{
     HealthRequest, LeaseLoad, LoadRequest, QueryRequest, RegisterContextRequest, ReleaseRequest,
@@ -12,7 +13,6 @@ use pyo3::{
 use std::{
     future::Future,
     sync::{Arc, Mutex, OnceLock},
-    time::Duration,
 };
 use tokio::runtime::{Handle, Runtime};
 use tonic::{
@@ -201,9 +201,9 @@ impl EngineRpcClient {
         // Avoid per-RPC overhead by eager-connecting and reusing a warmed client handle.
         let endpoint_cfg = Endpoint::from_shared(endpoint.clone())
             .map_err(|err| transport_connect_error(&endpoint, err))?
-            .connect_timeout(Duration::from_millis(500))
+            .connect_timeout(GRPC_CONNECT_TIMEOUT)
             .tcp_nodelay(true)
-            .http2_keep_alive_interval(Duration::from_secs(30))
+            .http2_keep_alive_interval(GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL)
             .keep_alive_while_idle(true);
 
         let channel = rt


### PR DESCRIPTION
## Summary

- Add shared gRPC transport defaults in `pegaflow-common/src/grpc.rs`, following [Neon](https://github.com/neondatabase/neon) `storage_broker` (client) and `pageserver` (server) keepalive settings.
- MetaServer client now builds every tonic `Endpoint` with 5s connect timeout, 5s HTTP/2 keepalive interval, and idle ping enabled; ping-ack timeout stays on tonic's 20s default.
- MetaServer and pegaflow-server gRPC servers enable 30s / 20s HTTP/2 keepalive.
- Python Engine RPC client reuses the same shared client defaults.

This is a focused split from #373: transport keepalive only, no RPC timeout / query retry / message-size changes.

## Neon reference

| Side | Neon source | Values |
|------|-------------|--------|
| Client | `storage_broker/src/lib.rs` | 5s interval, 5s connect, `keep_alive_while_idle(true)`, 20s timeout implicit |
| Server | `pageserver/src/page_service.rs` | 30s interval, 20s timeout |

## Test plan

- [x] `cargo check -p pegaflow-common -p pegaflow-core -p pegaflow-metaserver -p pegaflow-server -p pegaflow-py`
- [x] `cargo test -p pegaflow-core --lib internode::metaserver_client::tests`
- [x] pre-commit hooks on commit (fmt, clippy, `cargo test --release`)


Made with [Cursor](https://cursor.com)