### PR TITLE
feat(connector): share sleep-mode (cumem/VMM) KV via exported POSIX-FD handles

### DIFF
--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -160,6 +160,7 @@ class PegaKVConnector(KVConnectorBase_V1):
                 vllm_config=vllm_config,
                 kv_cache_config=kv_cache_config,
             )
+            _install_worker_sleep_rpc()
 
         logger.debug(
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
@@ -228,6 +229,22 @@ class PegaKVConnector(KVConnectorBase_V1):
     def unregister_context(self) -> None:
         if self._worker:
             self._worker.unregister_context()
+
+    # Sleep/wake lifecycle for VMM-IPC (sleep-mode) KV: call through
+    # vLLM's /collective_rpc via a thin Worker passthrough, e.g.
+    #   def pegaflow_sleep_unregister(self):
+    #       return get_kv_transfer_group().pegaflow_sleep_unregister()
+    def pegaflow_sleep_unregister(self) -> str:
+        if self._worker:
+            self._worker.unregister_for_sleep()
+            return "ok"
+        return "no-worker"
+
+    def pegaflow_wake_reregister(self) -> str:
+        if self._worker:
+            self._worker.reregister_after_wake()
+            return "ok"
+        return "no-worker"
 
     def handle_preemptions(self, preempted) -> None:
         if not self._worker:
@@ -385,6 +402,48 @@ class NoopKVConnector(KVConnectorBase_V1):
 
     def build_connector_meta(self, scheduler_output) -> PegaConnectorMetadata:
         return PegaConnectorMetadata()
+
+
+def _install_worker_sleep_rpc() -> None:
+    """Expose the VMM-IPC sleep/wake lifecycle over vLLM's /collective_rpc.
+
+    collective_rpc dispatches string method names on the Worker object, so
+    without these passthroughs pegaflow_sleep_unregister /
+    pegaflow_wake_reregister would be unreachable and a sleeping engine
+    would keep its KV VRAM pinned by the server's imported VMM mappings.
+    Installed at worker-role connector construction: the Worker class is
+    already imported there, and processes without PegaFlow pay nothing."""
+    try:
+        from vllm.v1.worker.gpu_worker import Worker
+    except ImportError:
+        return
+    if hasattr(Worker, "pegaflow_sleep_unregister"):
+        return
+
+    def pegaflow_sleep_unregister(self):
+        from vllm.distributed.kv_transfer.kv_transfer_state import (
+            get_kv_transfer_group,
+            has_kv_transfer_group,
+        )
+
+        if not has_kv_transfer_group():
+            return "no-connector"
+        fn = getattr(get_kv_transfer_group(), "pegaflow_sleep_unregister", None)
+        return fn() if fn else "unsupported"
+
+    def pegaflow_wake_reregister(self):
+        from vllm.distributed.kv_transfer.kv_transfer_state import (
+            get_kv_transfer_group,
+            has_kv_transfer_group,
+        )
+
+        if not has_kv_transfer_group():
+            return "no-connector"
+        fn = getattr(get_kv_transfer_group(), "pegaflow_wake_reregister", None)
+        return fn() if fn else "unsupported"
+
+    Worker.pegaflow_sleep_unregister = pegaflow_sleep_unregister
+    Worker.pegaflow_wake_reregister = pegaflow_wake_reregister
 
 
 def _resolve_device_id() -> int:

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -217,16 +217,74 @@ class WorkerConnector:
         self._save_queue.put(None)
         self._save_thread.join()
 
-    def unregister_context(self) -> None:
+    def unregister_context(self) -> bool:
+        # Exported VMM FDs belong to the registration lifetime: they pin
+        # the cumem physical memory, so EVERY teardown path must close
+        # them, not just the explicit sleep path.
+        self._close_exported_fds()
         if not self._registered_layers:
-            return
+            return True
 
+        ok = True
         if self._ctx.tp_rank == 0:
             ok, message = self._ctx.engine_client.unregister_context(self._ctx.instance_id)
             if not ok:
                 logger.warning("[PegaKVConnector] Unregister context failed: %s", message)
 
         self._registered_layers.clear()
+        return ok
+
+    @staticmethod
+    def _close_exported_fds() -> None:
+        from pegaflow.vmm_ipc import _FdServer
+
+        if _FdServer.has_instance():
+            _FdServer.instance().close_all()
+
+    def _drain_saves(self, timeout: float = 60.0) -> bool:
+        """Block until every queued save batch has been processed (the save
+        RPC inside _process_save_batch is synchronous, so afterwards the
+        server is not reading this worker's GPU memory for saves)."""
+        deadline = time.perf_counter() + timeout
+        while self._save_queue.unfinished_tasks:
+            if time.perf_counter() >= deadline:
+                return False
+            time.sleep(0.05)
+        return True
+
+    # --- sleep/wake lifecycle (invoked via vLLM's /collective_rpc) -------
+    # An imported VMM handle refcounts the exporter's physical memory, so
+    # BEFORE vLLM sleeps the server must drop its mappings (unregister) and
+    # this worker must close its exported FDs — otherwise sleep frees
+    # nothing. Wake maps fresh physical chunks into the SAME virtual
+    # addresses, so re-registration re-exports the same tensor objects.
+
+    def unregister_for_sleep(self) -> None:
+        """Raises on failure so the /collective_rpc caller sees a non-OK
+        response and refuses to sleep — sleeping with live server mappings
+        would free no VRAM while reporting success."""
+        if not self._drain_saves():
+            raise RuntimeError(
+                "pegaflow: async saves did not drain; refusing to unregister "
+                "for sleep while the server may still read GPU memory"
+            )
+        if not self.unregister_context():
+            raise RuntimeError(
+                "pegaflow: server unregister failed; sleeping now would keep "
+                "the server's imported VMM mappings pinning KV VRAM"
+            )
+        logger.info(
+            "[PegaKVConnector] unregistered for sleep "
+            "(saves drained, server mappings dropped, exported FDs closed)"
+        )
+
+    def reregister_after_wake(self) -> None:
+        kv_caches = getattr(self, "_last_registered_kv_caches", None)
+        if not kv_caches:
+            logger.warning("[PegaKVConnector] reregister_after_wake: no cached kv_caches; skipping")
+            return
+        self.register_kv_caches(kv_caches)
+        logger.info("[PegaKVConnector] re-registered %d KV caches after wake", len(kv_caches))
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register exactly the KV caches vLLM built on this device.
@@ -238,6 +296,10 @@ class WorkerConnector:
         assert self._ctx.device_id is not None, (
             "CUDA device id is unknown; cannot register KV caches"
         )
+        # Cached for reregister_after_wake: the cumem allocator keeps
+        # virtual addresses stable across sleep/wake, so the SAME tensor
+        # objects re-register with fresh physical handles.
+        self._last_registered_kv_caches = dict(kv_caches)
 
         if self._use_mla_layer_split_registration:
             kv_cache_tensors = getattr(self._kv_cache_config, "kv_cache_tensors", None)
@@ -288,7 +350,16 @@ class WorkerConnector:
                 f"KV cache for {layer_name} must have zero storage offset"
             )
 
