### PR TITLE
chore(rust): bump toolchain to 1.97.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,8 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@1.97.0
         with:
-          toolchain: stable
           components: rustfmt
       - name: Run rust format check
         run: |
@@ -124,9 +123,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler libibverbs-dev
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@1.97.0
         with:
-          toolchain: stable
           components: clippy
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -193,9 +191,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler libibverbs-dev
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@1.97.0
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: Run cargo check
@@ -261,7 +257,7 @@ jobs:
           sudo apt-get install -y protobuf-compiler libibverbs-dev
 
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.97.0
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get install -y protobuf-compiler libibverbs-dev
 
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.97.0
 
       - name: Install maturin
         run: pip install maturin

--- a/pegaflow-transfer/src/v2/fabric_engine.rs
+++ b/pegaflow-transfer/src/v2/fabric_engine.rs
@@ -255,7 +255,7 @@ impl FabricEngine {
     }
 
     pub fn poll_transfer_completion(&self) -> Option<TransferCompletionEntry> {
-        for (_, ctx) in self.workers.iter() {
+        for ctx in self.workers.values() {
             if let Ok(completion) = ctx.worker.cq_rx.try_recv() {
                 return Some(completion);
             }
@@ -266,7 +266,7 @@ impl FabricEngine {
 
     pub fn stop(&self) {
         self.stop_signal.store(true, SeqCst);
-        for (_, ctx) in self.workers.iter() {
+        for ctx in self.workers.values() {
             ctx.worker.stop();
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
 channel = "1.97.0"
-components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.97.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
## Summary

- pin local development, CI, and release builds to Rust 1.97.0
- update all non-Docker Rust toolchain installation points consistently
- address the new `clippy::for_kv_map` diagnostics by iterating over `BTreeMap::values()`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --no-default-features --features cuda-13,rdma -- -D warnings`
- `cargo test --release --no-default-features --features cuda-13,rdma`
- `prek run`

All checks passed on Rust 1.97.0.

## Follow-up

Cargo reports a non-blocking future-incompatibility warning from the transitive `proc-macro-error2 2.0.1` dependency. The example-only dependency path is tracked upstream in [RDMA-Rust/sideway#117](https://github.com/RDMA-Rust/sideway/issues/117).
