### PR TITLE
fix(core): survive heterogeneous NUMA topologies in RDMA fetch

### DIFF
--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -42,6 +42,9 @@ pub(crate) struct RdmaFetchStore {
     rdma_transport: Arc<RdmaTransport>,
     allocate_fn: AllocateFn,
     advertise_addr: String,
+    /// Local NUMA nodes with pinned pools (sorted); empty for global allocators.
+    /// Remote slots advertising other nodes are remapped onto these.
+    local_numa_nodes: Vec<NumaNode>,
     /// Lazy gRPC channel cache keyed by remote address. Tonic channels multiplex
     /// requests over a single HTTP/2 connection; cloning is cheap.
     grpc_channels: Arc<DashMap<String, EngineClient<Channel>>>,
@@ -58,13 +61,18 @@ impl RdmaFetchStore {
         rdma_transport: Arc<RdmaTransport>,
         allocate_fn: AllocateFn,
         advertise_addr: String,
+        local_numa_nodes: Vec<NumaNode>,
     ) -> Self {
-        info!("RDMA remote fetch enabled (advertise={})", advertise_addr);
+        info!(
+            "RDMA remote fetch enabled (advertise={}, local_numa_nodes={:?})",
+            advertise_addr, local_numa_nodes
+        );
         Self {
             metaserver_client,
             rdma_transport,
             allocate_fn,
             advertise_addr,
+            local_numa_nodes,
             grpc_channels: Arc::new(DashMap::new()),
             connect_group: Arc::new(Group::new()),
         }
@@ -126,6 +134,7 @@ impl RdmaFetchStore {
             &self.advertise_addr,
             namespace,
             hashes,
+            &self.local_numa_nodes,
         )
         .await
     }
@@ -151,6 +160,7 @@ async fn rdma_fetch_task(
     advertise_addr: &str,
     namespace: &str,
     block_hashes: &[Vec<u8>],
+    local_numa_nodes: &[NumaNode],
 ) -> PrefetchResult {
     let t0 = Instant::now();
 
@@ -199,7 +209,15 @@ async fn rdma_fetch_task(
 
     // 3. RDMA READ all blocks + build SealedBlocks
     let transfer_timeout = transfer_timeout_from_server(response.lock_timeout_secs);
-    let blocks = response.blocks;
+    let mut blocks = response.blocks;
+    // Expected steady state in heterogeneous clusters: counted in the fetch
+    // summary log + metric, not warned per fetch.
+    let numa_remapped = resolve_block_numas(&mut blocks, local_numa_nodes);
+    if numa_remapped > 0 {
+        core_metrics()
+            .rdma_fetch_numa_remapped
+            .add(numa_remapped as u64, &[]);
+    }
     let total_bytes: u64 = blocks
         .iter()
         .flat_map(|b| &b.slots)
@@ -239,7 +257,7 @@ async fn rdma_fetch_task(
         0.0
     };
     info!(
-        "RDMA fetch summary: req_id={req_id} remote={remote_addr} blocks={}/{} slots={} descs={} slabs={} bytes_mib={mb:.1} total_ms={elapsed_ms:.2} tp_mib_s={throughput_mib_s:.0}",
+        "RDMA fetch summary: req_id={req_id} remote={remote_addr} blocks={}/{} slots={} descs={} slabs={} numa_remapped={numa_remapped} bytes_mib={mb:.1} total_ms={elapsed_ms:.2} tp_mib_s={throughput_mib_s:.0}",
         result.len(),
         block_hashes.len(),
         transfer_timing.slot_count,
@@ -471,6 +489,36 @@ async fn fetch_blocks_via_rdma(
     timing.rebuild = rebuild_start.elapsed();
 
     Ok((result, timing))
+}
+
+/// Rewrite each slot's advertised NUMA node onto this machine's topology.
+///
+/// The remote node advertises where a block lives in *its* topology; that is a
+/// placement hint, not a valid key into local pools. Slots on nodes we don't
+/// have are spread deterministically across local nodes; with no NUMA pools
+/// (global allocator) they collapse to `UNKNOWN`. Returns the remapped count.
+fn resolve_block_numas(blocks: &mut [TransferBlockInfo], local_nodes: &[NumaNode]) -> usize {
+    let mut remapped = 0;
+    for (idx, slot) in blocks.iter_mut().flat_map(|b| &mut b.slots).enumerate() {
+        let advertised = NumaNode(slot.numa_node);
+        let resolved = if local_nodes.is_empty() {
+            NumaNode::UNKNOWN
+        } else if local_nodes.contains(&advertised) {
+            advertised
+        } else if advertised.is_unknown() {
+            // UNKNOWN is "no placement hint", not a node id: round-robin by
+            // slot position so a batch spreads across local pools instead of
+            // collapsing onto one node.
+            local_nodes[idx % local_nodes.len()]
+        } else {
+            local_nodes[slot.numa_node as usize % local_nodes.len()]
+        };
+        if resolved != advertised {
+            slot.numa_node = resolved.0;
+            remapped += 1;
+        }
+    }
+    remapped
 }
 
 fn sum_segment_bytes_by_numa(
@@ -715,6 +763,68 @@ mod tests {
             calls.fetch_add(1, Ordering::Relaxed);
             allocator.allocate(NonZeroU64::new(size)?, NumaNode::UNKNOWN)
         })
+    }
+
+    #[test]
+    fn resolve_block_numas_maps_foreign_nodes_onto_local_topology() {
+        let local = [NumaNode(0), NumaNode(1)];
+        let mut blocks = vec![TransferBlockInfo {
+            block_hash: vec![1],
+            slots: vec![
+                slot(1, 0, 0, 0),        // local node: kept
+                slot(1, 0, 0, 3),        // foreign node: remapped
+                slot(1, 0, 0, u32::MAX), // remote had no NUMA info: remapped
+            ],
+        }];
+
+        let remapped = resolve_block_numas(&mut blocks, &local);
+
+        assert_eq!(remapped, 2);
+        let numas: Vec<u32> = blocks[0].slots.iter().map(|s| s.numa_node).collect();
+        assert_eq!(numas[0], 0, "local node must be kept");
+        for numa in &numas[1..] {
+            assert!(
+                local.contains(&NumaNode(*numa)),
+                "foreign node must land on a local node, got {numa}"
+            );
+        }
+
+        // Resolution is idempotent: a second pass changes nothing.
+        assert_eq!(resolve_block_numas(&mut blocks, &local), 0);
+    }
+
+    #[test]
+    fn resolve_block_numas_spreads_unknown_slots_across_local_nodes() {
+        // UNKNOWN carries no placement hint; a batch of such slots must spread
+        // across local pools, not collapse onto a single node's slab.
+        let local = [NumaNode(0), NumaNode(1)];
+        let mut blocks = vec![TransferBlockInfo {
+            block_hash: vec![1],
+            slots: vec![slot(1, 0, 0, u32::MAX), slot(1, 0, 0, u32::MAX)],
+        }];
+
+        assert_eq!(resolve_block_numas(&mut blocks, &local), 2);
+
+        let numas: Vec<u32> = blocks[0].slots.iter().map(|s| s.numa_node).collect();
+        assert!(local.contains(&NumaNode(numas[0])));
+        assert!(local.contains(&NumaNode(numas[1])));
+        assert_ne!(
+            numas[0], numas[1],
+            "UNKNOWN slots must not pile onto one node"
+        );
+    }
+
+    #[test]
+    fn resolve_block_numas_without_local_pools_collapses_to_unknown() {
+        let mut blocks = vec![TransferBlockInfo {
+            block_hash: vec![1],
+            slots: vec![slot(1, 0, 0, 3)],
+        }];
+
+        let remapped = resolve_block_numas(&mut blocks, &[]);
+
+        assert_eq!(remapped, 1);
+        assert_eq!(blocks[0].slots[0].numa_node, NumaNode::UNKNOWN.0);
     }
 
     #[test]

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -28,6 +28,9 @@ pub(crate) struct CoreMetrics {
     pub pool_capacity_bytes: UpDownCounter<i64>,
     pub pool_used_bytes: UpDownCounter<i64>,
     pub pool_alloc_failures: Counter<u64>,
+    /// Allocations rejected up front because the target NUMA pool could never
+    /// satisfy them (missing pool or request above pool capacity).
+    pub pool_alloc_unsatisfiable: Counter<u64>,
 
     // Inflight (write path safety/health)
     pub inflight_bytes: UpDownCounter<i64>,
@@ -98,6 +101,10 @@ pub(crate) struct CoreMetrics {
     pub rdma_fetch_duration_seconds: Histogram<f64>,
     #[cfg(feature = "rdma")]
     pub rdma_fetch_bytes: Counter<u64>,
+    /// Fetched slots whose advertised NUMA node does not exist locally and was
+    /// remapped onto this machine's topology (heterogeneous cluster).
+    #[cfg(feature = "rdma")]
+    pub rdma_fetch_numa_remapped: Counter<u64>,
 }
 
 fn init_meter() -> Meter {
@@ -221,6 +228,13 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
             pool_alloc_failures: meter
                 .u64_counter("pegaflow_pool_alloc_failures")
                 .with_description("Pinned pool allocation failures after eviction retries")
+                .build(),
+            pool_alloc_unsatisfiable: meter
+                .u64_counter("pegaflow_pool_alloc_unsatisfiable")
+                .with_description(
+                    "Allocations rejected without eviction because the target \
+                     NUMA pool could never satisfy them",
+                )
                 .build(),
 
             // Inflight
@@ -445,6 +459,14 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
                 .u64_counter("pegaflow_rdma_fetch_bytes")
                 .with_unit("bytes")
                 .with_description("Total bytes fetched via RDMA from remote nodes")
+                .build(),
+            #[cfg(feature = "rdma")]
+            rdma_fetch_numa_remapped: meter
+                .u64_counter("pegaflow_rdma_fetch_numa_remapped")
+                .with_description(
+                    "Fetched slots whose advertised NUMA node was remapped \
+                     onto local topology (heterogeneous cluster)",
+                )
                 .build(),
         }
     })

--- a/pegaflow-core/src/pinned_pool.rs
+++ b/pegaflow-core/src/pinned_pool.rs
@@ -75,7 +75,10 @@ impl PinnedAllocation {
     }
 
     /// Get the underlying NonNull pointer.
-    #[cfg_attr(not(feature = "rdma"), allow(dead_code))]
+    #[cfg_attr(
+        not(feature = "rdma"),
+        allow(dead_code, reason = "only the RDMA fetch path builds raw segments")
+    )]
     pub(crate) fn as_non_null(&self) -> NonNull<u8> {
         self.ptr
     }
