### PR TITLE
fix(core): load blocks sealed by split-KV peers into contiguous device layouts

### DIFF
--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -393,18 +393,46 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
                     total_bytes += k.bytes + v.bytes;
                 }
                 BlockCopies::Contiguous(c) => {
-                    let ptr = block
-                        .block
-                        .raw()
-                        .segment_mapped_ptr(0)
-                        .unwrap()
-                        .add(host_offset);
-                    copies.push(CopyDesc {
-                        device: c.addr,
-                        host: ptr.host().as_ptr(),
-                        host_device: ptr.device().as_ptr() as u64,
-                        size: c.bytes,
-                    });
+                    let raw = block.block.raw();
+                    // Mirror of the Split branch's contiguous-host fallback:
+                    // a peer with a split-KV registration seals K and V as two
+                    // host segments, while this instance's device block is one
+                    // [K|V] span. Copy each segment to its half of the span.
+                    if let Some(seg1) = raw.segment_mapped_ptr(1) {
+                        let k_bytes = raw.segment_size(0).unwrap();
+                        let v_bytes = raw.segment_size(1).unwrap();
+                        if raw.num_segments() != 2 || k_bytes + v_bytes != c.bytes {
+                            return Err(EngineError::Storage(format!(
+                                "layer {layer_name}: stored block segments ({} x {k_bytes}+{v_bytes} bytes) \
+                                 do not span the contiguous device block ({} bytes): \
+                                 namespace is shared by incompatible KV layouts",
+                                raw.num_segments(),
+                                c.bytes
+                            )));
+                        }
+                        let k_ptr = raw.segment_mapped_ptr(0).unwrap().add(host_offset);
+                        let v_ptr = seg1.add(host_offset);
+                        copies.push(CopyDesc {
+                            device: c.addr,
+                            host: k_ptr.host().as_ptr(),
+                            host_device: k_ptr.device().as_ptr() as u64,
+                            size: k_bytes,
+                        });
+                        copies.push(CopyDesc {
+                            device: c.addr + k_bytes as u64,
+                            host: v_ptr.host().as_ptr(),
+                            host_device: v_ptr.device().as_ptr() as u64,
+                            size: v_bytes,
+                        });
+                    } else {
+                        let ptr = raw.segment_mapped_ptr(0).unwrap().add(host_offset);
+                        copies.push(CopyDesc {
+                            device: c.addr,
+                            host: ptr.host().as_ptr(),
+                            host_device: ptr.device().as_ptr() as u64,
+                            size: c.bytes,
+                        });
+                    }
                     total_bytes += c.bytes;
                 }
             }

