### PR TITLE
perf(build): enable Thin LTO for release artifacts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ version = "0.23.2"
 edition = "2024"
 license = "Apache-2.0"
 
+[profile.release]
+lto = "thin"
+codegen-units = 1
+
 [workspace.dependencies]
 # Workspace members
 pegaflow-common = { path = "pegaflow-common" }


### PR DESCRIPTION
## Summary

- enable Thin LTO for all release artifacts
- compile each crate with one codegen unit to maximize optimization opportunities
- this is stacked on #390; the review diff contains only the release profile change

## Generic release benchmark

Environment: Rust 1.97.0, CPU pinned to one core, Criterion with 10 samples, AB/BA order. Both variants used an isolated Cargo home, so no local clang/mold, `target-cpu=native`, or `tokio_unstable` configuration was present.

| Benchmark | Default release | Thin LTO + 1 CGU | Change |
| --- | ---: | ---: | ---: |
| 32K query/prefetch lease | 3.7152 ms | 3.5507 ms | -4.43% |
| 61-layer 32K save submit | 482.18 ms | 443.73 ms | -7.98% |

The two variants' 95% Criterion intervals do not overlap in either benchmark.

## Cost

- clean benchmark build: 27.05 s -> 48.03 s (+77.6%)
- peak build RSS: 749 MiB -> 976 MiB (+30.2%)
- benchmark binary only: 12.03 MB -> 8.60 MB (-28.5%)

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --no-default-features --features cuda-13,rdma -- -D warnings`
- `cargo test --release --no-default-features --features cuda-13,rdma`
- `cargo build --release --workspace --no-default-features --features cuda-13,rdma`
- `prek run`

Toxic-reviewer: approved after the generic A/B evidence was verified.
