### PR TITLE
feat(connector): support vLLM hybrid memory allocator (SupportsHMA)

### DIFF
--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -12,6 +12,7 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.distributed.parallel_state import get_pp_group, get_tensor_model_parallel_rank
 
@@ -33,7 +34,7 @@ from pegaflow.connector.worker import WorkerConnector
 from pegaflow.pegaflow import EngineRpcClient
 
 
-class PegaKVConnector(KVConnectorBase_V1):
+class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
     """v1 KV connector for PegaFlow with separated scheduler/worker logic."""
 
     def __init__(self, vllm_config, role: KVConnectorRole, kv_cache_config=None):
@@ -42,6 +43,14 @@ class PegaKVConnector(KVConnectorBase_V1):
         instance_id = resolve_instance_id(vllm_config)
         tp_size = vllm_config.parallel_config.tensor_parallel_size
         world_size = vllm_config.parallel_config.world_size
+        # HMA: number of KV cache groups (1 = uniform attention). NOTE: the
+        # original PR #202 multiplied world_size by num_kv_groups for the
+        # engine; since #346 the server seals layer topology from the
+        # registered layers themselves, so the true worker count is correct.
+        num_kv_groups = max(
+            1,
+            len(getattr(kv_cache_config, "kv_cache_groups", None) or []),
+        )
         is_mla = detect_mla(vllm_config)
         dcp_world_size = (
             getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1) or 1
@@ -61,14 +70,20 @@ class PegaKVConnector(KVConnectorBase_V1):
             )
 
         cross_layer_blocks = os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
+        if num_kv_groups > 1:
+            # HMA: layers in different groups live in different block
+            # tables, so a single fused cross-layer view (one block id list
+            # for ALL layers) cannot be correct — force per-layer.
+            cross_layer_blocks = False
         namespace = derive_namespace(
             vllm_config,
             effective_tp_size,
             dcp_world_size,
             pcp_world_size,
             cross_layer_blocks=cross_layer_blocks,
+            kv_group_signature=_kv_group_signature(kv_cache_config),
         )
-        block_size = vllm_config.cache_config.block_size
+        block_size = _resolve_connector_block_size(vllm_config, kv_cache_config)
 
         tp_rank: int | None = None
         device_id: int | None = None
@@ -137,7 +152,7 @@ class PegaKVConnector(KVConnectorBase_V1):
         # is silently ignored upstream and falls back to per-layer — surface
         # that instead of pretending the request was honored.
         env_cross_layer = os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
