### PR TITLE
feat(pd): first-token router forwarding + P-side partial tail-block save

### DIFF
--- a/pegaflow-server/src/bin/pegaflow-router.rs
+++ b/pegaflow-server/src/bin/pegaflow-router.rs
@@ -228,7 +228,8 @@ async fn pd_first_token_flow(
         .send()
         .await;
     state.finish_p(p_idx);
-    let p_response = p_response.map_err(|e| FlowError::transient(format!("prefill request: {e}")))?;
+    let p_response =
+        p_response.map_err(|e| FlowError::transient(format!("prefill request: {e}")))?;
     let p_status = p_response.status();
     let p_result: Value = p_response
         .json()
@@ -277,11 +278,13 @@ async fn pd_first_token_flow(
     d_body["prompt"] = json!(d_prompt);
     // An absent max_tokens must be made explicit: engines default it to 16,
     // silently truncating every open-ended request.
-    let d_max = org_max_tokens.map(|max| max.saturating_sub(1).max(1)).unwrap_or_else(|| {
-        (state.pd_max_model_len as u64)
-            .saturating_sub(d_prompt.len() as u64)
-            .max(1)
-    });
+    let d_max = org_max_tokens
+        .map(|max| max.saturating_sub(1).max(1))
+        .unwrap_or_else(|| {
+            (state.pd_max_model_len as u64)
+                .saturating_sub(d_prompt.len() as u64)
+                .max(1)
+        });
     d_body["max_tokens"] = json!(d_max);
     if let Some(min_tokens) = body.get("min_tokens").and_then(|v| v.as_u64()) {
         d_body["min_tokens"] = json!(min_tokens.saturating_sub(1));
@@ -432,7 +435,12 @@ fn reshape_single_token_response(leg: &PrefillLeg, is_chat: bool, org_stream: bo
     let finish = leg.finish_reason.clone().unwrap_or_else(|| "stop".into());
     let chunks = if is_chat {
         vec![
-            chat_chunk(&id, &model, json!({"role": "assistant", "content": leg.t1_text}), None),
+            chat_chunk(
+                &id,
+                &model,
+                json!({"role": "assistant", "content": leg.t1_text}),
+                None,
+            ),
             chat_chunk(&id, &model, json!({}), Some(&finish)),
         ]
     } else {
@@ -472,7 +480,10 @@ fn completion_chunk(id: &str, model: &str, text: &str, finish: Option<&str>) -> 
 fn merge_final_response(leg: &PrefillLeg, d_result: Value, is_chat: bool) -> Response {
     let d_choice = &d_result["choices"][0];
     let d_text = d_choice["text"].as_str().unwrap_or_default();
-    let finish = d_choice.get("finish_reason").cloned().unwrap_or(Value::Null);
+    let finish = d_choice
+        .get("finish_reason")
+        .cloned()
+        .unwrap_or(Value::Null);
     let d_completion_tokens = d_result["usage"]["completion_tokens"].as_u64().unwrap_or(0);
     let usage = json!({
         "prompt_tokens": leg.prompt_token_ids.len(),
@@ -493,7 +504,10 @@ fn merge_final_response(leg: &PrefillLeg, d_result: Value, is_chat: bool) -> Res
 /// Streaming splice: one synthetic chunk carrying t1, then D's completions
 /// SSE re-shaped to the client's API (chat delta chunks when the client
 /// spoke chat), with usage patched to cover both legs.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one-shot splice helper; bundling into a struct buys nothing"
+)]
 fn stream_spliced_response(
     state: RouterState,
     d_response: reqwest::Response,
@@ -524,13 +538,16 @@ fn stream_spliced_response(
             .unwrap_or_default()
             .to_string();
         let first = if is_chat {
-            chat_chunk(&id, &model, json!({"role": "assistant", "content": leg.t1_text}), None)
+            chat_chunk(
+                &id,
+                &model,
+                json!({"role": "assistant", "content": leg.t1_text}),
+                None,
+            )
         } else {
             completion_chunk(&id, &model, &leg.t1_text, None)
         };
-        let _ = tx
-            .send(Ok(format!("data: {first}\n\n").into()))
-            .await;
+        let _ = tx.send(Ok(format!("data: {first}\n\n").into())).await;
 
         let mut buffer = String::new();
         let mut stream = Box::pin(d_response.bytes_stream());
@@ -548,10 +565,7 @@ fn stream_spliced_response(
             while let Some(pos) = buffer.find("\n\n") {
                 let event = buffer[..pos].to_string();
                 buffer.drain(..pos + 2);
-                let Some(data) = event
-                    .lines()
-                    .find_map(|line| line.strip_prefix("data: "))
-                else {
+                let Some(data) = event.lines().find_map(|line| line.strip_prefix("data: ")) else {
                     continue;
                 };
                 if data.trim() == "[DONE]" {
@@ -565,8 +579,7 @@ fn stream_spliced_response(
                 // Patch usage to cover both legs (P's prompt + t1).
                 let is_usage_chunk = value.get("usage").is_some_and(|u| !u.is_null());
                 if is_usage_chunk {
-                    let d_completion =
-                        value["usage"]["completion_tokens"].as_u64().unwrap_or(0);
+                    let d_completion = value["usage"]["completion_tokens"].as_u64().unwrap_or(0);
                     value["usage"] = json!({
                         "prompt_tokens": leg.prompt_token_ids.len(),
                         "completion_tokens": d_completion + 1,
@@ -665,18 +678,26 @@ async fn handle_completion(
     if state.pd_first_token {
         // The splice takes choices[0] of a single prompt; anything else
         // would be silently mangled — refuse instead.
-        if body.get("n").and_then(|v| v.as_u64()).is_some_and(|n| n > 1) {
+        if body
+            .get("n")
+            .and_then(|v| v.as_u64())
+            .is_some_and(|n| n > 1)
+        {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(json!({"error": "P/D first-token routing does not support n > 1"})),
             )
                 .into_response();
         }
-        if body.get("prompt").and_then(|v| v.as_array()).is_some_and(|arr| {
-            // A flat array of ints is ONE pre-tokenized prompt; anything
-            // string-or-array-valued is a multi-prompt batch.
-            arr.iter().any(|v| v.is_string() || v.is_array())
-        }) {
+        if body
+            .get("prompt")
+            .and_then(|v| v.as_array())
+            .is_some_and(|arr| {
+                // A flat array of ints is ONE pre-tokenized prompt; anything
+                // string-or-array-valued is a multi-prompt batch.
+                arr.iter().any(|v| v.is_string() || v.is_array())
+            })
+        {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(json!({"error": "P/D first-token routing does not support batched prompts"})),

--- a/pegaflow-server/src/bin/pegaflow-router.rs
+++ b/pegaflow-server/src/bin/pegaflow-router.rs
@@ -53,6 +53,10 @@ struct RouterState {
     pd_first_token: bool,
     // Full P->D flow retries on a D failure in variant A.
     pd_flow_retries: usize,
+    // Model context limit: bounds the D leg's max_tokens when the client
+    // sent none (both vLLM and openinfer default an absent max_tokens to 16,
+    // which would silently truncate every open-ended chat request).
+    pd_max_model_len: usize,
 }
 
 impl RouterState {
@@ -95,6 +99,7 @@ impl RouterState {
             d_inflight: Arc::new(d_inflight),
             pd_first_token: false,
             pd_flow_retries: 1,
+            pd_max_model_len: 32768,
         }
     }
 
@@ -157,16 +162,39 @@ struct PrefillLeg {
     response: Value,
 }
 
-/// One P->D attempt of the variant-A flow. `Err(msg)` means the caller may
-/// retry the whole flow (the P leg is idempotent: same prompt, same
-/// content-addressed KV).
+/// A failed P->D attempt. `retryable` marks transient failures (network,
+/// 5xx/429) — the whole flow may re-run because the P leg is idempotent
+/// (same prompt, same content-addressed KV). Deterministic 4xx must not
+/// retry: it would burn P compute on a guaranteed-identical failure.
+struct FlowError {
+    retryable: bool,
+    msg: String,
+}
+
+impl FlowError {
+    fn transient(msg: String) -> Self {
+        Self {
+            retryable: true,
+            msg,
+        }
+    }
+
+    fn from_status(status: StatusCode, msg: String) -> Self {
+        Self {
+            retryable: !status.is_client_error() || status == StatusCode::TOO_MANY_REQUESTS,
+            msg,
+        }
+    }
+}
+
+/// One P->D attempt of the variant-A flow.
 async fn pd_first_token_flow(
     state: &RouterState,
     body: &Value,
     api_path: &str,
     req_id: &str,
     arrive_time: Instant,
-) -> Result<Response, String> {
+) -> Result<Response, FlowError> {
     let is_chat = api_path.ends_with("/chat/completions");
     let org_stream = body
         .get("stream")
@@ -200,16 +228,19 @@ async fn pd_first_token_flow(
         .send()
         .await;
     state.finish_p(p_idx);
-    let p_response = p_response.map_err(|e| format!("prefill request: {e}"))?;
+    let p_response = p_response.map_err(|e| FlowError::transient(format!("prefill request: {e}")))?;
     let p_status = p_response.status();
     let p_result: Value = p_response
         .json()
         .await
-        .map_err(|e| format!("prefill response parse: {e}"))?;
+        .map_err(|e| FlowError::transient(format!("prefill response parse: {e}")))?;
     if !p_status.is_success() {
-        return Err(format!("prefill status {p_status}: {p_result}"));
+        return Err(FlowError::from_status(
+            p_status,
+            format!("prefill status {p_status}: {p_result}"),
+        ));
     }
-    let leg = extract_prefill_leg(p_result)?;
+    let leg = extract_prefill_leg(p_result).map_err(FlowError::transient)?;
     info!(
         "prefill done: req={} P[{}] prompt_tokens={} t1={} latency={}ms",
         req_id,
@@ -231,13 +262,27 @@ async fn pd_first_token_flow(
         obj.remove("messages");
         obj.remove("max_completion_tokens");
         obj.remove("echo");
+        if is_chat {
+            // Chat-only field shapes that /v1/completions rejects
+            // (`logprobs` is a bool in chat, an int in completions).
+            obj.remove("logprobs");
+            obj.remove("top_logprobs");
+            obj.remove("response_format");
+            obj.remove("tools");
+            obj.remove("tool_choice");
+        }
     }
     let mut d_prompt = leg.prompt_token_ids.clone();
     d_prompt.push(leg.t1_id);
     d_body["prompt"] = json!(d_prompt);
-    if let Some(max) = org_max_tokens {
-        d_body["max_tokens"] = json!(max.saturating_sub(1).max(1));
-    }
+    // An absent max_tokens must be made explicit: engines default it to 16,
+    // silently truncating every open-ended request.
+    let d_max = org_max_tokens.map(|max| max.saturating_sub(1).max(1)).unwrap_or_else(|| {
+        (state.pd_max_model_len as u64)
+            .saturating_sub(d_prompt.len() as u64)
+            .max(1)
+    });
+    d_body["max_tokens"] = json!(d_max);
     if let Some(min_tokens) = body.get("min_tokens").and_then(|v| v.as_u64()) {
         d_body["min_tokens"] = json!(min_tokens.saturating_sub(1));
     }
@@ -260,14 +305,17 @@ async fn pd_first_token_flow(
         Ok(resp) => resp,
         Err(e) => {
             state.finish_d(d_idx);
-            return Err(format!("decode request: {e}"));
+            return Err(FlowError::transient(format!("decode request: {e}")));
         }
     };
     let d_status = d_response.status();
     if !d_status.is_success() {
         let detail = d_response.text().await.unwrap_or_default();
         state.finish_d(d_idx);
-        return Err(format!("decode status {d_status}: {detail}"));
+        return Err(FlowError::from_status(
+            d_status,
+            format!("decode status {d_status}: {detail}"),
+        ));
     }
 
     if org_stream {
@@ -282,11 +330,10 @@ async fn pd_first_token_flow(
             arrive_time,
         ))
     } else {
-        let d_result: Value = d_response
-            .json()
-            .await
-            .map_err(|e| format!("decode response parse: {e}"))?;
+        let d_result: Result<Value, _> = d_response.json().await;
         state.finish_d(d_idx);
+        let d_result =
+            d_result.map_err(|e| FlowError::transient(format!("decode response parse: {e}")))?;
         info!(
             "done: req={} D[{}] total={}ms inflight=[{}]",
             req_id,
@@ -342,11 +389,33 @@ fn extract_prefill_leg(p_result: Value) -> Result<PrefillLeg, String> {
     })
 }
 
+/// Strip the router-requested token-id fields (`return_token_ids`) from a
+/// P response before it reaches the client — internal splice protocol, not
+/// part of the public API the client called.
+fn strip_internal_token_fields(mut response: Value) -> Value {
+    if let Some(obj) = response.as_object_mut() {
+        obj.remove("prompt_token_ids");
+    }
+    if let Some(choices) = response.get_mut("choices").and_then(|c| c.as_array_mut()) {
+        for choice in choices {
+            if let Some(obj) = choice.as_object_mut() {
+                obj.remove("prompt_token_ids");
+                obj.remove("token_ids");
+            }
+        }
+    }
+    response
+}
+
 /// The no-D-leg case: P's non-streaming response answers the client. A
 /// streaming client gets it re-shaped as a minimal SSE exchange.
 fn reshape_single_token_response(leg: &PrefillLeg, is_chat: bool, org_stream: bool) -> Response {
     if !org_stream {
-        return (StatusCode::OK, Json(leg.response.clone())).into_response();
+        return (
+            StatusCode::OK,
+            Json(strip_internal_token_fields(leg.response.clone())),
+        )
+            .into_response();
     }
     let id = leg
         .response
@@ -410,7 +479,7 @@ fn merge_final_response(leg: &PrefillLeg, d_result: Value, is_chat: bool) -> Res
         "completion_tokens": d_completion_tokens + 1,
         "total_tokens": leg.prompt_token_ids.len() as u64 + d_completion_tokens + 1,
     });
-    let mut out = leg.response.clone();
+    let mut out = strip_internal_token_fields(leg.response.clone());
     out["usage"] = usage;
     if is_chat {
         out["choices"][0]["message"]["content"] = json!(format!("{}{}", leg.t1_text, d_text));
@@ -465,6 +534,10 @@ fn stream_spliced_response(
 
         let mut buffer = String::new();
         let mut stream = Box::pin(d_response.bytes_stream());
+        // t1 is already on the wire, so a mid-stream D failure cannot retry.
+        // The client must still be able to tell "finished" from "truncated":
+        // emit an error frame instead of a clean-looking EOF.
+        let mut saw_done = false;
         'outer: while let Some(chunk) = stream.next().await {
             let Ok(bytes) = chunk else {
                 error!("stream error: req={req_id}");
@@ -482,6 +555,7 @@ fn stream_spliced_response(
                     continue;
                 };
                 if data.trim() == "[DONE]" {
+                    saw_done = true;
                     let _ = tx.send(Ok("data: [DONE]\n\n".into())).await;
                     break 'outer;
                 }
@@ -539,6 +613,16 @@ fn stream_spliced_response(
                 }
             }
         }
+        if !saw_done {
+            let err = json!({
+                "error": {
+                    "message": "decode stream ended before completion",
+                    "type": "server_error",
+                    "code": "pd_decode_interrupted",
+                }
+            });
+            let _ = tx.send(Ok(format!("data: {err}\n\n").into())).await;
+        }
         state.finish_d(d_idx);
         info!(
             "done (stream): req={} D[{}] total={}ms inflight=[{}]",
@@ -579,13 +663,39 @@ async fn handle_completion(
     );
 
     if state.pd_first_token {
+        // The splice takes choices[0] of a single prompt; anything else
+        // would be silently mangled — refuse instead.
+        if body.get("n").and_then(|v| v.as_u64()).is_some_and(|n| n > 1) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "P/D first-token routing does not support n > 1"})),
+            )
+                .into_response();
+        }
+        if body.get("prompt").and_then(|v| v.as_array()).is_some_and(|arr| {
+            // A flat array of ints is ONE pre-tokenized prompt; anything
+            // string-or-array-valued is a multi-prompt batch.
+            arr.iter().any(|v| v.is_string() || v.is_array())
+        }) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "P/D first-token routing does not support batched prompts"})),
+            )
+                .into_response();
+        }
         let mut last_err = String::new();
         for attempt in 0..=state.pd_flow_retries {
             match pd_first_token_flow(&state, &body, api_path, &req_id, arrive_time).await {
                 Ok(response) => return response,
                 Err(err) => {
-                    error!("P/D flow attempt {attempt} failed: req={req_id} {err}");
-                    last_err = err;
+                    error!(
+                        "P/D flow attempt {attempt} failed: req={req_id} retryable={} {}",
+                        err.retryable, err.msg
+                    );
+                    last_err = err.msg;
+                    if !err.retryable {
+                        break;
+                    }
                 }
             }
         }
@@ -854,6 +964,11 @@ struct Args {
     /// (a strict decode node rejects when the remote KV never lands).
     #[arg(long, default_value_t = 1)]
     pd_flow_retries: usize,
+
+    /// Model context limit, bounding the D leg's max_tokens when the client
+    /// sent none (engines default an absent max_tokens to 16).
+    #[arg(long, default_value_t = 32768)]
+    pd_max_model_len: usize,
 }
 
 #[tokio::main]
@@ -866,6 +981,7 @@ async fn main() {
     let mut state = RouterState::new(args.prefill.clone(), args.decode.clone());
     state.pd_first_token = args.pd_first_token;
     state.pd_flow_retries = args.pd_flow_retries;
+    state.pd_max_model_len = args.pd_max_model_len;
     if state.pd_first_token {
         info!(
             "P/D first-token forwarding on (flow retries: {})",

--- a/pegaflow-server/src/bin/pegaflow-router.rs
+++ b/pegaflow-server/src/bin/pegaflow-router.rs
@@ -5,6 +5,17 @@
 //! 1. Receive request
 //! 2. Send to P node (max_tokens=1)
 //! 3. Forward to D node (P response means KV is ready)
+//!
+//! `--pd-first-token` (variant A, for decode nodes that refuse ALL prompt
+//! compute — GLM5.2 openinfer-D): P's single generated token is returned to
+//! the client as part of the merged response AND appended to the token-id
+//! prompt forwarded to D, so D's first forward is a true one-token decode.
+//! P runs with `return_token_ids`; D is always driven through
+//! `/v1/completions` with pre-tokenized ids (chat templates apply only on P),
+//! and its SSE stream is re-shaped to the client's API. A D failure (e.g. the
+//! strict no-prefill decode node rejecting a request whose remote KV never
+//! landed) retries the whole P→D flow — content-addressed KV makes the P leg
+//! idempotent.
 
 use std::sync::{
     Arc,
@@ -38,6 +49,10 @@ struct RouterState {
     // Track in-flight requests per node
     p_inflight: Arc<Vec<AtomicUsize>>,
     d_inflight: Arc<Vec<AtomicUsize>>,
+    // Variant A: forward P's first token into D's context (see module doc).
+    pd_first_token: bool,
+    // Full P->D flow retries on a D failure in variant A.
+    pd_flow_retries: usize,
 }
 
 impl RouterState {
@@ -78,6 +93,8 @@ impl RouterState {
             d_index: Arc::new(AtomicUsize::new(0)),
             p_inflight: Arc::new(p_inflight),
             d_inflight: Arc::new(d_inflight),
+            pd_first_token: false,
+            pd_flow_retries: 1,
         }
     }
 
@@ -126,6 +143,420 @@ impl RouterState {
     }
 }
 
+/// What the variant-A flow extracted from the P leg.
+struct PrefillLeg {
+    /// P's full prompt token ids (post chat template on the chat API).
+    prompt_token_ids: Vec<u32>,
+    /// The single generated token.
+    t1_id: u32,
+    /// Its detokenized text (chat: message.content; completions: text).
+    t1_text: String,
+    /// P's finish reason for that token ("stop" = EOS at t1: skip D).
+    finish_reason: Option<String>,
+    /// P's full response (the client envelope when D is skipped).
+    response: Value,
+}
+
+/// One P->D attempt of the variant-A flow. `Err(msg)` means the caller may
+/// retry the whole flow (the P leg is idempotent: same prompt, same
+/// content-addressed KV).
+async fn pd_first_token_flow(
+    state: &RouterState,
+    body: &Value,
+    api_path: &str,
+    req_id: &str,
+    arrive_time: Instant,
+) -> Result<Response, String> {
+    let is_chat = api_path.ends_with("/chat/completions");
+    let org_stream = body
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let org_max_tokens = ["max_completion_tokens", "max_tokens"]
+        .iter()
+        .find_map(|k| body.get(*k).and_then(|v| v.as_u64()));
+
+    // ---- P leg: prefill + exactly one generated token, with token ids ----
+    let mut p_body = body.clone();
+    p_body["max_tokens"] = json!(1);
+    if p_body.get("max_completion_tokens").is_some() {
+        p_body["max_completion_tokens"] = json!(1);
+    }
+    p_body["stream"] = json!(false);
+    p_body["request_id"] = json!(req_id);
+    p_body["return_token_ids"] = json!(true);
+    // The appended-token contract needs t1 to exist even at instant EOS.
+    p_body["min_tokens"] = json!(1);
+    if let Some(obj) = p_body.as_object_mut() {
+        obj.remove("stream_options");
+    }
+
+    let (p_client, p_url, p_idx) = state.get_next_p();
+    let p_url = format!("{}{}", p_url, api_path);
+    let p_response = p_client
+        .post(&p_url)
+        .header("X-Request-Id", req_id)
+        .json(&p_body)
+        .send()
+        .await;
+    state.finish_p(p_idx);
+    let p_response = p_response.map_err(|e| format!("prefill request: {e}"))?;
+    let p_status = p_response.status();
+    let p_result: Value = p_response
+        .json()
+        .await
+        .map_err(|e| format!("prefill response parse: {e}"))?;
+    if !p_status.is_success() {
+        return Err(format!("prefill status {p_status}: {p_result}"));
+    }
+    let leg = extract_prefill_leg(p_result)?;
+    info!(
+        "prefill done: req={} P[{}] prompt_tokens={} t1={} latency={}ms",
+        req_id,
+        p_idx,
+        leg.prompt_token_ids.len(),
+        leg.t1_id,
+        arrive_time.elapsed().as_millis()
+    );
+
+    // EOS at t1, or the client only asked for one token: P's response IS the
+    // final answer — no decode leg.
+    if leg.finish_reason.as_deref() == Some("stop") || org_max_tokens == Some(1) {
+        return Ok(reshape_single_token_response(&leg, is_chat, org_stream));
+    }
+
+    // ---- D leg: pre-tokenized prompt + t1, always /v1/completions ----
+    let mut d_body = body.clone();
+    if let Some(obj) = d_body.as_object_mut() {
+        obj.remove("messages");
+        obj.remove("max_completion_tokens");
+        obj.remove("echo");
+    }
+    let mut d_prompt = leg.prompt_token_ids.clone();
+    d_prompt.push(leg.t1_id);
+    d_body["prompt"] = json!(d_prompt);
+    if let Some(max) = org_max_tokens {
+        d_body["max_tokens"] = json!(max.saturating_sub(1).max(1));
+    }
+    if let Some(min_tokens) = body.get("min_tokens").and_then(|v| v.as_u64()) {
+        d_body["min_tokens"] = json!(min_tokens.saturating_sub(1));
+    }
+    d_body["stream"] = json!(org_stream);
+    d_body["request_id"] = json!(req_id);
+    if org_stream {
+        // Usage patching (t1 + P-side prompt length) needs the final counts.
+        d_body["stream_options"] = json!({"include_usage": true});
+    }
+
+    let (d_client, d_url, d_idx) = state.get_next_d();
+    let d_url = format!("{}/v1/completions", d_url);
+    let d_response = match d_client
+        .post(&d_url)
+        .header("X-Request-Id", req_id)
+        .json(&d_body)
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            state.finish_d(d_idx);
+            return Err(format!("decode request: {e}"));
+        }
+    };
+    let d_status = d_response.status();
+    if !d_status.is_success() {
+        let detail = d_response.text().await.unwrap_or_default();
+        state.finish_d(d_idx);
+        return Err(format!("decode status {d_status}: {detail}"));
+    }
+
+    if org_stream {
+        Ok(stream_spliced_response(
+            state.clone(),
+            d_response,
+            leg,
+            is_chat,
+            body.get("stream_options").cloned(),
+            req_id.to_string(),
+            d_idx,
+            arrive_time,
+        ))
+    } else {
+        let d_result: Value = d_response
+            .json()
+            .await
+            .map_err(|e| format!("decode response parse: {e}"))?;
+        state.finish_d(d_idx);
+        info!(
+            "done: req={} D[{}] total={}ms inflight=[{}]",
+            req_id,
+            d_idx,
+            arrive_time.elapsed().as_millis(),
+            state.get_inflight_summary()
+        );
+        Ok(merge_final_response(&leg, d_result, is_chat))
+    }
+}
+
+/// Pull prompt ids + the single token out of P's chat/completions response.
+fn extract_prefill_leg(p_result: Value) -> Result<PrefillLeg, String> {
+    let choice = p_result
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .ok_or("prefill response has no choices")?;
+    // Completions responses carry prompt_token_ids on the choice; chat
+    // responses carry it at the top level.
+    let prompt_token_ids: Vec<u32> = choice
+        .get("prompt_token_ids")
+        .or_else(|| p_result.get("prompt_token_ids"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .ok_or("prefill response missing prompt_token_ids (P must support return_token_ids)")?;
+    let token_ids: Vec<u32> = choice
+        .get("token_ids")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .ok_or("prefill response missing token_ids")?;
+    let t1_id = *token_ids
+        .first()
+        .ok_or("prefill generated no token (min_tokens=1 expected)")?;
+    let t1_text = choice
+        .get("text")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            choice
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|v| v.as_str())
+        })
+        .unwrap_or_default()
+        .to_string();
+    let finish_reason = choice
+        .get("finish_reason")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    Ok(PrefillLeg {
+        prompt_token_ids,
+        t1_id,
+        t1_text,
+        finish_reason,
+        response: p_result,
+    })
+}
+
+/// The no-D-leg case: P's non-streaming response answers the client. A
+/// streaming client gets it re-shaped as a minimal SSE exchange.
+fn reshape_single_token_response(leg: &PrefillLeg, is_chat: bool, org_stream: bool) -> Response {
+    if !org_stream {
+        return (StatusCode::OK, Json(leg.response.clone())).into_response();
+    }
+    let id = leg
+        .response
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("pd-1")
+        .to_string();
+    let model = leg
+        .response
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let finish = leg.finish_reason.clone().unwrap_or_else(|| "stop".into());
+    let chunks = if is_chat {
+        vec![
+            chat_chunk(&id, &model, json!({"role": "assistant", "content": leg.t1_text}), None),
+            chat_chunk(&id, &model, json!({}), Some(&finish)),
+        ]
+    } else {
+        vec![completion_chunk(&id, &model, &leg.t1_text, Some(&finish))]
+    };
+    let mut sse = String::new();
+    for chunk in chunks {
+        sse.push_str(&format!("data: {chunk}\n\n"));
+    }
+    sse.push_str("data: [DONE]\n\n");
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "text/event-stream")
+        .body(Body::from(sse))
+        .unwrap()
+}
+
+fn chat_chunk(id: &str, model: &str, delta: Value, finish: Option<&str>) -> Value {
+    json!({
+        "id": id,
+        "object": "chat.completion.chunk",
+        "model": model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+    })
+}
+
+fn completion_chunk(id: &str, model: &str, text: &str, finish: Option<&str>) -> Value {
+    json!({
+        "id": id,
+        "object": "text_completion",
+        "model": model,
+        "choices": [{"index": 0, "text": text, "finish_reason": finish}],
+    })
+}
+
+/// Non-streaming merge: t1 + D's completion, with usage covering both legs.
+fn merge_final_response(leg: &PrefillLeg, d_result: Value, is_chat: bool) -> Response {
+    let d_choice = &d_result["choices"][0];
+    let d_text = d_choice["text"].as_str().unwrap_or_default();
+    let finish = d_choice.get("finish_reason").cloned().unwrap_or(Value::Null);
+    let d_completion_tokens = d_result["usage"]["completion_tokens"].as_u64().unwrap_or(0);
+    let usage = json!({
+        "prompt_tokens": leg.prompt_token_ids.len(),
+        "completion_tokens": d_completion_tokens + 1,
+        "total_tokens": leg.prompt_token_ids.len() as u64 + d_completion_tokens + 1,
+    });
+    let mut out = leg.response.clone();
+    out["usage"] = usage;
+    if is_chat {
+        out["choices"][0]["message"]["content"] = json!(format!("{}{}", leg.t1_text, d_text));
+    } else {
+        out["choices"][0]["text"] = json!(format!("{}{}", leg.t1_text, d_text));
+    }
+    out["choices"][0]["finish_reason"] = finish;
+    (StatusCode::OK, Json(out)).into_response()
+}
+
+/// Streaming splice: one synthetic chunk carrying t1, then D's completions
+/// SSE re-shaped to the client's API (chat delta chunks when the client
+/// spoke chat), with usage patched to cover both legs.
+#[allow(clippy::too_many_arguments)]
+fn stream_spliced_response(
+    state: RouterState,
+    d_response: reqwest::Response,
+    leg: PrefillLeg,
+    is_chat: bool,
+    client_stream_options: Option<Value>,
+    req_id: String,
+    d_idx: usize,
+    arrive_time: Instant,
+) -> Response {
+    let include_usage = client_stream_options
+        .as_ref()
+        .and_then(|o| o.get("include_usage"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<axum::body::Bytes, std::io::Error>>(100);
+    tokio::spawn(async move {
+        let id = leg
+            .response
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("pd-1")
+            .to_string();
+        let model = leg
+            .response
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let first = if is_chat {
+            chat_chunk(&id, &model, json!({"role": "assistant", "content": leg.t1_text}), None)
+        } else {
+            completion_chunk(&id, &model, &leg.t1_text, None)
+        };
+        let _ = tx
+            .send(Ok(format!("data: {first}\n\n").into()))
+            .await;
+
+        let mut buffer = String::new();
+        let mut stream = Box::pin(d_response.bytes_stream());
+        'outer: while let Some(chunk) = stream.next().await {
+            let Ok(bytes) = chunk else {
+                error!("stream error: req={req_id}");
+                break;
+            };
+            buffer.push_str(&String::from_utf8_lossy(&bytes));
+            // SSE events are \n\n-delimited; hold the trailing partial event.
+            while let Some(pos) = buffer.find("\n\n") {
+                let event = buffer[..pos].to_string();
+                buffer.drain(..pos + 2);
+                let Some(data) = event
+                    .lines()
+                    .find_map(|line| line.strip_prefix("data: "))
+                else {
+                    continue;
+                };
+                if data.trim() == "[DONE]" {
+                    let _ = tx.send(Ok("data: [DONE]\n\n".into())).await;
+                    break 'outer;
+                }
+                let Ok(mut value) = serde_json::from_str::<Value>(data) else {
+                    continue;
+                };
+                // Patch usage to cover both legs (P's prompt + t1).
+                let is_usage_chunk = value.get("usage").is_some_and(|u| !u.is_null());
+                if is_usage_chunk {
+                    let d_completion =
+                        value["usage"]["completion_tokens"].as_u64().unwrap_or(0);
+                    value["usage"] = json!({
+                        "prompt_tokens": leg.prompt_token_ids.len(),
+                        "completion_tokens": d_completion + 1,
+                        "total_tokens": leg.prompt_token_ids.len() as u64 + d_completion + 1,
+                    });
+                    if !include_usage {
+                        // We forced include_usage on the D leg; a client that
+                        // didn't ask for it must not see a usage-only chunk.
+                        if value
+                            .get("choices")
+                            .and_then(|c| c.as_array())
+                            .is_none_or(|c| c.is_empty())
+                        {
+                            continue;
+                        }
+                        value.as_object_mut().map(|o| o.remove("usage"));
+                    }
+                }
+                let out = if is_chat {
+                    let text = value["choices"][0]["text"].as_str().unwrap_or_default();
+                    let finish = value["choices"][0]
+                        .get("finish_reason")
+                        .and_then(|v| v.as_str());
+                    let delta = if text.is_empty() {
+                        json!({})
+                    } else {
+                        json!({"content": text})
+                    };
+                    let mut chunk = chat_chunk(&id, &model, delta, finish);
+                    if is_usage_chunk && include_usage {
+                        chunk["usage"] = value["usage"].clone();
+                        chunk["choices"] = json!([]);
+                    }
+                    chunk
+                } else {
+                    value
+                };
+                if tx
+                    .send(Ok(format!("data: {out}\n\n").into()))
+                    .await
+                    .is_err()
+                {
+                    break 'outer;
+                }
+            }
+        }
+        state.finish_d(d_idx);
+        info!(
+            "done (stream): req={} D[{}] total={}ms inflight=[{}]",
+            req_id,
+            d_idx,
+            arrive_time.elapsed().as_millis(),
+            state.get_inflight_summary()
+        );
+    });
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "text/event-stream")
+        .body(Body::from_stream(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+        ))
+        .unwrap()
+}
+
 async fn handle_completion(
     State(state): State<RouterState>,
     _headers: HeaderMap,
@@ -146,6 +577,24 @@ async fn handle_completion(
         req_id,
         state.get_inflight_summary()
     );
+
+    if state.pd_first_token {
+        let mut last_err = String::new();
+        for attempt in 0..=state.pd_flow_retries {
+            match pd_first_token_flow(&state, &body, api_path, &req_id, arrive_time).await {
+                Ok(response) => return response,
+                Err(err) => {
+                    error!("P/D flow attempt {attempt} failed: req={req_id} {err}");
+                    last_err = err;
+                }
+            }
+        }
+        return (
+            StatusCode::BAD_GATEWAY,
+            Json(json!({"error": format!("P/D flow failed after retries: {last_err}")})),
+        )
+            .into_response();
+    }
 
     // Save original values to restore for D request
     let org_max_tokens = body.get("max_tokens").cloned();
@@ -392,6 +841,19 @@ struct Args {
     /// Decode endpoints
     #[arg(long, required = true, num_args = 1..)]
     decode: Vec<String>,
+
+    /// Variant A first-token forwarding: return P's single token to the
+    /// client and append it (as a token id) to the prompt D receives, so a
+    /// strict no-prefill decode node's first forward is a one-token decode.
+    /// Requires P to support `return_token_ids` and D to accept token-id
+    /// prompts on /v1/completions.
+    #[arg(long, default_value_t = false)]
+    pd_first_token: bool,
+
+    /// Full P->D flow retries when the D leg fails in --pd-first-token mode
+    /// (a strict decode node rejects when the remote KV never lands).
+    #[arg(long, default_value_t = 1)]
+    pd_flow_retries: usize,
 }
 
 #[tokio::main]
@@ -401,7 +863,15 @@ async fn main() {
 
     let args = Args::parse();
 
-    let state = RouterState::new(args.prefill.clone(), args.decode.clone());
+    let mut state = RouterState::new(args.prefill.clone(), args.decode.clone());
+    state.pd_first_token = args.pd_first_token;
+    state.pd_flow_retries = args.pd_flow_retries;
+    if state.pd_first_token {
+        info!(
+            "P/D first-token forwarding on (flow retries: {})",
+            state.pd_flow_retries
+        );
+    }
 
     let app = Router::new()
         .route("/v1/chat/completions", post(chat_completions))

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -148,7 +148,14 @@ class PegaKVConnector(KVConnectorBase_V1):
         self._scheduler: SchedulerConnector | None = None
         self._worker: WorkerConnector | None = None
         if role == KVConnectorRole.SCHEDULER:
-            self._scheduler = SchedulerConnector(self._ctx)
+            pd_tail_save = os.environ.get("PEGAFLOW_PD_TAIL_SAVE") == "1" or bool(
+                vllm_config.kv_transfer_config.get_from_extra_config(
+                    "pegaflow.pd_tail_save", False
+                )
+            )
+            self._scheduler = SchedulerConnector(
+                self._ctx, pd_tail_save=pd_tail_save, vllm_config=vllm_config
+            )
             # Open the liveness stream from the scheduler process only. One
             # stream per vllm replica is enough — if any tp worker crashes,
             # the scheduler dies too, closing this stream and triggering

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -148,10 +148,8 @@ class PegaKVConnector(KVConnectorBase_V1):
         self._scheduler: SchedulerConnector | None = None
         self._worker: WorkerConnector | None = None
         if role == KVConnectorRole.SCHEDULER:
-            pd_tail_save = os.environ.get("PEGAFLOW_PD_TAIL_SAVE") == "1" or bool(
-                vllm_config.kv_transfer_config.get_from_extra_config(
-                    "pegaflow.pd_tail_save", False
-                )
+            pd_tail_save = bool(
+                vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.pd_tail_save", False)
             )
             self._scheduler = SchedulerConnector(
                 self._ctx, pd_tail_save=pd_tail_save, vllm_config=vllm_config

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -107,11 +107,14 @@ class SchedulerConnector:
                     f"run vLLM with --prefix-caching-hash-algo xxhash_cbor"
                 )
             from vllm.utils.hashing import get_hash_fn_by_name
-            from vllm.v1.core.kv_cache_utils import NONE_HASH, hash_block_tokens
+            from vllm.v1.core import kv_cache_utils
 
             self._tail_hash_fn = get_hash_fn_by_name(algo)
-            self._none_hash = NONE_HASH
-            self._hash_block_tokens = hash_block_tokens
+            self._hash_block_tokens = kv_cache_utils.hash_block_tokens
+            # NONE_HASH is only assigned by vLLM's init_none_hash(), which
+            # runs after connector construction — it must be read lazily
+            # through the module, never imported by name here.
+            self._kv_cache_utils = kv_cache_utils
             logger.info("[PegaKVConnector] P/D tail-block save enabled (algo=%s)", algo)
         self._tail_saved: set[str] = set()
 
@@ -495,7 +498,7 @@ class SchedulerConnector:
         block_hashes = self._block_hashes.get(req_id) or ()
         if tail_idx >= len(allocated) or tail_idx > len(block_hashes):
             return None  # tail block not allocated / full-block hashes lagging
-        parent = block_hashes[tail_idx - 1] if tail_idx > 0 else self._none_hash
+        parent = block_hashes[tail_idx - 1] if tail_idx > 0 else self._kv_cache_utils.NONE_HASH
         tail_tokens = list(req.prompt_token_ids[tail_idx * vbs : prompt_len])
         tail_key = bytes(self._hash_block_tokens(self._tail_hash_fn, parent, tail_tokens, None))
         self._tail_saved.add(req_id)

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -93,17 +93,16 @@ class SchedulerConnector:
         # saves the partial tail block under a key derived with vLLM's OWN
         # hash function over (last_full_hash, tail_prompt_token_ids, None) —
         # well-defined, and independently derivable by the decode peer.
-        # Requires a replicable hash algo (the `_cbor` variants); the pickle
-        # variants cannot be derived outside this process and are rejected.
+        # Only xxhash_cbor is validated cross-engine; everything else is
+        # rejected (the pickle-based algos aren't even derivable elsewhere).
         self._tail_hash_fn = None
         if pd_tail_save:
-            if vllm_config is None:
-                raise ValueError("pd_tail_save requires vllm_config")
+            assert vllm_config is not None
             algo = vllm_config.cache_config.prefix_caching_hash_algo
-            if "cbor" not in str(algo):
+            if algo != "xxhash_cbor":
                 raise ValueError(
-                    f"pegaflow.pd_tail_save requires a cbor prefix-caching hash algo "
-                    f"(cross-engine derivable); got {algo!r} — "
+                    f"pegaflow.pd_tail_save requires prefix_caching_hash_algo "
+                    f"'xxhash_cbor' (cross-engine derivable, validated); got {algo!r} — "
                     f"run vLLM with --prefix-caching-hash-algo xxhash_cbor"
                 )
             from vllm.utils.hashing import get_hash_fn_by_name
@@ -480,11 +479,7 @@ class SchedulerConnector:
         # decode peer cannot know lora / cache_salt / multimodal dimensions
         # that vLLM folds into block 0's extra_keys. Saving would alias
         # differently-salted prompts onto one key — refuse instead.
-        if (
-            getattr(req, "lora_request", None) is not None
-            or getattr(req, "cache_salt", None)
-            or getattr(req, "mm_features", None)
-        ):
+        if req.lora_request is not None or req.cache_salt or req.mm_features:
             return None
         vbs = self._ctx.virtual_block_size
         prompt_len = req.num_prompt_tokens

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -78,8 +78,39 @@ class _QueryProbe:
 class SchedulerConnector:
     """Holds scheduler-only state and behaviors."""
 
-    def __init__(self, context: ConnectorContext):
+    def __init__(
+        self,
+        context: ConnectorContext,
+        pd_tail_save: bool = False,
+        vllm_config=None,
+    ):
         self._ctx = context
+
+        # P/D tail-block extension (`pegaflow.pd_tail_save`): vLLM only hashes
+        # full blocks, so a prompt's partial tail block never enters the tier
+        # and a strict no-prefill decode peer would have to recompute it.
+        # When enabled, the step that schedules the final prompt chunk also
+        # saves the partial tail block under a key derived with vLLM's OWN
+        # hash function over (last_full_hash, tail_prompt_token_ids, None) —
+        # well-defined, and independently derivable by the decode peer.
+        # Requires a replicable hash algo (the `_cbor` variants); the pickle
+        # variants cannot be derived outside this process and are rejected.
+        self._tail_hash_fn = None
+        if pd_tail_save:
+            if vllm_config is None:
+                raise ValueError("pd_tail_save requires vllm_config")
+            algo = vllm_config.cache_config.prefix_caching_hash_algo
+            if "cbor" not in str(algo):
+                raise ValueError(
+                    f"pegaflow.pd_tail_save requires a cbor prefix-caching hash algo "
+                    f"(cross-engine derivable); got {algo!r} — "
+                    f"run vLLM with --prefix-caching-hash-algo xxhash_cbor"
+                )
+            from vllm.utils.hashing import get_hash_fn_by_name
+
+            self._tail_hash_fn = get_hash_fn_by_name(algo)
+            logger.info("[PegaKVConnector] P/D tail-block save enabled (algo=%s)", algo)
+        self._tail_saved: set[str] = set()
 
         # Load state
         self._pending_load_intents: dict[str, LoadIntent] = {}
@@ -404,6 +435,59 @@ class SchedulerConnector:
 
     def _consume_save_intent(self, req_id: str) -> SaveIntent | None:
         """Calculate and return SaveIntent for new blocks that need saving."""
+        regular = self._consume_full_block_saves(req_id)
+        tail = self._consume_tail_save(req_id)
+        if tail is None:
+            return regular
+        if regular is None:
+            return tail
+        return SaveIntent(
+            block_ids=regular.block_ids + tail.block_ids,
+            block_hashes=regular.block_hashes + tail.block_hashes,
+        )
+
+    def _consume_tail_save(self, req_id: str) -> SaveIntent | None:
+        """P/D tail extension: save the prompt's partial tail block once its
+        prompt rows are final (the step scheduling the final prompt chunk).
+
+        The saved page may contain rows past the prompt (the first generated
+        token lands in it on the next step, racing the async D2H) — harmless:
+        the key covers only the tail *prompt* tokens, and the decode peer
+        recomputes every position past them anyway.
+        """
+        if self._tail_hash_fn is None or req_id in self._tail_saved:
+            return None
+        req = self._requests.get(req_id)
+        if req is None:
+            return None
+        vbs = self._ctx.virtual_block_size
+        prompt_len = req.num_prompt_tokens
+        tail_len = prompt_len % vbs
+        if tail_len == 0:
+            return None
+        if self._scheduled_tokens.get(req_id, 0) < prompt_len:
+            return None  # tail prompt rows not written yet
+        tail_idx = prompt_len // vbs
+        allocated = self._allocated_blocks.get(req_id, [])
+        block_hashes = self._block_hashes.get(req_id) or ()
+        if tail_idx >= len(allocated) or tail_idx > len(block_hashes):
+            return None  # tail block not allocated / full-block hashes lagging
+        from vllm.v1.core.kv_cache_utils import NONE_HASH, hash_block_tokens
+
+        parent = block_hashes[tail_idx - 1] if tail_idx > 0 else NONE_HASH
+        tail_tokens = list(req.prompt_token_ids[tail_idx * vbs : prompt_len])
+        tail_key = bytes(hash_block_tokens(self._tail_hash_fn, parent, tail_tokens, None))
+        self._tail_saved.add(req_id)
+        logger.info(
+            "[PegaKVConnector] req=%s pd_tail_save: block_id=%d tail_tokens=%d key=%s",
+            req_id,
+            allocated[tail_idx],
+            tail_len,
+            tail_key.hex(),
+        )
+        return SaveIntent(block_ids=(allocated[tail_idx],), block_hashes=(tail_key,))
+
+    def _consume_full_block_saves(self, req_id: str) -> SaveIntent | None:
         # block_hashes are at virtual_block_size granularity, 1-to-1 with block_ids.
         block_hashes = self._block_hashes.get(req_id)
         if block_hashes is None:
@@ -490,6 +574,7 @@ class SchedulerConnector:
         self._scheduled_tokens.pop(req_id, None)
         self._next_stored_block_idx.pop(req_id, None)
         self._pending_saves.discard(req_id)
+        self._tail_saved.discard(req_id)
 
     def _count_available_block_prefix(
         self, block_hashes: Iterable[bytes], req_id: str

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -107,14 +107,13 @@ class SchedulerConnector:
                     f"run vLLM with --prefix-caching-hash-algo xxhash_cbor"
                 )
             from vllm.utils.hashing import get_hash_fn_by_name
+            from vllm.v1.core.kv_cache_utils import NONE_HASH, hash_block_tokens
 
             self._tail_hash_fn = get_hash_fn_by_name(algo)
+            self._none_hash = NONE_HASH
+            self._hash_block_tokens = hash_block_tokens
             logger.info("[PegaKVConnector] P/D tail-block save enabled (algo=%s)", algo)
         self._tail_saved: set[str] = set()
-        # req_id -> prompt tokens covered by caches at admission (local
-        # prefix hit + pegaflow load) — positions that are never scheduled.
-        self._local_computed_at_admission: dict[str, int] = {}
-        self._unscheduled_prompt_tokens: dict[str, int] = {}
 
         # Load state
         self._pending_load_intents: dict[str, LoadIntent] = {}
@@ -146,12 +145,6 @@ class SchedulerConnector:
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
         req_id = request.request_id
-
-        # Prompt positions the local prefix cache already covers — they are
-        # never scheduled, so the tail save's completeness condition must
-        # count them (request.num_computed_tokens is not yet set when
-        # update_state_after_alloc runs).
-        self._local_computed_at_admission[req_id] = num_computed_tokens
 
         if not self._ctx.read_enabled:
             logger.debug(
@@ -310,18 +303,6 @@ class SchedulerConnector:
             self._allocated_blocks[req_id] = []
             self._scheduled_tokens[req_id] = 0
             self._next_stored_block_idx[req_id] = base_block_idx
-            # Prompt positions that will never be *scheduled*: the local
-            # prefix-cache hit plus the pegaflow-loaded prefix. The tail
-            # save's "prompt rows all written" condition must count them, or
-            # a request whose prompt shares a cached prefix (every multi-turn
-            # turn >= 2) never fires its tail save. Only the read-enabled
-            # branch needs this — the write-only branch folds computed tokens
-            # into _scheduled_tokens directly.
-            self._unscheduled_prompt_tokens[req_id] = (
-                self._local_computed_at_admission.get(req_id, 0) + num_external_tokens
-                if self._ctx.read_enabled
-                else 0
-            )
 
         if num_external_tokens > 0:
             block_ids = list(blocks.get_block_ids()[0]) if blocks else []
@@ -402,7 +383,12 @@ class SchedulerConnector:
                     req.num_computed_tokens + num_tokens,
                 )
 
-            if save_intent := self._consume_save_intent(req_id):
+            # Positions with valid KV after this step, from the scheduler's
+            # own invariant (num_computed_tokens covers prefix-cache hits and
+            # is reset on preemption — no connector-side bookkeeping can be
+            # trusted across a preempt/resume cycle).
+            written = req.num_computed_tokens + num_tokens
+            if save_intent := self._consume_save_intent(req_id, written):
                 potential_saves[req_id] = save_intent
 
         # Process cached (running) requests
@@ -435,7 +421,8 @@ class SchedulerConnector:
                     prior_computed_tokens + num_tokens,
                 )
 
-            if save_intent := self._consume_save_intent(req_id):
+            written = cached_reqs.num_computed_tokens[idx] + num_tokens
+            if save_intent := self._consume_save_intent(req_id, written):
                 potential_saves[req_id] = save_intent
 
         save_intents = potential_saves
@@ -455,10 +442,14 @@ class SchedulerConnector:
             preempted_req_ids=scheduler_output.preempted_req_ids or None,
         )
 
-    def _consume_save_intent(self, req_id: str) -> SaveIntent | None:
-        """Calculate and return SaveIntent for new blocks that need saving."""
+    def _consume_save_intent(self, req_id: str, written: int) -> SaveIntent | None:
+        """Calculate and return SaveIntent for new blocks that need saving.
+
+        `written` = positions with valid KV once this step's schedule runs
+        (scheduler-authoritative num_computed_tokens + this step's tokens).
+        """
         regular = self._consume_full_block_saves(req_id)
-        tail = self._consume_tail_save(req_id)
+        tail = self._consume_tail_save(req_id, written)
         if tail is None:
             return regular
         if regular is None:
@@ -468,7 +459,7 @@ class SchedulerConnector:
             block_hashes=regular.block_hashes + tail.block_hashes,
         )
 
-    def _consume_tail_save(self, req_id: str) -> SaveIntent | None:
+    def _consume_tail_save(self, req_id: str, written: int) -> SaveIntent | None:
         """P/D tail extension: save the prompt's partial tail block once its
         prompt rows are final (the step scheduling the final prompt chunk).
 
@@ -482,14 +473,21 @@ class SchedulerConnector:
         req = self._requests.get(req_id)
         if req is None:
             return None
+        # The tail key is derived from (parent hash, token ids) alone; the
+        # decode peer cannot know lora / cache_salt / multimodal dimensions
+        # that vLLM folds into block 0's extra_keys. Saving would alias
+        # differently-salted prompts onto one key — refuse instead.
+        if (
+            getattr(req, "lora_request", None) is not None
+            or getattr(req, "cache_salt", None)
+            or getattr(req, "mm_features", None)
+        ):
+            return None
         vbs = self._ctx.virtual_block_size
         prompt_len = req.num_prompt_tokens
         tail_len = prompt_len % vbs
         if tail_len == 0:
             return None
-        written = self._unscheduled_prompt_tokens.get(req_id, 0) + self._scheduled_tokens.get(
-            req_id, 0
-        )
         if written < prompt_len:
             return None  # tail prompt rows not written yet
         tail_idx = prompt_len // vbs
@@ -497,11 +495,9 @@ class SchedulerConnector:
         block_hashes = self._block_hashes.get(req_id) or ()
         if tail_idx >= len(allocated) or tail_idx > len(block_hashes):
             return None  # tail block not allocated / full-block hashes lagging
-        from vllm.v1.core.kv_cache_utils import NONE_HASH, hash_block_tokens
-
-        parent = block_hashes[tail_idx - 1] if tail_idx > 0 else NONE_HASH
+        parent = block_hashes[tail_idx - 1] if tail_idx > 0 else self._none_hash
         tail_tokens = list(req.prompt_token_ids[tail_idx * vbs : prompt_len])
-        tail_key = bytes(hash_block_tokens(self._tail_hash_fn, parent, tail_tokens, None))
+        tail_key = bytes(self._hash_block_tokens(self._tail_hash_fn, parent, tail_tokens, None))
         self._tail_saved.add(req_id)
         logger.info(
             "[PegaKVConnector] req=%s pd_tail_save: block_id=%d tail_tokens=%d key=%s",
@@ -600,8 +596,6 @@ class SchedulerConnector:
         self._next_stored_block_idx.pop(req_id, None)
         self._pending_saves.discard(req_id)
         self._tail_saved.discard(req_id)
-        self._local_computed_at_admission.pop(req_id, None)
-        self._unscheduled_prompt_tokens.pop(req_id, None)
 
     def _count_available_block_prefix(
         self, block_hashes: Iterable[bytes], req_id: str

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -111,6 +111,10 @@ class SchedulerConnector:
             self._tail_hash_fn = get_hash_fn_by_name(algo)
             logger.info("[PegaKVConnector] P/D tail-block save enabled (algo=%s)", algo)
         self._tail_saved: set[str] = set()
+        # req_id -> prompt tokens covered by caches at admission (local
+        # prefix hit + pegaflow load) — positions that are never scheduled.
+        self._local_computed_at_admission: dict[str, int] = {}
+        self._unscheduled_prompt_tokens: dict[str, int] = {}
 
         # Load state
         self._pending_load_intents: dict[str, LoadIntent] = {}
@@ -142,6 +146,12 @@ class SchedulerConnector:
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
         req_id = request.request_id
+
+        # Prompt positions the local prefix cache already covers — they are
+        # never scheduled, so the tail save's completeness condition must
+        # count them (request.num_computed_tokens is not yet set when
+        # update_state_after_alloc runs).
+        self._local_computed_at_admission[req_id] = num_computed_tokens
 
         if not self._ctx.read_enabled:
             logger.debug(
@@ -300,6 +310,18 @@ class SchedulerConnector:
             self._allocated_blocks[req_id] = []
             self._scheduled_tokens[req_id] = 0
             self._next_stored_block_idx[req_id] = base_block_idx
+            # Prompt positions that will never be *scheduled*: the local
+            # prefix-cache hit plus the pegaflow-loaded prefix. The tail
+            # save's "prompt rows all written" condition must count them, or
+            # a request whose prompt shares a cached prefix (every multi-turn
+            # turn >= 2) never fires its tail save. Only the read-enabled
+            # branch needs this — the write-only branch folds computed tokens
+            # into _scheduled_tokens directly.
+            self._unscheduled_prompt_tokens[req_id] = (
+                self._local_computed_at_admission.get(req_id, 0) + num_external_tokens
+                if self._ctx.read_enabled
+                else 0
+            )
 
         if num_external_tokens > 0:
             block_ids = list(blocks.get_block_ids()[0]) if blocks else []
@@ -465,7 +487,10 @@ class SchedulerConnector:
         tail_len = prompt_len % vbs
         if tail_len == 0:
             return None
-        if self._scheduled_tokens.get(req_id, 0) < prompt_len:
+        written = self._unscheduled_prompt_tokens.get(req_id, 0) + self._scheduled_tokens.get(
+            req_id, 0
+        )
+        if written < prompt_len:
             return None  # tail prompt rows not written yet
         tail_idx = prompt_len // vbs
         allocated = self._allocated_blocks.get(req_id, [])
@@ -575,6 +600,8 @@ class SchedulerConnector:
         self._next_stored_block_idx.pop(req_id, None)
         self._pending_saves.discard(req_id)
         self._tail_saved.discard(req_id)
+        self._local_computed_at_admission.pop(req_id, None)
+        self._unscheduled_prompt_tokens.pop(req_id, None)
 
     def _count_available_block_prefix(
         self, block_hashes: Iterable[bytes], req_id: str

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -337,7 +337,7 @@ class TestDecodeHashRefresh:
         sc._allocated_blocks["r1"] = [10, 11, 12, 13]
         sc._scheduled_tokens["r1"] = 128  # 4 * 32
 
-        intent = sc._consume_save_intent("r1")
+        intent = sc._consume_save_intent("r1", 0)
         assert intent is not None
         assert len(intent.block_ids) == 4
         assert len(intent.block_hashes) == 4
@@ -354,7 +354,7 @@ class TestDecodeHashRefresh:
         sc._scheduled_tokens["r1"] = 128  # 4 * 32
 
         # Save initial 4 blocks
-        intent = sc._consume_save_intent("r1")
+        intent = sc._consume_save_intent("r1", 0)
         assert intent is not None
         assert len(intent.block_ids) == 4
 
@@ -365,14 +365,14 @@ class TestDecodeHashRefresh:
         sc._scheduled_tokens["r1"] += 64  # 2 * 32 more tokens
 
         # Before refresh: _block_hashes is stale (4 entries) → no new saves
-        stale_intent = sc._consume_save_intent("r1")
+        stale_intent = sc._consume_save_intent("r1", 0)
         assert stale_intent is None  # still capped at 4
 
         # Refresh hashes (simulates what build_connector_meta does)
         sc._block_hashes["r1"] = tuple(req.block_hashes)
 
         # Now the 2 decode blocks become saveable
-        intent2 = sc._consume_save_intent("r1")
+        intent2 = sc._consume_save_intent("r1", 0)
         assert intent2 is not None
         assert len(intent2.block_ids) == 2
         assert intent2.block_ids == (14, 15)
@@ -413,7 +413,7 @@ class TestDecodeHashRefresh:
             202,
         ]
 
-        intent = sc._consume_save_intent("r1")
+        intent = sc._consume_save_intent("r1", 0)
 
         assert intent is not None
         assert intent.block_hashes == block_hashes[6:9]

--- a/python/tests/test_pd_tail_save.py
+++ b/python/tests/test_pd_tail_save.py
@@ -140,13 +140,9 @@ class TestTailSaveThroughBuildConnectorMeta:
                 req_ids=[r["id"] for r in cached],
                 new_block_ids=[r.get("new_blocks") for r in cached],
                 num_computed_tokens=[r["computed"] for r in cached],
-                resumed_req_ids=set(
-                    r["id"] for r in cached if r.get("resumed", False)
-                ),
+                resumed_req_ids={r["id"] for r in cached if r.get("resumed", False)},
             ),
-            num_scheduled_tokens={
-                r["id"]: r["scheduled"] for r in (list(new) + list(cached))
-            },
+            num_scheduled_tokens={r["id"]: r["scheduled"] for r in (list(new) + list(cached))},
             preempted_req_ids=set(),
         )
         return sc.build_connector_meta(scheduler_output)

--- a/python/tests/test_pd_tail_save.py
+++ b/python/tests/test_pd_tail_save.py
@@ -68,7 +68,7 @@ def _make_connector(req, allocated: list[int]) -> SchedulerConnector:
     # Inject the tail machinery directly: these tests pin the TRIGGER, not
     # vLLM's hash function (covered by the cross-engine e2e gates).
     sc._tail_hash_fn = object()
-    sc._none_hash = b"\x00" * 32
+    sc._kv_cache_utils = SimpleNamespace(NONE_HASH=b"\x00" * 32)
     sc._hash_block_tokens = lambda fn, parent, tokens, extra: b"tail:%d" % len(tokens)
     sc._requests[req.request_id] = req
     sc._block_hashes[req.request_id] = tuple(req.block_hashes)

--- a/python/tests/test_pd_tail_save.py
+++ b/python/tests/test_pd_tail_save.py
@@ -1,0 +1,202 @@
+"""P/D tail-block save trigger (`pegaflow.pd_tail_save`).
+
+The trigger condition is the part that has bitten twice: the tail block must
+be saved exactly on the step whose schedule finishes the prompt, using the
+scheduler-authoritative `num_computed_tokens + num_scheduled_tokens` — any
+connector-side accumulator lies across preempt/resume cycles and can save a
+torn tail page into a content-addressed tier that dedups late corrections.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: E402
+import hashlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from pegaflow.connector.common import ConnectorContext
+from pegaflow.connector.scheduler import SchedulerConnector
+
+VBS = 16  # virtual block size for these tests
+
+
+def _hash(i: int) -> bytes:
+    return hashlib.sha256(f"block_{i}".encode()).digest()
+
+
+def _make_ctx() -> ConnectorContext:
+    return ConnectorContext(
+        **{
+            "instance_id": "test",
+            "namespace": "ns",
+            "block_size": VBS,
+            "tp_size": 1,
+            "world_size": 1,
+            "tp_rank": 0,
+            "device_id": 0,
+            "engine_client": MagicMock(),
+            "state_manager": MagicMock(),
+            "is_mla": False,
+            "dcp_world_size": 1,
+            "dcp_rank": 0,
+        }
+    )  # type: ignore[arg-type]
+
+
+def _make_request(req_id: str, prompt_len: int, full_hashes: int):
+    """Quacks like vllm.v1.request.Request, with the tail-relevant fields
+    explicit (no MagicMock auto-attributes: the lora/salt/mm guard reads
+    them)."""
+    return SimpleNamespace(
+        request_id=req_id,
+        num_prompt_tokens=prompt_len,
+        num_tokens=prompt_len,
+        prompt_token_ids=list(range(prompt_len)),
+        block_hashes=[_hash(i) for i in range(full_hashes)],
+        lora_request=None,
+        cache_salt=None,
+        mm_features=None,
+    )
+
+
+def _make_connector(req, allocated: list[int]) -> SchedulerConnector:
+    sc = SchedulerConnector(_make_ctx())
+    # Inject the tail machinery directly: these tests pin the TRIGGER, not
+    # vLLM's hash function (covered by the cross-engine e2e gates).
+    sc._tail_hash_fn = object()
+    sc._none_hash = b"\x00" * 32
+    sc._hash_block_tokens = lambda fn, parent, tokens, extra: b"tail:%d" % len(tokens)
+    sc._requests[req.request_id] = req
+    sc._block_hashes[req.request_id] = tuple(req.block_hashes)
+    sc._allocated_blocks[req.request_id] = allocated
+    sc._scheduled_tokens[req.request_id] = 0
+    sc._block_index_offsets[req.request_id] = 0
+    sc._next_stored_block_idx[req.request_id] = 0
+    return sc
+
+
+class TestTailSaveTrigger:
+    def test_fires_exactly_when_written_covers_the_prompt(self):
+        # prompt 50 = 3 full blocks (48) + 2-token tail in block idx 3
+        req = _make_request("r1", prompt_len=50, full_hashes=3)
+        sc = _make_connector(req, allocated=[10, 11, 12, 13])
+
+        assert sc._consume_tail_save("r1", written=49) is None
+        intent = sc._consume_tail_save("r1", written=50)
+        assert intent is not None
+        assert intent.block_ids == (13,)
+        # Once saved, never again (content-addressed dedup upstream would
+        # reject a correction, so a re-save is pure waste).
+        assert sc._consume_tail_save("r1", written=51) is None
+
+    def test_block_aligned_prompt_has_no_tail(self):
+        req = _make_request("r1", prompt_len=48, full_hashes=3)
+        sc = _make_connector(req, allocated=[10, 11, 12])
+        assert sc._consume_tail_save("r1", written=48) is None
+
+    def test_sub_block_prompt_uses_none_hash_parent(self):
+        req = _make_request("r1", prompt_len=10, full_hashes=0)
+        sc = _make_connector(req, allocated=[10])
+        intent = sc._consume_tail_save("r1", written=10)
+        assert intent is not None
+        assert intent.block_ids == (10,)
+        assert intent.block_hashes == (b"tail:10",)
+
+    def test_salted_or_lora_requests_never_tail_save(self):
+        # The tail key carries no extra_keys; saving would alias
+        # differently-salted prompts onto one content-addressed key.
+        for field, value in (("cache_salt", "tenant-a"), ("lora_request", object())):
+            req = _make_request("r1", prompt_len=50, full_hashes=3)
+            setattr(req, field, value)
+            sc = _make_connector(req, allocated=[10, 11, 12, 13])
+            assert sc._consume_tail_save("r1", written=50) is None
+
+    def test_tail_block_not_yet_allocated_defers(self):
+        req = _make_request("r1", prompt_len=50, full_hashes=3)
+        sc = _make_connector(req, allocated=[10, 11, 12])  # tail block missing
+        assert sc._consume_tail_save("r1", written=50) is None
+
+
+class TestTailSaveThroughBuildConnectorMeta:
+    """`written` must come from the scheduler's own per-step counters."""
+
+    def _step(self, sc, *, new=None, cached=None):
+        new = new or []
+        cached = cached or []
+        scheduler_output = SimpleNamespace(
+            scheduled_new_reqs=[
+                SimpleNamespace(
+                    req_id=r["id"],
+                    block_ids=(r["blocks"],),
+                    num_computed_tokens=r["computed"],
+                )
+                for r in new
+            ],
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=[r["id"] for r in cached],
+                new_block_ids=[r.get("new_blocks") for r in cached],
+                num_computed_tokens=[r["computed"] for r in cached],
+                resumed_req_ids=set(
+                    r["id"] for r in cached if r.get("resumed", False)
+                ),
+            ),
+            num_scheduled_tokens={
+                r["id"]: r["scheduled"] for r in (list(new) + list(cached))
+            },
+            preempted_req_ids=set(),
+        )
+        return sc.build_connector_meta(scheduler_output)
+
+    def test_prefix_hit_new_request_fires_on_admission_step(self):
+        # Multi-turn turn>=2: the whole previous context is a local prefix
+        # hit (num_computed_tokens=48), only the 2-token tail is scheduled.
+        req = _make_request("r1", prompt_len=50, full_hashes=3)
+        sc = _make_connector(req, allocated=[10, 11, 12, 13])
+        meta = self._step(
+            sc,
+            new=[{"id": "r1", "blocks": [10, 11, 12, 13], "computed": 48, "scheduled": 2}],
+        )
+        intent = meta.save_intents.get("r1")
+        assert intent is not None
+        assert 13 in intent.block_ids
+
+    def test_preempt_resume_does_not_fire_early(self):
+        # Chunked prefill: 32 of 50 scheduled, then preempted (all progress
+        # discarded), then resumed 32, then the final 18. A cumulative
+        # accumulator would see 32+32=64 >= 50 mid-resume and save a tail
+        # page whose rows are not written yet.
+        req = _make_request("r1", prompt_len=50, full_hashes=3)
+        sc = _make_connector(req, allocated=[10, 11, 12, 13])
+
+        meta = self._step(
+            sc,
+            new=[{"id": "r1", "blocks": [10, 11, 12, 13], "computed": 0, "scheduled": 32}],
+        )
+        assert meta.save_intents.get("r1") is None or 13 not in meta.save_intents["r1"].block_ids
+
+        # Preempted; resume re-schedules from scratch.
+        meta = self._step(
+            sc,
+            cached=[
+                {
+                    "id": "r1",
+                    "new_blocks": ([10, 11, 12, 13],),
+                    "computed": 0,
+                    "scheduled": 32,
+                    "resumed": True,
+                }
+            ],
+        )
+        assert meta.save_intents.get("r1") is None or 13 not in meta.save_intents["r1"].block_ids
+
+        meta = self._step(
+            sc,
+            cached=[{"id": "r1", "new_blocks": None, "computed": 32, "scheduled": 18}],
+        )
+        intent = meta.save_intents.get("r1")
+        assert intent is not None
+        assert 13 in intent.block_ids


### PR DESCRIPTION
# feat(pd): first-token router forwarding + P-side partial tail-block save

P-side half of the cross-engine GLM5.2 P/D deployment (vLLM TP8 prefill on one 8×H200 node, openinfer EP8 strict no-prefill decode on another; companion PR in the openinfer repo). Two pieces:

## Connector: `pegaflow.pd_tail_save`

vLLM only hashes full blocks, so a prompt's partial tail block never enters the tier — a strict no-prefill decode peer would have to recompute it. When enabled, the step whose schedule finishes the prompt also saves the partial tail page under a key derived with vLLM's **own** hash function over `(last_full_block_hash, tail_prompt_token_ids, None)` — independently derivable by the decode peer. The page may already carry the racing first generated token's row; harmless, the key covers only prompt positions and the peer recomputes everything past them.

Trigger correctness (reviewed, tested):
- `written = num_computed_tokens + num_scheduled_tokens` straight from the scheduler's per-step output. The first version kept a connector-side accumulator; that lies across preempt/resume cycles and can save a **torn tail page under a valid content-addressed key** — and the tier's late-duplicate dedup would then reject the correct bytes forever. `num_computed_tokens` also covers the local prefix-cache hit case (every multi-turn turn ≥ 2 on P).
- Requests with `lora_request`, `cache_salt`, or multimodal features never tail-save: the tail key carries no extra_keys, so it would alias differently-salted prompts onto one key.
- Unit tests cover the trigger boundary, preempt/resume, the prefix-hit admission step, sub-block prompts (NONE_HASH parent), and the salt/lora refusal.

## Router: `--pd-first-token` (variant A)

P is called with `max_tokens=1 + return_token_ids`; its single token goes back to the client **and** is appended to the token-id prompt D receives on `/v1/completions` — the decode node's first forward is a one-token decode, zero prompt positions computed. D failures before any bytes reach the client retry the whole P→D flow (the P leg is idempotent: same prompt, same content-addressed KV).

API-contract hardening from review:
- Explicit `max_tokens` on the D leg — engines default an absent value to 16, silently truncating every open-ended chat request (`--pd-max-model-len` bounds it).
- Chat-only field shapes (`logprobs` bool, `tools`, `response_format`, …) are stripped before the completions call instead of 400-ing deterministically through every retry; deterministic 4xx no longer consumes flow retries at all.
- `n > 1` and batched prompts get an upfront 400 instead of a silent `choices[0]` splice.
- A decode stream that dies mid-flight emits an error SSE frame (`pd_decode_interrupted`) instead of a clean-looking EOF.
- Internal token-id fields are stripped from client-facing responses; in-flight counters no longer leak on parse failures.

## Verified

Full-chain verification lives with the openinfer-side PR and `docs/models/glm52/pd-m2-execution.md` there: token-identical output vs direct vLLM, zero-prefill admission throughout, gsm8k/NIAH accuracy parity, failure injection (kill P / kill metaserver ⇒ clean errors + automatic recovery), and an equal-card multi-turn acceptance benchmark vs 2× mixed vLLM.

## Follow-up (tracked)

Metaserver metadata is in-memory; on restart, pegaflow-server does not re-publish its block catalog, so previously saved prefixes stay undiscoverable until the producer re-saves them. The clean fix is a catalog re-publish on metaserver reconnect (registry-failover semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
