### PR TITLE
refactor(transfer): narrow rc_backend hot-path lock and index MR lookups

### DIFF
--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -13,7 +13,7 @@ use sideway::ibverbs::AccessFlags;
 
 use self::runtime::RcRuntime;
 use self::session::{RcSession, RdmaOp};
-use self::state::{AddrConnection, RcBackendState, RegisteredMemoryEntry};
+use self::state::{AddrConnection, RcBackendState, RegisteredMemoryEntry, RemoteMemorySnapshot};
 use std::ptr::NonNull;
 
 use mea::oneshot;
@@ -163,14 +163,11 @@ impl RcBackend {
         }
 
         let mut state = self.state.lock();
-        state.registered.insert(
-            raw,
-            RegisteredMemoryEntry {
-                base_ptr: raw,
-                len,
-                mrs,
-            },
-        );
+        Arc::make_mut(&mut state.registered).insert(RegisteredMemoryEntry {
+            base_ptr: raw,
+            len,
+            mrs,
+        })?;
         debug!(
             "memory registered: ptr={:#x}, len={}, nics={}",
             raw,
@@ -183,7 +180,7 @@ impl RcBackend {
     pub(crate) fn unregister_memory(&self, ptr: NonNull<u8>) -> Result<()> {
         let raw = ptr.as_ptr() as u64;
         let mut state = self.state.lock();
-        let removed = state.registered.remove(&raw);
+        let removed = Arc::make_mut(&mut state.registered).remove(raw);
         if removed.is_none() {
             return Err(TransferError::MemoryNotRegistered { ptr: raw });
         }
@@ -196,17 +193,16 @@ impl RcBackend {
         let state = self.state.lock();
         (0..self.nic_count())
             .map(|nic_idx| {
-                let mut regions: Vec<RegisteredMemoryRegion> = state
+                // LocalMemoryMap iterates in base_ptr order already.
+                state
                     .registered
-                    .values()
+                    .iter()
                     .map(|entry| RegisteredMemoryRegion {
                         base_ptr: entry.base_ptr,
                         len: entry.len as u64,
                         rkey: entry.mrs[nic_idx].rkey(),
                     })
-                    .collect();
-                regions.sort_unstable_by_key(|entry| entry.base_ptr);
-                regions
+                    .collect()
             })
             .collect()
     }
@@ -337,10 +333,15 @@ impl RcBackend {
         for (nic_idx, sessions) in pending.into_iter().enumerate() {
             let remote = &remote_nics[nic_idx];
             let remote_first_qpn = remote.endpoints[0].qp_num;
-            state.nics[nic_idx].cache_remote_memory(remote_first_qpn, &remote.memory_regions)?;
+            let snapshot = Arc::new(RemoteMemorySnapshot::from_handshake(
+                &remote.memory_regions,
+            )?);
+            state.nics[nic_idx]
+                .remote_memory
+                .insert(remote_first_qpn, snapshot);
             state.nics[nic_idx]
                 .sessions
-                .insert(remote_first_qpn, sessions);
+                .insert(remote_first_qpn, Arc::new(sessions));
             remote_first_qpns.push(remote_first_qpn);
         }
         let removed = state.connecting.remove(remote_addr);
@@ -440,10 +441,16 @@ impl RcBackend {
             }
         }
 
-        // --- Lock: look up connection + prepare ops ---
+        // --- Short lock: snapshot connection state (sessions, remote memory,
+        // local MR map are all Arc snapshots; lookups happen outside the lock) ---
         let lookup_start = Instant::now();
-        let mut nic_work: Vec<(Arc<RcSession>, Vec<RdmaOp>)> = Vec::new();
-        {
+        struct NicWork {
+            nic_idx: usize,
+            sessions: Arc<Vec<Arc<RcSession>>>,
+            remote_memory: Arc<RemoteMemorySnapshot>,
+            rot: usize,
+        }
+        let (registered, nic_snapshots) = {
             let state = self.state.lock();
 
             let conn = state
@@ -453,62 +460,79 @@ impl RcBackend {
                     "no connection for remote addr {remote_addr}"
                 )))?;
 
-            // Per-WQE round-robin across the N sessions per NIC so a single
-            // batch can fill all N QPs (per-call RR would leave the rest idle).
+            let mut snapshots = Vec::new();
             for (nic_idx, nic_descs) in per_nic.iter().enumerate() {
                 if nic_descs.is_empty() {
                     continue;
                 }
-
                 let remote_first_qpn = conn.remote_first_qpns[nic_idx];
-                let sessions = state.nics[nic_idx]
-                    .sessions
-                    .get(&remote_first_qpn)
-                    .expect("session vec must exist for established connection");
-                let n = sessions.len();
+                let nic = &state.nics[nic_idx];
+                let sessions = nic.sessions.get(&remote_first_qpn).ok_or_else(|| {
+                    TransferError::Backend(format!(
+                        "session vec missing for established connection: remote={remote_addr}, nic={nic_idx}"
+                    ))
+                })?;
+                let remote_memory = nic.remote_memory.get(&remote_first_qpn).ok_or_else(|| {
+                    TransferError::Backend(format!(
+                        "remote memory snapshot missing for established connection: remote={remote_addr}, nic={nic_idx}"
+                    ))
+                })?;
                 // Rotate the starting bucket each call so small batches still
                 // hit different QPs across calls.
                 let rot = conn.rr_counters[nic_idx].fetch_add(1, Ordering::Relaxed);
+                snapshots.push(NicWork {
+                    nic_idx,
+                    sessions: Arc::clone(sessions),
+                    remote_memory: Arc::clone(remote_memory),
+                    rot,
+                });
+            }
+            (Arc::clone(&state.registered), snapshots)
+        };
 
-                let per_bucket = nic_descs.len().div_ceil(n);
-                let mut buckets: Vec<Vec<RdmaOp>> =
-                    (0..n).map(|_| Vec::with_capacity(per_bucket)).collect();
+        // --- Build ops outside the lock ---
+        let mut nic_work: Vec<(Arc<RcSession>, Vec<RdmaOp>)> = Vec::new();
+        for nic in nic_snapshots {
+            let nic_descs = &per_nic[nic.nic_idx];
+            // Per-WQE round-robin across the N sessions per NIC so a single
+            // batch can fill all N QPs (per-call RR would leave the rest idle).
+            let n = nic.sessions.len();
+            let per_bucket = nic_descs.len().div_ceil(n);
+            let mut buckets: Vec<Vec<RdmaOp>> =
+                (0..n).map(|_| Vec::with_capacity(per_bucket)).collect();
 
-                for (i, desc) in nic_descs.iter().enumerate() {
-                    let local_ptr = desc.local_ptr.as_ptr() as u64;
-                    let remote_ptr = desc.remote_ptr.as_ptr() as u64;
-                    let len = desc.len;
+            for (i, desc) in nic_descs.iter().enumerate() {
+                let local_ptr = desc.local_ptr.as_ptr() as u64;
+                let remote_ptr = desc.remote_ptr.as_ptr() as u64;
+                let len = desc.len;
 
-                    if len == 0 {
-                        return Err(TransferError::InvalidArgument("len must be non-zero"));
-                    }
-
-                    let local_mr = state
-                        .find_local_mr(nic_idx, local_ptr, len)
-                        .ok_or(TransferError::MemoryNotRegistered { ptr: local_ptr })?;
-
-                    let remote_rkey = state.nics[nic_idx]
-                        .find_remote_rkey(remote_first_qpn, remote_ptr, len)
-                        .ok_or(TransferError::InvalidArgument(
-                            "remote memory not found in handshake snapshot",
-                        ))?;
-
-                    let bucket = rot.wrapping_add(i) % n;
-                    buckets[bucket].push(RdmaOp {
-                        local_mr,
-                        local_ptr,
-                        remote_ptr,
-                        len,
-                        remote_rkey,
-                    });
+                if len == 0 {
+                    return Err(TransferError::InvalidArgument("len must be non-zero"));
                 }
 
-                for (q_idx, prepared) in buckets.into_iter().enumerate() {
-                    if prepared.is_empty() {
-                        continue;
-                    }
-                    nic_work.push((Arc::clone(&sessions[q_idx]), prepared));
+                let local_mr = registered
+                    .find_mr(nic.nic_idx, local_ptr, len)
+                    .ok_or(TransferError::MemoryNotRegistered { ptr: local_ptr })?;
+
+                let remote_rkey = nic.remote_memory.find_rkey(remote_ptr, len).ok_or(
+                    TransferError::InvalidArgument("remote memory not found in handshake snapshot"),
+                )?;
+
+                let bucket = nic.rot.wrapping_add(i) % n;
+                buckets[bucket].push(RdmaOp {
+                    local_mr,
+                    local_ptr,
+                    remote_ptr,
+                    len,
+                    remote_rkey,
+                });
+            }
+
+            for (q_idx, prepared) in buckets.into_iter().enumerate() {
+                if prepared.is_empty() {
+                    continue;
                 }
+                nic_work.push((Arc::clone(&nic.sessions[q_idx]), prepared));
             }
         }
         let lookup_dur = lookup_start.elapsed();

--- a/pegaflow-transfer/src/rc_backend/session.rs
+++ b/pegaflow-transfer/src/rc_backend/session.rs
@@ -27,9 +27,9 @@ use crate::error::{Result, TransferError};
 const MAX_WR_CHAIN_OPS: usize = 4;
 const MAX_SEND_WR: u32 = 128;
 // One QP per CQ; all WRs are signaled, so CQ depth = SQ depth suffices.
+// One-sided RDMA only: no recvs are ever posted, so the send CQ doubles as
+// the recv CQ and the recv queue stays at the minimal depth drivers accept.
 const SEND_CQ_SIZE: u32 = MAX_SEND_WR;
-// Recv queue unused (one-sided RDMA only), keep minimal for driver compatibility.
-const RECV_CQ_SIZE: u32 = 2;
 const MAX_RECV_WR: u32 = 1;
 const MAX_RD_ATOMIC: u8 = 16;
 const PSN_MASK: u32 = 0x00ff_ffff;
@@ -53,7 +53,6 @@ enum SessionCommand {
 pub(crate) struct RcSession {
     qp: Mutex<GenericQueuePair>,
     send_cq: GenericCompletionQueue,
-    _recv_cq: GenericCompletionQueue,
     pub(crate) local_endpoint: RcEndpoint,
     cmd_tx: std_mpsc::Sender<SessionCommand>,
 }
@@ -67,17 +66,12 @@ impl RcSession {
             .build()
             .map_err(|error| TransferError::Backend(error.to_string()))?
             .into();
-        cq_builder.setup_cqe(RECV_CQ_SIZE);
-        let recv_cq: GenericCompletionQueue = cq_builder
-            .build()
-            .map_err(|error| TransferError::Backend(error.to_string()))?
-            .into();
 
         let mut qp_builder = runtime.pd.create_qp_builder();
         qp_builder
             .setup_qp_type(QueuePairType::ReliableConnection)
             .setup_send_cq(send_cq.clone())
-            .setup_recv_cq(recv_cq.clone())
+            .setup_recv_cq(send_cq.clone())
             .setup_max_send_wr(MAX_SEND_WR)
             .setup_max_recv_wr(MAX_RECV_WR)
             .setup_max_send_sge(1)
@@ -110,7 +104,6 @@ impl RcSession {
         let session = Arc::new(Self {
             qp: Mutex::new(qp),
             send_cq,
-            _recv_cq: recv_cq,
             local_endpoint,
             cmd_tx,
         });

--- a/pegaflow-transfer/src/rc_backend/state.rs
+++ b/pegaflow-transfer/src/rc_backend/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
@@ -8,6 +8,7 @@ use super::session::RcSession;
 use crate::engine::{NicHandshake, RegisteredMemoryRegion};
 use crate::error::{Result, TransferError};
 
+#[derive(Clone)]
 pub(super) struct RegisteredMemoryEntry {
     pub(super) base_ptr: u64,
     pub(super) len: usize,
@@ -15,11 +16,140 @@ pub(super) struct RegisteredMemoryEntry {
     pub(super) mrs: Vec<Arc<MemoryRegion>>,
 }
 
-#[derive(Clone, Copy)]
+/// Local registered memory, ordered by base pointer. Insertion rejects
+/// overlapping regions so `find_mr` can resolve any address with a single
+/// predecessor lookup. Shared as an RCU-style snapshot: register/unregister
+/// clone-and-swap under the state lock, the transfer hot path reads its own
+/// `Arc` outside the lock.
+#[derive(Clone, Default)]
+pub(super) struct LocalMemoryMap {
+    entries: BTreeMap<u64, RegisteredMemoryEntry>,
+}
+
+impl LocalMemoryMap {
+    /// Insert a region. Rejects any overlap with an existing registration,
+    /// including an exact same-base duplicate: replacing would dereg the old
+    /// MR whose rkey peers already hold from a handshake, so their next READ
+    /// would fail with a remote access error — better to fail loudly here.
+    pub(super) fn insert(&mut self, entry: RegisteredMemoryEntry) -> Result<()> {
+        if entry.len == 0 {
+            return Err(TransferError::InvalidArgument("len must be non-zero"));
+        }
+        let end =
+            entry
+                .base_ptr
+                .checked_add(entry.len as u64)
+                .ok_or(TransferError::InvalidArgument(
+                    "memory region overflows address space",
+                ))?;
+        // Prior entries passed this same check, so their end cannot overflow.
+        let overlap = self
+            .entries
+            .range(..=entry.base_ptr)
+            .next_back()
+            .filter(|(_, prev)| entry.base_ptr < prev.base_ptr + prev.len as u64)
+            .or_else(|| {
+                self.entries
+                    .range(entry.base_ptr..)
+                    .next()
+                    .filter(|&(&next_base, _)| next_base < end)
+            });
+        if let Some((_, existing)) = overlap {
+            return Err(TransferError::Backend(format!(
+                "memory region [{:#x}, len={:#x}) overlaps registered region [{:#x}, len={:#x})",
+                entry.base_ptr, entry.len, existing.base_ptr, existing.len
+            )));
+        }
+        self.entries.insert(entry.base_ptr, entry);
+        Ok(())
+    }
+
+    pub(super) fn remove(&mut self, base_ptr: u64) -> Option<RegisteredMemoryEntry> {
+        self.entries.remove(&base_ptr)
+    }
+
+    /// Entries in base_ptr order.
+    pub(super) fn iter(&self) -> impl Iterator<Item = &RegisteredMemoryEntry> {
+        self.entries.values()
+    }
+
+    /// Find the MR (for `nic_idx`) of the region fully covering `[ptr, ptr+len)`.
+    pub(super) fn find_mr(
+        &self,
+        nic_idx: usize,
+        ptr: u64,
+        len: usize,
+    ) -> Option<Arc<MemoryRegion>> {
+        self.find_entry(ptr, len)
+            .map(|entry| Arc::clone(&entry.mrs[nic_idx]))
+    }
+
+    /// Non-overlap makes the predecessor the only possible covering region.
+    fn find_entry(&self, ptr: u64, len: usize) -> Option<&RegisteredMemoryEntry> {
+        let end = ptr.checked_add(len as u64)?;
+        let (_, entry) = self.entries.range(..=ptr).next_back()?;
+        (end <= entry.base_ptr + entry.len as u64).then_some(entry)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
 struct RemoteMemoryEntry {
     base_ptr: u64,
     end_ptr: u64,
     rkey: u32,
+}
+
+/// Sorted, non-overlapping remote regions from one handshake. Immutable after
+/// validation; shared via `Arc` so rkey lookup runs outside the state lock.
+#[derive(Debug)]
+pub(super) struct RemoteMemorySnapshot {
+    entries: Vec<RemoteMemoryEntry>,
+}
+
+impl RemoteMemorySnapshot {
+    /// Validate and index the remote memory regions received during handshake.
+    pub(super) fn from_handshake(remote_memory_regions: &[RegisteredMemoryRegion]) -> Result<Self> {
+        let mut entries = Vec::with_capacity(remote_memory_regions.len());
+        for entry in remote_memory_regions.iter().copied() {
+            if entry.len == 0 {
+                return Err(TransferError::Backend(
+                    "handshake response contains zero-length memory region".to_string(),
+                ));
+            }
+            let Some(end_ptr) = entry.base_ptr.checked_add(entry.len) else {
+                return Err(TransferError::Backend(
+                    "handshake response contains memory region overflow".to_string(),
+                ));
+            };
+            entries.push(RemoteMemoryEntry {
+                base_ptr: entry.base_ptr,
+                end_ptr,
+                rkey: entry.rkey,
+            });
+        }
+        entries.sort_unstable_by_key(|e| e.base_ptr);
+        for pair in entries.windows(2) {
+            if pair[1].base_ptr < pair[0].end_ptr {
+                return Err(TransferError::Backend(
+                    "handshake response contains overlapping memory regions".to_string(),
+                ));
+            }
+        }
+        Ok(Self { entries })
+    }
+
+    /// Look up the rkey of the region fully covering `[ptr, ptr+len)`.
+    pub(super) fn find_rkey(&self, ptr: u64, len: usize) -> Option<u32> {
+        let end = ptr.checked_add(len as u64)?;
+        let index = match self.entries.binary_search_by_key(&ptr, |e| e.base_ptr) {
+            Ok(i) => i,
+            Err(0) => return None,
+            Err(i) => i - 1,
+        };
+        // binary_search already guarantees entry.base_ptr <= ptr.
+        let entry = &self.entries[index];
+        (end <= entry.end_ptr).then_some(entry.rkey)
+    }
 }
 
 /// Per-NIC state: pending/connected sessions and remote memory cache.
@@ -31,35 +161,12 @@ pub(super) struct PerNicState {
     /// Pre-connect sessions in FIFO order (first prepared, first connected).
     pub(super) pending: VecDeque<Arc<RcSession>>,
     /// Connected session vectors keyed by first remote QPN; each Vec has N sessions.
-    pub(super) sessions: HashMap<u32, Vec<Arc<RcSession>>>,
-    /// Remote memory cache keyed by first remote QPN (shared across the N sessions).
-    remote_memory: HashMap<u32, Vec<RemoteMemoryEntry>>,
+    pub(super) sessions: HashMap<u32, Arc<Vec<Arc<RcSession>>>>,
+    /// Remote memory snapshots keyed by first remote QPN (shared across the N sessions).
+    pub(super) remote_memory: HashMap<u32, Arc<RemoteMemorySnapshot>>,
 }
 
 impl PerNicState {
-    /// Look up the remote rkey for `[remote_ptr, remote_ptr+len)` from the
-    /// handshake snapshot cached for `remote_first_qpn`.
-    pub(super) fn find_remote_rkey(
-        &self,
-        remote_first_qpn: u32,
-        remote_ptr: u64,
-        len: usize,
-    ) -> Option<u32> {
-        let end = remote_ptr.checked_add(len as u64)?;
-        let entries = self.remote_memory.get(&remote_first_qpn)?;
-        let index = match entries.binary_search_by_key(&remote_ptr, |e| e.base_ptr) {
-            Ok(i) => i,
-            Err(0) => return None,
-            Err(i) => i - 1,
-        };
-        let entry = &entries[index];
-        if remote_ptr >= entry.base_ptr && end <= entry.end_ptr {
-            Some(entry.rkey)
-        } else {
-            None
-        }
-    }
-
     /// Remove a pending session by its local QPN. Returns the session if found.
     pub(super) fn remove_pending_by_qpn(&mut self, qpn: u32) -> Option<Arc<RcSession>> {
         let pos = self
@@ -73,42 +180,6 @@ impl PerNicState {
         self.sessions.remove(&remote_first_qpn);
         self.remote_memory.remove(&remote_first_qpn);
     }
-
-    /// Validate and cache the remote memory regions received during handshake.
-    pub(super) fn cache_remote_memory(
-        &mut self,
-        remote_first_qpn: u32,
-        remote_memory_regions: &[RegisteredMemoryRegion],
-    ) -> Result<()> {
-        let mut cached = Vec::with_capacity(remote_memory_regions.len());
-        for entry in remote_memory_regions.iter().copied() {
-            if entry.len == 0 {
-                return Err(TransferError::Backend(
-                    "handshake response contains zero-length memory region".to_string(),
-                ));
-            }
-            let Some(end_ptr) = entry.base_ptr.checked_add(entry.len) else {
-                return Err(TransferError::Backend(
-                    "handshake response contains memory region overflow".to_string(),
-                ));
-            };
-            cached.push(RemoteMemoryEntry {
-                base_ptr: entry.base_ptr,
-                end_ptr,
-                rkey: entry.rkey,
-            });
-        }
-        cached.sort_unstable_by_key(|e| e.base_ptr);
-        for pair in cached.windows(2) {
-            if pair[1].base_ptr < pair[0].end_ptr {
-                return Err(TransferError::Backend(
-                    "handshake response contains overlapping memory regions".to_string(),
-                ));
-            }
-        }
-        self.remote_memory.insert(remote_first_qpn, cached);
-        Ok(())
-    }
 }
 
 pub(super) struct AddrConnection {
@@ -120,7 +191,7 @@ pub(super) struct AddrConnection {
 }
 
 pub(super) struct RcBackendState {
-    pub(super) registered: HashMap<u64, RegisteredMemoryEntry>,
+    pub(super) registered: Arc<LocalMemoryMap>,
     pub(super) nics: Vec<PerNicState>,
     /// addr -> established connection info
     pub(super) addr_connections: HashMap<String, AddrConnection>,
@@ -136,30 +207,11 @@ impl RcBackendState {
 
     pub(super) fn new(nic_count: usize) -> Self {
         Self {
-            registered: HashMap::new(),
+            registered: Arc::new(LocalMemoryMap::default()),
             nics: (0..nic_count).map(|_| PerNicState::default()).collect(),
             addr_connections: HashMap::new(),
             connecting: HashSet::new(),
         }
-    }
-
-    /// Find a registered local MR that fully covers `[ptr, ptr+len)`,
-    /// returning the MR for the given NIC index.
-    pub(super) fn find_local_mr(
-        &self,
-        nic_idx: usize,
-        ptr: u64,
-        len: usize,
-    ) -> Option<Arc<MemoryRegion>> {
-        let end = ptr.checked_add(len as u64)?;
-        self.registered.values().find_map(|entry| {
-            let entry_end = entry.base_ptr.checked_add(entry.len as u64)?;
-            if ptr >= entry.base_ptr && end <= entry_end {
-                Some(Arc::clone(&entry.mrs[nic_idx]))
-            } else {
-                None
-            }
-        })
     }
 }
 
@@ -168,8 +220,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cache_remote_memory_rejects_overlapping_regions() {
-        let mut nic = PerNicState::default();
+    fn remote_snapshot_rejects_overlapping_regions() {
         let regions = vec![
             RegisteredMemoryRegion {
                 base_ptr: 0x1000,
@@ -183,9 +234,8 @@ mod tests {
             },
         ];
 
-        let error = nic
-            .cache_remote_memory(1, &regions)
-            .expect_err("overlap should fail");
+        let error =
+            RemoteMemorySnapshot::from_handshake(&regions).expect_err("overlap should fail");
         assert_eq!(
             error,
             TransferError::Backend(
@@ -195,9 +245,7 @@ mod tests {
     }
 
     #[test]
-    fn find_remote_rkey_uses_sorted_snapshot() {
-        let mut nic = PerNicState::default();
-        let remote_qpn = 42;
+    fn remote_snapshot_finds_rkey_in_sorted_entries() {
         let regions = vec![
             RegisteredMemoryRegion {
                 base_ptr: 0x3000,
@@ -215,13 +263,43 @@ mod tests {
                 rkey: 2,
             },
         ];
-        nic.cache_remote_memory(remote_qpn, &regions)
-            .expect("snapshot cache");
+        let snapshot = RemoteMemorySnapshot::from_handshake(&regions).expect("snapshot");
 
-        let hit = nic.find_remote_rkey(remote_qpn, 0x2080, 0x10);
-        assert_eq!(hit, Some(2));
+        assert_eq!(snapshot.find_rkey(0x2080, 0x10), Some(2));
+        assert!(snapshot.find_rkey(0x2500, 0x10).is_none());
+    }
 
-        let miss = nic.find_remote_rkey(remote_qpn, 0x2500, 0x10);
-        assert!(miss.is_none());
+    fn entry(base_ptr: u64, len: usize) -> RegisteredMemoryEntry {
+        RegisteredMemoryEntry {
+            base_ptr,
+            len,
+            mrs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn local_map_rejects_overlap_and_finds_covering_region() {
+        let mut map = LocalMemoryMap::default();
+        map.insert(entry(0x1000, 0x100)).expect("first region");
+        map.insert(entry(0x3000, 0x100)).expect("disjoint region");
+
+        // Overlap with predecessor and successor both rejected.
+        assert!(map.insert(entry(0x10ff, 0x10)).is_err());
+        assert!(map.insert(entry(0x2f80, 0x100)).is_err());
+        // Same-base duplicate rejected (replace would dereg a broadcast MR).
+        assert!(map.insert(entry(0x1000, 0x80)).is_err());
+        // Adjacent regions (prev.end == base) allowed — K/V segments abut.
+        map.insert(entry(0x1100, 0x100)).expect("adjacent region");
+        // Zero-length rejected.
+        assert!(map.insert(entry(0x5000, 0)).is_err());
+
+        // Fully covered → hit; straddling a region boundary stays within that
+        // region's entry → miss even though the next region abuts.
+        assert_eq!(
+            map.find_entry(0x1080, 0x20).map(|e| e.base_ptr),
+            Some(0x1000)
+        );
+        assert!(map.find_entry(0x10f0, 0x20).is_none());
+        assert!(map.find_entry(0x0f00, 0x10).is_none());
     }
 }

--- a/python/src/rdma_v1.rs
+++ b/python/src/rdma_v1.rs
@@ -267,6 +267,10 @@ impl PegaRdmaV1Engine {
         Ok(())
     }
 
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "PyO3 binding mirroring the NIXL descriptor-list call shape"
+    )]
     fn read_async_indices(
         &self,
         py: Python<'_>,


### PR DESCRIPTION
## What

Phase 2 of #383 — v1 RC backend (`rc_backend/`) hot-path cleanups. Four changes:

1. **Local MR lookup: linear scan → predecessor search.** `registered` moves from `HashMap` to a `LocalMemoryMap` (BTreeMap keyed by base_ptr); `find_mr` resolves any address with one predecessor lookup instead of scanning every registered region per descriptor. Registration now **rejects overlapping regions**, which makes predecessor lookup sound by construction — mirroring the validation the remote side already does on handshake snapshots. Same-base duplicate registration is also rejected: silently replacing would dereg an MR whose rkey peers already hold from a handshake, turning their next READ into a remote access error. The overlap error carries both regions' base/len for diagnosis.
2. **`batch_transfer_async` no longer holds the global state mutex across op building.** Previously the lock covered the whole per-descriptor MR/rkey lookup loop, serializing concurrent fetches to different peers. Now a short lock snapshots Arc'd state — the local memory map (RCU-style clone-and-swap on the rare register/unregister), the per-connection `RemoteMemorySnapshot`, and the session vec — and all per-descriptor lookups run outside the lock. Lifetime safety is unchanged: ops already held `Arc<MemoryRegion>`/`Arc<RcSession>` past the lock on master; the snapshots only extend how long a concurrently-deregistered MR stays alive, never shorten it.
3. **Removed the per-session recv CQ.** The path is one-sided RDMA only — no recvs are ever posted, no IMM, no SRQ — so no recv completion can exist. The send CQ is passed as the recv CQ at QP creation.
4. **Hot-path `.expect("session vec must exist…")` is now an error return**, degrading the fetch to recompute instead of panicking the caller on inconsistent state.

Also includes a standalone commit adding `#[allow(clippy::too_many_arguments)]` to `read_async_indices` (pre-existing 8-arg PyO3 binding flagged by clippy 1.95, blocks any commit via pre-commit).

## Behavior changes

- `register_memory` now returns an error for overlapping or duplicate-base registrations (previously: silent `HashMap::insert` replacement). Current callers register disjoint regions once (pinned-pool shards; deduped vLLM KV bases), so this should only fire on genuinely broken layouts — loudly, at startup, with both regions in the message.
- A missing session/remote-memory entry for an established connection is now a returned `Backend` error instead of a panic.

## Not claimed

No performance numbers in this PR: this machine has no RDMA fabric, so the lock-scope and lookup changes are verified by unit tests and review only. Framed as a correctness/scalability cleanup, not a measured win.

## Testing

- [x] `cargo test -p pegaflow-transfer` (17 passed) — includes new `LocalMemoryMap` cases: overlap with predecessor/successor rejected, same-base rejected, adjacent regions allowed, zero-length rejected, covered/straddling lookup
- [x] `cargo clippy -p pegaflow-transfer -p pegaflow-core --all-targets` clean, `cargo fmt --check` clean, pre-commit hooks pass
- [x] Toxic-review pass: concurrency equivalence vs master traced (unregister/invalidate races, Arc lifetimes, CQ destruction order); review findings applied (overlap error detail, same-base rejection, `len > 0` invariant inside `insert`, adjacent-boundary test, redundant bound check removed)
- [x] Real-link A/B on an 8× 400G IB node: `cpu_bench` master vs PR across large-set / single-block / descriptor-heavy / 4-NIC shapes — no regression, differences ≤3% within noise (table in PR comment); crate tests pass on the real-NIC node
- [ ] **Before merge**: vLLM e2e for the connector-visible `register_memory` rejection path (test node GPUs were fully occupied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

