### PR TITLE
chore: bump version to 0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "colored",
  "libc",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "axum",
  "clap",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-pd-wire"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "prost",
  "tonic",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "axum",
  "clap",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.23.0"
+version = "0.23.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.23.0"
+version = "0.23.1"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -114,6 +114,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.23.0"
+version = "0.23.1"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## Summary

Patch release after v0.23.0. Changes since `v0.23.0` are already on `master`:

- #374 — quiet load-completion logs; expose prefetch stale GC metrics
- #376 — cancel prefetch gauge when polling stops before QueryReady
- #375 — Neon-style HTTP/2 keepalive for internal gRPC

This PR only bumps the workspace/package version to **0.23.1**.

## Test plan

- [x] Pre-commit hooks passed on commit
- [ ] Merge to master, tag `v0.23.1`, publish wheel


Made with [Cursor](https://cursor.com)