@@ -432,6 +435,18 @@ impl ShardedPinnedPool {
             .unwrap_or(0)
     }
 
+    /// Upper bound for a single allocation: one allocation lives in one shard,
+    /// so nothing larger than the biggest shard can ever be satisfied.
+    /// Reads a constant set at construction; takes no allocator locks (this
+    /// sits on the allocation hot path).
+    fn max_allocation_capacity(&self) -> u64 {
+        self.shards
+            .iter()
+            .map(|s| s.allocatable_bytes)
+            .max()
+            .unwrap_or(0)
+    }
+
     /// Return all backing memory regions (one per shard).
     fn memory_regions(&self) -> Vec<(NonNull<u8>, usize)> {
         self.shards.iter().map(|s| s.memory_region()).collect()
@@ -581,6 +596,29 @@ impl NumaAwarePinnedPools {
             .unwrap_or(0)
     }
 
+    /// Upper bound for a single allocation on a specific NUMA node.
+    /// Zero when the node has no pool: no amount of eviction can help.
+    fn max_allocation_capacity_for_node(&self, numa_node: NumaNode) -> u64 {
+        if numa_node.is_unknown() {
+            return 0;
+        }
+        self.pools
+            .get(&numa_node.0)
+            .map(|pool| pool.max_allocation_capacity())
+            .unwrap_or(0)
+    }
+
+    /// NUMA nodes that have pools, sorted for deterministic iteration.
+    #[cfg_attr(
+        not(feature = "rdma"),
+        allow(dead_code, reason = "only the RDMA fetch path consumes topology")
+    )]
+    fn node_ids(&self) -> Vec<NumaNode> {
+        let mut ids: Vec<NumaNode> = self.pools.keys().map(|id| NumaNode(*id)).collect();
+        ids.sort_by_key(|node| node.0);
+        ids
+    }
+
     /// Return all backing memory regions across all NUMA nodes and shards.
     fn memory_regions(&self) -> Vec<(NonNull<u8>, usize)> {
         self.pools
@@ -697,6 +735,28 @@ impl PinnedAllocator {
         match self {
             Self::Global(pool) => pool.largest_free_allocation(),
             Self::Numa(pools) => pools.largest_free_allocation_for_node(numa_node),
+        }
+    }
+
+    /// Upper bound for a single allocation on the requested target: what the
+    /// target pool could satisfy if it were completely empty. A request above
+    /// this bound can never succeed, no matter how much the cache evicts.
+    pub(crate) fn max_allocation_capacity_for_node(&self, numa_node: NumaNode) -> u64 {
+        match self {
+            Self::Global(pool) => pool.max_allocation_capacity(),
+            Self::Numa(pools) => pools.max_allocation_capacity_for_node(numa_node),
+        }
+    }
+
+    /// NUMA nodes with pools, sorted. Empty for global allocators.
+    #[cfg_attr(
+        not(feature = "rdma"),
+        allow(dead_code, reason = "only the RDMA fetch path consumes topology")
+    )]
+    pub(crate) fn numa_node_ids(&self) -> Vec<NumaNode> {
+        match self {
+            Self::Global(_) => Vec::new(),
+            Self::Numa(pools) => pools.node_ids(),
         }
     }
 

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -5,8 +5,6 @@ pub(crate) mod transfer_lock;
 mod write_path;
 
 use bytesize::ByteSize;
