### PR TITLE
fix: end transfer-lock leaks — QPN collision ownership, RAII release guard, session worker leak, fetch chunk clamp

### DIFF
--- a/pegaflow-core/src/backing/mod.rs
+++ b/pegaflow-core/src/backing/mod.rs
@@ -4,6 +4,8 @@ pub(super) mod rdma;
 pub(super) mod rdma_fetch;
 pub(super) mod ssd;
 pub(super) mod ssd_cache;
+#[cfg(feature = "rdma")]
+mod transfer_lock_guard;
 pub(super) mod uring;
 
 use std::sync::Arc;

--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -180,7 +180,7 @@ async fn rdma_fetch_task(
 
     // 2. gRPC QueryBlocksForTransfer (connection already established)
     let query_start = Instant::now();
-    let (client, response) = match query_remote_blocks(
+    let (client, mut response) = match query_remote_blocks(
         grpc_channels,
         remote_addr,
         namespace,
@@ -200,7 +200,16 @@ async fn rdma_fetch_task(
     };
     let query_elapsed = query_start.elapsed();
 
-    let transfer_session_id = response.transfer_session_id.clone();
+    // The holder pinned the blocks when the query created this session, so
+    // every exit from here — completion, error, panic, or this future being
+    // dropped — must send ReleaseTransferLock. The guard's Drop covers the
+    // paths no explicit call can reach.
+    let lock_guard = TransferLockGuard::new(
+        client,
+        std::mem::take(&mut response.transfer_session_id),
+        remote_addr,
+        req_id,
+    );
 
     // 3. RDMA READ all blocks + build SealedBlocks
     let transfer_timeout = transfer_timeout_from_server(response.lock_timeout_secs);
@@ -224,7 +233,7 @@ async fn rdma_fetch_task(
         Err(e) => {
             warn!("RDMA transfer from {remote_addr} failed: {e}");
             rdma.engine().invalidate_connection(remote_addr);
-            spawn_release_lock(client, transfer_session_id);
+            lock_guard.release();
             core_metrics()
                 .rdma_fetch_total
                 .add(1, &[KeyValue::new("status", "error")]);
@@ -233,7 +242,7 @@ async fn rdma_fetch_task(
     };
 
     // 4. Release transfer lock (fire-and-forget: spawns a detached task)
-    spawn_release_lock(client, transfer_session_id);
+    lock_guard.release();
 
     let elapsed = t0.elapsed();
     let mb = total_bytes as f64 / (1024.0 * 1024.0);
@@ -665,19 +674,70 @@ fn transfer_timeout_from_server(lock_timeout_secs: u32) -> Duration {
         .max(MIN_TRANSFER_TIMEOUT)
 }
 
-/// Release a transfer lock in a detached task. Does not block the caller.
-fn spawn_release_lock(mut client: EngineClient<Channel>, transfer_session_id: String) {
-    if transfer_session_id.is_empty() {
-        return;
-    }
-    tokio::spawn(async move {
-        let req = ReleaseTransferLockRequest {
-            transfer_session_id: transfer_session_id.clone(),
-        };
-        if let Err(e) = client.release_transfer_lock(req).await {
-            warn!("ReleaseTransferLock failed for session {transfer_session_id}: {e}");
+/// Releases a transfer session exactly once, on whichever exit runs first:
+/// `release()` on the coded completion paths, or `Drop` when the fetch task
+/// panics or its future is dropped mid-await. A session that is never
+/// released pins the remote blocks until the holder's GC expires it.
+struct TransferLockGuard {
+    client: EngineClient<Channel>,
+    session_id: String,
+    remote_addr: String,
+    req_id: String,
+    // Captured at construction (always inside the runtime) so Drop can spawn
+    // even from a panic unwind; spawning on a shut-down runtime is a no-op.
+    handle: tokio::runtime::Handle,
+}
+
+impl TransferLockGuard {
+    fn new(
+        client: EngineClient<Channel>,
+        session_id: String,
+        remote_addr: &str,
+        req_id: &str,
+    ) -> Self {
+        Self {
+            client,
+            session_id,
+            remote_addr: remote_addr.to_string(),
+            req_id: req_id.to_string(),
+            handle: tokio::runtime::Handle::current(),
         }
-    });
+    }
+
+    /// Release on a completed fetch (success or handled error). Fire-and-forget.
+    fn release(mut self) {
+        self.spawn_release();
+    }
+
+    fn spawn_release(&mut self) {
+        let session_id = std::mem::take(&mut self.session_id);
+        if session_id.is_empty() {
+            return;
+        }
+        let mut client = self.client.clone();
+        self.handle.spawn(async move {
+            let req = ReleaseTransferLockRequest {
+                transfer_session_id: session_id.clone(),
+            };
+            if let Err(e) = client.release_transfer_lock(req).await {
+                warn!("ReleaseTransferLock failed for session {session_id}: {e}");
+            }
+        });
+    }
+}
+
+impl Drop for TransferLockGuard {
+    fn drop(&mut self) {
+        if self.session_id.is_empty() {
+            return;
+        }
+        // Only panic/cancellation reaches here — the coded paths call release().
+        warn!(
+            "RDMA fetch aborted without releasing transfer lock; releasing via drop guard: session={} remote={} req_id={}",
+            self.session_id, self.remote_addr, self.req_id
+        );
+        self.spawn_release();
+    }
 }
 
 #[cfg(test)]
@@ -743,5 +803,173 @@ mod tests {
             Err(err) => err,
         };
         assert!(err.contains("failed to allocate fetch chunk"));
+    }
+
+    mod lock_guard {
+        use super::super::*;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use pegaflow_proto::proto::engine::engine_server::{Engine, EngineServer};
+        use pegaflow_proto::proto::engine::{
+            HealthRequest, HealthResponse, LoadRequest, LoadResponse, QueryRequest, QueryResponse,
+            RegisterContextRequest, RegisterContextResponse, ReleaseRequest, ReleaseResponse,
+            ReleaseTransferLockResponse, SaveRequest, SaveResponse, SessionEvent, SessionRequest,
+            ShutdownRequest, ShutdownResponse, UnregisterRequest, UnregisterResponse,
+        };
+        use tokio_stream::wrappers::TcpListenerStream;
+        use tonic::{Request, Response, Status};
+
+        /// Stub engine that only counts ReleaseTransferLock calls.
+        struct ReleaseCounter(Arc<AtomicUsize>);
+
+        #[tonic::async_trait]
+        impl Engine for ReleaseCounter {
+            async fn release_transfer_lock(
+                &self,
+                _request: Request<ReleaseTransferLockRequest>,
+            ) -> Result<Response<ReleaseTransferLockResponse>, Status> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(Response::new(ReleaseTransferLockResponse {
+                    status: None,
+                    released_blocks: 0,
+                }))
+            }
+
+            async fn query_blocks_for_transfer(
+                &self,
+                _request: Request<QueryBlocksForTransferRequest>,
+            ) -> Result<Response<QueryBlocksForTransferResponse>, Status> {
+                Err(Status::unimplemented("stub"))
+            }
+            async fn rdma_handshake(
+                &self,
+                _request: Request<RdmaHandshakeRequest>,
+            ) -> Result<Response<pegaflow_proto::proto::engine::RdmaHandshakeResponse>, Status>
+            {
+                Err(Status::unimplemented("stub"))
+            }
+            async fn health(
+                &self,
+                _request: Request<HealthRequest>,
+            ) -> Result<Response<HealthResponse>, Status> {
+                Err(Status::unimplemented("stub"))
+            }
+            async fn register_context_batch(
+                &self,
+                _request: Request<RegisterContextRequest>,
+            ) -> Result<Response<RegisterContextResponse>, Status> {
+                Err(Status::unimplemented("stub"))
+            }
+            async fn save(
+                &self,
+                _request: Request<SaveRequest>,
+            ) -> Result<Response<SaveResponse>, Status> {
+                Err(Status::unimplemented("stub"))
+            }
+            async fn load(
+                &self,
+                _request: Request<LoadRequest>,
+            ) -> Result<Response<LoadResponse>, Status> {
+                Err(Status::unimplemented("stub"))
+            }
+            async fn query_prefetch(
+                &self,
+                _request: Request<QueryRequest>,
+            ) -> Result<Response<QueryResponse>, Status> {
+                Err(Status::unimplemented("stub"))
+            }
+            async fn release(
+                &self,
+                _request: Request<ReleaseRequest>,
+            ) -> Result<Response<ReleaseResponse>, Status> {
+                Err(Status::unimplemented("stub"))
+            }
+            async fn unregister_context(
+                &self,
+                _request: Request<UnregisterRequest>,
+            ) -> Result<Response<UnregisterResponse>, Status> {
+                Err(Status::unimplemented("stub"))
+            }
+            async fn shutdown(
+                &self,
+                _request: Request<ShutdownRequest>,
+            ) -> Result<Response<ShutdownResponse>, Status> {
+                Err(Status::unimplemented("stub"))
+            }
+            type SessionStream = futures::stream::Empty<Result<SessionEvent, Status>>;
+            async fn session(
+                &self,
+                _request: Request<SessionRequest>,
+            ) -> Result<Response<Self::SessionStream>, Status> {
+                Err(Status::unimplemented("stub"))
+            }
+        }
+
+        /// Serve a ReleaseCounter on an ephemeral loopback port; return a
+        /// connected client and the shared counter.
+        async fn start_counter_server() -> (EngineClient<Channel>, Arc<AtomicUsize>) {
+            let counter = Arc::new(AtomicUsize::new(0));
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind loopback");
+            let addr = listener.local_addr().expect("local addr");
+            let service = EngineServer::new(ReleaseCounter(Arc::clone(&counter)));
+            tokio::spawn(
+                tonic::transport::Server::builder()
+                    .add_service(service)
+                    .serve_with_incoming(TcpListenerStream::new(listener)),
+            );
+            let channel = Endpoint::from_shared(format!("http://{addr}"))
+                .expect("endpoint")
+                .connect_lazy();
+            (EngineClient::new(channel), counter)
+        }
+
+        async fn wait_for_count(counter: &AtomicUsize, expected: usize) {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while counter.load(Ordering::SeqCst) < expected {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("release RPC should arrive");
+        }
+
+        fn guard(client: &EngineClient<Channel>, session: &str) -> TransferLockGuard {
+            TransferLockGuard::new(client.clone(), session.to_string(), "remote", "req")
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn releases_exactly_once_on_every_exit_path() {
+            let (client, counter) = start_counter_server().await;
+
+            // Explicit release on the coded path.
+            guard(&client, "explicit").release();
+            wait_for_count(&counter, 1).await;
+
+            // Drop without release (future cancelled) still releases.
+            drop(guard(&client, "dropped"));
+            wait_for_count(&counter, 2).await;
+
+            // Panic unwinding through the guard still releases.
+            let g = guard(&client, "panicked");
+            let task = tokio::spawn(async move {
+                let _g = g;
+                panic!("simulated fetch panic");
+            });
+            assert!(task.await.is_err());
+            wait_for_count(&counter, 3).await;
+
+            // No double release: settle window after all three paths.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            assert_eq!(counter.load(Ordering::SeqCst), 3);
+
+            // Empty session (holder returned none) never sends an RPC.
+            guard(&client, "").release();
+            drop(guard(&client, ""));
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            assert_eq!(counter.load(Ordering::SeqCst), 3);
+        }
     }
 }

--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -11,7 +11,7 @@ use mea::singleflight::Group;
 use pegaflow_proto::proto::engine::engine_client::EngineClient;
 use pegaflow_proto::proto::engine::{
     QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, RdmaHandshakeRequest,
-    ReleaseTransferLockRequest, TransferBlockInfo,
+    TransferBlockInfo,
 };
 use pegaflow_transfer::{ConnectionStatus, HandshakeMetadata, TransferDesc, TransferOp};
 use tonic::transport::{Channel, Endpoint};
@@ -20,6 +20,7 @@ use pegaflow_common::NumaNode;
 
 use opentelemetry::KeyValue;
 
+use super::transfer_lock_guard::TransferLockGuard;
 use super::{AllocateFn, PrefetchResult, RdmaTransport};
 use crate::block::{BlockKey, RawBlock, SealedBlock, Segment};
 use crate::internode::MetaServerClient;
@@ -731,72 +732,6 @@ fn transfer_timeout_from_server(lock_timeout_secs: u32) -> Duration {
         .max(MIN_TRANSFER_TIMEOUT)
 }
 
-/// Releases a transfer session exactly once, on whichever exit runs first:
-/// `release()` on the coded completion paths, or `Drop` when the fetch task
-/// panics or its future is dropped mid-await. A session that is never
-/// released pins the remote blocks until the holder's GC expires it.
-struct TransferLockGuard {
-    client: EngineClient<Channel>,
-    session_id: String,
-    remote_addr: String,
-    req_id: String,
-    // Captured at construction (always inside the runtime) so Drop can spawn
-    // even from a panic unwind; spawning on a shut-down runtime is a no-op.
-    handle: tokio::runtime::Handle,
-}
-
-impl TransferLockGuard {
-    fn new(
-        client: EngineClient<Channel>,
-        session_id: String,
-        remote_addr: &str,
-        req_id: &str,
-    ) -> Self {
-        Self {
-            client,
-            session_id,
-            remote_addr: remote_addr.to_string(),
-            req_id: req_id.to_string(),
-            handle: tokio::runtime::Handle::current(),
-        }
-    }
-
-    /// Release on a completed fetch (success or handled error). Fire-and-forget.
-    fn release(mut self) {
-        self.spawn_release();
-    }
-
-    fn spawn_release(&mut self) {
-        let session_id = std::mem::take(&mut self.session_id);
-        if session_id.is_empty() {
-            return;
-        }
-        let mut client = self.client.clone();
-        self.handle.spawn(async move {
-            let req = ReleaseTransferLockRequest {
-                transfer_session_id: session_id.clone(),
-            };
-            if let Err(e) = client.release_transfer_lock(req).await {
-                warn!("ReleaseTransferLock failed for session {session_id}: {e}");
-            }
-        });
-    }
-}
-
-impl Drop for TransferLockGuard {
-    fn drop(&mut self) {
-        if self.session_id.is_empty() {
-            return;
-        }
-        // Only panic/cancellation reaches here — the coded paths call release().
-        warn!(
-            "RDMA fetch aborted without releasing transfer lock; releasing via drop guard: session={} remote={} req_id={}",
-            self.session_id, self.remote_addr, self.req_id
-        );
-        self.spawn_release();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -885,173 +820,5 @@ mod tests {
         // One chunk sized to the batch total, not to the 256 MiB cap.
         assert_eq!(*sizes.lock().unwrap(), vec![4096]);
         assert_eq!(slabs.chunk_count, 1);
-    }
-
-    mod lock_guard {
-        use super::super::*;
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        use pegaflow_proto::proto::engine::engine_server::{Engine, EngineServer};
-        use pegaflow_proto::proto::engine::{
-            HealthRequest, HealthResponse, LoadRequest, LoadResponse, QueryRequest, QueryResponse,
-            RegisterContextRequest, RegisterContextResponse, ReleaseRequest, ReleaseResponse,
-            ReleaseTransferLockResponse, SaveRequest, SaveResponse, SessionEvent, SessionRequest,
-            ShutdownRequest, ShutdownResponse, UnregisterRequest, UnregisterResponse,
-        };
-        use tokio_stream::wrappers::TcpListenerStream;
-        use tonic::{Request, Response, Status};
-
-        /// Stub engine that only counts ReleaseTransferLock calls.
-        struct ReleaseCounter(Arc<AtomicUsize>);
-
-        #[tonic::async_trait]
-        impl Engine for ReleaseCounter {
-            async fn release_transfer_lock(
-                &self,
-                _request: Request<ReleaseTransferLockRequest>,
-            ) -> Result<Response<ReleaseTransferLockResponse>, Status> {
-                self.0.fetch_add(1, Ordering::SeqCst);
-                Ok(Response::new(ReleaseTransferLockResponse {
-                    status: None,
-                    released_blocks: 0,
-                }))
-            }
-
-            async fn query_blocks_for_transfer(
-                &self,
-                _request: Request<QueryBlocksForTransferRequest>,
-            ) -> Result<Response<QueryBlocksForTransferResponse>, Status> {
-                Err(Status::unimplemented("stub"))
-            }
-            async fn rdma_handshake(
-                &self,
-                _request: Request<RdmaHandshakeRequest>,
-            ) -> Result<Response<pegaflow_proto::proto::engine::RdmaHandshakeResponse>, Status>
-            {
-                Err(Status::unimplemented("stub"))
-            }
-            async fn health(
-                &self,
-                _request: Request<HealthRequest>,
-            ) -> Result<Response<HealthResponse>, Status> {
-                Err(Status::unimplemented("stub"))
-            }
-            async fn register_context_batch(
-                &self,
-                _request: Request<RegisterContextRequest>,
-            ) -> Result<Response<RegisterContextResponse>, Status> {
-                Err(Status::unimplemented("stub"))
-            }
-            async fn save(
-                &self,
-                _request: Request<SaveRequest>,
-            ) -> Result<Response<SaveResponse>, Status> {
-                Err(Status::unimplemented("stub"))
-            }
-            async fn load(
-                &self,
-                _request: Request<LoadRequest>,
-            ) -> Result<Response<LoadResponse>, Status> {
-                Err(Status::unimplemented("stub"))
-            }
-            async fn query_prefetch(
-                &self,
-                _request: Request<QueryRequest>,
-            ) -> Result<Response<QueryResponse>, Status> {
-                Err(Status::unimplemented("stub"))
-            }
-            async fn release(
-                &self,
-                _request: Request<ReleaseRequest>,
-            ) -> Result<Response<ReleaseResponse>, Status> {
-                Err(Status::unimplemented("stub"))
-            }
-            async fn unregister_context(
-                &self,
-                _request: Request<UnregisterRequest>,
-            ) -> Result<Response<UnregisterResponse>, Status> {
-                Err(Status::unimplemented("stub"))
-            }
-            async fn shutdown(
-                &self,
-                _request: Request<ShutdownRequest>,
-            ) -> Result<Response<ShutdownResponse>, Status> {
-                Err(Status::unimplemented("stub"))
-            }
-            type SessionStream = futures::stream::Empty<Result<SessionEvent, Status>>;
-            async fn session(
-                &self,
-                _request: Request<SessionRequest>,
-            ) -> Result<Response<Self::SessionStream>, Status> {
-                Err(Status::unimplemented("stub"))
-            }
-        }
-
-        /// Serve a ReleaseCounter on an ephemeral loopback port; return a
-        /// connected client and the shared counter.
-        async fn start_counter_server() -> (EngineClient<Channel>, Arc<AtomicUsize>) {
-            let counter = Arc::new(AtomicUsize::new(0));
-            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-                .await
-                .expect("bind loopback");
-            let addr = listener.local_addr().expect("local addr");
-            let service = EngineServer::new(ReleaseCounter(Arc::clone(&counter)));
-            tokio::spawn(
-                tonic::transport::Server::builder()
-                    .add_service(service)
-                    .serve_with_incoming(TcpListenerStream::new(listener)),
-            );
-            let channel = Endpoint::from_shared(format!("http://{addr}"))
-                .expect("endpoint")
-                .connect_lazy();
-            (EngineClient::new(channel), counter)
-        }
-
-        async fn wait_for_count(counter: &AtomicUsize, expected: usize) {
-            tokio::time::timeout(Duration::from_secs(5), async {
-                while counter.load(Ordering::SeqCst) < expected {
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                }
-            })
-            .await
-            .expect("release RPC should arrive");
-        }
-
-        fn guard(client: &EngineClient<Channel>, session: &str) -> TransferLockGuard {
-            TransferLockGuard::new(client.clone(), session.to_string(), "remote", "req")
-        }
-
-        #[tokio::test(flavor = "multi_thread")]
-        async fn releases_exactly_once_on_every_exit_path() {
-            let (client, counter) = start_counter_server().await;
-
-            // Explicit release on the coded path.
-            guard(&client, "explicit").release();
-            wait_for_count(&counter, 1).await;
-
-            // Drop without release (future cancelled) still releases.
-            drop(guard(&client, "dropped"));
-            wait_for_count(&counter, 2).await;
-
-            // Panic unwinding through the guard still releases.
-            let g = guard(&client, "panicked");
-            let task = tokio::spawn(async move {
-                let _g = g;
-                panic!("simulated fetch panic");
-            });
-            assert!(task.await.is_err());
-            wait_for_count(&counter, 3).await;
-
-            // No double release: settle window after all three paths.
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            assert_eq!(counter.load(Ordering::SeqCst), 3);
-
-            // Empty session (holder returned none) never sends an RPC.
-            guard(&client, "").release();
-            drop(guard(&client, ""));
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            assert_eq!(counter.load(Ordering::SeqCst), 3);
-        }
     }
 }

--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -348,7 +348,11 @@ async fn fetch_blocks_via_rdma(
         return Ok((Vec::new(), TransferTiming::default()));
     }
 
-    let mut slabs = ChunkedSlabs::new(allocate_fn, FETCH_CHUNK_BYTES);
+    let mut slabs = ChunkedSlabs::new(
+        allocate_fn,
+        FETCH_CHUNK_BYTES,
+        sum_segment_bytes_by_numa(blocks)?,
+    );
 
     // (block_hash, Vec<(slot_segments, slot_numa)>) — for building SealedBlock afterwards.
     // The per-slot NUMA is preserved so a re-served fetched block advertises real topology.
@@ -484,23 +488,62 @@ async fn fetch_blocks_via_rdma(
     Ok((result, timing))
 }
 
+/// Total staged bytes per NUMA node for one fetch batch. Used to right-size
+/// the last chunk of each NUMA so small fetches don't over-allocate.
+fn sum_segment_bytes_by_numa(
+    blocks: &[TransferBlockInfo],
+) -> Result<HashMap<NumaNode, u64>, String> {
+    let mut bytes_per_numa: HashMap<NumaNode, u64> = HashMap::new();
+    for block_info in blocks {
+        for slot in &block_info.slots {
+            let numa = NumaNode(slot.numa_node);
+            let mut add = 0u64;
+            if slot.k_size > 0 {
+                add += slot.k_size;
+            }
+            if slot.v_size > 0 && slot.v_ptr != 0 {
+                add = add
+                    .checked_add(slot.v_size)
+                    .ok_or_else(|| format!("segment bytes overflow on {numa}"))?;
+            }
+            let total = bytes_per_numa.entry(numa).or_insert(0);
+            *total = total
+                .checked_add(add)
+                .ok_or_else(|| format!("numa bytes overflow while summing segments on {numa}"))?;
+        }
+    }
+    Ok(bytes_per_numa)
+}
+
 /// Bump allocator over bounded pinned chunks, one active chunk per NUMA node.
 /// Each staged segment holds an Arc to its own chunk, so starting a fresh
 /// chunk never invalidates previously staged segments, and fetched blocks are
 /// freed chunk-by-chunk on eviction instead of all-or-nothing per fetch.
+///
+/// A chunk is sized `min(remaining bytes on that NUMA, chunk_bytes)`: the cap
+/// bounds LRU-reclaim amplification on large fetches, the remaining-bytes
+/// clamp keeps small fetches from grabbing a whole `chunk_bytes` slab (which
+/// would fail outright on pools smaller than the cap).
 struct ChunkedSlabs<'a> {
     allocate_fn: &'a AllocateFn,
     chunk_bytes: u64,
     current: HashMap<NumaNode, NumaSlab>,
+    /// Bytes of this batch not yet staged, per NUMA.
+    remaining: HashMap<NumaNode, u64>,
     chunk_count: usize,
 }
 
 impl<'a> ChunkedSlabs<'a> {
-    fn new(allocate_fn: &'a AllocateFn, chunk_bytes: u64) -> Self {
+    fn new(
+        allocate_fn: &'a AllocateFn,
+        chunk_bytes: u64,
+        remaining: HashMap<NumaNode, u64>,
+    ) -> Self {
         Self {
             allocate_fn,
             chunk_bytes,
             current: HashMap::new(),
+            remaining,
             chunk_count: 0,
         }
     }
@@ -514,11 +557,16 @@ impl<'a> ChunkedSlabs<'a> {
         if let Some(slab) = self.current.get_mut(&numa)
             && let Ok(seg) = slab.allocate(len, segment_kind)
         {
+            self.consume_remaining(numa, len);
             return Ok(seg);
         }
 
         // No chunk on this NUMA yet, or the current one can't fit the segment.
-        let chunk = self.chunk_bytes.max(len as u64);
+        let remaining = *self
+            .remaining
+            .get(&numa)
+            .expect("remaining bytes tracked for every NUMA in the batch");
+        let chunk = remaining.min(self.chunk_bytes).max(len as u64);
         let allocation = (self.allocate_fn)(chunk, Some(numa)).ok_or_else(|| {
             format!("failed to allocate fetch chunk ({chunk} bytes) on {numa} for {segment_kind}")
         })?;
@@ -533,10 +581,19 @@ impl<'a> ChunkedSlabs<'a> {
                 capacity,
             },
         );
+        self.consume_remaining(numa, len);
         self.current
             .get_mut(&numa)
             .expect("chunk just inserted")
             .allocate(len, segment_kind)
+    }
+
+    fn consume_remaining(&mut self, numa: NumaNode, len: usize) {
+        let rem = self
+            .remaining
+            .get_mut(&numa)
+            .expect("remaining bytes tracked for every NUMA in the batch");
+        *rem = rem.saturating_sub(len as u64);
     }
 }
 
@@ -744,8 +801,8 @@ impl Drop for TransferLockGuard {
 mod tests {
     use super::*;
     use std::num::NonZeroU64;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     fn test_allocate_fn(calls: Arc<AtomicUsize>) -> AllocateFn {
         let allocator = Arc::new(crate::pinned_pool::PinnedAllocator::new_global(
@@ -761,11 +818,15 @@ mod tests {
         })
     }
 
+    fn remaining(bytes: u64) -> HashMap<NumaNode, u64> {
+        HashMap::from([(NumaNode(0), bytes)])
+    }
+
     #[test]
     fn chunked_slabs_bump_within_chunk_then_refill() {
         let calls = Arc::new(AtomicUsize::new(0));
         let allocate_fn = test_allocate_fn(Arc::clone(&calls));
-        let mut slabs = ChunkedSlabs::new(&allocate_fn, 1024);
+        let mut slabs = ChunkedSlabs::new(&allocate_fn, 1024, remaining(1536));
 
         let (p1, a1) = slabs.alloc_segment(NumaNode(0), 512, "K").expect("first");
         let (p2, _a2) = slabs.alloc_segment(NumaNode(0), 512, "V").expect("second");
@@ -784,7 +845,7 @@ mod tests {
     fn chunked_slabs_oversized_segment_gets_dedicated_chunk() {
         let calls = Arc::new(AtomicUsize::new(0));
         let allocate_fn = test_allocate_fn(Arc::clone(&calls));
-        let mut slabs = ChunkedSlabs::new(&allocate_fn, 1024);
+        let mut slabs = ChunkedSlabs::new(&allocate_fn, 1024, remaining(4096));
 
         slabs
             .alloc_segment(NumaNode(0), 4096, "K")
@@ -796,13 +857,34 @@ mod tests {
     #[test]
     fn chunked_slabs_allocation_failure_is_an_error() {
         let allocate_fn: AllocateFn = Arc::new(|_, _| None);
-        let mut slabs = ChunkedSlabs::new(&allocate_fn, 1024);
+        let mut slabs = ChunkedSlabs::new(&allocate_fn, 1024, remaining(512));
 
         let err = match slabs.alloc_segment(NumaNode(0), 512, "K") {
             Ok(_) => panic!("allocation should fail"),
             Err(err) => err,
         };
         assert!(err.contains("failed to allocate fetch chunk"));
+    }
+
+    #[test]
+    fn chunked_slabs_chunk_clamped_to_batch_remaining() {
+        // A small fetch must not request the whole chunk_bytes cap — that
+        // fails outright on pools smaller than the cap (jz p2p IT regression).
+        let sizes = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&sizes);
+        let inner = test_allocate_fn(Arc::new(AtomicUsize::new(0)));
+        let allocate_fn: AllocateFn = Arc::new(move |size, numa| {
+            recorded.lock().unwrap().push(size);
+            inner(size, numa)
+        });
+        let mut slabs = ChunkedSlabs::new(&allocate_fn, 256 << 20, remaining(4096));
+
+        slabs.alloc_segment(NumaNode(0), 1024, "K").expect("first");
+        slabs.alloc_segment(NumaNode(0), 3072, "V").expect("second");
+
+        // One chunk sized to the batch total, not to the 256 MiB cap.
+        assert_eq!(*sizes.lock().unwrap(), vec![4096]);
+        assert_eq!(slabs.chunk_count, 1);
     }
 
     mod lock_guard {

--- a/pegaflow-core/src/backing/transfer_lock_guard.rs
+++ b/pegaflow-core/src/backing/transfer_lock_guard.rs
@@ -1,0 +1,244 @@
+// RAII release of a remote transfer-lock session acquired via
+// QueryBlocksForTransfer. See `rdma_fetch` for the fetch flow that owns it.
+
+use log::warn;
+use pegaflow_proto::proto::engine::ReleaseTransferLockRequest;
+use pegaflow_proto::proto::engine::engine_client::EngineClient;
+use tonic::transport::Channel;
+
+/// Releases a transfer session exactly once, on whichever exit runs first:
+/// `release()` on the coded completion paths, or `Drop` when the fetch task
+/// panics or its future is dropped mid-await. A session that is never
+/// released pins the remote blocks until the holder's GC expires it.
+pub(super) struct TransferLockGuard {
+    client: EngineClient<Channel>,
+    session_id: String,
+    remote_addr: String,
+    req_id: String,
+    // Captured at construction (always inside the runtime) so Drop can spawn
+    // even from a panic unwind; spawning on a shut-down runtime is a no-op.
+    handle: tokio::runtime::Handle,
+}
+
+impl TransferLockGuard {
+    pub(super) fn new(
+        client: EngineClient<Channel>,
+        session_id: String,
+        remote_addr: &str,
+        req_id: &str,
+    ) -> Self {
+        Self {
+            client,
+            session_id,
+            remote_addr: remote_addr.to_string(),
+            req_id: req_id.to_string(),
+            handle: tokio::runtime::Handle::current(),
+        }
+    }
+
+    /// Release on a completed fetch (success or handled error). Fire-and-forget.
+    pub(super) fn release(mut self) {
+        self.spawn_release();
+    }
+
+    fn spawn_release(&mut self) {
+        let session_id = std::mem::take(&mut self.session_id);
+        if session_id.is_empty() {
+            return;
+        }
+        let mut client = self.client.clone();
+        self.handle.spawn(async move {
+            let req = ReleaseTransferLockRequest {
+                transfer_session_id: session_id.clone(),
+            };
+            if let Err(e) = client.release_transfer_lock(req).await {
+                warn!("ReleaseTransferLock failed for session {session_id}: {e}");
+            }
+        });
+    }
+}
+
+impl Drop for TransferLockGuard {
+    fn drop(&mut self) {
+        if self.session_id.is_empty() {
+            return;
+        }
+        // Only panic/cancellation reaches here — the coded paths call release().
+        warn!(
+            "RDMA fetch aborted without releasing transfer lock; releasing via drop guard: session={} remote={} req_id={}",
+            self.session_id, self.remote_addr, self.req_id
+        );
+        self.spawn_release();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use pegaflow_proto::proto::engine::engine_server::{Engine, EngineServer};
+    use pegaflow_proto::proto::engine::{
+        HealthRequest, HealthResponse, LoadRequest, LoadResponse, QueryBlocksForTransferRequest,
+        QueryBlocksForTransferResponse, QueryRequest, QueryResponse, RdmaHandshakeRequest,
+        RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse, ReleaseRequest,
+        ReleaseResponse, ReleaseTransferLockResponse, SaveRequest, SaveResponse, SessionEvent,
+        SessionRequest, ShutdownRequest, ShutdownResponse, UnregisterRequest, UnregisterResponse,
+    };
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::transport::Endpoint;
+    use tonic::{Request, Response, Status};
+
+    /// Stub engine that only counts ReleaseTransferLock calls.
+    struct ReleaseCounter(Arc<AtomicUsize>);
+
+    #[tonic::async_trait]
+    impl Engine for ReleaseCounter {
+        async fn release_transfer_lock(
+            &self,
+            _request: Request<ReleaseTransferLockRequest>,
+        ) -> Result<Response<ReleaseTransferLockResponse>, Status> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(Response::new(ReleaseTransferLockResponse {
+                status: None,
+                released_blocks: 0,
+            }))
+        }
+
+        async fn query_blocks_for_transfer(
+            &self,
+            _request: Request<QueryBlocksForTransferRequest>,
+        ) -> Result<Response<QueryBlocksForTransferResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn rdma_handshake(
+            &self,
+            _request: Request<RdmaHandshakeRequest>,
+        ) -> Result<Response<RdmaHandshakeResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn health(
+            &self,
+            _request: Request<HealthRequest>,
+        ) -> Result<Response<HealthResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn register_context_batch(
+            &self,
+            _request: Request<RegisterContextRequest>,
+        ) -> Result<Response<RegisterContextResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn save(
+            &self,
+            _request: Request<SaveRequest>,
+        ) -> Result<Response<SaveResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn load(
+            &self,
+            _request: Request<LoadRequest>,
+        ) -> Result<Response<LoadResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn query_prefetch(
+            &self,
+            _request: Request<QueryRequest>,
+        ) -> Result<Response<QueryResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn release(
+            &self,
+            _request: Request<ReleaseRequest>,
+        ) -> Result<Response<ReleaseResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn unregister_context(
+            &self,
+            _request: Request<UnregisterRequest>,
+        ) -> Result<Response<UnregisterResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn shutdown(
+            &self,
+            _request: Request<ShutdownRequest>,
+        ) -> Result<Response<ShutdownResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        type SessionStream = futures::stream::Empty<Result<SessionEvent, Status>>;
+        async fn session(
+            &self,
+            _request: Request<SessionRequest>,
+        ) -> Result<Response<Self::SessionStream>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+    }
+
+    /// Serve a ReleaseCounter on an ephemeral loopback port; return a
+    /// connected client and the shared counter.
+    async fn start_counter_server() -> (EngineClient<Channel>, Arc<AtomicUsize>) {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let service = EngineServer::new(ReleaseCounter(Arc::clone(&counter)));
+        tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(service)
+                .serve_with_incoming(TcpListenerStream::new(listener)),
+        );
+        let channel = Endpoint::from_shared(format!("http://{addr}"))
+            .expect("endpoint")
+            .connect_lazy();
+        (EngineClient::new(channel), counter)
+    }
+
+    async fn wait_for_count(counter: &AtomicUsize, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while counter.load(Ordering::SeqCst) < expected {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("release RPC should arrive");
+    }
+
+    fn guard(client: &EngineClient<Channel>, session: &str) -> TransferLockGuard {
+        TransferLockGuard::new(client.clone(), session.to_string(), "remote", "req")
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn releases_exactly_once_on_every_exit_path() {
+        let (client, counter) = start_counter_server().await;
+
+        // Explicit release on the coded path.
+        guard(&client, "explicit").release();
+        wait_for_count(&counter, 1).await;
+
+        // Drop without release (future cancelled) still releases.
+        drop(guard(&client, "dropped"));
+        wait_for_count(&counter, 2).await;
+
+        // Panic unwinding through the guard still releases.
+        let g = guard(&client, "panicked");
+        let task = tokio::spawn(async move {
+            let _g = g;
+            panic!("simulated fetch panic");
+        });
+        assert!(task.await.is_err());
+        wait_for_count(&counter, 3).await;
+
+        // No double release: settle window after all three paths.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+
+        // Empty session (holder returned none) never sends an RPC.
+        guard(&client, "").release();
+        drop(guard(&client, ""));
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+    }
+}

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -879,6 +879,9 @@ impl PegaEngine {
         };
         rdma.engine()
             .complete_handshake(client_addr, &server_meta, &client_meta)
+            // Without the abort, the client stays in `connecting` forever and
+            // every retry fails with "already in progress".
+            .inspect_err(|_| rdma.engine().abort_handshake(client_addr, &server_meta))
             .map_err(|e| format!("complete_handshake failed: {e}"))?;
         info!("RDMA handshake accepted: client={client_addr}");
         Ok(server_meta.to_bytes())

--- a/pegaflow-transfer/src/bin/cpu_bench.rs
+++ b/pegaflow-transfer/src/bin/cpu_bench.rs
@@ -566,17 +566,17 @@ fn create_engine_context(
         .complete_handshake("bench-server", &client_meta, &server_meta)
         .expect("client complete_handshake failed");
 
-    let nic_count = nic_names.len();
+    let expected_qps = nic_names.len() * qps_per_peer;
     assert_eq!(
         server.num_qps(),
-        nic_count,
-        "server should have {nic_count} QP(s) after handshake, got {}",
+        expected_qps,
+        "server should have {expected_qps} QP(s) after handshake, got {}",
         server.num_qps()
     );
     assert_eq!(
         client.num_qps(),
-        nic_count,
-        "client should have {nic_count} QP(s) after handshake, got {}",
+        expected_qps,
+        "client should have {expected_qps} QP(s) after handshake, got {}",
         client.num_qps()
     );
 

--- a/pegaflow-transfer/src/rc_backend/mod.rs
+++ b/pegaflow-transfer/src/rc_backend/mod.rs
@@ -13,7 +13,9 @@ use sideway::ibverbs::AccessFlags;
 
 use self::runtime::RcRuntime;
 use self::session::{RcSession, RdmaOp};
-use self::state::{AddrConnection, RcBackendState, RegisteredMemoryEntry, RemoteMemorySnapshot};
+use self::state::{
+    AddrConnection, ConnNic, RcBackendState, RegisteredMemoryEntry, RemoteMemorySnapshot,
+};
 use std::ptr::NonNull;
 
 use mea::oneshot;
@@ -327,23 +329,20 @@ impl RcBackend {
             }
         }
 
-        // Store sessions + addr_connections
-        let mut state = self.state.lock();
-        let mut remote_first_qpns = Vec::with_capacity(nic_count);
-        for (nic_idx, sessions) in pending.into_iter().enumerate() {
-            let remote = &remote_nics[nic_idx];
-            let remote_first_qpn = remote.endpoints[0].qp_num;
+        // Validate snapshots and assemble the connection before locking.
+        let mut conn_nics = Vec::with_capacity(nic_count);
+        for (sessions, remote) in pending.into_iter().zip(remote_nics) {
             let snapshot = Arc::new(RemoteMemorySnapshot::from_handshake(
                 &remote.memory_regions,
             )?);
-            state.nics[nic_idx]
-                .remote_memory
-                .insert(remote_first_qpn, snapshot);
-            state.nics[nic_idx]
-                .sessions
-                .insert(remote_first_qpn, Arc::new(sessions));
-            remote_first_qpns.push(remote_first_qpn);
+            conn_nics.push(ConnNic {
+                sessions: Arc::new(sessions),
+                remote_memory: snapshot,
+                rr_counter: AtomicUsize::new(0),
+            });
         }
+
+        let mut state = self.state.lock();
         let removed = state.connecting.remove(remote_addr);
         debug_assert!(removed, "connecting set should contain {remote_addr}");
         let local_qpns: Vec<Vec<u32>> = local_nics
@@ -358,13 +357,11 @@ impl RcBackend {
             "RDMA connection established: remote={remote_addr}, qps_per_peer={}, local_qpns={local_qpns:?}, remote_qpns={remote_qpns:?}",
             self.qps_per_peer
         );
-        let rr_counters = (0..nic_count).map(|_| AtomicUsize::new(0)).collect();
         state.addr_connections.insert(
             remote_addr.to_string(),
             AddrConnection {
-                remote_first_qpns,
+                nics: conn_nics,
                 local_nics,
-                rr_counters,
             },
         );
         Ok(())
@@ -392,13 +389,11 @@ impl RcBackend {
             .map(|c| c.local_nics.clone())
     }
 
-    /// Remove connection state on transfer failure.
+    /// Remove connection state on transfer failure. The connection owns its
+    /// sessions, so in-flight work keeps its QPs alive through their Arcs.
     pub(crate) fn invalidate_connection(&self, remote_addr: &str) {
         let mut state = self.state.lock();
-        if let Some(conn) = state.addr_connections.remove(remote_addr) {
-            for (nic_idx, &remote_first_qpn) in conn.remote_first_qpns.iter().enumerate() {
-                state.nics[nic_idx].cleanup_connection(remote_first_qpn);
-            }
+        if state.addr_connections.remove(remote_addr).is_some() {
             info!("connection invalidated: remote={remote_addr}");
         }
     }
@@ -465,25 +460,14 @@ impl RcBackend {
                 if nic_descs.is_empty() {
                     continue;
                 }
-                let remote_first_qpn = conn.remote_first_qpns[nic_idx];
-                let nic = &state.nics[nic_idx];
-                let sessions = nic.sessions.get(&remote_first_qpn).ok_or_else(|| {
-                    TransferError::Backend(format!(
-                        "session vec missing for established connection: remote={remote_addr}, nic={nic_idx}"
-                    ))
-                })?;
-                let remote_memory = nic.remote_memory.get(&remote_first_qpn).ok_or_else(|| {
-                    TransferError::Backend(format!(
-                        "remote memory snapshot missing for established connection: remote={remote_addr}, nic={nic_idx}"
-                    ))
-                })?;
+                let nic = &conn.nics[nic_idx];
                 // Rotate the starting bucket each call so small batches still
                 // hit different QPs across calls.
-                let rot = conn.rr_counters[nic_idx].fetch_add(1, Ordering::Relaxed);
+                let rot = nic.rr_counter.fetch_add(1, Ordering::Relaxed);
                 snapshots.push(NicWork {
                     nic_idx,
-                    sessions: Arc::clone(sessions),
-                    remote_memory: Arc::clone(remote_memory),
+                    sessions: Arc::clone(&nic.sessions),
+                    remote_memory: Arc::clone(&nic.remote_memory),
                     rot,
                 });
             }

--- a/pegaflow-transfer/src/rc_backend/session.rs
+++ b/pegaflow-transfer/src/rc_backend/session.rs
@@ -108,7 +108,12 @@ impl RcSession {
             cmd_tx,
         });
 
-        Self::spawn_worker(Arc::downgrade(&session), cmd_rx, runtime.numa_node)?;
+        Self::spawn_worker(
+            Arc::downgrade(&session),
+            cmd_rx,
+            runtime.numa_node,
+            local_endpoint.qp_num,
+        )?;
         Ok(session)
     }
 
@@ -204,6 +209,7 @@ impl RcSession {
         session: Weak<Self>,
         cmd_rx: std_mpsc::Receiver<SessionCommand>,
         numa_node: NumaNode,
+        qpn: u32,
     ) -> Result<()> {
         thread::Builder::new()
             .name("pegaflow-rc-session".to_string())
@@ -213,14 +219,13 @@ impl RcSession {
                 {
                     warn!("Failed to pin rc session worker to {}: {}", numa_node, e);
                 }
-                let mut qpn = 0;
+                debug!("session worker started: local_qpn={qpn}, numa={numa_node}");
                 while let Ok(command) = cmd_rx.recv() {
                     // The upgraded Arc pins the session (and its QP) for the
                     // duration of the batch.
                     let Some(session) = session.upgrade() else {
                         break;
                     };
-                    qpn = session.local_endpoint.qp_num;
                     match command {
                         SessionCommand::Transfer { ops, op, done_tx } => {
                             let result = Self::execute_batch(&session, ops, op);

--- a/pegaflow-transfer/src/rc_backend/session.rs
+++ b/pegaflow-transfer/src/rc_backend/session.rs
@@ -224,6 +224,13 @@ impl RcSession {
                     // The upgraded Arc pins the session (and its QP) for the
                     // duration of the batch.
                     let Some(session) = session.upgrade() else {
+                        // The session died between enqueue and execution: fail
+                        // accepted commands explicitly instead of dropping
+                        // them as a generic channel-closed error.
+                        Self::reply_session_invalidated(command);
+                        while let Ok(queued) = cmd_rx.try_recv() {
+                            Self::reply_session_invalidated(queued);
+                        }
                         break;
                     };
                     match command {
@@ -239,6 +246,13 @@ impl RcSession {
             })
             .map_err(|e| TransferError::Backend(format!("failed to spawn session worker: {e}")))?;
         Ok(())
+    }
+
+    fn reply_session_invalidated(command: SessionCommand) {
+        let SessionCommand::Transfer { done_tx, .. } = command;
+        let _ = done_tx.send(Err(TransferError::Backend(
+            "session invalidated before batch execution".to_string(),
+        )));
     }
 
     fn post_rdma_wr_chain(

--- a/pegaflow-transfer/src/rc_backend/session.rs
+++ b/pegaflow-transfer/src/rc_backend/session.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::mpsc as std_mpsc;
+use std::sync::{Arc, Weak};
 
 use mea::oneshot;
 use std::thread;
@@ -108,7 +108,7 @@ impl RcSession {
             cmd_tx,
         });
 
-        Self::spawn_worker(Arc::clone(&session), cmd_rx, runtime.numa_node)?;
+        Self::spawn_worker(Arc::downgrade(&session), cmd_rx, runtime.numa_node)?;
         Ok(session)
     }
 
@@ -197,8 +197,11 @@ impl RcSession {
         Ok(done_rx)
     }
 
+    // The worker holds only a Weak ref: a strong Arc here would keep the
+    // session (and its cmd_tx) alive forever, so recv() could never
+    // disconnect and every invalidated connection would leak its thread + QP.
     fn spawn_worker(
-        session: Arc<Self>,
+        session: Weak<Self>,
         cmd_rx: std_mpsc::Receiver<SessionCommand>,
         numa_node: NumaNode,
     ) -> Result<()> {
@@ -210,27 +213,24 @@ impl RcSession {
                 {
                     warn!("Failed to pin rc session worker to {}: {}", numa_node, e);
                 }
-                debug!(
-                    "session worker started: local_qpn={}, numa={}",
-                    session.local_endpoint.qp_num, numa_node
-                );
+                let mut qpn = 0;
                 while let Ok(command) = cmd_rx.recv() {
+                    // The upgraded Arc pins the session (and its QP) for the
+                    // duration of the batch.
+                    let Some(session) = session.upgrade() else {
+                        break;
+                    };
+                    qpn = session.local_endpoint.qp_num;
                     match command {
                         SessionCommand::Transfer { ops, op, done_tx } => {
                             let result = Self::execute_batch(&session, ops, op);
                             if done_tx.send(result).is_err() {
-                                debug!(
-                                    "session worker reply receiver dropped: local_qpn={}",
-                                    session.local_endpoint.qp_num
-                                );
+                                debug!("session worker reply receiver dropped: local_qpn={qpn}");
                             }
                         }
                     }
                 }
-                debug!(
-                    "session worker stopped: local_qpn={}",
-                    session.local_endpoint.qp_num
-                );
+                debug!("session worker stopped: local_qpn={qpn}");
             })
             .map_err(|e| TransferError::Backend(format!("failed to spawn session worker: {e}")))?;
         Ok(())

--- a/pegaflow-transfer/src/rc_backend/state.rs
+++ b/pegaflow-transfer/src/rc_backend/state.rs
@@ -152,18 +152,12 @@ impl RemoteMemorySnapshot {
     }
 }
 
-/// Per-NIC state: pending/connected sessions and remote memory cache.
-///
-/// With per-peer N QPs, `sessions` and `remote_memory` are keyed by the
-/// **first** remote QPN of that NIC pair — this is the stable connection id.
+/// Per-NIC state: sessions awaiting handshake completion. Established
+/// sessions live inside their `AddrConnection`.
 #[derive(Default)]
 pub(super) struct PerNicState {
     /// Pre-connect sessions in FIFO order (first prepared, first connected).
     pub(super) pending: VecDeque<Arc<RcSession>>,
-    /// Connected session vectors keyed by first remote QPN; each Vec has N sessions.
-    pub(super) sessions: HashMap<u32, Arc<Vec<Arc<RcSession>>>>,
-    /// Remote memory snapshots keyed by first remote QPN (shared across the N sessions).
-    pub(super) remote_memory: HashMap<u32, Arc<RemoteMemorySnapshot>>,
 }
 
 impl PerNicState {
@@ -175,19 +169,26 @@ impl PerNicState {
             .position(|s| s.local_endpoint.qp_num == qpn)?;
         self.pending.remove(pos)
     }
-
-    pub(super) fn cleanup_connection(&mut self, remote_first_qpn: u32) {
-        self.sessions.remove(&remote_first_qpn);
-        self.remote_memory.remove(&remote_first_qpn);
-    }
 }
 
+/// One NIC's slice of an established connection: the N connected sessions
+/// and the remote memory snapshot from the handshake.
+pub(super) struct ConnNic {
+    pub(super) sessions: Arc<Vec<Arc<RcSession>>>,
+    pub(super) remote_memory: Arc<RemoteMemorySnapshot>,
+    /// Round-robin counter for picking among the N sessions.
+    pub(super) rr_counter: AtomicUsize,
+}
+
+/// The connection owns its sessions and snapshots directly. Keying them in a
+/// shared map by remote QPN is unsound: QPNs are only unique within one
+/// remote HCA, so two peers can collide, and the second handshake would
+/// silently overwrite the first peer's sessions (and invalidating one peer
+/// would destroy the other's).
 pub(super) struct AddrConnection {
-    /// First remote QPN per NIC — stable id used to key sessions/remote_memory.
-    pub(super) remote_first_qpns: Vec<u32>,
+    /// Indexed by nic_idx.
+    pub(super) nics: Vec<ConnNic>,
     pub(super) local_nics: Vec<NicHandshake>,
-    /// Round-robin counter per NIC for picking among the N sessions of that pair.
-    pub(super) rr_counters: Vec<AtomicUsize>,
 }
 
 pub(super) struct RcBackendState {
@@ -202,7 +203,11 @@ pub(super) struct RcBackendState {
 
 impl RcBackendState {
     pub(super) fn num_qps(&self) -> usize {
-        self.nics.iter().map(|n| n.sessions.len()).sum()
+        self.addr_connections
+            .values()
+            .flat_map(|conn| conn.nics.iter())
+            .map(|nic| nic.sessions.len())
+            .sum()
     }
 
     pub(super) fn new(nic_count: usize) -> Self {


### PR DESCRIPTION
## Incident

On a 4-node H200 production cluster (v0.23.2), two holder nodes logged a steady stream of `Transfer lock expired` warnings (~270 sessions per holder over 11h, still growing), each session pinning up to ~1,400 blocks for the full 120s lock timeout before GC reclaimed them. Holder-side RPC counters showed the smoking gun: `query_blocks_for_transfer ok=2235` vs `release_transfer_lock ok=1961` — the release deficit matched the cumulative timeout count almost exactly, while the requesters logged **zero** fetch errors. The releases were never sent, not failing.

## Root cause chain (all confirmed by logs / stderr)

1. **Cross-peer QPN collision.** `PerNicState` kept `sessions` and `remote_memory` in `HashMap`s keyed by the *remote first QPN*. QPNs are only unique within one remote HCA — peers booted from the same image at the same time allocate near-identical QPNs, so two peers' keys collide. The second peer's handshake silently **overwrote** the first peer's entries, so transfers to the first peer ran against the wrong remote-memory snapshot → `remote memory not found in handshake snapshot`.
2. **Cross-peer destruction → permanent wedge.** That error invalidated peer 1's connection, and cleanup by the *colliding QPN key* destroyed peer 2's session vec while peer 2's `addr_connections` entry survived. Every later fetch toward peer 2 hit `.expect("session vec must exist for established connection")` — a panic on v0.23.2 — and since the connection still looked `Existing`, it never re-handshook.
3. **Panic → silent lock leak.** Each panic killed the detached prefetch task (panics go to stderr only, none of the usual WARN patterns), so `ReleaseTransferLock` was never sent and the holder pinned the blocks until the 120s GC. Requester stderr showed 340 / 311 panic groups, each aligned ~122s before a holder-side lock timeout.

## Fixes

- **`a9aa74e` (root cause)** — `AddrConnection` now *owns* its per-NIC state (`ConnNic { sessions, remote_memory, rr_counter }`). The QPN-keyed global maps are deleted, so the collision class is unrepresentable; `invalidate_connection` is one atomic remove, and a half-removed connection can no longer be observed. Also fixes the mirror wedge on the accept side: `rdma_accept_handshake` now aborts the handshake when `complete_handshake` fails instead of leaving the client stuck in `connecting` forever.
- **`7788555` (defense in depth)** — requester-side RAII `TransferLockGuard`: the session is released on *every* exit — completion, handled error, panic unwind, or the future being dropped. The drop path logs a WARN with `session/remote/req_id` so any remaining abort path is visible in production. Covered by a loopback tonic test asserting exactly-once release across all three exits.
- **`3cea9bf`** — session worker threads captured `Arc<RcSession>` while the session owned the only command `Sender`, so `recv()` could never disconnect: every invalidated/aborted connection leaked its worker thread, QP, and CQ forever. The worker now holds a `Weak` and upgrades per batch.
- **`562d521`** — #387 capped fetch staging chunks at 256 MiB but also made every fetch allocate at least that much, which fails outright on pools smaller than the cap. Found by the `p2p_rdma` IT (16 MiB pool), which #387 had broken — confirmed by A/B against master on real hardware. Chunks are now sized `min(remaining bytes on that NUMA, 256 MiB)`, keeping the amplification cap for large fetches.
- **`bb480ef` / `9fa2830`** — split `TransferLockGuard` into its own module (file back under the 1k-line limit); log real QPNs across the worker lifecycle.

## Breaking metric change

`pegaflow_rdma_qps` previously reported map entries (peers × NICs); it now reports actual QP count, i.e. scaled up by `qps_per_peer`, matching its own description ("Active RC queue pairs") and the `cpu_bench` assertion. Expect a step in dashboards.

## Validation

- `p2p_rdma` IT on an H200 node with 400G IB (`PEGAFLOW_IB_DEVICE=mlx5_gpu*`): **fails on master** (chunk allocation error), **passes on this branch** (4/4 blocks RDMA-fetched, data verified, lock released, all session workers exit cleanly on teardown — previously they leaked).
- `cargo clippy --workspace --all-targets` clean; 125 pegaflow-core + 17 pegaflow-transfer tests pass; pre-commit hooks (incl. `cargo test --release`) passed on every commit.
- Two adversarial review rounds; final verdict approve.

## Follow-ups (pre-existing, out of scope, issues to be filed)

1. A local allocation failure during fetch tears down a healthy RDMA connection (invalidate + full re-handshake loop under pool pressure); string errors can't distinguish connection-broken from local-OOM.
2. `rdma_accept_handshake` has an `unreachable!` reachable under simultaneous mutual handshake (invalidate → `get_or_prepare` window); should return an error instead.
3. Transfer-timeout path returns pinned staging buffers to the pool while in-flight READ WQEs may still DMA into them; same family: QP destroy with outstanding WQEs after a completion error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