-        self._prefer_cross_layer = env_cross_layer and not is_mla
+        self._prefer_cross_layer = env_cross_layer and not is_mla and num_kv_groups == 1
         if is_mla and env_cross_layer:
             logger.warning(
                 "[PegaKVConnector] PEGAFLOW_CROSS_LAYER_BLOCKS=1 is ignored for MLA "
@@ -148,9 +163,9 @@ class PegaKVConnector(KVConnectorBase_V1):
         self._scheduler: SchedulerConnector | None = None
         self._worker: WorkerConnector | None = None
         if role == KVConnectorRole.SCHEDULER:
-            self._scheduler = SchedulerConnector(self._ctx)
+            self._scheduler = SchedulerConnector(self._ctx, kv_cache_config)
             # Open the liveness stream from the scheduler process only. One
-            # stream per vllm replica is enough — if any tp worker crashes,
+            # stream per vllm replica is enough - if any tp worker crashes,
             # the scheduler dies too, closing this stream and triggering
             # server-side cleanup of the instance's CUDA IPC mappings.
             engine_client.start_session_watcher(instance_id, namespace, tp_size, world_size)
@@ -163,7 +178,8 @@ class PegaKVConnector(KVConnectorBase_V1):
 
         logger.debug(
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
-            "tp_rank=%s tp_size=%d pp_rank=%d pp_size=%d world_size=%d namespace=%s "
+            "tp_rank=%s tp_size=%d pp_rank=%d pp_size=%d world_size=%d "
+            "num_kv_groups=%d namespace=%s "
             "is_mla=%s transfer_backend=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d mode=%s",
             role.name,
             instance_id,
@@ -173,6 +189,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             pp_rank,
             pp_size,
             world_size,
+            num_kv_groups,
             namespace,
             is_mla,
             transfer_backend,
@@ -254,6 +271,23 @@ class PegaKVConnector(KVConnectorBase_V1):
         if self._scheduler:
             return self._scheduler.request_finished(request, block_ids)
         return (False, None)
+
+    def request_finished_all_groups(
+        self,
+        request,
+        block_ids: tuple[list[int], ...],  # noqa: ARG002 - scheduler ignores ids
+    ) -> tuple[bool, dict[str, Any] | None]:
+        # HMA twin of request_finished; the scheduler's implementation never
+        # consumes block ids (saves are cut from scheduler_output tracking).
+        if self._scheduler:
+            return self._scheduler.request_finished(request, [])
+        return (False, None)
+
+    def bind_gpu_block_pool(self, gpu_block_pool) -> None:
+        # Called unconditionally by the vLLM scheduler; multi-group saves
+        # need the pool to detect slid-out sliding-window blocks.
+        if self._scheduler:
+            self._scheduler.bind_gpu_block_pool(gpu_block_pool)
 
     def take_events(self) -> Iterable:
         return ()
@@ -410,6 +444,52 @@ def _resolve_device_id() -> int:
         return int(mapped)
     except ValueError:
         return local_id
+
+
+def _kv_group_signature(kv_cache_config) -> str:
+    """Storage-isolation fingerprint of the HMA group layout. Which token
+    positions a save/load covers depends on it, so two layouts must never
+    share stored blocks (see derive_namespace)."""
+    groups = getattr(kv_cache_config, "kv_cache_groups", None) or []
+    if len(groups) <= 1:
+        return ""
+    parts = []
+    for group in groups:
+        spec = getattr(group, "kv_cache_spec", None)
+        parts.append(
+            f"{type(spec).__name__}:{getattr(spec, 'block_size', 0)}:"
+            f"{getattr(spec, 'sliding_window', None)}:{len(group.layer_names)}"
+        )
+    return "|".join(parts)
+
+
+def _resolve_connector_block_size(vllm_config, kv_cache_config) -> int:
+    """Resolve the block/hash granularity PegaFlow can safely use.
+
+    PegaFlow connector metadata assumes request.block_hashes and physical
+    block ids are 1:1 for EVERY KV cache group (the positional-alignment
+    invariant the HMA save/load paths rely on). Heterogeneous group block
+    sizes would need a per-group hash mapping; refuse loudly instead of
+    corrupting save/load hash mappings.
+    """
+    fallback = vllm_config.cache_config.block_size
+    groups = getattr(kv_cache_config, "kv_cache_groups", None) or []
+    if not groups:
+        return fallback
+
+    group_block_sizes: list[int] = []
+    for group in groups:
+        spec = getattr(group, "kv_cache_spec", None)
+        group_block_sizes.append(getattr(spec, "block_size", fallback))
+
+    if len(set(group_block_sizes)) > 1:
+        raise ValueError(
+            "PegaKVConnector does not support heterogeneous KV cache group "
+            f"block sizes yet: {group_block_sizes}. Refusing to avoid "
+            "corrupt save/load hash mappings."
+        )
+
+    return group_block_sizes[0]
 
 
 __all__ = ["PegaKVConnector", "NoopKVConnector", "KVConnectorRole"]

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -103,18 +103,44 @@ class ConnectorContext:
 
 @dataclass(frozen=True)
 class LoadIntent:
-    """Intent for a KV load operation."""
+    """Intent for a KV load operation.
 
-    block_ids: tuple[int, ...]
-    lease: bytes
+    group_block_ids[i] holds the destination pool slot indices for
+    kv_cache_group i, POSITIONALLY aligned with the leased hash range —
+    all groups share one block granularity (enforced at init), so entry p
+    of every group is the same token range. Sliding-window groups carry
+    the null block id (vLLM reserves that slot and never reads it) at
+    out-of-window positions; loading into it is harmless, and keeping the
+    full-length list preserves the load RPC's len(lease hashes) ==
+    len(destination ids) contract.
+
+    group_leases[i] is a server lease over the SAME hash range for group
+    i's load RPC. The server consumes a lease on first use
+    (query_leases.consume), so per-group load RPCs cannot share one — the
+    scheduler mints one per group. An empty lease marks a group whose
+    mint failed; the worker reports that group's real destinations as
+    load errors so vLLM recomputes them.
+    """
+
+    group_block_ids: tuple[tuple[int, ...], ...]
+    group_leases: tuple[bytes, ...]
     num_tokens: int
 
 
 @dataclass(frozen=True)
 class SaveIntent:
-    """Intent for a KV save operation."""
+    """Intent for a KV save operation.
 
-    block_ids: tuple[int, ...]
+    group_block_ids[i] holds the pool slot indices for kv_cache_group i,
+    positionally parallel to block_hashes (shared across groups — same
+    token ranges). A position is included only when EVERY group still
+    holds a live, hash-matching block for it (checked against the bound
+    GPU block pool), so every stored hash is complete across all layers;
+    sliding-window positions that slid out before saving are skipped for
+    all groups together.
+    """
+
+    group_block_ids: tuple[tuple[int, ...], ...]
     block_hashes: tuple[bytes, ...]
 
 
@@ -126,12 +152,18 @@ class PegaConnectorMetadata(KVConnectorMetadata):
         load_intents: dict[str, LoadIntent] | None = None,
         save_intents: dict[str, SaveIntent] | None = None,
         preempted_req_ids: set[str] | None = None,
+        layer_to_group: dict[str, int] | None = None,
+        group_layer_names: list[list[str]] | None = None,
     ):
         super().__init__()
         # Maps request_id -> intent
         self.load_intents: dict[str, LoadIntent] = load_intents or {}
         self.save_intents: dict[str, SaveIntent] = save_intents or {}
         self.preempted_req_ids: set[str] = preempted_req_ids or set()
+        # Maps layer_name -> kv_cache_group index (built from KVCacheConfig)
+        self.layer_to_group: dict[str, int] = layer_to_group or {}
+        # group_layer_names[i] = list of layer names in kv_cache_group i
+        self.group_layer_names: list[list[str]] = group_layer_names or []
 
     def __repr__(self) -> str:
         return (
@@ -200,6 +232,7 @@ def derive_namespace(
     dcp_world_size: int = 1,
     pcp_world_size: int = 1,
     cross_layer_blocks: bool = False,
+    kv_group_signature: str = "",
 ) -> str:
     """
     Derive namespace for storage isolation.
@@ -233,6 +266,10 @@ def derive_namespace(
         "pcp_world_size": pcp_world_size,
         "cross_layer_blocks": cross_layer_blocks,
         "mla_layer_split_kv_cache": bool(additional_config.get("mla_layer_split_kv_cache", False)),
+        # HMA group layout (spec type / block_size / window per group):
+        # which positions each save/load covers depends on it, so two
+        # layouts must never share stored blocks.
+        "kv_group_signature": kv_group_signature,
     }
 
     factor_str = str(sorted(factors.items()))

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -199,7 +199,7 @@ class SchedulerConnector:
             return "transient"
         try:
             blk = pool.blocks[block_id]
-        except (IndexError, TypeError, AttributeError):
+        except (KeyError, IndexError, TypeError, AttributeError):
             return "dead"
         if getattr(blk, "is_null", False):
             return "dead"
@@ -684,10 +684,10 @@ class SchedulerConnector:
             # block slid out (and its slot got reused) before this save —
             # saving it would poison the store under a valid hash.
             logger.warning(
-                "[PegaKVConnector] req=%s multi-group save skipped: GPU block pool not bound",
+                "[PegaKVConnector] req=%s multi-group save deferred: GPU block "
+                "pool not bound (cursor kept; retried once it binds)",
                 req_id,
             )
-            self._next_stored_block_idx[req_id] = saveable_block_idx
             return None
 
         # A position is saved only when EVERY group still holds a live,

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -78,8 +78,67 @@ class _QueryProbe:
 class SchedulerConnector:
     """Holds scheduler-only state and behaviors."""
 
-    def __init__(self, context: ConnectorContext):
+    def __init__(self, context: ConnectorContext, kv_cache_config=None):
         self._ctx = context
+
+        # Group layout from KVCacheConfig (populated on scheduler role only).
+        # A Gemma-style SWA hybrid (5 sliding : 1 full) yields SEVERAL sliding-window groups plus
+        # one full-attention group, and vLLM orders them by first-layer index
+        # (FA is typically LAST) — never assume 2 groups or that group 0 is
+        # full attention.
+        self._group_layer_names: list[list[str]] = []
+        self._layer_to_group: dict[str, int] = {}
+        self._num_groups: int = 1
+        self._fa_group_idx: int = 0
+        # GPU block pool, bound by the vLLM scheduler via
+        # bind_gpu_block_pool. Multi-group saves need it to detect
+        # sliding-window blocks that were freed (and possibly reused)
+        # before their save was cut.
+        self._gpu_block_pool = None
+        self._pool_hash_mismatch_logged = False
+
+        if kv_cache_config is not None:
+            groups = getattr(kv_cache_config, "kv_cache_groups", None) or []
+            if groups:
+                self._num_groups = len(groups)
+                self._group_layer_names = [list(g.layer_names) for g in groups]
+                fa_groups: list[int] = []
+                for g_idx, g in enumerate(groups):
+                    for ln in g.layer_names:
+                        self._layer_to_group[ln] = g_idx
+                    spec_name = type(getattr(g, "kv_cache_spec", None)).__name__
+                    if spec_name == "FullAttentionSpec":
+                        fa_groups.append(g_idx)
+                    elif self._num_groups > 1 and spec_name != "SlidingWindowSpec":
+                        # Every positional assumption below (1 block per
+                        # scheduler block, content hashes, window masking)
+                        # is attention-specific. Mamba/SSM, cross-attention
+                        # and other state groups must fail loudly, not be
+                        # saved/loaded as if they were positional KV.
+                        raise ValueError(
+                            f"PegaKVConnector does not support KV cache group "
+                            f"spec {spec_name} in hybrid (multi-group) models; "
+                            f"only FullAttentionSpec + SlidingWindowSpec groups "
+                            f"are supported."
+                        )
+                if self._num_groups > 1 and not fa_groups:
+                    raise ValueError(
+                        "PegaKVConnector needs at least one FullAttentionSpec "
+                        "group in hybrid models (it is the computed-prefix "
+                        "reference; sliding-window groups under-count via "
+                        "masked positions)."
+                    )
+                # The FA group's blocks are never masked out, so it is the
+                # reference for computed-prefix accounting. Never assume 2
+                # groups or that group 0 is full attention: a Gemma-style
+                # 5:1 hybrid yields 5 SWA groups + 1 FA group, FA last.
+                self._fa_group_idx = fa_groups[0] if fa_groups else 0
+                logger.info(
+                    "[PegaKVConnector] KV cache groups: %d groups, fa_group=%d, layer_counts=%s",
+                    self._num_groups,
+                    self._fa_group_idx,
+                    [len(g.layer_names) for g in groups],
+                )
 
         # Load state
         self._pending_load_intents: dict[str, LoadIntent] = {}
@@ -90,10 +149,11 @@ class SchedulerConnector:
         self._prefetch_tracker = PrefetchTracker()
 
         # Save state (per-request)
+        # _allocated_blocks[req_id][g] = list of block IDs for kv_cache_group g
         self._block_hashes: dict[str, tuple[bytes, ...]] = {}
         self._external_matched_blocks: dict[str, int] = {}
         self._block_index_offsets: dict[str, int] = {}
-        self._allocated_blocks: dict[str, list[int]] = {}
+        self._allocated_blocks: dict[str, list[list[int]]] = {}
         self._scheduled_tokens: dict[str, int] = {}
         self._next_stored_block_idx: dict[str, int] = {}
 
@@ -104,6 +164,102 @@ class SchedulerConnector:
         # Completion tracking
         self._pending_saves: set[str] = set()
         self._held_requests: set[str] = set()
+
+        # GPU blocks ref-pinned for in-flight multi-group saves: the save
+        # copy runs asynchronously after the scheduler step, so without a
+        # pin a sliding-window block can slide out, be reused by another
+        # request, and get stored under the original hash (poisoning the
+        # cache). Pinned at intent cut, released on save completion or
+        # request cleanup.
+        self._pinned_save_blocks: dict[str, list] = {}
+
+    def bind_gpu_block_pool(self, gpu_block_pool) -> None:
+        """Called unconditionally by the vLLM scheduler after the KV cache
+        manager is built. Multi-group saves consult the pool to skip
+        sliding-window blocks that were freed (and possibly reused by
+        another request) before their save was cut."""
+        self._gpu_block_pool = gpu_block_pool
+
+    def _null_block_id(self) -> int:
+        pool = self._gpu_block_pool
+        null_block = getattr(pool, "null_block", None) if pool is not None else None
+        return getattr(null_block, "block_id", 0)
+
+    def _classify_block_for_save(self, block_id: int, expected_hash: bytes, group_idx: int) -> str:
+        """One of:
+        "valid"     — the block still holds `expected_hash` content;
+        "transient" — the block exists but is not sealed/hashed yet (a
+                      freshly scheduled position): retry next round;
+        "dead"      — slid out (null placeholder) or reused by another
+                      request (foreign hash): this position can never be
+                      saved again.
+        """
+        pool = self._gpu_block_pool
+        if pool is None:
+            return "transient"
+        try:
+            blk = pool.blocks[block_id]
+        except (IndexError, TypeError, AttributeError):
+            return "dead"
+        if getattr(blk, "is_null", False):
+            return "dead"
+        bh = getattr(blk, "block_hash", None)
+        if bh is None:
+            # Allocated but not yet committed to the prefix cache.
+            return "transient"
+        raw = getattr(bh, "block_hash", bh)
+        if raw == expected_hash:
+            return "valid"
+        # vLLM >= 0.22 stores BlockHashWithGroupId: the plain content hash
+        # with a 4-byte big-endian group id appended. Strip and verify both
+        # parts — comparing the packed bytes against the plain request hash
+        # can never match and silently disabled every hybrid save.
+        if (
+            isinstance(raw, (bytes, bytearray))
+            and isinstance(expected_hash, (bytes, bytearray))
+            and len(raw) == len(expected_hash) + 4
+            and bytes(raw[:-4]) == bytes(expected_hash)
+            and int.from_bytes(raw[-4:], "big") == group_idx
+        ):
+            return "valid"
+        if not self._pool_hash_mismatch_logged:
+            self._pool_hash_mismatch_logged = True
+            logger.warning(
+                "[PegaKVConnector] pool hash mismatch (types %s vs %s, lengths %s vs %s)"
+                " — treating block as reused",
+                type(raw).__name__,
+                type(expected_hash).__name__,
+                len(raw) if isinstance(raw, (bytes, bytearray)) else "?",
+                len(expected_hash),
+            )
+        return "dead"
+
+    def _pin_save_blocks(self, req_id: str, blocks: list) -> bool:
+        """Ref-pin GPU blocks so the async save copy cannot race a
+        slide-out + reuse. Returns False when the pool lacks the ref API
+        (version drift): the caller then refuses the save rather than
+        risking a poisoned store."""
+        if not all(hasattr(b, "incr_ref") for b in blocks):
+            return False
+        for b in blocks:
+            b.incr_ref()
+        self._pinned_save_blocks.setdefault(req_id, []).extend(blocks)
+        return True
+
+    def _unpin_save_blocks(self, req_id: str) -> None:
+        blocks = self._pinned_save_blocks.pop(req_id, None)
+        if not blocks:
+            return
+        pool = self._gpu_block_pool
+        free_blocks = getattr(pool, "free_blocks", None)
+        if free_blocks is not None:
+            # Decrements ref counts and returns fully-released blocks to
+            # the pool's free list.
+            free_blocks(blocks)
+        else:
+            for b in blocks:
+                if hasattr(b, "decr_ref"):
+                    b.decr_ref()
 
     def get_num_new_matched_tokens(
         self,
@@ -271,52 +427,128 @@ class SchedulerConnector:
             self._next_stored_block_idx[req_id] = base_block_idx
 
         if num_external_tokens > 0:
-            block_ids = list(blocks.get_block_ids()[0]) if blocks else []
+            if num_external_tokens % self._ctx.virtual_block_size != 0:
+                self._release_pending_query_probe(req_id)
+                raise RuntimeError(
+                    f"req {req_id} external tokens {num_external_tokens} not "
+                    f"block-aligned (block={self._ctx.virtual_block_size})"
+                )
+            num_load_blocks = num_external_tokens // self._ctx.virtual_block_size
+
+            # Destination ids per group, positionally aligned across groups
+            # (uniform block granularity, enforced at connector init). The
+            # locally-computed prefix is measured on the FULL-ATTENTION
+            # group: its blocks are never masked, so hashed == computed.
+            # SWA groups pad out-of-window positions with the null block
+            # and would undercount.
+            block_ids_by_group = blocks.get_block_ids() if blocks else ()
+            fa = min(self._fa_group_idx, max(0, len(block_ids_by_group) - 1))
             num_computed_blocks = (
-                sum(block.block_hash is not None for block in blocks.blocks[0]) if blocks else 0
+                sum(blk.block_hash is not None for blk in blocks.blocks[fa]) if blocks else 0
             )
             start_block_idx = num_computed_blocks
-            num_load_blocks = num_external_tokens // self._ctx.virtual_block_size
-            expected_load_blocks = len(block_ids) - num_computed_blocks
-            if (
-                num_external_tokens % self._ctx.virtual_block_size != 0
-                or num_load_blocks != expected_load_blocks
-            ):
+
+            fa_ids = block_ids_by_group[fa] if block_ids_by_group else []
+            if len(fa_ids) < start_block_idx + num_load_blocks:
                 self._release_pending_query_probe(req_id)
                 raise RuntimeError(
                     f"req {req_id} load block mismatch: external={num_load_blocks} "
-                    f"expected={expected_load_blocks}"
+                    f"allocated={len(fa_ids)} computed={num_computed_blocks}"
                 )
 
             pending_probe = self._pending_query_probes.get(req_id)
-            load_intent = LoadIntent(
-                block_ids=tuple(block_ids[start_block_idx:]),
-                lease=pending_probe.lease if pending_probe is not None else b"",
-                num_tokens=num_external_tokens,
-            )
             if (
                 pending_probe is not None
                 and tuple(
                     self._block_hashes[req_id][start_block_idx : start_block_idx + num_load_blocks]
                 )
-                != pending_probe.leased_hashes
+                != pending_probe.leased_hashes[:num_load_blocks]
             ):
                 self._release_pending_query_probe(req_id)
                 raise RuntimeError(f"req {req_id} load hashes do not match pending query probe")
-            if not load_intent.lease:
+
+            # The load RPC requires len(lease hashes) == len(destination ids)
+            # per (lease, block_ids) pair. When vLLM accepts fewer blocks than
+            # the leased hit (e.g. full-prompt hits are trimmed by one block so
+            # the last token is computed for logits), pad the destinations up
+            # to the lease length with the null block id — vLLM reserves that
+            # slot and never reads it, so the extra DMA is harmless.
+            lease_blocks = (
+                pending_probe.require_hit_blocks() if pending_probe is not None else num_load_blocks
+            )
+            null_id = self._null_block_id()
+            group_block_ids: list[tuple[int, ...]] = []
+            for g_ids in block_ids_by_group:
+                dest = list(g_ids[start_block_idx : start_block_idx + num_load_blocks])
+                dest += [null_id] * (lease_blocks - len(dest))
+                group_block_ids.append(tuple(dest))
+
+            primary_lease = pending_probe.lease if pending_probe is not None else b""
+            if not primary_lease:
                 raise RuntimeError(f"req {req_id} missing query lease for external load")
+
+            # The server consumes a lease on first load, so every group's
+            # load RPC needs its own. Mint (num_groups - 1) extra leases
+            # over the same hash range — the initial probe made those
+            # blocks resident, so these normally return Ready instantly.
+            # A failed mint leaves an empty lease: the worker reports that
+            # group's destinations as load errors and vLLM recomputes.
+            # Known trade-offs, deliberate for now:
+            # - the (num_groups - 1) extra mints are sequential blocking
+            #   RPCs in the scheduler step; they only run on an external
+            #   hit and the target is a local socket, but batching them
+            #   into one multi-lease RPC is the obvious follow-up.
+            # - a mint answered with QueryLoading counts as failed and may
+            #   leave a server-side prefetch running under the synthetic
+            #   "-hma<g>" request id; the server GC reaps it (it is
+            #   rare — the primary probe just proved residency).
+            group_leases: list[bytes] = [primary_lease]
+            if pending_probe is not None and len(group_block_ids) > 1:
+                leased = list(pending_probe.leased_hashes)
+                for g_idx in range(1, len(group_block_ids)):
+                    lease = b""
+                    try:
+                        result = self._ctx.engine_client.query_prefetch(
+                            self._ctx.instance_id,
+                            leased,
+                            req_id=f"{req_id}-hma{g_idx}",
+                        )
+                        if isinstance(result, QueryReady) and result.num_hit_blocks == lease_blocks:
+                            lease = result.lease
+                        elif isinstance(result, QueryReady) and result.lease:
+                            self._ctx.engine_client.release(result.lease)
+                    except Exception:
+                        logger.exception(
+                            "[PegaKVConnector] req=%s group %d lease mint failed",
+                            req_id,
+                            g_idx,
+                        )
+                    if not lease:
+                        logger.warning(
+                            "[PegaKVConnector] req=%s group %d has no lease; its "
+                            "blocks will be recomputed",
+                            req_id,
+                            g_idx,
+                        )
+                    group_leases.append(lease)
+
+            load_intent = LoadIntent(
+                group_block_ids=tuple(group_block_ids),
+                group_leases=tuple(group_leases),
+                num_tokens=num_external_tokens,
+            )
             self._pending_load_intents[req_id] = load_intent
             self._pending_query_probes.pop(req_id, None)
             logger.debug(
-                "[PegaKVConnector] req=%s alloc: total_blocks=%d computed_blocks=%d "
-                "load_blocks=%d start_block_idx=%d load_tokens=%d pending_loads=%d",
+                "[PegaKVConnector] req=%s alloc: computed_blocks=%d load_blocks=%d "
+                "lease_blocks=%d load_tokens=%d pending_loads=%d num_groups=%d",
                 req_id,
-                len(block_ids),
                 num_computed_blocks,
-                len(load_intent.block_ids),
-                start_block_idx,
+                num_load_blocks,
+                lease_blocks,
                 load_intent.num_tokens,
                 len(self._pending_load_intents),
+                len(group_block_ids),
             )
 
     def build_connector_meta(self, scheduler_output: "SchedulerOutput") -> PegaConnectorMetadata:
@@ -338,8 +570,9 @@ class SchedulerConnector:
 
             # Populate block IDs from scheduler_output — single source of
             # truth for the save path (consistent with offloading connector).
+            # req.block_ids is tuple[list[int], ...]: one list per kv_cache_group.
             if req.block_ids:
-                self._allocated_blocks[req_id] = list(req.block_ids[0])
+                self._allocated_blocks[req_id] = [list(g) for g in req.block_ids]
 
             if self._ctx.read_enabled:
                 self._scheduled_tokens[req_id] += num_tokens
@@ -366,12 +599,18 @@ class SchedulerConnector:
 
             num_tokens = scheduler_output.num_scheduled_tokens.get(req_id, 0)
 
-            # Append newly allocated blocks
+            # Append newly allocated blocks (new_block_ids: tuple[list[int], ...])
             new_block_ids = cached_reqs.new_block_ids[idx]
             if req_id in cached_reqs.resumed_req_ids:
-                self._allocated_blocks[req_id] = list(new_block_ids[0]) if new_block_ids else []
+                self._allocated_blocks[req_id] = (
+                    [list(g) for g in new_block_ids] if new_block_ids else []
+                )
             elif new_block_ids:
-                self._allocated_blocks[req_id].extend(new_block_ids[0])
+                for g_idx, g_ids in enumerate(new_block_ids):
+                    if g_idx < len(self._allocated_blocks[req_id]):
+                        self._allocated_blocks[req_id][g_idx].extend(g_ids)
+                    else:
+                        self._allocated_blocks[req_id].append(list(g_ids))
 
             if self._ctx.read_enabled:
                 self._scheduled_tokens[req_id] += num_tokens
@@ -400,6 +639,11 @@ class SchedulerConnector:
             load_intents=load_intents,
             save_intents=save_intents,
             preempted_req_ids=scheduler_output.preempted_req_ids or None,
+            # Only for true multi-group configs: shipping layer_to_group on
+            # single-group models flips the worker into HMA save mode and
+            # silently discards page-first (MLA) block striping.
+            layer_to_group=self._layer_to_group if self._num_groups > 1 else None,
+            group_layer_names=self._group_layer_names if self._num_groups > 1 else None,
         )
 
     def _consume_save_intent(self, req_id: str) -> SaveIntent | None:
@@ -409,48 +653,109 @@ class SchedulerConnector:
         if block_hashes is None:
             return None
 
+        # allocated is list[list[int]]: one list per kv_cache_group
         allocated = self._allocated_blocks.get(req_id, [])
         scheduled = self._scheduled_tokens.get(req_id, 0)
         base_block_idx = self._block_index_offsets.get(req_id, 0)
         start_block_idx = self._next_stored_block_idx.get(req_id, base_block_idx)
 
-        # _allocated_blocks tracks request block IDs in global request order.
-        # In external-hit cases, the prefix-loaded block IDs are still present at
-        # the front, so save intents must slice by global block index rather than
-        # rebasing to a local-only view.
-        local_saveable = min(
-            len(allocated),
-            scheduled // self._ctx.virtual_block_size,
-        )
-        saveable_block_idx = min(len(block_hashes), base_block_idx + local_saveable)
+        if not allocated:
+            return None
+
+        # Use virtual_block_size because block_hashes are at the scheduler hash
+        # granularity. In external-hit cases, scheduled tokens are local-only,
+        # so add the first local block index tracked during allocation.
+        local_ready_blocks = scheduled // self._ctx.virtual_block_size
+        saveable_block_idx = min(len(block_hashes), base_block_idx + local_ready_blocks)
+
+        # All groups allocate one block per scheduler block (uniform block
+        # granularity, enforced at init), so the per-group lists are
+        # POSITIONALLY parallel: entry p of every group covers the same
+        # token range as block_hashes[p]. Never save past what every group
+        # has an entry for.
+        saveable_block_idx = min(saveable_block_idx, min(len(g) for g in allocated))
         new_blocks = saveable_block_idx - start_block_idx
         if new_blocks <= 0:
             return None
 
-        self._next_stored_block_idx[req_id] = saveable_block_idx
-        hash_start = start_block_idx
-        save_hashes = block_hashes[hash_start : hash_start + new_blocks]
-        save_block_ids = allocated[hash_start : hash_start + new_blocks]
+        multi_group = self._num_groups > 1
+        if multi_group and self._gpu_block_pool is None:
+            # Without the pool we cannot tell whether a sliding-window
+            # block slid out (and its slot got reused) before this save —
+            # saving it would poison the store under a valid hash.
+            logger.warning(
+                "[PegaKVConnector] req=%s multi-group save skipped: GPU block pool not bound",
+                req_id,
+            )
+            self._next_stored_block_idx[req_id] = saveable_block_idx
+            return None
+
+        # A position is saved only when EVERY group still holds a live,
+        # hash-matching block for it, so every stored hash is complete
+        # across all layers (a partially-covered hash could serve garbage
+        # to the uncovered layers on a later load).
+        #   dead      (slid out / reused): skipped for all groups together
+        #             and never revisited — an unavoidable, correct hole.
+        #   transient (not sealed yet):    STOP here; the cursor does not
+        #             advance, so the position is retried next round
+        #             instead of being punched out of the hash chain.
+        # Positions that pass are ref-pinned until the async save copy
+        # completes (finished_sending) — otherwise a sliding-window block
+        # can slide out and be reused between this check and the DMA read.
+        save_hashes: list[bytes] = []
+        group_ids: list[list[int]] = [[] for _ in allocated]
+        skipped = 0
+        stop_at = saveable_block_idx
+        for p in range(start_block_idx, saveable_block_idx):
+            ids_p = [g[p] for g in allocated]
+            if multi_group:
+                states = [
+                    self._classify_block_for_save(gid, block_hashes[p], g_idx)
+                    for g_idx, gid in enumerate(ids_p)
+                ]
+                if "transient" in states and "dead" not in states:
+                    stop_at = p
+                    break
+                if "dead" in states:
+                    skipped += 1
+                    continue
+                blks = [self._gpu_block_pool.blocks[gid] for gid in ids_p]
+                if not self._pin_save_blocks(req_id, blks):
+                    logger.warning(
+                        "[PegaKVConnector] req=%s save skipped: block pool "
+                        "lacks ref-pin API; refusing unpinned async saves",
+                        req_id,
+                    )
+                    stop_at = p
+                    break
+            save_hashes.append(block_hashes[p])
+            for g_idx, gid in enumerate(ids_p):
+                group_ids[g_idx].append(gid)
+
+        self._next_stored_block_idx[req_id] = stop_at
+        if not save_hashes:
+            return None
 
         logger.debug(
-            "[PegaKVConnector] req=%s save_intent: start=%d hash_start=%d "
-            "base_block_idx=%d saveable_block_idx=%d new_blocks=%d total_hashes=%d",
+            "[PegaKVConnector] req=%s save_intent: start=%d saveable=%d "
+            "saved=%d skipped_stale=%d total_hashes=%d num_groups=%d",
             req_id,
-            hash_start,
-            hash_start,
-            base_block_idx,
+            start_block_idx,
             saveable_block_idx,
-            new_blocks,
+            len(save_hashes),
+            skipped,
             len(block_hashes),
+            len(allocated),
         )
 
         return SaveIntent(
-            block_ids=tuple(save_block_ids),
-            block_hashes=save_hashes,
+            group_block_ids=tuple(tuple(g) for g in group_ids),
+            block_hashes=tuple(save_hashes),
         )
 
     def update_connector_output(self, connector_output: "KVConnectorOutput") -> None:
         for req_id in connector_output.finished_sending or []:
+            self._unpin_save_blocks(req_id)
             self._pending_saves.discard(req_id)
             logger.debug("[PegaKVConnector] Request %s save completed", req_id)
 
@@ -481,6 +786,7 @@ class SchedulerConnector:
 
     def _cleanup_request(self, req_id: str) -> None:
         """Clean up all state for a completed request."""
+        self._unpin_save_blocks(req_id)
         self._release_pending_query_probe(req_id)
         self._requests.pop(req_id, None)
         self._block_hashes.pop(req_id, None)

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -550,7 +550,6 @@ class WorkerConnector:
         # when their pending group states drain; their failed block ids are
         # recorded immediately so vLLM recomputes those blocks either way.
         failed_ids_by_req: dict[str, list[int]] = {}
-        states_by_req: dict[str, list[PyLoadState]] = {}
         launched: list[tuple[str, PyLoadState, int, list[int], set[str]]] = []
 
         groups_launched = 0
@@ -633,8 +632,6 @@ class WorkerConnector:
                 continue
 
             req_ids = {req_id for req_id, _ in contribs}
-            for req_id in req_ids:
-                states_by_req.setdefault(req_id, []).append(load_state)
             launched.append((shm_name, load_state, load_start, all_block_ids, req_ids))
             groups_launched += 1
 
@@ -822,7 +819,16 @@ class WorkerConnector:
                         # blocks hold its KV; hashes are shared (positional).
                         g_idx = layer_to_group.get(layer_name, 0)
                         if g_idx >= len(save_intent.group_block_ids):
-                            g_idx = 0
+                            # Remapping to group 0 would save the WRONG
+                            # physical blocks under valid hashes.
+                            logger.warning(
+                                "[PegaKVConnector] save skipped for layer %s: "
+                                "group %d not in intent (%d groups)",
+                                layer_name,
+                                g_idx,
+                                len(save_intent.group_block_ids),
+                            )
+                            continue
                         layer_ids = save_intent.group_block_ids[g_idx]
                         layer_hashes = save_intent.block_hashes
                     else:

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -183,8 +183,11 @@ class WorkerConnector:
         self._save_completion_events: dict[str, threading.Event] = {}
         self._current_metadata: PegaConnectorMetadata | None = None
 
-        self._pending_loads: dict[str, PyLoadState] = {}
-        self._pending_load_reqs: dict[str, set[str]] = {}
+        # _pending_loads[req_id] = list of PyLoadState objects, one per kv_cache_group.
+        # A request is done loading only when ALL group states are ready.
+        self._pending_loads: dict[str, list[PyLoadState]] = {}
+        self._shm_to_load_state: dict[str, PyLoadState] = {}  # shm_name -> load_state
+        self._pending_load_reqs: dict[str, set[str]] = {}  # shm_name -> req_ids
         self._pending_load_meta: dict[
             str, tuple[float, int, list[int]]
         ] = {}  # shm_name -> (start_time, num_blocks, block_ids)
@@ -392,10 +395,10 @@ class WorkerConnector:
             load_stats_to_record: list[tuple[float, int, bool]] = []
             now = time.perf_counter()
 
-            for shm_name, req_ids in self._pending_load_reqs.items():
-                sample_req_id = next(iter(req_ids))
-                load_state = self._pending_loads.get(sample_req_id)
+            for shm_name, req_ids in list(self._pending_load_reqs.items()):
+                load_state = self._shm_to_load_state.get(shm_name)
                 if load_state is None:
+                    completed_shms.append(shm_name)
                     continue
 
                 meta = self._pending_load_meta.get(shm_name)
@@ -426,7 +429,6 @@ class WorkerConnector:
                         duration = now - start_time
                         load_stats_to_record.append((duration, num_blocks, success))
 
-                    completed_reqs.update(req_ids)
                     completed_shms.append(shm_name)
                 elif timed_out:
                     assert meta is not None
@@ -442,15 +444,25 @@ class WorkerConnector:
                     )
                     self._failed_load_block_ids.update(block_ids)
                     load_stats_to_record.append((duration, num_blocks, False))
-                    completed_reqs.update(req_ids)
                     completed_shms.append(shm_name)
                     timeout_triggered = True
+                else:
+                    continue
+
+                # Remove this group's load_state from each req's pending list.
+                # A request is fully done only when all group states are terminal.
+                for req_id in req_ids:
+                    states = self._pending_loads.get(req_id)
+                    if states is not None:
+                        self._pending_loads[req_id] = [ls for ls in states if ls is not load_state]
+                        if not self._pending_loads[req_id]:
+                            del self._pending_loads[req_id]
+                            completed_reqs.add(req_id)
 
             for shm_name in completed_shms:
-                shm_req_ids = self._pending_load_reqs.pop(shm_name, set())
+                self._pending_load_reqs.pop(shm_name, None)
+                self._shm_to_load_state.pop(shm_name, None)
                 self._pending_load_meta.pop(shm_name, None)
-                for req_id in shm_req_ids:
-                    self._pending_loads.pop(req_id, None)
 
             # Drain sync-failure reqs recorded by start_load_kv so they also
             # reach vLLM as finished_recving in this pass.
@@ -496,96 +508,170 @@ class WorkerConnector:
         total_requests = len(metadata.load_intents)
         load_start = time.perf_counter()
 
-        all_block_ids: list[int] = []
-        loads: list[tuple[bytes, list[int]]] = []
-        request_ids: list[str] = []
-
-        for req_id, load_intent in metadata.load_intents.items():
-            block_ids = list(load_intent.block_ids)
-            all_block_ids.extend(block_ids)
-            loads.append((load_intent.lease, block_ids))
-            request_ids.append(req_id)
-
-        if not all_block_ids:
-            return
-
+        # Layers per kv_cache_group. Without HMA metadata every layer maps
+        # to group 0 and this degenerates to the legacy single-RPC path.
+        # Cross-layer mode is only reachable single-group (the facade
+        # forces per-layer registration when kv_cache_groups > 1).
+        layer_to_group = metadata.layer_to_group
         if self._cross_layer_mode:
-            target_layers = [self._cross_layer_key]
+            layers_by_group: dict[int, list[str]] = {0: [self._cross_layer_key]}
+            num_groups = 1
         else:
             assert self._registered_layers, (
                 "KV caches must be registered before submitting load intents"
             )
-            target_layers = list(self._registered_layers)
+            if layer_to_group:
+                layers_by_group = {}
+                for layer_name in self._registered_layers:
+                    layers_by_group.setdefault(layer_to_group.get(layer_name, 0), []).append(
+                        layer_name
+                    )
+                num_groups = max(
+                    (len(li.group_block_ids) for li in metadata.load_intents.values()),
+                    default=1,
+                )
+            else:
+                layers_by_group = {0: list(self._registered_layers)}
+                num_groups = 1
 
-        if not target_layers:
-            return
+        def _real_ids(ids: list[int]) -> list[int]:
+            # Block 0 is vLLM's reserved null block: SWA groups carry it at
+            # out-of-window positions and the scheduler pads with it to match
+            # the lease length. It is never read, so it must not be reported
+            # as a failed (recompute-me) block.
+            return [b for b in ids if b != 0]
 
-        load_state = PyLoadState()
-        shm_name = load_state.shm_name()
+        # Per-request failure ids are gathered across ALL group RPCs and
+        # resolved only after the loop: a request whose other groups have
+        # in-flight loads must NOT be reported failed immediately, or
+        # get_finished reports it in finished_recving twice (once from the
+        # sync-failure drain, again when the pending shm completes) — vLLM
+        # asserts on the duplicate. Deferred requests surface exactly once,
+        # when their pending group states drain; their failed block ids are
+        # recorded immediately so vLLM recomputes those blocks either way.
+        failed_ids_by_req: dict[str, list[int]] = {}
+        states_by_req: dict[str, list[PyLoadState]] = {}
+        launched: list[tuple[str, PyLoadState, int, list[int], set[str]]] = []
 
-        try:
-            ok, message = self._ctx.engine_client.load(
-                self._ctx.instance_id,
-                self._ctx.effective_tp_rank,
-                self._ctx.device_id,
-                shm_name,
-                target_layers,
-                loads,
-            )
-        except Exception as e:
-            logger.error(
-                "[PegaKVConnector] Load RPC exception: %s (reqs=%s blocks=%d, "
-                "marking blocks as load errors)",
-                e,
-                request_ids,
-                len(all_block_ids),
-            )
-            self._release_load_leases(loads)
-            self._record_load_failure(request_ids, all_block_ids, load_start)
-            self._ctx.state_manager.mark_unavailable(f"load rpc exception: {e}")
-            return
+        groups_launched = 0
+        for g_idx in range(num_groups):
+            target_layers = layers_by_group.get(g_idx, [])
+            if not target_layers:
+                continue
 
-        if not ok:
-            logger.error(
-                "[PegaKVConnector] Load RPC failed: %s (reqs=%s blocks=%d, "
-                "marking blocks as load errors)",
-                message,
-                request_ids,
-                len(all_block_ids),
-            )
-            self._release_load_leases(loads)
-            self._record_load_failure(request_ids, all_block_ids, load_start)
-            self._ctx.state_manager.mark_unavailable(f"load rpc failed: {message}")
-            return
+            all_block_ids: list[int] = []
+            loads: list[tuple[bytes, list[int]]] = []
+            contribs: list[tuple[str, list[int]]] = []
+            for req_id, load_intent in metadata.load_intents.items():
+                groups = load_intent.group_block_ids
+                if g_idx >= len(groups):
+                    # This intent has no data for the group. Never clamp to
+                    # group 0: its lease was already consumed by the group-0
+                    # RPC and resubmitting it would fail the whole RPC.
+                    continue
+                block_ids = list(groups[g_idx])
+                if not block_ids:
+                    continue
+                lease = (
+                    load_intent.group_leases[g_idx]
+                    if g_idx < len(load_intent.group_leases)
+                    else b""
+                )
+                real = _real_ids(block_ids)
+                if not lease:
+                    # Lease mint failed scheduler-side.
+                    failed_ids_by_req.setdefault(req_id, []).extend(real)
+                    continue
+                if not real:
+                    # Every destination is the null block (a fully
+                    # out-of-window SWA slice): loading it moves no useful
+                    # bytes. Skip the work and release the lease.
+                    try:
+                        self._ctx.engine_client.release(lease)
+                    except Exception:
+                        logger.exception("[PegaKVConnector] null-slice lease release failed")
+                    continue
+                all_block_ids.extend(block_ids)
+                loads.append((lease, block_ids))
+                contribs.append((req_id, real))
 
-        num_layers = len(target_layers)
-        num_blocks = len(all_block_ids)
+            if not loads:
+                continue
 
-        schedule_end = time.perf_counter()
-        schedule_time_us = (schedule_end - load_start) * 1e6
+            load_state = PyLoadState()
+            shm_name = load_state.shm_name()
+            num_blocks = len(all_block_ids)
+
+            try:
+                ok, message = self._ctx.engine_client.load(
+                    self._ctx.instance_id,
+                    self._ctx.effective_tp_rank,
+                    self._ctx.device_id,
+                    shm_name,
+                    target_layers,
+                    loads,
+                )
+            except Exception as e:
+                ok, message = False, repr(e)
+
+            if not ok:
+                logger.error(
+                    "[PegaKVConnector] Load RPC failed: %s (group=%d blocks=%d, "
+                    "marking blocks as load errors)",
+                    message,
+                    g_idx,
+                    num_blocks,
+                )
+                self._release_load_leases(loads)
+                for req_id, real in contribs:
+                    failed_ids_by_req.setdefault(req_id, []).extend(real)
+                with self._stats_lock:
+                    self._stats.record_load(
+                        time.perf_counter() - load_start, num_blocks, success=False
+                    )
+                self._ctx.state_manager.mark_unavailable(f"load rpc failed: {message}")
+                continue
+
+            req_ids = {req_id for req_id, _ in contribs}
+            for req_id in req_ids:
+                states_by_req.setdefault(req_id, []).append(load_state)
+            launched.append((shm_name, load_state, load_start, all_block_ids, req_ids))
+            groups_launched += 1
 
         with self._load_completion_lock:
-            for req_id in request_ids:
-                self._pending_loads[req_id] = load_state
-            self._pending_load_reqs[shm_name] = set(request_ids)
-            # Keep load_start as the shared baseline so timeout and stats duration
-            # are comparable to the sync-failure path (which also uses load_start).
-            # all_block_ids is not mutated after this point; keep the reference
-            # instead of an extra defensive copy.
-            self._pending_load_meta[shm_name] = (
-                load_start,
-                num_blocks,
-                all_block_ids,
-            )
+            for shm_name, load_state, started, block_ids, req_ids in launched:
+                for req_id in req_ids:
+                    self._pending_loads.setdefault(req_id, []).append(load_state)
+                self._pending_load_reqs[shm_name] = set(req_ids)
+                self._shm_to_load_state[shm_name] = load_state
+                self._pending_load_meta[shm_name] = (
+                    started,
+                    len(block_ids),
+                    _real_ids(block_ids),
+                )
+            for req_id, ids in failed_ids_by_req.items():
+                # Recompute these blocks no matter what.
+                self._failed_load_block_ids.update(ids)
+                if not self._pending_loads.get(req_id):
+                    # No other group in flight: report the failure now.
+                    self._failed_load_reqs.add(req_id)
+                # else: the request completes exactly once when its pending
+                # group states drain in get_finished.
 
+        if failed_ids_by_req:
+            with self._stats_lock:
+                self._stats.record_load(
+                    time.perf_counter() - load_start,
+                    sum(len(v) for v in failed_ids_by_req.values()),
+                    success=False,
+                )
+
+        schedule_time_us = (time.perf_counter() - load_start) * 1e6
         logger.debug(
-            "[PegaKVConnector] started async load: %d blocks across %d layers for %d reqs, "
-            "schedule %.0f us, shm=%s",
-            num_blocks,
-            num_layers,
+            "[PegaKVConnector] started async load: %d group RPCs for %d reqs, schedule %.0f us",
+            groups_launched,
             total_requests,
             schedule_time_us,
-            shm_name,
         )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
@@ -694,11 +780,16 @@ class WorkerConnector:
         for task in batch:
             all_request_ids.extend(task.request_ids)
 
+            layer_to_group = task.metadata.layer_to_group
             for save_intent in task.metadata.save_intents.values():
-                if not save_intent.block_ids:
+                if not save_intent.group_block_ids:
                     continue
 
-                block_ids = save_intent.block_ids
+                # Group-0 view feeds the legacy single-group paths
+                # (cross-layer, page-first MLA striping); HMA metadata
+                # overrides per layer below. Multi-group never reaches
+                # cross-layer/page-first (both are single-group only).
+                block_ids = save_intent.group_block_ids[0]
                 block_hashes = save_intent.block_hashes
 
                 if self._cross_layer_mode:
@@ -722,15 +813,41 @@ class WorkerConnector:
                     )
                     target_layers = tuple(self._registered_layers)
 
-                if not block_ids:
+                if not block_ids and not layer_to_group:
                     continue
 
                 for layer_name in target_layers:
+                    if layer_to_group:
+                        # HMA: this layer's group decides which physical
+                        # blocks hold its KV; hashes are shared (positional).
+                        g_idx = layer_to_group.get(layer_name, 0)
+                        if g_idx >= len(save_intent.group_block_ids):
+                            g_idx = 0
+                        layer_ids = save_intent.group_block_ids[g_idx]
+                        layer_hashes = save_intent.block_hashes
+                    else:
+                        layer_ids = block_ids
+                        layer_hashes = block_hashes
+
+                    if not layer_ids:
+                        continue
+
+                    if len(layer_ids) != len(layer_hashes):
+                        logger.warning(
+                            "[PegaKVConnector] save_intent mismatch layer=%s "
+                            "block_count=%d hash_count=%d reqs=%s",
+                            layer_name,
+                            len(layer_ids),
+                            len(layer_hashes),
+                            task.request_ids,
+                        )
+                        continue
+
                     if layer_name not in saves_by_layer:
                         saves_by_layer[layer_name] = ([], [])
 
-                    saves_by_layer[layer_name][0].extend(block_ids)
-                    saves_by_layer[layer_name][1].extend(block_hashes)
+                    saves_by_layer[layer_name][0].extend(layer_ids)
+                    saves_by_layer[layer_name][1].extend(layer_hashes)
 
         if saves_by_layer:
             # Ensure all GPU kernels have completed before reading KV cache
@@ -844,12 +961,12 @@ class WorkerConnector:
         """
         tp_size = self._ctx.tp_size
         if tp_size <= 1:
-            return list(save_intent.block_ids), list(save_intent.block_hashes)
+            return list(save_intent.group_block_ids[0]), list(save_intent.block_hashes)
         tp_rank = self._ctx.tp_rank or 0
         ids: list[int] = []
         hashes: list[bytes] = []
         for block_id, block_hash in zip(
-            save_intent.block_ids, save_intent.block_hashes, strict=True
+            save_intent.group_block_ids[0], save_intent.block_hashes, strict=True
         ):
             if block_id % tp_size == tp_rank:
                 ids.append(block_id)

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -196,7 +196,7 @@ def test_page_first_block_shard_is_a_partition():
 
     block_ids = tuple(range(13))
     block_hashes = tuple(bytes([i]) for i in block_ids)
-    intent = SaveIntent(block_ids=block_ids, block_hashes=block_hashes)
+    intent = SaveIntent(group_block_ids=(tuple(block_ids),), block_hashes=block_hashes)
     tp_size = 4
 
     seen: list[int] = []
@@ -230,7 +230,7 @@ def test_page_first_saves_all_layers_for_this_ranks_block_stripe():
     meta = PegaConnectorMetadata(
         save_intents={
             "r1": SaveIntent(
-                block_ids=(0, 1, 2, 3),
+                group_block_ids=((0, 1, 2, 3),),
                 block_hashes=(b"h0", b"h1", b"h2", b"h3"),
             )
         }
@@ -272,7 +272,7 @@ def test_page_first_layer_split_saves_own_layers_for_all_blocks():
     meta = PegaConnectorMetadata(
         save_intents={
             "r1": SaveIntent(
-                block_ids=(0, 1, 2, 3),
+                group_block_ids=((0, 1, 2, 3),),
                 block_hashes=(b"h0", b"h1", b"h2", b"h3"),
             )
         }
@@ -334,12 +334,12 @@ class TestDecodeHashRefresh:
         blocks = _make_fake_blocks([10, 11, 12, 13])
 
         sc.update_state_after_alloc(req, blocks, num_external_tokens=0)
-        sc._allocated_blocks["r1"] = [10, 11, 12, 13]
+        sc._allocated_blocks["r1"] = [[10, 11, 12, 13]]
         sc._scheduled_tokens["r1"] = 128  # 4 * 32
 
         intent = sc._consume_save_intent("r1")
         assert intent is not None
-        assert len(intent.block_ids) == 4
+        assert len(intent.group_block_ids[0]) == 4
         assert len(intent.block_hashes) == 4
 
     def test_decode_blocks_saved_after_refresh(self):
@@ -350,18 +350,18 @@ class TestDecodeHashRefresh:
         blocks = _make_fake_blocks([10, 11, 12, 13])
 
         sc.update_state_after_alloc(req, blocks, num_external_tokens=0)
-        sc._allocated_blocks["r1"] = [10, 11, 12, 13]
+        sc._allocated_blocks["r1"] = [[10, 11, 12, 13]]
         sc._scheduled_tokens["r1"] = 128  # 4 * 32
 
         # Save initial 4 blocks
         intent = sc._consume_save_intent("r1")
         assert intent is not None
-        assert len(intent.block_ids) == 4
+        assert len(intent.group_block_ids[0]) == 4
 
         # Simulate decode: request grows by 2 blocks
         new_hashes = [_hash(i) for i in range(4, 6)]
         req.block_hashes.extend(new_hashes)  # live Request grows
-        sc._allocated_blocks["r1"].extend([14, 15])  # new block_ids
+        sc._allocated_blocks["r1"][0].extend([14, 15])  # new block_ids
         sc._scheduled_tokens["r1"] += 64  # 2 * 32 more tokens
 
         # Before refresh: _block_hashes is stale (4 entries) → no new saves
@@ -374,8 +374,8 @@ class TestDecodeHashRefresh:
         # Now the 2 decode blocks become saveable
         intent2 = sc._consume_save_intent("r1")
         assert intent2 is not None
-        assert len(intent2.block_ids) == 2
-        assert intent2.block_ids == (14, 15)
+        assert len(intent2.group_block_ids[0]) == 2
+        assert intent2.group_block_ids == ((14, 15),)
         assert intent2.block_hashes == (new_hashes[0], new_hashes[1])
 
     def test_cleanup_removes_request_ref(self):
@@ -401,23 +401,206 @@ class TestDecodeHashRefresh:
         sc._block_index_offsets["r1"] = 6
         sc._next_stored_block_idx["r1"] = 6
         sc._scheduled_tokens["r1"] = 48  # 3 virtual blocks beyond the external hit
+        sc._allocated_blocks["r1"] = [[100, 101, 102, 103, 104, 105, 200, 201, 202]]
+
+        intent = sc._consume_save_intent("r1")
+
+        assert intent is not None
+        assert intent.block_hashes == block_hashes[6:9]
+        assert intent.group_block_ids == ((200, 201, 202),)
+
+    @staticmethod
+    def _pool_block(plain_hash, group_idx, refs=None):
+        """Fake KVCacheBlock with vLLM's packed BlockHashWithGroupId bytes
+        (plain content hash + 4-byte big-endian group id) and the ref-pin
+        API the save path requires."""
+
+        class Blk:
+            def __init__(self):
+                self.is_null = False
+                self.block_hash = (
+                    plain_hash + group_idx.to_bytes(4, "big") if plain_hash is not None else None
+                )
+                self.ref_cnt = 1
+
+            def incr_ref(self):
+                self.ref_cnt += 1
+                if refs is not None:
+                    refs.append(self)
+
+            def decr_ref(self):
+                self.ref_cnt -= 1
+
+        return Blk()
+
+    def _six_group_pool(self, hashes, refs=None):
+        pool_blocks = {}
+        for g in range(6):
+            for p in range(len(hashes)):
+                bid = g * len(hashes) + p + 1
+                pool_blocks[bid] = self._pool_block(hashes[p], g, refs)
+        return pool_blocks
+
+    def test_six_group_swa_hybrid_save_skips_stale_positions(self):
+        """A Gemma-style hybrid yields 6 kv_cache_groups (5 SWA + 1 FA, FA
+        last). A position is stored only when EVERY group's block still
+        holds the expected content (pool hashes carry a 4-byte group-id
+        suffix); a slid-out SWA block whose slot was reused drops that
+        position for all groups, permanently."""
+        from types import SimpleNamespace as NS
+
+        sc = self._make_connector()
+        sc._num_groups = 6
+        hashes = tuple(_hash(i) for i in range(3))
+
+        pool_blocks = self._six_group_pool(hashes)
+        # An SWA group's position-0 block was freed and reused -> foreign hash.
+        pool_blocks[7] = self._pool_block(b"foreign-content-hash", 2)
+        sc.bind_gpu_block_pool(NS(blocks=pool_blocks, null_block=NS(block_id=0)))
+
+        sc._block_hashes["r1"] = hashes
+        sc._block_index_offsets["r1"] = 0
+        sc._next_stored_block_idx["r1"] = 0
+        sc._scheduled_tokens["r1"] = 3 * 32
+        sc._allocated_blocks["r1"] = [[g * 3 + p + 1 for p in range(3)] for g in range(6)]
+
+        intent = sc._consume_save_intent("r1")
+
+        assert intent is not None
+        # Position 0 dropped (group 2's block 7 was reused); 1 and 2 saved.
+        assert intent.block_hashes == hashes[1:3]
+        assert intent.group_block_ids == tuple((g * 3 + 2, g * 3 + 3) for g in range(6))
+        # Cursor advanced past the dead position: it is never revisited.
+        assert sc._next_stored_block_idx["r1"] == 3
+        assert sc._consume_save_intent("r1") is None
+
+    def test_six_group_save_stops_at_unsealed_position(self):
+        """A block that exists but is not hashed yet (freshly scheduled) is
+        TRANSIENT: the save stops there and the cursor does not advance, so
+        the position is retried next round instead of becoming a permanent
+        hole in the stored hash chain."""
+        from types import SimpleNamespace as NS
+
+        sc = self._make_connector()
+        sc._num_groups = 6
+        hashes = tuple(_hash(i) for i in range(3))
+
+        pool_blocks = self._six_group_pool(hashes)
+        pool_blocks[8] = self._pool_block(None, 2)  # position 1: not sealed yet
+        sc.bind_gpu_block_pool(NS(blocks=pool_blocks, null_block=NS(block_id=0)))
+
+        sc._block_hashes["r1"] = hashes
+        sc._block_index_offsets["r1"] = 0
+        sc._next_stored_block_idx["r1"] = 0
+        sc._scheduled_tokens["r1"] = 3 * 32
+        sc._allocated_blocks["r1"] = [[g * 3 + p + 1 for p in range(3)] for g in range(6)]
+
+        intent = sc._consume_save_intent("r1")
+
+        assert intent is not None
+        assert intent.block_hashes == hashes[0:1]
+        assert sc._next_stored_block_idx["r1"] == 1  # retry position 1 later
+
+        # The block seals -> the next round resumes from position 1.
+        pool_blocks[8].block_hash = hashes[1] + (2).to_bytes(4, "big")
+        intent2 = sc._consume_save_intent("r1")
+        assert intent2 is not None
+        assert intent2.block_hashes == hashes[1:3]
+        assert sc._next_stored_block_idx["r1"] == 3
+
+    def test_six_group_save_pins_blocks_until_send_completes(self):
+        """Saved positions are ref-pinned across the async copy and released
+        exactly once on finished_sending — the window where a slid-out SWA
+        block could be reused mid-DMA."""
+        from types import SimpleNamespace as NS
+
+        sc = self._make_connector()
+        sc._num_groups = 6
+        hashes = tuple(_hash(i) for i in range(2))
+
+        refs: list = []
+        pool_blocks = self._six_group_pool(hashes, refs)
+        sc.bind_gpu_block_pool(NS(blocks=pool_blocks, null_block=NS(block_id=0)))
+
+        sc._block_hashes["r1"] = hashes
+        sc._block_index_offsets["r1"] = 0
+        sc._next_stored_block_idx["r1"] = 0
+        sc._scheduled_tokens["r1"] = 2 * 32
+        sc._allocated_blocks["r1"] = [[g * 2 + p + 1 for p in range(2)] for g in range(6)]
+
+        intent = sc._consume_save_intent("r1")
+        assert intent is not None
+        assert len(refs) == 12  # 2 positions x 6 groups
+        assert all(b.ref_cnt == 2 for b in refs)
+
+        sc.update_connector_output(NS(finished_sending=["r1"], finished_recving=None))
+        assert all(b.ref_cnt == 1 for b in refs)
+        assert "r1" not in sc._pinned_save_blocks
+
+    def test_hybrid_save_positional_groups(self):
+        """Groups are positionally parallel: entry p of every group covers
+        the same token range as block_hashes[p] (vLLM 0.22 semantics —
+        SWA groups stay full-length with null padding, never suffix-only)."""
+        sc = self._make_connector()
+        block_hashes = tuple(_hash(i) for i in range(6))
+
+        sc._block_hashes["r1"] = block_hashes
+        sc._block_index_offsets["r1"] = 0
+        sc._next_stored_block_idx["r1"] = 0
+        sc._scheduled_tokens["r1"] = 6 * 32
         sc._allocated_blocks["r1"] = [
-            100,
-            101,
-            102,
-            103,
-            104,
-            105,
-            200,
-            201,
-            202,
+            [10, 11, 12, 13, 14, 15],
+            [30, 31, 32, 33, 34, 35],
+        ]
+
+        intent = sc._consume_save_intent("r1")
+
+        assert intent is not None
+        assert intent.block_hashes == block_hashes[0:6]
+        assert intent.group_block_ids == (
+            (10, 11, 12, 13, 14, 15),
+            (30, 31, 32, 33, 34, 35),
+        )
+
+    def test_hybrid_save_capped_by_shortest_group(self):
+        """A group that has fewer positional entries caps the save range."""
+        sc = self._make_connector()
+        block_hashes = tuple(_hash(i) for i in range(6))
+
+        sc._block_hashes["r1"] = block_hashes
+        sc._block_index_offsets["r1"] = 0
+        sc._next_stored_block_idx["r1"] = 0
+        sc._scheduled_tokens["r1"] = 6 * 32
+        sc._allocated_blocks["r1"] = [
+            [10, 11, 12, 13, 14, 15],
+            [30, 31, 32],
+        ]
+
+        intent = sc._consume_save_intent("r1")
+
+        assert intent is not None
+        assert intent.block_hashes == block_hashes[0:3]
+        assert intent.group_block_ids == ((10, 11, 12), (30, 31, 32))
+
+    def test_external_hit_hybrid_save_positional(self):
+        """External-hit save indexes every group by GLOBAL block position."""
+        sc = self._make_connector(dcp_world_size=1)
+        block_hashes = tuple(_hash(i) for i in range(9))
+
+        sc._block_hashes["r1"] = block_hashes
+        sc._block_index_offsets["r1"] = 6
+        sc._next_stored_block_idx["r1"] = 6
+        sc._scheduled_tokens["r1"] = 48
+        sc._allocated_blocks["r1"] = [
+            [100, 101, 102, 103, 104, 105, 200, 201, 202],
+            [300, 301, 302, 303, 304, 305, 306, 307, 308],
         ]
 
         intent = sc._consume_save_intent("r1")
 
         assert intent is not None
         assert intent.block_hashes == block_hashes[6:9]
-        assert intent.block_ids == (200, 201, 202)
+        assert intent.group_block_ids == ((200, 201, 202), (306, 307, 308))
 
     def test_save_only_mode_counts_precomputed_prefix_as_saveable(self):
         """NIXL-loaded prefix should be saveable in Pega save-only mode."""
@@ -450,7 +633,7 @@ class TestDecodeHashRefresh:
         metadata = sc.build_connector_meta(scheduler_output)
 
         intent = metadata.save_intents["r1"]
-        assert intent.block_ids == (10, 11, 12)
+        assert intent.group_block_ids[0] == (10, 11, 12)
         assert intent.block_hashes == tuple(block_hashes[:3])
 
     def test_save_only_mode_handles_full_prompt_hit_recompute_token(self):
@@ -481,7 +664,7 @@ class TestDecodeHashRefresh:
         metadata = sc.build_connector_meta(scheduler_output)
 
         intent = metadata.save_intents["r1"]
-        assert intent.block_ids == (10, 11, 12, 13)
+        assert intent.group_block_ids[0] == (10, 11, 12, 13)
         assert intent.block_hashes == tuple(block_hashes)
 
     def test_read_write_mode_does_not_save_unowned_precomputed_prefix(self):
@@ -540,7 +723,7 @@ class TestDecodeHashRefresh:
 
         intent = metadata.save_intents["r1"]
         assert intent.block_hashes == tuple(block_hashes[2:3])
-        assert intent.block_ids == (12,)
+        assert intent.group_block_ids[0] == (12,)
 
 
 class TestSchedulerQueryProbeReuse:
@@ -618,16 +801,36 @@ class TestSchedulerQueryProbeReuse:
 
         engine_client.release.assert_not_called()
 
-    def test_load_block_mismatch_releases_probe_and_raises(self):
+    def test_partial_accept_pads_destinations_to_lease_length(self):
+        """vLLM may accept fewer blocks than the leased hit (full-prompt
+        hits are trimmed so the last token is computed for logits). The
+        lease still covers the full hit, so destinations are padded with
+        the null block id (0) to satisfy the server's count contract."""
         sc, engine_client = self._make_connector()
         req = _make_fake_request("r1", [_hash(i) for i in range(2)])
         blocks = _make_fake_blocks([10, 11])
         blocks.blocks = [[SimpleNamespace(block_hash=None), SimpleNamespace(block_hash=None)]]
 
         assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
+        sc.update_state_after_alloc(req, blocks, num_external_tokens=16)
+
+        intent = sc._pending_load_intents["r1"]
+        assert intent.group_block_ids == ((10, 0),)
+        assert intent.num_tokens == 16
+        engine_client.release.assert_not_called()
+
+    def test_load_block_mismatch_releases_probe_and_raises(self):
+        """Allocation SHORTER than the accepted external range is a real
+        contract violation and still raises."""
+        sc, engine_client = self._make_connector()
+        req = _make_fake_request("r1", [_hash(i) for i in range(2)])
+        blocks = _make_fake_blocks([10])
+        blocks.blocks = [[SimpleNamespace(block_hash=None)]]
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
 
         with pytest.raises(RuntimeError, match="load block mismatch"):
-            sc.update_state_after_alloc(req, blocks, num_external_tokens=16)
+            sc.update_state_after_alloc(req, blocks, num_external_tokens=32)
 
         engine_client.release.assert_called_once_with(b"lease-1")
         assert "r1" not in sc._pending_query_probes

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -136,8 +136,8 @@ def _load_metadata(req_id: str, block_ids: tuple[int, ...]) -> PegaConnectorMeta
     return PegaConnectorMetadata(
         load_intents={
             req_id: LoadIntent(
-                block_ids=block_ids,
-                lease=f"lease-{req_id}".encode(),
+                group_block_ids=(block_ids,),
+                group_leases=(f"lease-{req_id}".encode(),),
                 num_tokens=len(block_ids) * 16,
             )
         }
@@ -440,3 +440,92 @@ def test_register_version_mismatch_rpc_error_stops_startup(monkeypatch):
     assert len(client.register_calls) == 1
 
     worker.shutdown()
+
+
+def test_partial_group_failure_reports_request_exactly_once(monkeypatch):
+    """HMA loads are one RPC per kv_cache_group. When one group fails
+    (e.g. its lease mint failed) while another group's load is in flight,
+    the request must surface in finished_recving exactly ONCE — after the
+    in-flight group drains — with the failed group's blocks reported for
+    recomputation. A premature duplicate report trips vLLM's scheduler
+    asserts."""
+
+    class ControllableLoadState:
+        instances: list = []
+
+        def __init__(self):
+            self.ready = False
+            ControllableLoadState.instances.append(self)
+
+        def shm_name(self) -> str:
+            return f"shm-{id(self)}"
+
+        def is_ready(self) -> bool:
+            return self.ready
+
+        def get_state(self) -> int:
+            return 1 if self.ready else 0
+
+    from pegaflow.connector import worker as worker_mod
+
+    monkeypatch.setattr(worker_mod, "PyLoadState", ControllableLoadState)
+
+    worker, client, _ = _make_worker()
+    worker._cross_layer_mode = False
+    worker._registered_layers = ["layer_a", "layer_b"]
+
+    meta = PegaConnectorMetadata(
+        load_intents={
+            "r1": LoadIntent(
+                group_block_ids=((1, 2), (3, 4)),
+                group_leases=(b"lease-0", b""),  # group-1 mint failed
+                num_tokens=32,
+            )
+        },
+        layer_to_group={"layer_a": 0, "layer_b": 1},
+        group_layer_names=[["layer_a"], ["layer_b"]],
+    )
+    worker.start_load_kv(meta, _stub_forward_context())
+
+    # Only the leased group launched an RPC.
+    assert len(client.load_calls) == 1
+    assert client.load_calls[0][4] == ["layer_a"]
+
+    # The failed group's blocks are recompute-marked immediately...
+    assert worker.get_block_ids_with_load_errors() == {3, 4}
+    # ...but the request is NOT reported while group-0 is still in flight.
+    _, recving = worker.get_finished(set())
+    assert not recving
+
+    # Group-0 completes -> exactly one finished_recving report.
+    ControllableLoadState.instances[0].ready = True
+    _, recving = worker.get_finished(set())
+    assert recving == {"r1"}
+    _, recving = worker.get_finished(set())
+    assert not recving
+
+
+def test_all_null_group_slice_releases_lease_without_rpc(monkeypatch):
+    """A group slice whose destinations are all the null block (a fully
+    out-of-window SWA window) moves no useful bytes: no RPC is issued and
+    the minted lease is released instead of leaking server-side."""
+    worker, client, _ = _make_worker()
+    worker._cross_layer_mode = False
+    worker._registered_layers = ["layer_a", "layer_b"]
+
+    meta = PegaConnectorMetadata(
+        load_intents={
+            "r1": LoadIntent(
+                group_block_ids=((1, 2), (0, 0)),
+                group_leases=(b"lease-0", b"lease-1"),
+                num_tokens=32,
+            )
+        },
+        layer_to_group={"layer_a": 0, "layer_b": 1},
+        group_layer_names=[["layer_a"], ["layer_b"]],
+    )
+    worker.start_load_kv(meta, _stub_forward_context())
+
+    assert len(client.load_calls) == 1
+    assert client.load_calls[0][4] == ["layer_a"]
+    assert client.release_calls == [b"lease-1"]


### PR DESCRIPTION
## What

Adds vLLM **hybrid memory allocator (HMA)** support to `PegaKVConnector`: models that mix sliding-window and full attention (Gemma-style 5:1 layouts and similar) currently cannot use PegaFlow at all — vLLM refuses to combine a non-`SupportsHMA` connector with the hybrid KV cache manager, and disabling the manager makes SWA models allocate full-window KV.

Closes #228. Builds on and supersedes #202 — thanks @xiaguan for the groundwork; this rework exists because the on-GPU group semantics turned out to be different from what #202 assumed (details below).

## Design

Observed semantics on vLLM 0.22.1 (`KVCacheBlocks`, `SlidingWindowManager`, and the in-tree HMA reference `SimpleCPUOffloadConnector`):

- **Per-group block lists are positional, not suffix-shortened.** SWA groups keep full-length lists with the *null block* filling out-of-window positions. So all alignment here is by block position, shared with the (single) hash stream. #202's common-suffix arithmetic was replaced accordingly.
- **Group counts are model-derived.** A 48-layer 5:1 hybrid yields **6** groups (5 SWA + 1 full-attention), and the full-attention group is **last** — nothing assumes 2 groups or that group 0 is full attention. The locally-computed prefix is measured on the FA group (SWA groups under-count: masked positions lose their hashes).
- **Loads are one RPC per kv_cache_group**, each group's layers paired with that group's destination block ids. The engine **consumes a query lease on first use**, so the scheduler mints one lease per group (extra `query_prefetch` over the already-resident range); a failed mint degrades to reporting that group's real destinations as load errors, which vLLM recomputes.
- **Null-padded destinations preserve the lease contract.** vLLM trims full-prompt hits by one block (logits) and SWA groups don't allocate out-of-window positions; destination lists are padded with the null block id up to the lease length. The null block is never read by the model, so the extra DMA is harmless and `len(lease hashes) == len(destinations)` holds.
- **Saves are gated per position on ALL groups** via `bind_gpu_block_pool`, with three-state classification: *valid* positions are **ref-pinned until `finished_sending`** (the save copy is asynchronous — without the pin, a sliding-window block can slide out and be reused mid-DMA, storing foreign bytes under a valid hash); *transient* positions (allocated but not yet sealed/hashed) stop the cursor and retry next round instead of punching permanent holes in the hash chain; *dead* positions (slid out / reused — pool hash carries vLLM's 4-byte group-id suffix, stripped and verified) are skipped for all groups together so every stored hash is complete across all layers.
- **Partial group failures surface exactly once.** Loads being per-group RPCs means one group can fail while another is in flight; failed groups' blocks are recompute-marked immediately, but the request is reported in `finished_recving` only after its in-flight group states drain (a premature duplicate report trips vLLM's scheduler asserts). Fully-out-of-window SWA slices (all-null destinations) skip their RPC and release the minted lease.
- **Non-attention groups are refused loudly.** In multi-group configs only `FullAttentionSpec` + `SlidingWindowSpec` are accepted — Mamba/SSM or cross-attention state must not be saved/loaded as positional KV. Single-group models are untouched (including MLA page-first striping, which stays on the legacy path).
- **Safety rails:** the storage namespace gains a kv-group-signature factor (two group layouts must never share blocks); cross-layer registration is forced off for multi-group; heterogeneous per-group block sizes are **rejected loudly at init** — supporting them needs per-group hash granularity and is called out as future work rather than silently corrupting hash↔block mappings.
- `request_finished_all_groups` is implemented; `world_size` stays the true worker count (after #346 the server seals topology from registered layers, so #202's `world_size * num_groups` is no longer needed).

## Validation

- Full python unit suite passes; new tests cover positional multi-group saves, shortest-group capping, external-hit positional indexing, a 6-group SWA-hybrid save with a reused block (group-id-suffixed pool hashes, permanent skip), transient-position cursor stop/resume, ref-pin bookkeeping across `finished_sending`, exactly-once reporting under partial group failure, all-null-slice lease release, and partial-accept destination padding.
- Live on vLLM 0.22.1 (RTX 3090):
  - dense model: cross-restart prefix reuse, 335/335 blocks, ~0.2 s vs ~2.5 s cold;
  - 48-layer 5:1 SWA hybrid (hybrid manager disabled, single-group — the heterogeneous-block-size case): cross-restart reuse 264/265 blocks, 0.52 s vs 4.09 s cold, **byte-identical output**.
- We were not able to run the repo's exact `test_vllm_e2e_correctness.py` gate (no `/data/models/Qwen3-4B` here); happy to iterate if CI or a reviewer run surfaces anything.

## Limitations / future work

- Heterogeneous per-group block sizes (e.g. a full-attention group with fewer bytes/token getting larger blocks under uniform-page-size grouping) are detected and refused. Supporting them needs per-group hash striding and likely per-group-class layer topologies.
- Out-of-window SWA loads currently DMA into the null block (correct but wasted bandwidth on long prefixes); trailing-window leases per SWA group would trim that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
