### PR TITLE
test(p2p_rdma): parameterize hardcoded IB device name via PEGAFLOW_IB_DEVICE env var

### DIFF
--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -288,6 +288,12 @@ async fn wait_for_prefetch_done(
     }
 }
 
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn ib_device() -> String {
+    std::env::var("PEGAFLOW_IB_DEVICE").unwrap_or_else(|_| "mlx5_1".into())
+}
+
 // ── Test ────────────────────────────────────────────────────────────────────
 
 const NUM_BLOCKS: usize = 4;
@@ -298,7 +304,7 @@ const LAYER: &str = "layer_0";
 const DEVICE_ID: i32 = 0;
 
 #[tokio::test]
-#[ignore] // Requires RDMA hardware (mlx5_1), CUDA GPU, and Python+torch
+#[ignore] // Requires RDMA hardware (PEGAFLOW_IB_DEVICE env var, default: mlx5_1), CUDA GPU, and Python+torch
 async fn p2p_rdma_remote_fetch_roundtrip() {
     pegaflow_common::logging::init_stdout_colored("debug");
     let _cuda_ctx = CudaContext::new(0).expect("CUDA init");
@@ -314,7 +320,7 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
     let config_a = StorageConfig {
         metaserver_addr: Some(format!("http://127.0.0.1:{meta_port}")),
         advertise_addr: Some(format!("127.0.0.1:{port_a}")),
-        rdma_nic_names: Some(vec!["mlx5_1".into()]),
+        rdma_nic_names: Some(vec![ib_device()]),
         ..StorageConfig::default()
     };
     let engine_a = Arc::new(
@@ -394,7 +400,7 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
     let config_b = StorageConfig {
         metaserver_addr: Some(format!("http://127.0.0.1:{meta_port}")),
         advertise_addr: Some(format!("127.0.0.1:{port_b}")),
-        rdma_nic_names: Some(vec!["mlx5_1".into()]),
+        rdma_nic_names: Some(vec![ib_device()]),
         ..StorageConfig::default()
     };
     let engine_b =


### PR DESCRIPTION
## Problem

The `p2p_rdma` integration test (`pegaflow-server/tests/p2p_rdma.rs`) hardcodes the RDMA NIC name `"mlx5_1"` in two places (Engine A config and Engine B config). Anyone running this test on a machine with a different IB device name has to manually `sed` the source file before each run.

## Fix

Add a helper function `ib_device()` that reads the NIC name from the `PEGAFLOW_IB_DEVICE` environment variable, falling back to `"mlx5_1"` when unset:

```rust
fn ib_device() -> String {
    std::env::var("PEGAFLOW_IB_DEVICE").unwrap_or_else(|_| "mlx5_1".into())
}
```

Replace the two hardcoded `"mlx5_1"` occurrences with `ib_device()`.

## Test

Verified on a server with `rxe0` as the RDMA NIC.

**With env var** — test uses the specified NIC and passes:
```
$ PEGAFLOW_IB_DEVICE=rxe0 RUST_LOG=info \
  cargo test -p pegaflow-server --test p2p_rdma \
  -- --ignored --nocapture p2p_rdma_remote_fetch_roundtrip

INFO pegaflow_transfer::rc_backend::runtime: RDMA NIC ready: nic=rxe0, ...
test p2p_rdma_remote_fetch_roundtrip ... ok
test result: ok. 1 passed; 0 failed
```

**Without env var** — falls back to `mlx5_1`, fails as expected on a machine without that device:
```
$ RUST_LOG=info cargo test -p pegaflow-server --test p2p_rdma \
  -- --ignored --nocapture p2p_rdma_remote_fetch_roundtrip

engine A should start: Storage("Failed to initialise RDMA transport (nics=[\"mlx5_1\"]): \
rdma device not found: mlx5_1")
test p2p_rdma_remote_fetch_roundtrip ... FAILED
```

The default behavior is unchanged — users who already have `mlx5_1` can continue running the test without setting any env var.

Closes #379