-            wrapper = CudaIPCWrapper(kv_cache)
+            # Sleep-mode (cumem/VMM) tensors have no legacy IPC handles —
+            # share them via exported POSIX-FD handles instead. On any
+            # registration failure the caller's except path below closes
+            # the published exports (they pin physical memory).
+            from pegaflow.vmm_ipc import VmmCudaIPCWrapper, is_cumem_tensor
+
+            if is_cumem_tensor(kv_cache):
+                wrapper = VmmCudaIPCWrapper(kv_cache)
+            else:
+                wrapper = CudaIPCWrapper(kv_cache)
             wrapper_bytes = pickle.dumps(wrapper)
 
             registration = _infer_kv_cache_registration(
@@ -318,28 +389,35 @@ class WorkerConnector:
                     registration.num_blocks,
                 )
 
-        ok, message = self._ctx.engine_client.register_context_batch(
-            self._ctx.instance_id,
-            self._ctx.namespace,
-            self._ctx.effective_tp_rank,
-            self._ctx.pp_rank,
-            self._ctx.effective_tp_size,
-            self._ctx.world_size,
-            self._ctx.device_id,
-            layer_names,
-            ipc_wrappers,
-            layer_num_blocks,
-            layer_bytes_per_block,
-            layer_kv_stride_bytes,
-            layer_segments,
-            self._ctx.transfer_backend,
-            self._page_first,
-        )
-
-        if not ok:
-            if "PegaFlow version mismatch" in message:
-                raise RuntimeError(f"Register context failed: {message}")
-            raise RuntimeError(f"Register context batch failed for layers {layer_names}: {message}")
+        try:
+            ok, message = self._ctx.engine_client.register_context_batch(
+                self._ctx.instance_id,
+                self._ctx.namespace,
+                self._ctx.effective_tp_rank,
+                self._ctx.pp_rank,
+                self._ctx.effective_tp_size,
+                self._ctx.world_size,
+                self._ctx.device_id,
+                layer_names,
+                ipc_wrappers,
+                layer_num_blocks,
+                layer_bytes_per_block,
+                layer_kv_stride_bytes,
+                layer_segments,
+                self._ctx.transfer_backend,
+                self._page_first,
+            )
+            if not ok:
+                if "PegaFlow version mismatch" in message:
+                    raise RuntimeError(f"Register context failed: {message}")
+                raise RuntimeError(
+                    f"Register context batch failed for layers {layer_names}: {message}"
+                )
+        except Exception:
+            # Exported VMM FDs pin the cumem physical memory; a failed (or
+            # retried) registration must not leak them.
+            self._close_exported_fds()
+            raise
 
         if split_layer_count:
             logger.info(

--- a/python/pegaflow/vmm_ipc.py
+++ b/python/pegaflow/vmm_ipc.py
@@ -121,7 +121,15 @@ class _FdServer:
                 # kill (broad except) this thread — a dead handoff thread
                 # hangs every later registration.
                 conn.settimeout(5.0)
-                token = conn.recv(64).decode(errors="replace")
+                # SOCK_STREAM is not message-framed: read the fixed-length
+                # 32-byte token (uuid4().hex) fully before the lookup.
+                buf = b""
+                while len(buf) < 32:
+                    chunk = conn.recv(32 - len(buf))
+                    if not chunk:
+                        break
+                    buf += chunk
+                token = buf.decode(errors="replace")
                 with self._exports_lock:
                     exp = self._exports.get(token)
                     # Send under the lock with a dup: close_all may close
@@ -161,10 +169,25 @@ class _FdServer:
                 return token
         fd = export_fd()
         with self._exports_lock:
+            # Re-check: a concurrent publisher may have won while we
+            # minted; keeping both would leak a memory-pinning FD.
+            token = self._token_by_dmem.get(d_mem)
+            if token is not None and token in self._exports:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                return token
             token = uuid.uuid4().hex
             self._exports[token] = _Export(fd=fd, d_mem=d_mem, size=size)
             self._token_by_dmem[d_mem] = token
             return token
+
+    def close(self) -> None:
+        """Close exports and the listening socket, ending the accept loop
+        (tests create private instances; the process singleton lives for
+        the worker lifetime)."""
+        self.close_all()
+        with contextlib.suppress(OSError):
+            self._sock.close()
 
     def close_all(self) -> None:
         """Drop every exported FD. MUST run before vLLM sleeps: an exported
@@ -312,15 +335,19 @@ def _import_mapping(uds_path: str, token: str, size: int, device_index: int) -> 
         if cached is not None:
             return cached
 
+    fd_size = array.array("i").itemsize
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
+        # A wedged/dead handoff peer must fail the registration, not hang
+        # the server's embedded interpreter.
+        s.settimeout(10.0)
         s.connect(uds_path)
         s.sendall(token.encode())
-        msg, ancillary, _, _ = s.recvmsg(1, socket.CMSG_SPACE(4))
+        msg, ancillary, _, _ = s.recvmsg(1, socket.CMSG_SPACE(fd_size))
         if msg != b"F" or not ancillary:
             raise RuntimeError(f"FD handoff failed for token {token!r}")
         fds = array.array("i")
-        fds.frombytes(ancillary[0][2][:4])
+        fds.frombytes(ancillary[0][2][:fd_size])
         fd = fds[0]
     finally:
         s.close()
@@ -331,8 +358,10 @@ def _import_mapping(uds_path: str, token: str, size: int, device_index: int) -> 
     mapped = False
     try:
         _check(
+            # osHandle is a void*-sized parameter carrying the fd value;
+            # c_void_p keeps the call ABI-correct on all platforms.
             cuda.cuMemImportFromShareableHandle(
-                ctypes.byref(handle), ctypes.c_int(fd), _CU_MEM_HANDLE_TYPE_POSIX_FD
+                ctypes.byref(handle), ctypes.c_void_p(fd), _CU_MEM_HANDLE_TYPE_POSIX_FD
             ),
             "cuMemImportFromShareableHandle",
         )
@@ -363,8 +392,15 @@ def _import_mapping(uds_path: str, token: str, size: int, device_index: int) -> 
         raise
 
     mapping = _Mapping(va.value, size, handle.value, fd)
+
+    def _drop_entry(_ref, _token=token):
+        with _mappings_lock:
+            if _mappings.get(_token) is _ref:
+                del _mappings[_token]
+
     with _mappings_lock:
-        _mappings[token] = weakref.ref(mapping)
+        ref = weakref.ref(mapping, _drop_entry)
+        _mappings[token] = ref
     logger.info(
         "[pegaflow.vmm] imported %d bytes on device %d (token %s)", size, device_index, token[:8]
     )

--- a/python/pegaflow/vmm_ipc.py
+++ b/python/pegaflow/vmm_ipc.py
@@ -1,0 +1,399 @@
+"""CUDA VMM (cuMemCreate) cross-process sharing for sleep-mode KV caches.
+
+vLLM's --enable-sleep-mode allocates KV under its cumem allocator; legacy
+CUDA IPC (storage._share_cuda_()) cannot share those allocations, so
+PegaFlow registration used to die with "invalid argument". This module
+shares them the VMM way instead:
+
+  worker:  cuMemExportToShareableHandle(POSIX_FD)  [stock vLLM allocations
+           are exportable on any GPU whose driver reports fabric/posix
+           handle support — the C extension requests the type at create]
+  handoff: unix socket + SCM_RIGHTS (pidfd_getfd is blocked between
+           sibling processes under yama ptrace_scope=1)
+  server:  cuMemImportFromShareableHandle + cuMemAddressReserve + cuMemMap
+           inside pegaflow-server's embedded python; the returned object
+           duck-types the registry contract (data_ptr / device.index /
+           untyped_storage().nbytes).
+
+Sleep/wake lifecycle (driven by the orchestrator via /collective_rpc):
+an imported handle REFCOUNTS the physical memory, so the server must drop
+its mappings and the worker must close its exported FDs BEFORE vLLM
+sleeps, or sleep frees nothing. Wake maps fresh physical chunks into the
+SAME virtual addresses (tensor objects stay valid), so re-registration
+just re-exports and re-registers the same tensors.
+"""
+
+from __future__ import annotations
+
+import array
+import contextlib
+import ctypes
+import os
+import socket
+import threading
+import uuid
+import weakref
+from dataclasses import dataclass
+
+from pegaflow.logging_utils import get_connector_logger
+
+logger = get_connector_logger()
+
+_CU_MEM_HANDLE_TYPE_POSIX_FD = 1
+_CU_MEM_LOCATION_TYPE_DEVICE = 1
+_CU_MEM_ACCESS_FLAGS_READWRITE = 3
+
+
+class _AccessDesc(ctypes.Structure):
+    _fields_ = [("loc_type", ctypes.c_int), ("loc_id", ctypes.c_int), ("flags", ctypes.c_int)]
+
+
+_libcuda = None
+
+
+def _cuda() -> ctypes.CDLL:
+    global _libcuda
+    if _libcuda is None:
+        _libcuda = ctypes.CDLL("libcuda.so.1")
+    return _libcuda
+
+
+def _check(rc: int, what: str) -> None:
+    if rc != 0:
+        raise RuntimeError(f"{what} failed: CUresult={rc}")
+
+
+# --------------------------------------------------------------------------
+# Worker side: export + FD handoff server
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class _Export:
+    fd: int
+    d_mem: int
+    size: int
+
+
+class _FdServer:
+    """One per worker process: serves exported allocation FDs over an
+    abstract unix socket. The server connects during registration, sends a
+    token, and receives the FD via SCM_RIGHTS."""
+
+    _instance: _FdServer | None = None
+    _lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self.path = f"\0pegaflow-vmm-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+        self._exports: dict[str, _Export] = {}
+        # One export per cumem allocation, shared by every KV tensor inside
+        # it: d_mem -> token of the existing export.
+        self._token_by_dmem: dict[int, str] = {}
+        self._exports_lock = threading.Lock()
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._sock.bind(self.path)
+        self._sock.listen(16)
+        t = threading.Thread(target=self._serve, name="pegaflow-vmm-fds", daemon=True)
+        t.start()
+
+    @classmethod
+    def has_instance(cls) -> bool:
+        with cls._lock:
+            return cls._instance is not None
+
+    @classmethod
+    def instance(cls) -> _FdServer:
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = _FdServer()
+            return cls._instance
+
+    def _serve(self) -> None:
+        while True:
+            try:
+                conn, _ = self._sock.accept()
+            except OSError:
+                return
+            try:
+                # Abstract sockets have no filesystem permissions: any local
+                # process can connect. The 128-bit token is the secret, and
+                # the connection must never be able to wedge (timeout) or
+                # kill (broad except) this thread — a dead handoff thread
+                # hangs every later registration.
+                conn.settimeout(5.0)
+                token = conn.recv(64).decode(errors="replace")
+                with self._exports_lock:
+                    exp = self._exports.get(token)
+                    # Send under the lock with a dup: close_all may close
+                    # the original fd concurrently, and the fd NUMBER can
+                    # be reused by a new export — sending a dup taken
+                    # while the export is provably alive cannot hand out
+                    # the wrong descriptor.
+                    dup_fd = os.dup(exp.fd) if exp is not None else -1
+                if dup_fd < 0:
+                    conn.sendall(b"E")
+                else:
+                    try:
+                        conn.sendmsg(
+                            [b"F"],
+                            [
+                                (
+                                    socket.SOL_SOCKET,
+                                    socket.SCM_RIGHTS,
+                                    array.array("i", [dup_fd]).tobytes(),
+                                )
+                            ],
+                        )
+                    finally:
+                        os.close(dup_fd)
+            except Exception:
+                logger.exception("[pegaflow.vmm] fd handoff request failed")
+            finally:
+                conn.close()
+
+    def publish_allocation(self, d_mem: int, size: int, export_fd) -> str:
+        """Publish (or reuse) the export for the allocation at d_mem.
+        export_fd is a callable minting the FD only when a new export is
+        actually needed."""
+        with self._exports_lock:
+            token = self._token_by_dmem.get(d_mem)
+            if token is not None and token in self._exports:
+                return token
+        fd = export_fd()
+        with self._exports_lock:
+            token = uuid.uuid4().hex
+            self._exports[token] = _Export(fd=fd, d_mem=d_mem, size=size)
+            self._token_by_dmem[d_mem] = token
+            return token
+
+    def close_all(self) -> None:
+        """Drop every exported FD. MUST run before vLLM sleeps: an exported
+        FD holds a reference to the physical memory."""
+        with self._exports_lock:
+            for exp in self._exports.values():
+                with contextlib.suppress(OSError):
+                    os.close(exp.fd)
+            self._exports.clear()
+            self._token_by_dmem.clear()
+
+
+def _find_cumem_allocation(storage_ptr: int):
+    """(d_mem, size, p_memHandle) of the vLLM cumem allocation covering
+    storage_ptr, or None if the pointer is not cumem-managed."""
+    try:
+        from vllm.device_allocator.cumem import CuMemAllocator
+    except ImportError:
+        return None
+    try:
+        alloc = CuMemAllocator.get_instance()
+    except Exception:
+        return None
+    for _, data in alloc.pointer_to_data.items():
+        device, size, d_mem, p_mem_handle = data.handle
+        if d_mem <= storage_ptr < d_mem + size:
+            return d_mem, size, p_mem_handle
+    return None
+
+
+def is_cumem_tensor(tensor) -> bool:
+    """True only for tensors provably inside a vLLM cumem allocation;
+    anything unreadable (test fakes, CPU tensors) takes the legacy path."""
+    try:
+        ptr = tensor.untyped_storage().data_ptr()
+    except (AttributeError, RuntimeError):
+        return False
+    return _find_cumem_allocation(ptr) is not None
+
+
+class VmmCudaIPCWrapper:
+    """Drop-in sibling of CudaIPCWrapper for cumem (sleep-mode) tensors.
+
+    Pickled to the server; to_tensor() runs THERE and returns a duck-typed
+    mapped view (registry only needs data_ptr / device.index /
+    untyped_storage().nbytes)."""
+
+    def __init__(self, tensor) -> None:
+        from pegaflow.ipc_wrapper import CudaIPCWrapper
+
+        storage = tensor.untyped_storage()
+        assert tensor.storage_offset() == 0, "Tensor must have zero storage offset"
+        found = _find_cumem_allocation(storage.data_ptr())
+        if found is None:
+            raise RuntimeError("tensor is not managed by the vLLM cumem allocator")
+        d_mem, size, p_mem_handle = found
+
+        def _export_fd() -> int:
+            # The generic allocation handle lives at the C-side pointer
+            # vLLM hands back to python; re-read AT EXPORT TIME — wake_up
+            # creates a fresh physical handle at the same address after
+            # every sleep.
+            generic = ctypes.c_uint64.from_address(p_mem_handle).value
+            fd = ctypes.c_int(-1)
+            rc = _cuda().cuMemExportToShareableHandle(
+                ctypes.byref(fd), ctypes.c_uint64(generic), _CU_MEM_HANDLE_TYPE_POSIX_FD, 0
+            )
+            if rc != 0:
+                raise RuntimeError(
+                    f"cuMemExportToShareableHandle failed (CUresult={rc}): the "
+                    "allocation was not created with an exportable handle type. "
+                    "vLLM's cumem allocator requests one only when the driver "
+                    "reports CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED "
+                    "(observed true on recent drivers even for consumer GPUs); "
+                    "on this platform sleep-mode KV cannot be shared with "
+                    "PegaFlow — disable sleep mode or the connector."
+                )
+            return fd.value
+
+        server = _FdServer.instance()
+        self.token = server.publish_allocation(d_mem, size, _export_fd)
+
+        self.uds_path = server.path
+        self.alloc_size = size
+        self.offset = storage.data_ptr() - d_mem
+        self.nbytes = storage.nbytes()
+        self.device_uuid = CudaIPCWrapper._get_device_uuid(tensor.device.index)
+
+    # ---- server side ----
+    def to_tensor(self):
+        device_index = _resolve_device_index(self.device_uuid)
+        mapping = _import_mapping(self.uds_path, self.token, self.alloc_size, device_index)
+        return _VmmMappedView(mapping, self.offset, self.nbytes, device_index)
+
+
+def _resolve_device_index(device_uuid: str) -> int:
+    from pegaflow.ipc_wrapper import CudaIPCWrapper
+
+    return CudaIPCWrapper._get_device_index_from_uuid(device_uuid)
+
+
+# --------------------------------------------------------------------------
+# Server side: import + mapping cache (one mapping per allocation, shared
+# by every layer wrapper that lives inside it)
+# --------------------------------------------------------------------------
+
+
+class _Mapping:
+    """Released when the LAST view holding it is garbage-collected — the
+    registry's drop_instance decrefs its held views and runs gc.collect(),
+    which is exactly the moment the server must stop pinning the worker's
+    physical memory (so sleep can actually free VRAM)."""
+
+    def __init__(self, va: int, size: int, handle: int, fd: int) -> None:
+        self.va, self.size, self.handle, self.fd = va, size, handle, fd
+        self._released = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        cuda = _cuda()
+        try:
+            cuda.cuMemUnmap(ctypes.c_uint64(self.va), ctypes.c_size_t(self.size))
+            cuda.cuMemAddressFree(ctypes.c_uint64(self.va), ctypes.c_size_t(self.size))
+            cuda.cuMemRelease(ctypes.c_uint64(self.handle))
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(self.fd)
+
+    def __del__(self) -> None:
+        # Interpreter-shutdown GC must never raise through __del__.
+        with contextlib.suppress(Exception):
+            self.release()
+
+
+_mappings: dict[str, weakref.ref[_Mapping]] = {}
+_mappings_lock = threading.Lock()
+
+
+def _import_mapping(uds_path: str, token: str, size: int, device_index: int) -> _Mapping:
+    with _mappings_lock:
+        ref = _mappings.get(token)
+        cached = ref() if ref is not None else None
+        if cached is not None:
+            return cached
+
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        s.connect(uds_path)
+        s.sendall(token.encode())
+        msg, ancillary, _, _ = s.recvmsg(1, socket.CMSG_SPACE(4))
+        if msg != b"F" or not ancillary:
+            raise RuntimeError(f"FD handoff failed for token {token!r}")
+        fds = array.array("i")
+        fds.frombytes(ancillary[0][2][:4])
+        fd = fds[0]
+    finally:
+        s.close()
+
+    cuda = _cuda()
+    handle = ctypes.c_uint64()
+    va = ctypes.c_uint64()
+    mapped = False
+    try:
+        _check(
+            cuda.cuMemImportFromShareableHandle(
+                ctypes.byref(handle), ctypes.c_int(fd), _CU_MEM_HANDLE_TYPE_POSIX_FD
+            ),
+            "cuMemImportFromShareableHandle",
+        )
+        _check(
+            cuda.cuMemAddressReserve(ctypes.byref(va), ctypes.c_size_t(size), 0, 0, 0),
+            "cuMemAddressReserve",
+        )
+        _check(cuda.cuMemMap(va, ctypes.c_size_t(size), 0, handle, 0), "cuMemMap")
+        mapped = True
+        desc = _AccessDesc(
+            _CU_MEM_LOCATION_TYPE_DEVICE, device_index, _CU_MEM_ACCESS_FLAGS_READWRITE
+        )
+        _check(
+            cuda.cuMemSetAccess(va, ctypes.c_size_t(size), ctypes.byref(desc), 1),
+            "cuMemSetAccess",
+        )
+    except Exception:
+        # A failed import must not pin the exporter's physical memory or
+        # leak the received descriptor.
+        if mapped:
+            cuda.cuMemUnmap(va, ctypes.c_size_t(size))
+        if va.value:
+            cuda.cuMemAddressFree(va, ctypes.c_size_t(size))
+        if handle.value:
+            cuda.cuMemRelease(handle)
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        raise
+
+    mapping = _Mapping(va.value, size, handle.value, fd)
+    with _mappings_lock:
+        _mappings[token] = weakref.ref(mapping)
+    logger.info(
+        "[pegaflow.vmm] imported %d bytes on device %d (token %s)", size, device_index, token[:8]
+    )
+    return mapping
+
+
+class _Device:
+    def __init__(self, index: int) -> None:
+        self.index = index
+
+
+class _VmmMappedView:
+    """Registry-contract duck: data_ptr() / device.index /
+    untyped_storage().nbytes(). Keeping the object alive keeps the CUDA
+    mapping alive (mirrors how the registry holds IPC tensors); when the
+    registry drops it, the shared _Mapping releases and the worker's
+    physical memory is unpinned."""
+
+    def __init__(self, mapping: _Mapping, offset: int, nbytes: int, device_index: int) -> None:
+        self._mapping = mapping
+        self._ptr = mapping.va + offset
+        self._nbytes = nbytes
+        self.device = _Device(device_index)
+
+    def data_ptr(self) -> int:
+        return self._ptr
+
+    def untyped_storage(self):
+        return self
+
+    def nbytes(self) -> int:
+        return self._nbytes

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -331,9 +331,7 @@ def test_register_non_version_failure_reports_batch_layers(monkeypatch):
 
 def test_register_kv_caches_ignores_shared_by_without_layer_split_opt_in(monkeypatch):
     kv_cache_config = MagicMock()
-    kv_cache_config.kv_cache_groups = [
-        MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))
-    ]
+    kv_cache_config.kv_cache_groups = [MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))]
     kv_cache_config.kv_cache_tensors = [
         MagicMock(shared_by=("layer.1",)),
     ]
@@ -360,9 +358,7 @@ def test_register_kv_caches_ignores_shared_by_without_layer_split_opt_in(monkeyp
 
 def test_register_kv_caches_uses_layer_split_shared_by_plan(monkeypatch):
     kv_cache_config = MagicMock()
-    kv_cache_config.kv_cache_groups = [
-        MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))
-    ]
+    kv_cache_config.kv_cache_groups = [MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))]
     kv_cache_config.kv_cache_tensors = [
         MagicMock(shared_by=("layer.1",)),
         MagicMock(shared_by=()),
@@ -440,3 +436,52 @@ def test_register_version_mismatch_rpc_error_stops_startup(monkeypatch):
     assert len(client.register_calls) == 1
 
     worker.shutdown()
+
+
+class _PickleableStubWrapper:
+    """Module-level so pickle.dumps in register_kv_caches accepts it."""
+
+    def __init__(self, tensor):
+        pass
+
+
+def test_unregister_for_sleep_raises_when_server_unregister_fails():
+    """Sleeping with live server-side VMM mappings frees no VRAM, so a
+    failed unregister must surface as an exception (a non-OK
+    /collective_rpc response), not a logged-and-ignored warning."""
+    worker, client, _ = _make_worker()
+    worker._registered_layers = ["layer_a"]
+    client.unregister_context = lambda instance_id: (False, "server busy")
+
+    with pytest.raises(RuntimeError, match="unregister failed"):
+        worker.unregister_for_sleep()
+
+
+def test_registration_failure_closes_exported_fds(monkeypatch):
+    """Exported VMM FDs pin physical memory: a failed register RPC must
+    close them, or every retry leaks descriptors that also block sleep
+    from freeing VRAM."""
+    closed = []
+
+    class FakeServer:
+        def close_all(self):
+            closed.append(True)
+
+    from pegaflow import vmm_ipc
+
+    monkeypatch.setattr(vmm_ipc._FdServer, "has_instance", classmethod(lambda cls: True))
+    monkeypatch.setattr(vmm_ipc._FdServer, "instance", classmethod(lambda cls: FakeServer()))
+
+    import torch
+
+    from pegaflow.connector import worker as worker_mod
+
+    monkeypatch.setattr(worker_mod, "CudaIPCWrapper", _PickleableStubWrapper)
+
+    worker, client, _ = _make_worker()
+    client.register_response = (False, "boom")
+    kv = {"layer_a": torch.zeros(2, 4, 16, dtype=torch.uint8)}
+
+    with pytest.raises(RuntimeError, match="boom"):
+        worker.register_kv_caches(kv)
+    assert closed

--- a/python/tests/test_vmm_ipc.py
+++ b/python/tests/test_vmm_ipc.py
@@ -1,0 +1,230 @@
+"""Unit tests for the VMM-IPC layer (sleep-mode KV sharing).
+
+CPU-only: the FD handoff runs over a real abstract unix socket with plain
+file descriptors, and the CUDA driver is replaced by a call-recording fake.
+No torch, vLLM, GPU, or server required (default gate compatible).
+"""
+
+import array
+import ctypes
+import gc
+import os
+import socket
+import tempfile
+
+import pytest
+
+from pegaflow import vmm_ipc
+from pegaflow.vmm_ipc import (
+    _FdServer,
+    _import_mapping,
+    _Mapping,
+    _VmmMappedView,
+    is_cumem_tensor,
+)
+
+
+@pytest.fixture()
+def fd_server():
+    server = _FdServer()
+    yield server
+    server.close_all()
+
+
+def _receive_fd(uds_path: str, token: str) -> tuple[bytes, int | None]:
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        s.connect(uds_path)
+        s.sendall(token.encode())
+        msg, ancillary, _, _ = s.recvmsg(1, socket.CMSG_SPACE(4))
+        if not ancillary:
+            return msg, None
+        fds = array.array("i")
+        fds.frombytes(ancillary[0][2][:4])
+        return msg, fds[0]
+    finally:
+        s.close()
+
+
+class TestFdServer:
+    def test_handoff_delivers_the_same_file(self, fd_server):
+        with tempfile.NamedTemporaryFile() as f:
+            fd = os.dup(f.fileno())
+            token = fd_server.publish_allocation(0x1000, 4096, lambda: fd)
+
+            msg, received = _receive_fd(fd_server.path, token)
+
+            assert msg == b"F"
+            assert received is not None
+            # SCM_RIGHTS dup'd the descriptor: same underlying file.
+            assert os.fstat(received).st_ino == os.fstat(fd).st_ino
+            os.close(received)
+
+    def test_unknown_token_is_refused(self, fd_server):
+        msg, received = _receive_fd(fd_server.path, "nope")
+        assert msg == b"E"
+        assert received is None
+
+    def test_close_all_invalidates_exports(self, fd_server):
+        r, w = os.pipe()
+        os.close(w)
+        token = fd_server.publish_allocation(0x2000, 1, lambda: r)
+
+        fd_server.close_all()
+
+        with pytest.raises(OSError):
+            os.fstat(r)
+        msg, received = _receive_fd(fd_server.path, token)
+        assert msg == b"E"
+        assert received is None
+
+    def test_one_export_per_allocation_is_reused(self, fd_server):
+        r, w = os.pipe()
+        os.close(w)
+        calls = []
+
+        def mint():
+            calls.append(1)
+            return r
+
+        t1 = fd_server.publish_allocation(0x3000, 64, mint)
+        t2 = fd_server.publish_allocation(0x3000, 64, mint)
+        assert t1 == t2
+        assert len(calls) == 1  # layers in one allocation share the export
+
+    def test_garbage_request_does_not_kill_the_handoff_thread(self, fd_server):
+        # Abstract sockets are connectable by any local process: junk bytes
+        # or a stalled client must never wedge or kill the serving thread.
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect(fd_server.path)
+        s.sendall(b"\xff\xfe\xfd")
+        s.close()
+
+        with tempfile.NamedTemporaryFile() as f:
+            fd = os.dup(f.fileno())
+            token = fd_server.publish_allocation(0x4000, 128, lambda: fd)
+            msg, received = _receive_fd(fd_server.path, token)
+            assert msg == b"F"
+            assert received is not None
+            os.close(received)
+
+
+class _FakeCuda:
+    """Records driver calls; returns success and hands out fake handles."""
+
+    def __init__(self):
+        self.calls = []
+
+    def _record(self, name):
+        def call(*args):
+            self.calls.append(name)
+            if name == "cuMemImportFromShareableHandle":
+                ctypes.cast(args[0], ctypes.POINTER(ctypes.c_uint64))[0] = 0xBEEF
+                return 0
+            if name == "cuMemAddressReserve":
+                ctypes.cast(args[0], ctypes.POINTER(ctypes.c_uint64))[0] = 0xA000
+                return 0
+            return 0
+
+        return call
+
+    def __getattr__(self, name):
+        return self._record(name)
+
+
+@pytest.fixture()
+def fake_cuda(monkeypatch):
+    fake = _FakeCuda()
+    monkeypatch.setattr(vmm_ipc, "_libcuda", fake)
+    return fake
+
+
+class TestImportMapping:
+    def _publish(self, fd_server) -> str:
+        r, w = os.pipe()
+        os.close(w)
+        return fd_server.publish_allocation(0x5000, 8192, lambda: r)
+
+    def test_full_import_flow_and_cache(self, fd_server, fake_cuda):
+        token = self._publish(fd_server)
+
+        mapping = _import_mapping(fd_server.path, token, 8192, device_index=0)
+
+        assert mapping.va == 0xA000
+        for expected in (
+            "cuMemImportFromShareableHandle",
+            "cuMemAddressReserve",
+            "cuMemMap",
+            "cuMemSetAccess",
+        ):
+            assert expected in fake_cuda.calls
+        # Second wrapper inside the same allocation reuses the mapping
+        # (no second handoff/import).
+        n_calls = len(fake_cuda.calls)
+        again = _import_mapping(fd_server.path, token, 8192, device_index=0)
+        assert again is mapping
+        assert len(fake_cuda.calls) == n_calls
+
+    def test_view_gc_releases_mapping_and_fd(self, fd_server, fake_cuda):
+        token = self._publish(fd_server)
+        mapping = _import_mapping(fd_server.path, token, 8192, device_index=0)
+        received_fd = mapping.fd
+        view = _VmmMappedView(mapping, offset=256, nbytes=1024, device_index=0)
+
+        assert view.data_ptr() == 0xA000 + 256
+        assert view.untyped_storage().nbytes() == 1024
+        assert view.device.index == 0
+
+        del view, mapping
+        gc.collect()
+
+        assert "cuMemUnmap" in fake_cuda.calls
+        assert "cuMemRelease" in fake_cuda.calls
+        with pytest.raises(OSError):
+            os.fstat(received_fd)
+
+    def test_release_is_idempotent(self, fake_cuda):
+        r, w = os.pipe()
+        os.close(w)
+        m = _Mapping(va=1, size=2, handle=3, fd=r)
+        m.release()
+        n = fake_cuda.calls.count("cuMemRelease")
+        m.release()
+        assert fake_cuda.calls.count("cuMemRelease") == n
+
+
+class TestImportFailureCleanup:
+    def test_map_failure_releases_handle_and_fd(self, fd_server, monkeypatch):
+        class FailingMapCuda(_FakeCuda):
+            def _record(self, name):
+                base = super()._record(name)
+
+                def call(*args):
+                    rc = base(*args)
+                    return 999 if name == "cuMemMap" else rc
+
+                return call
+
+        fake = FailingMapCuda()
+        monkeypatch.setattr(vmm_ipc, "_libcuda", fake)
+
+        r, w = os.pipe()
+        os.close(w)
+        token = fd_server.publish_allocation(0x6000, 4096, lambda: r)
+
+        with pytest.raises(RuntimeError, match="cuMemMap"):
+            _import_mapping(fd_server.path, token, 4096, device_index=0)
+
+        # A failed import must not pin the exporter's physical memory or
+        # leak the received descriptor.
+        assert "cuMemRelease" in fake.calls
+        assert "cuMemAddressFree" in fake.calls
+
+
+class TestCumemDetection:
+    def test_fake_and_plain_objects_take_the_legacy_path(self):
+        class FakeTensor:
+            pass
+
+        assert is_cumem_tensor(FakeTensor()) is False
+        assert is_cumem_tensor(object()) is False

--- a/python/tests/test_vmm_ipc.py
+++ b/python/tests/test_vmm_ipc.py
@@ -28,14 +28,14 @@ from pegaflow.vmm_ipc import (
 def fd_server():
     server = _FdServer()
     yield server
-    server.close_all()
+    server.close()  # ends the accept loop; per-test instances must not leak threads
 
 
 def _receive_fd(uds_path: str, token: str) -> tuple[bytes, int | None]:
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
         s.connect(uds_path)
-        s.sendall(token.encode())
+        s.sendall(token.encode().ljust(32))
         msg, ancillary, _, _ = s.recvmsg(1, socket.CMSG_SPACE(4))
         if not ancillary:
             return msg, None


### PR DESCRIPTION
## What

Lets `PegaKVConnector` work with vLLM's **sleep mode**. Sleep mode allocates KV under the cumem (CUDA VMM / `cuMemCreate`) allocator, which legacy CUDA IPC cannot share — `storage._share_cuda_()` fails with `CUDA error: invalid argument`, so today PegaFlow and `--enable-sleep-mode` are mutually exclusive. With this PR the combination gives the best of both worlds: seconds-scale sleep/wake **and** KV prefixes that survive in the external cache (which sleep otherwise discards).

No vLLM changes are needed: vLLM's cumem extension already requests exportable handle types wherever the driver reports fabric/POSIX handle support (which includes consumer GPUs — verified on RTX 3090), so the allocations are exportable as POSIX FDs out of the box.

## Design

New module `pegaflow/vmm_ipc.py`, plus a wrapper-selection branch at registration and two lifecycle methods:

- **Worker (export):** for a KV tensor inside a cumem allocation, the covering allocation's generic handle is exported with `cuMemExportToShareableHandle(POSIX_FD)`. One export per allocation, shared by every KV tensor inside it. Detection is fail-safe: anything not provably cumem-managed takes the existing legacy-IPC path unchanged.
- **Handoff:** an abstract unix socket + `SCM_RIGHTS`, served by one per-worker thread. Each FD is gated by a 128-bit random token (abstract socket names are world-visible in `/proc/net/unix`, so the token is the secret). `pidfd_getfd` was considered and rejected: yama `ptrace_scope=1` forbids it between sibling processes, which is exactly the worker↔server relationship.
- **Server (import):** `to_tensor()` runs in the server's embedded interpreter and imports/maps via ctypes (`cuMemImportFromShareableHandle` → `cuMemAddressReserve` → `cuMemMap` → `cuMemSetAccess`), returning a duck-typed view that satisfies the registry contract (`data_ptr` / `device.index` / `untyped_storage().nbytes`). One mapping per allocation, shared across layer views.
- **Lifetime is the load-bearing part:** an imported VMM handle **refcounts the exporter's physical memory**. Mapping release is tied to view GC — `registry.drop_instance` already decrefs held views and runs `gc.collect()`, which unmaps/releases the import. Symmetrically, the worker exposes:
  - `unregister_for_sleep()` — unregister + close all exported FDs. Must run **before** vLLM sleeps, or sleep frees no VRAM.
  - `reregister_after_wake()` — wake maps **fresh physical chunks into the same virtual addresses**, so the cached kv-cache dict re-registers the same tensor objects; generic handles are re-read at export time.
  Both are reachable through vLLM's `/collective_rpc`: the connector installs thin `Worker.pegaflow_sleep_unregister` / `Worker.pegaflow_wake_reregister` passthroughs at worker-role construction (the Worker class is already imported there; non-PegaFlow processes pay nothing), so an orchestrator drives: `collective_rpc(pegaflow_sleep_unregister)` → `/sleep` → `/wake_up` → `collective_rpc(pegaflow_wake_reregister)`. `unregister_for_sleep` **raises** when saves haven't drained or the server unregister RPC fails — a non-OK response the caller must treat as "do not sleep" (sleeping with live mappings frees no VRAM while reporting success).
- **Lifecycle guarantees hardened by adversarial review:** exported FDs belong to the registration lifetime — every teardown path closes them (`unregister_context`, registration-failure rollback), not just the sleep path; one export per cumem allocation is shared by all layer tensors inside it; the FD-handoff thread is wedge-proof (per-connection timeout, broad exception guard — abstract sockets are connectable by any local process) and TOCTOU-safe (dup-under-lock so a concurrently reused fd number can never hand out the wrong descriptor); a failed import releases the handle/VA/fd instead of pinning the exporter's memory.

The Rust tree already contains a complete-but-unwired VMM wrapper (`pegaflow-transfer/src/cuda_lib/cumem.rs`); this PR deliberately stays in Python to avoid touching the data plane — the imported mapping is an ordinary device VA, so `MemcpyBackend`/`KernelBackend` work unchanged. Migrating the import into `CudaTensorRegistry` on top of that module would be a natural follow-up.

## Validation

- **Unit tests (CPU-only, default-gate compatible):** real SCM_RIGHTS handoff over an abstract socket (same-inode assertion), unknown-token refusal, `close_all` invalidation, per-allocation export reuse, garbage/stalled-client resilience of the handoff thread, import-flow + mapping-cache reuse against a call-recording fake driver, import-failure cleanup, GC-driven release including FD close, release idempotence, fail-safe cumem detection, registration-failure FD rollback, and unregister-failure raising.
- **Live (vLLM 0.22.1, RTX 3090):** engine boots with sleep mode + connector (previously an instant init crash; 36 imports for a 36-layer model); sleep L1 drops the GPU from ~21 GB to ~1.0 GB (nothing left pinned); wake + re-register in seconds; a 5.3k-token prefix replay after wake hits **335/335 blocks at 0.2 s** — the KV that sleep discarded is refilled from the server. Sleep-level-2 (weights discarded) park/wake with warm replay also verified.
- We were not able to run the repo's exact `test_vllm_e2e_correctness.py` gate (no `/data/models/Qwen3-4B` here); happy to iterate if CI or a reviewer run surfaces anything.

## Limitations

- POSIX-FD export requires driver-reported handle-type support at `cuMemCreate` time (vLLM requests it when `CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED` probes true; on drivers where it probes false, allocations are unexportable and this path cannot engage — the connector then fails registration exactly as before this PR).
- Linux-only (abstract sockets, SCM_RIGHTS) — consistent with the existing pidfd code in-tree.
- The sleep/wake lifecycle must be driven by whatever controls `/sleep`/`/wake_up`; the PR documents the contract but cannot enforce ordering from inside the connector (vLLM has no connector sleep hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
