### PR TITLE
fix(core): register only resident RDMA-prefetched blocks

### DIFF
--- a/pegaflow-core/src/cache.rs
+++ b/pegaflow-core/src/cache.rs
@@ -30,6 +30,7 @@ pub(crate) struct TinyLfuCache<K, V> {
     freq: Option<TinyLfu>,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum CacheInsertOutcome {
     /// Key was not present and is now inserted.
     InsertedNew,

--- a/pegaflow-core/src/storage/prefetch.rs
+++ b/pegaflow-core/src/storage/prefetch.rs
@@ -254,24 +254,18 @@ impl PrefetchScheduler {
             );
         }
 
-        // RDMA-fetched blocks are now resident on this node. Re-advertise them
-        // to the MetaServer so peers can discover and fetch from here too.
-        // SSD prefetch is skipped: those blocks were already registered by this
-        // node's own save path, and eviction explicitly unregisters them.
-        let rdma_registration: Option<(String, Vec<Vec<u8>>)> =
-            if result.source == Some(PrefetchSource::Rdma) && !result.cache_inserts.is_empty() {
-                let namespace = result.cache_inserts[0].0.namespace.clone();
-                let hashes = result
-                    .cache_inserts
-                    .iter()
-                    .map(|(k, _)| k.hash.clone())
-                    .collect();
-                Some((namespace, hashes))
-            } else {
-                None
-            };
-
-        read_cache.batch_insert(result.cache_inserts);
+        // RDMA-fetched blocks that survive cache admission are now resident on
+        // this node. Re-advertise only those resident blocks to the MetaServer
+        // so peers can discover and fetch from here too. SSD prefetch is
+        // skipped: those blocks were already registered by this node's own save
+        // path, and eviction explicitly unregisters them.
+        let rdma_registration = if result.source == Some(PrefetchSource::Rdma) {
+            let resident_keys = read_cache.batch_insert_resident_keys(result.cache_inserts);
+            rdma_registration_from_resident_keys(result.source, &resident_keys)
+        } else {
+            read_cache.batch_insert(result.cache_inserts);
+            None
+        };
 
         if let Some(client) = &self.metaserver_client
             && let Some((namespace, hashes)) = rdma_registration
@@ -511,6 +505,19 @@ fn build_ready_result(
     }
 }
 
+fn rdma_registration_from_resident_keys(
+    source: Option<PrefetchSource>,
+    resident_keys: &[BlockKey],
+) -> Option<(String, Vec<Vec<u8>>)> {
+    if source != Some(PrefetchSource::Rdma) || resident_keys.is_empty() {
+        return None;
+    }
+
+    let namespace = resident_keys[0].namespace.clone();
+    let hashes = resident_keys.iter().map(|key| key.hash.clone()).collect();
+    Some((namespace, hashes))
+}
+
 async fn run_prefetch_task(deps: PrefetchTaskDeps, input: PrefetchTaskInput) -> PrefetchTaskResult {
     let PrefetchTaskInput {
         req_id,
@@ -653,5 +660,27 @@ mod tests {
         assert!(Arc::ptr_eq(&result.ready_blocks[0], &b1));
         assert_eq!(result.missing, 2);
         assert_eq!(result.cache_inserts.len(), 2);
+    }
+
+    #[test]
+    fn rdma_registration_uses_only_resident_keys() {
+        let k1 = key(1);
+        let k3 = key(3);
+
+        let (namespace, hashes) =
+            rdma_registration_from_resident_keys(Some(PrefetchSource::Rdma), &[k1, k3])
+                .expect("RDMA resident keys should register");
+
+        assert_eq!(namespace, "ns");
+        assert_eq!(hashes, vec![vec![1], vec![3]]);
+    }
+
+    #[test]
+    fn rdma_registration_skips_ssd_and_empty_resident_keys() {
+        let k1 = key(1);
+
+        assert!(rdma_registration_from_resident_keys(Some(PrefetchSource::Ssd), &[k1]).is_none());
+        assert!(rdma_registration_from_resident_keys(Some(PrefetchSource::Rdma), &[]).is_none());
+        assert!(rdma_registration_from_resident_keys(None, &[]).is_none());
     }
 }

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -57,6 +57,23 @@ impl ReadCache {
         }
     }
 