-#[cfg(not(feature = "rdma"))]
-use log::warn;
 use log::{debug, info, warn};
 use std::collections::HashSet;
 use std::num::NonZeroU64;
@@ -200,6 +198,8 @@ impl StorageEngine {
         }
 
         let is_numa = allocator.is_numa();
+        #[cfg(feature = "rdma")]
+        let local_numa_nodes = allocator.numa_node_ids();
         let engine = Arc::new_cyclic(move |weak_engine: &Weak<Self>| {
             // Build shared allocate_fn for backing stores.
             let alloc_weak = weak_engine.clone();
@@ -224,6 +224,7 @@ impl StorageEngine {
                     Arc::clone(rdma),
                     allocate_fn.clone(),
                     advertise,
+                    local_numa_nodes.clone(),
                 ))))
             });
             #[cfg(not(feature = "rdma"))]
@@ -298,6 +299,24 @@ impl StorageEngine {
     ) -> Option<Arc<PinnedAllocation>> {
         let requested_bytes = size.get();
         let node = numa_node.unwrap_or(NumaNode::UNKNOWN);
+
+        // A request beyond what the target pool could hold when empty can
+        // never be satisfied (missing NUMA pool, or size above pool capacity).
+        // Bail out before reclaim: evicting would wipe the read cache for
+        // nothing (a remote block advertising a NUMA node this machine does
+        // not have used to evict the entire resident cache per attempt).
+        let max_capacity = self.allocator.max_allocation_capacity_for_node(node);
+        if requested_bytes > max_capacity {
+            log::error!(
+                "Pinned allocation can never be satisfied; skipping cache reclaim: \
+                 requested={} max_single_allocation={} numa={:?}",
+                ByteSize(requested_bytes),
+                ByteSize(max_capacity),
+                numa_node
+            );
+            core_metrics().pool_alloc_unsatisfiable.add(1, &[]);
+            return None;
+        }
 
         loop {
             if let Some(alloc) = self.allocator.allocate(size, node) {
@@ -670,13 +689,65 @@ mod tests {
     #[tokio::test]
     async fn allocate_bounded_reclaim_terminates() {
         // With a tiny pool, allocation of a huge block should fail fast
-        // (not loop forever) thanks to MAX_RECLAIM_ROUNDS.
+        // (not loop forever): the request exceeds what the pool could ever
+        // hold, so it is rejected before any reclaim.
         let storage =
             StorageEngine::new_with_config(4096, false, StorageConfig::default(), &[]).unwrap();
 
         // Try to allocate more than the entire pool
         let result = storage.allocate(NonZeroU64::new(1 << 30).unwrap(), None);
         assert!(result.is_none(), "should fail, not loop forever");
+    }
+
+    #[tokio::test]
+    async fn alloc_for_missing_numa_pool_fails_fast_without_evicting() {
+        // A remote block can advertise a NUMA node that does not exist on this
+        // machine. The allocation must fail without touching the read cache:
+        // reclaim can never make room on a pool that does not exist.
+        let storage = StorageEngine::new_with_config(
+            1 << 20,
+            false,
+            StorageConfig::default(),
+            &[NumaNode(0)],
+        )
+        .unwrap();
+
+        let key1 = BlockKey::new("ns".into(), vec![1]);
+        let key2 = BlockKey::new("ns".into(), vec![2]);
+        storage.test_insert_cache(key1.clone(), Arc::new(SealedBlock::from_slots(Vec::new())));
+        storage.test_insert_cache(key2.clone(), Arc::new(SealedBlock::from_slots(Vec::new())));
+
+        let result = storage.allocate(NonZeroU64::new(4096).unwrap(), Some(NumaNode(3)));
+        assert!(result.is_none());
+
+        assert_eq!(
+            storage.read_cache.contains_keys(&[key1, key2]),
+            vec![true, true],
+            "unsatisfiable allocation must not evict resident blocks"
+        );
+    }
+
+    #[tokio::test]
+    async fn alloc_larger_than_node_capacity_fails_fast_without_evicting() {
+        let storage = StorageEngine::new_with_config(
+            1 << 20,
+            false,
+            StorageConfig::default(),
+            &[NumaNode(0)],
+        )
+        .unwrap();
+
+        let key = BlockKey::new("ns".into(), vec![1]);
+        storage.test_insert_cache(key.clone(), Arc::new(SealedBlock::from_slots(Vec::new())));
+
+        let result = storage.allocate(NonZeroU64::new(1 << 30).unwrap(), Some(NumaNode(0)));
+        assert!(result.is_none());
+
+        assert_eq!(
+            storage.read_cache.contains_keys(&[key]),
+            vec![true],
+            "oversized allocation must not evict resident blocks"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

In a cluster mixing machines with different NUMA node counts (e.g. 2-node and 6-node hosts), the RDMA fetch path broke down in two compounding ways when a small-topology machine fetched blocks from a large-topology peer:

1. **Eviction storm.** A remote slot advertising a NUMA node with no local pool made `StorageEngine::allocate` enter its reclaim loop with `largest_free_allocation_for_node() == 0` forever — the loop's only remaining exit was an empty read cache. **Every failed fetch attempt evicted the machine's entire resident cache** and flooded the MetaServer removal queue, which then cascaded into cluster-wide cache churn.

2. **Guaranteed fetch failure.** The advertised `numa_node` was used verbatim as a key into local pinned pools, so `failed to allocate slab for NUMAx` aborted the whole batch. On heterogeneous clusters, cross-topology fetch could never succeed.

Observed in production; the slab-allocation failures and full-cache eviction storms were confirmed live before p2p was disabled as a stopgap.

## Fix

**Guard (storm killer):** `StorageEngine::allocate` now rejects requests that are provably unsatisfiable — larger than what the target pool could hold when completely empty (missing NUMA pool → 0, or size above per-shard capacity) — *before* any reclaim, with an error log and a new `pegaflow_pool_alloc_unsatisfiable` counter. The capacity bound is a construction-time constant read (`allocatable_bytes`), no allocator locks on the hot path.

**Root cause (topology resolution):** the fetch path now treats the advertised NUMA node as a placement hint, not a pool key. `resolve_block_numas` rewrites each slot onto local topology right after `QueryBlocksForTransfer`:
- local node → kept;
- foreign node id → deterministic spread by id modulo local nodes;
- `UNKNOWN` (no hint) → round-robin by slot position, so a batch spreads across pools instead of collapsing onto one node;
- no local NUMA pools (global allocator) → `UNKNOWN`.

Rebuilt `SealedBlock`s carry the **resolved local** node, so re-serving fetched blocks advertises real topology to peers (and resolution is idempotent on the next hop). Remap counts appear in the existing `RDMA fetch summary` log line (`numa_remapped=N`) and a new `pegaflow_rdma_fetch_numa_remapped` counter — expected steady state on heterogeneous clusters, so no per-fetch warn.

Also fixes the duplicate `warn` import in `storage/mod.rs` that broke `pegaflow-core` builds without the `rdma` feature.

## Scope note

The guard closes the *deterministic* full-cache wipe (allocation that can never succeed). Reclaim can still evict deeply when a request is satisfiable in principle but the pool is fragmented or pinned by inflight/still-referenced blocks — out of scope here.

## Tests (TDD)

All new tests were written first and observed failing on the old code:

- `alloc_for_missing_numa_pool_fails_fast_without_evicting` — the incident scenario: NUMA pool only for node 0, allocation for node 3 must fail **without** touching resident cache (previously wiped it).
- `alloc_larger_than_node_capacity_fails_fast_without_evicting` — oversized request, same contract.
- `resolve_block_numas_maps_foreign_nodes_onto_local_topology` — keep/remap/idempotency.
- `resolve_block_numas_spreads_unknown_slots_across_local_nodes` — UNKNOWN batches must not pile onto one node.
- `resolve_block_numas_without_local_pools_collapses_to_unknown` — global-allocator receiver.

Verified: `cargo test -p pegaflow-core` passes with `cuda-13,rdma` (128) and `cuda-13` without rdma (123, previously did not compile); workspace clippy clean on both combos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)