--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -401,13 +401,14 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
                     if let Some(seg1) = raw.segment_mapped_ptr(1) {
                         let k_bytes = raw.segment_size(0).unwrap();
                         let v_bytes = raw.segment_size(1).unwrap();
-                        if raw.num_segments() != 2 || k_bytes + v_bytes != c.bytes {
+                        let c_bytes = c.bytes;
+                        if raw.num_segments() != 2 || k_bytes + v_bytes != c_bytes {
                             return Err(EngineError::Storage(format!(
-                                "layer {layer_name}: stored block segments ({} x {k_bytes}+{v_bytes} bytes) \
-                                 do not span the contiguous device block ({} bytes): \
-                                 namespace is shared by incompatible KV layouts",
+                                "layer {layer_name}: stored block has {} segments \
+                                 ({k_bytes}+{v_bytes} bytes) but contiguous device block \
+                                 is {c_bytes} bytes: namespace is shared by incompatible \
+                                 KV layouts",
                                 raw.num_segments(),
-                                c.bytes
                             )));
                         }
                         let k_ptr = raw.segment_mapped_ptr(0).unwrap().add(host_offset);
@@ -540,4 +541,113 @@ fn process_save_task(
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroU64;
+
+    use crate::block::Segment;
+    use crate::storage::{StorageConfig, StorageEngine};
+
+    fn cuda_available() -> bool {
+        cudarc::driver::CudaContext::new(0).is_ok()
+    }
+
+    fn alloc_segment(storage: &StorageEngine, size: usize) -> Segment {
+        let alloc = storage
+            .allocate(NonZeroU64::new(size as u64).unwrap(), None)
+            .expect("test pool should have space");
+        let ptr = alloc.as_non_null();
+        Segment::new(ptr, size, alloc)
+    }
+
+    /// A contiguous-layout device block paired with a split-host block (K and V
+    /// as separate segments) must emit two copies: K to the device base, V right
+    /// after K. This is the P/D disaggregation scenario where a split-KV prefill
+    /// instance seals blocks and a contiguous-layout decode instance loads them.
+    #[test]
+    fn contiguous_device_with_split_host_emits_two_copies() {
+        if !cuda_available() {
+            return;
+        }
+        let storage =
+            StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]).unwrap();
+
+        let seg_size = 512;
+        let block_size = seg_size * 2;
+
+        let raw = RawBlock::two_segments(
+            alloc_segment(&storage, seg_size),
+            alloc_segment(&storage, seg_size),
+        );
+
+        let layout = KVCacheLayout::new(0x1000, block_size * 100, 100, block_size, 0, 1).unwrap();
+
+        let layer = LayerTransferData {
+            layer_name: "test".into(),
+            layout,
+            blocks: vec![TransferBlock {
+                block_idx: 0,
+                block: HostBlock::Owned(raw),
+            }],
+        };
+
+        let (copies, total) = build_copy_descs(&[layer]).unwrap();
+
+        assert_eq!(copies.len(), 2, "split host must produce two copies");
+        assert_eq!(total, block_size);
+        assert_eq!(copies[0].device, 0x1000);
+        assert_eq!(copies[0].size, seg_size);
+        assert_eq!(copies[1].device, 0x1000 + seg_size as u64);
+        assert_eq!(copies[1].size, seg_size);
+    }
+
+    /// When the two host segments do not exactly span the contiguous device
+    /// block, `build_copy_descs` must reject instead of copying misaligned bytes.
+    #[test]
+    fn contiguous_device_rejects_mismatched_split_host() {
+        if !cuda_available() {
+            return;
+        }
+        let storage =
+            StorageEngine::new_with_config(1 << 20, false, StorageConfig::default(), &[]).unwrap();
+
+        let k_size = 512;
+        let v_size = 256;
+        let device_block_size = 1024; // != k_size + v_size
+
+        let raw = RawBlock::two_segments(
+            alloc_segment(&storage, k_size),
+            alloc_segment(&storage, v_size),
+        );
+
+        let layout = KVCacheLayout::new(
+            0x1000,
+            device_block_size * 100,
+            100,
+            device_block_size,
+            0,
+            1,
+        )
+        .unwrap();
+
+        let layer = LayerTransferData {
+            layer_name: "test".into(),
+            layout,
+            blocks: vec![TransferBlock {
+                block_idx: 0,
+                block: HostBlock::Owned(raw),
+            }],
+        };
+
+        let err = build_copy_descs(&[layer])
+            .err()
+            .expect("mismatched sizes should error");
+        assert!(
+            err.to_string().contains("incompatible KV layouts"),
+            "expected incompatible-layout error, got: {err}"
+        );
+    }
 }

--- a/python/src/rdma_v1.rs
+++ b/python/src/rdma_v1.rs
@@ -267,6 +267,10 @@ impl PegaRdmaV1Engine {
         Ok(())
     }
 
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "mirrors the NIXL read_async_indices FFI signature 1:1"
+    )]
     fn read_async_indices(
         &self,
         py: Python<'_>,


### PR DESCRIPTION
## Problem

`build_copy_descs` pairs a `Contiguous` device block with only the host block's segment 0 for the full span. A block sealed by a peer with a **split-KV registration** (e.g. the vLLM connector's KV-first `(2, num_blocks, ...)` layout) stores K and V as **two separate host segments**, so a contiguous-layout instance loading it reads past the K allocation and restores garbage V data — silently.

This is the missing half of an existing asymmetry: the `Split` branch already falls back gracefully when the host block is contiguous (`v_ptr = k_ptr + k.bytes`), but the `Contiguous` branch had no handling for a split host block.

## Fix

When the host block carries two segments, emit one copy per segment targeting each half of the device span. Blocks whose segments don't exactly span the device block are rejected with an explicit error (same "incompatible KV layouts" family as the existing slot-count guard) instead of copying misaligned bytes.

Also carries a one-line `#[allow(too_many_arguments)]` on `rdma_v1::read_async_indices` — newer clippy fails the pre-commit hook on master; the signature mirrors the NIXL FFI 1:1.

## Validation

End-to-end P/D disaggregation on an 8-GPU H200 node (jz node 34):

- **P** = vLLM + PegaKVConnector (Qwen3-8B, `--block-size 16`, per-layer split-KV registration, 36 slots)
- **D** = openinfer decode instance (per-layer fused `[K|V]` pages, contiguous registration, 36 slots)
- 3-prompt smoke (short / cross-block / block-aligned), `temperature=0`: all outputs **byte-identical** to D's local-prefill baseline.
- RDMA fetch path exercised: 441 blocks / 992 MiB restored in 41.8 ms (23.7 GiB/s) for a 7k-token prompt.

Without this fix the same setup restores corrupted V segments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)