+    pub(super) fn batch_insert_resident_keys(
+        &self,
+        blocks: Vec<(BlockKey, Arc<SealedBlock>)>,
+    ) -> Vec<BlockKey> {
+        let mut inner = self.inner.lock();
+        let mut resident_keys = Vec::new();
+        for (key, block) in blocks {
+            match insert_block(&mut inner, key.clone(), block) {
+                CacheInsertOutcome::InsertedNew | CacheInsertOutcome::AlreadyExists => {
+                    resident_keys.push(key);
+                }
+                CacheInsertOutcome::Rejected => {}
+            }
+        }
+        resident_keys
+    }
+
     pub(super) fn batch_insert_refs(&self, blocks: &[(BlockKey, Arc<SealedBlock>)]) {
         let mut inner = self.inner.lock();
         for (key, block) in blocks {
@@ -89,9 +106,14 @@ impl ReadCache {
     }
 }
 
-fn insert_block(inner: &mut ReadCacheInner, key: BlockKey, block: Arc<SealedBlock>) {
+fn insert_block(
+    inner: &mut ReadCacheInner,
+    key: BlockKey,
+    block: Arc<SealedBlock>,
+) -> CacheInsertOutcome {
     let footprint_bytes = block.memory_footprint();
-    match inner.cache.insert(key, block) {
+    let outcome = inner.cache.insert(key, block);
+    match outcome {
         CacheInsertOutcome::InsertedNew => {
             let m = core_metrics();
             m.cache_block_insertions.add(1, &[]);
@@ -102,6 +124,7 @@ fn insert_block(inner: &mut ReadCacheInner, key: BlockKey, block: Arc<SealedBloc
             core_metrics().cache_block_admission_rejections.add(1, &[]);
         }
     }
+    outcome
 }
 
 #[cfg(test)]
@@ -203,5 +226,41 @@ mod tests {
         assert_eq!(removed.len(), 2);
         assert_eq!(cache.get_blocks(&[key1, key2]).len(), 0);
         assert!(cache.remove_all().is_empty());
+    }
+
+    #[test]
+    fn batch_insert_resident_keys_excludes_lfu_rejected_blocks() {
+        let cache = ReadCache::new(1, true, Some(1));
+        let hot_key = BlockKey::new("ns".into(), vec![1]);
+        let cold_key = BlockKey::new("ns".into(), vec![2]);
+
+        assert_eq!(
+            cache.batch_insert_resident_keys(vec![(hot_key.clone(), make_block())]),
+            vec![hot_key.clone()]
+        );
+
+        for _ in 0..2 {
+            assert_eq!(cache.get_blocks(std::slice::from_ref(&hot_key)).len(), 1);
+        }
+
+        assert!(
+            cache
+                .batch_insert_resident_keys(vec![(cold_key.clone(), make_block())])
+                .is_empty()
+        );
+        assert_eq!(cache.get_blocks(&[hot_key]).len(), 1);
+        assert_eq!(cache.get_blocks(&[cold_key]).len(), 0);
+    }
+
+    #[test]
+    fn batch_insert_resident_keys_includes_already_existing_blocks() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        cache.batch_insert(vec![(key.clone(), make_block())]);
+
+        assert_eq!(
+            cache.batch_insert_resident_keys(vec![(key.clone(), make_block())]),
+            vec![key]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- make ReadCache report which inserted blocks are actually resident after admission
- register RDMA-prefetched blocks to MetaServer only when they are resident in the local ReadCache
- keep SSD prefetch on the existing no-reregister path and add regression tests for LFU rejection/registration filtering

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p pegaflow-core`
- `cargo clippy -p pegaflow-core --all-targets -- -D warnings`
- `cargo check -p pegaflow-core`

## Note
- `./scripts/check.sh` currently stops at Python ruff format because existing Python files would be reformatted; this PR only changes Rust core files.