### PR TITLE
fix(connector): cancel prefetch gauge when polling stops before QueryReady

### DIFF
--- a/python/pegaflow/connector/connector_metrics.py
+++ b/python/pegaflow/connector/connector_metrics.py
@@ -84,6 +84,10 @@ class PrefetchTracker:
         self._prefetch_durations.append(duration_ms)
         self._prefetch_blocks.append(hit_blocks)
 
+    def on_prefetch_cancel(self) -> None:
+        """Called when prefetch polling stops before QueryReady (e.g. request finish)."""
+        self._pending_prefetches = max(0, self._pending_prefetches - 1)
+
     @property
     def pending_prefetches(self) -> int:
         """Current number of requests waiting for prefetch."""

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -539,6 +539,23 @@ class SchedulerConnector:
 
         return result
 
+    def _cancel_prefetch_tracking(self, req_id: str) -> bool:
+        """Drop in-flight prefetch metrics when polling stops before QueryReady."""
+        started_at = self._prefetch_start_times.pop(req_id, None)
+        if started_at is None:
+            return False
+
+        self._prefetch_tracker.on_prefetch_cancel()
+        waited_ms = (time.perf_counter() - started_at) * 1000
+        logger.warning(
+            "[PegaKVConnector] Prefetch aborted before ready: req=%s waited_ms=%.2f "
+            "pending_prefetches=%d",
+            req_id,
+            waited_ms,
+            self._prefetch_tracker.pending_prefetches,
+        )
+        return True
+
     def get_stats(self) -> PegaKVConnectorStats | None:
         """Get current connector stats for metrics exposure."""
         # Get stats from prefetch tracker
@@ -568,6 +585,7 @@ class SchedulerConnector:
 
     def _release_query_probe(self, req_id: str, probe: _QueryProbe) -> bool:
         if not probe.lease:
+            self._cancel_prefetch_tracking(req_id)
             return True  # nothing leased server-side (still loading, or zero-hit Ready)
         try:
             self._ctx.engine_client.release(probe.lease)

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -539,11 +539,11 @@ class SchedulerConnector:
 
         return result
 
-    def _cancel_prefetch_tracking(self, req_id: str) -> bool:
+    def _cancel_prefetch_tracking(self, req_id: str) -> None:
         """Drop in-flight prefetch metrics when polling stops before QueryReady."""
         started_at = self._prefetch_start_times.pop(req_id, None)
         if started_at is None:
-            return False
+            return
 
         self._prefetch_tracker.on_prefetch_cancel()
         waited_ms = (time.perf_counter() - started_at) * 1000
@@ -554,7 +554,6 @@ class SchedulerConnector:
             waited_ms,
             self._prefetch_tracker.pending_prefetches,
         )
-        return True
 
     def get_stats(self) -> PegaKVConnectorStats | None:
         """Get current connector stats for metrics exposure."""

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -541,10 +541,10 @@ class SchedulerConnector:
 
     def _cancel_prefetch_tracking(self, req_id: str) -> None:
         """Drop in-flight prefetch metrics when polling stops before QueryReady."""
-        started_at = self._prefetch_start_times.pop(req_id, None)
-        if started_at is None:
+        if req_id not in self._prefetch_start_times:
             return
 
+        started_at = self._prefetch_start_times.pop(req_id)
         self._prefetch_tracker.on_prefetch_cancel()
         waited_ms = (time.perf_counter() - started_at) * 1000
         logger.warning(

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -575,6 +575,20 @@ class TestSchedulerQueryProbeReuse:
 
         assert sc._count_available_block_prefix([_hash(i) for i in range(4)], "r1") is None
 
+    def test_prefetch_loading_cancelled_on_request_cleanup(self):
+        sc, engine_client = self._make_connector()
+        engine_client.query_prefetch.return_value = QueryLoading()
+        req = _make_fake_request("r1", [_hash(i) for i in range(4)])
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (None, False)
+        assert sc._prefetch_tracker.pending_prefetches == 1
+
+        sc._cleanup_request("r1")
+
+        assert sc._prefetch_tracker.pending_prefetches == 0
+        assert "r1" not in sc._prefetch_start_times
+        assert "r1" not in sc._pending_query_probes
+
     def test_save_only_mode_skips_query(self):
         engine_client = MagicMock()
         sc = SchedulerConnector(


### PR DESCRIPTION
## Summary

- Decrement `vllm:pega_pending_prefetches` when a `QueryLoading` probe is released without ever receiving `QueryReady` (e.g. request abort/finish during prefetch polling).
- Add `PrefetchTracker.on_prefetch_cancel()` and call it from `_release_query_probe()` for lease-less (still-loading) probes.
- Emit a `warning` log (`Prefetch aborted before ready`) with `req_id`, wait time, and remaining gauge depth so production leaks are diagnosable.

Observed on haitao glm52 prefill: `sum(vllm:pega_pending_prefetches)` stuck at 59 while new prefetches kept completing; guoji (local RAM only, rarely `QueryLoading`) stayed at 0. PegaFlow server prefetch inflight metrics were healthy — this is a scheduler-side metrics lifecycle bug, not async GPU load.

## Test plan

- [x] `cd python && uv run --extra test pytest tests/test_combine_hashes.py::TestSchedulerQueryProbeReuse::test_prefetch_loading_cancelled_on_request_cleanup tests/test_combine_hashes.py::TestSchedulerQueryProbeReuse::test_query_loading_returns_retry -q`
- [ ] After deploy on haitao glm52 prefill: confirm `sum(vllm:pega_pending_prefetches)` no longer monotonically increases; grep prefill logs for `Prefetch aborted before ready` on client abort paths
- [ ] Rolling restart prefill pods once to clear already-leaked gauge baselines

AI assistance was used for investigation and this patch.


Made with [Cursor](https://cursor.com)