### PR TITLE
fix(core): register RDMA-fetched blocks to MetaServer after prefetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "colored",
  "libc",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "axum",
  "clap",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-pd-wire"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "prost",
  "tonic",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "log",
  "pegaflow-common",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "axum",
  "clap",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.23.1"
+version = "0.23.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -229,8 +229,12 @@ impl StorageEngine {
             #[cfg(not(feature = "rdma"))]
             let rdma_fetch = None;
 
-            let prefetch =
-                PrefetchScheduler::new(ssd_store.clone(), rdma_fetch, max_prefetch_blocks);
+            let prefetch = PrefetchScheduler::new(
+                ssd_store.clone(),
+                rdma_fetch,
+                metaserver_client.clone(),
+                max_prefetch_blocks,
+            );
 
             let transfer_lock = Arc::new(transfer_lock::TransferLockManager::new(
                 transfer_lock_timeout,

--- a/pegaflow-core/src/storage/prefetch.rs
+++ b/pegaflow-core/src/storage/prefetch.rs
@@ -13,6 +13,7 @@ use tokio::task::JoinHandle;
 use crate::backing::RdmaFetchStore;
 use crate::backing::{PrefetchResult, SsdBackingStore};
 use crate::block::{BlockKey, PrefetchStatus, SealedBlock};
+use crate::internode::MetaServerClient;
 use crate::metrics::core_metrics;
 
 use super::read_cache::ReadCache;
@@ -155,6 +156,7 @@ pub(super) struct PrefetchScheduler {
     state: Arc<Mutex<PrefetchState>>,
     ssd_store: Option<Arc<SsdBackingStore>>,
     rdma_fetch: Option<RdmaFetch>,
+    metaserver_client: Option<Arc<MetaServerClient>>,
     max_prefetch_blocks: usize,
 }
 
@@ -162,6 +164,7 @@ impl PrefetchScheduler {
     pub(super) fn new(
         ssd_store: Option<Arc<SsdBackingStore>>,
         rdma_fetch: Option<RdmaFetch>,
+        metaserver_client: Option<Arc<MetaServerClient>>,
         max_prefetch_blocks: usize,
     ) -> Self {
         Self {
@@ -172,6 +175,7 @@ impl PrefetchScheduler {
             })),
             ssd_store,
             rdma_fetch,
+            metaserver_client,
             max_prefetch_blocks,
         }
     }
@@ -250,7 +254,31 @@ impl PrefetchScheduler {
             );
         }
 
+        // RDMA-fetched blocks are now resident on this node. Re-advertise them
+        // to the MetaServer so peers can discover and fetch from here too.
+        // SSD prefetch is skipped: those blocks were already registered by this
+        // node's own save path, and eviction explicitly unregisters them.
+        let rdma_registration: Option<(String, Vec<Vec<u8>>)> =
+            if result.source == Some(PrefetchSource::Rdma) && !result.cache_inserts.is_empty() {
+                let namespace = result.cache_inserts[0].0.namespace.clone();
+                let hashes = result
+                    .cache_inserts
+                    .iter()
+                    .map(|(k, _)| k.hash.clone())
+                    .collect();
+                Some((namespace, hashes))
+            } else {
+                None
+            };
+
         read_cache.batch_insert(result.cache_inserts);
+
+        if let Some(client) = &self.metaserver_client
+            && let Some((namespace, hashes)) = rdma_registration
+        {
+            client.try_register_namespace(namespace, hashes);
+        }
+
         PollResult::Ready(PrefetchStatus::Ready {
             blocks: result.ready_blocks,
             missing: result.missing,

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -224,6 +224,32 @@ async fn wait_for_metaserver_registration(
     }
 }
 
+async fn wait_for_metaserver_ownership(
+    store: &BlockHashStore,
+    namespace: &str,
+    hashes: &[Vec<u8>],
+    node: &str,
+    expected: usize,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let found = store.query_prefix(namespace, hashes);
+        let owned = found
+            .iter()
+            .filter(|entry| entry.nodes.iter().any(|n| &**n == node))
+            .count();
+        if owned >= expected {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for MetaServer ownership by {node} ({owned} / {expected})"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
 async fn wait_for_prefetch_done(
     engine: &PegaEngine,
     instance_id: &str,
@@ -406,6 +432,19 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
         &block_hashes,
         NUM_BLOCKS,
         Duration::from_secs(30),
+    )
+    .await;
+
+    // ── 8b. Verify Engine B re-registered fetched blocks to MetaServer ──
+    // RDMA-fetched blocks are now resident on B, so B must advertise them so
+    // other nodes can discover and fetch from B (not just from A).
+    wait_for_metaserver_ownership(
+        &meta_store,
+        NAMESPACE,
+        &block_hashes,
+        &format!("127.0.0.1:{port_b}"),
+        NUM_BLOCKS,
+        Duration::from_secs(10),
     )
     .await;
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.23.1"
+version = "0.23.2"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -114,6 +114,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.23.1"
+version = "0.23.2"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## Problem

RDMA prefetch pulled blocks into the local read cache but never re-advertised them to the MetaServer. Once the original holder evicted those blocks (unregister), the MetaServer believed nobody owned them — even though the fetcher still held valid, RDMA-servable copies in pinned RAM.

**Scenario that breaks:**

1. Node A saves blocks → registered to MetaServer as owned by A
2. Node B RDMA-READs them into local pinned RAM → **not registered** (the bug)
3. Node A evicts via LRU → `try_unregister` → MetaServer thinks nobody owns them
4. Node C queries MetaServer → no hit → cannot discover blocks on Node B, even though they exist and are servable

## Fix

After RDMA prefetch completes and blocks are inserted into the read cache, the fetched block hashes are registered to the MetaServer via the same fire-and-forget path (`try_register_namespace`) used by the normal save path.

SSD prefetch is intentionally skipped: those blocks were already registered by this node's own save path, and eviction explicitly unregisters them — the SSD case is internally consistent.

## Changes

- `pegaflow-core/src/storage/prefetch.rs`: `PrefetchScheduler` now holds an optional `MetaServerClient`. In `poll_existing`, after `read_cache.batch_insert`, RDMA-sourced blocks are registered to the MetaServer.
- `pegaflow-core/src/storage/mod.rs`: pass `metaserver_client` into `PrefetchScheduler::new`.
- `pegaflow-server/tests/p2p_rdma.rs`: added `wait_for_metaserver_ownership` helper and a test assertion verifying the fetching node re-registers the blocks it pulled.

## Verification

- `cargo build -p pegaflow-core --no-default-features --features cuda-13,rdma` — passes
- `cargo clippy -p pegaflow-core --no-default-features --features cuda-13,rdma` — clean
- `cargo test -p pegaflow-core --no-default-features --features cuda-13,rdma -- storage::prefetch` — 2/2 pass
- All pre-commit hooks pass
- p2p_rdma integration test compiles (requires RDMA hardware to run)