### PR TITLE
feat(cache): prioritize reclaiming redundant KV replicas

### DIFF
--- a/pegaflow-core/src/backing/transfer_lock_guard.rs
+++ b/pegaflow-core/src/backing/transfer_lock_guard.rs
@@ -85,7 +85,8 @@ mod tests {
         QueryBlocksForTransferResponse, QueryRequest, QueryResponse, RdmaHandshakeRequest,
         RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse, ReleaseRequest,
         ReleaseResponse, ReleaseTransferLockResponse, SaveRequest, SaveResponse, SessionEvent,
-        SessionRequest, ShutdownRequest, ShutdownResponse, UnregisterRequest, UnregisterResponse,
+        SessionRequest, SetColdBlocksRequest, SetColdBlocksResponse, ShutdownRequest,
+        ShutdownResponse, UnregisterRequest, UnregisterResponse,
     };
     use tokio_stream::wrappers::TcpListenerStream;
     use tonic::transport::Endpoint;
@@ -159,6 +160,12 @@ mod tests {
             &self,
             _request: Request<UnregisterRequest>,
         ) -> Result<Response<UnregisterResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn set_cold_blocks(
+            &self,
+            _request: Request<SetColdBlocksRequest>,
+        ) -> Result<Response<SetColdBlocksResponse>, Status> {
             Err(Status::unimplemented("stub"))
         }
         async fn shutdown(

--- a/pegaflow-core/src/backing/transfer_lock_guard.rs
+++ b/pegaflow-core/src/backing/transfer_lock_guard.rs
@@ -85,7 +85,7 @@ mod tests {
         QueryBlocksForTransferResponse, QueryRequest, QueryResponse, RdmaHandshakeRequest,
         RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse, ReleaseRequest,
         ReleaseResponse, ReleaseTransferLockResponse, SaveRequest, SaveResponse, SessionEvent,
-        SessionRequest, SetColdBlocksRequest, SetColdBlocksResponse, ShutdownRequest,
+        SessionRequest, SetReclaimableBlocksRequest, SetReclaimableBlocksResponse, ShutdownRequest,
         ShutdownResponse, UnregisterRequest, UnregisterResponse,
     };
     use tokio_stream::wrappers::TcpListenerStream;
@@ -162,10 +162,10 @@ mod tests {
         ) -> Result<Response<UnregisterResponse>, Status> {
             Err(Status::unimplemented("stub"))
         }
-        async fn set_cold_blocks(
+        async fn set_reclaimable_blocks(
             &self,
-            _request: Request<SetColdBlocksRequest>,
-        ) -> Result<Response<SetColdBlocksResponse>, Status> {
+            _request: Request<SetReclaimableBlocksRequest>,
+        ) -> Result<Response<SetReclaimableBlocksResponse>, Status> {
             Err(Status::unimplemented("stub"))
         }
         async fn shutdown(

--- a/pegaflow-core/src/cache.rs
+++ b/pegaflow-core/src/cache.rs
@@ -99,8 +99,8 @@ impl TinyLfuCache<BlockKey, ArcSealedBlock> {
         CacheInsertOutcome::InsertedNew
     }
 
-    pub(crate) fn remove_lru(&mut self) -> Option<(BlockKey, ArcSealedBlock)> {
-        self.lru.remove_lru()
+    pub(crate) fn remove(&mut self, key: &BlockKey) -> Option<ArcSealedBlock> {
+        self.lru.remove(key)
     }
 
     pub(crate) fn remove_all(&mut self) -> Vec<(BlockKey, ArcSealedBlock)> {

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -4,7 +4,8 @@ use log::{debug, error, info, warn};
 use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_TIMEOUT};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
-    HeartbeatNodeRequest, InsertBlockHashesRequest, RemoveBlockHashesRequest, UnregisterNodeRequest,
+    HeartbeatNodeRequest, InsertBlockHashesRequest, InsertBlockHashesResponse,
+    RemoveBlockHashesRequest, UnregisterNodeRequest,
 };
 #[cfg(feature = "rdma")]
 use pegaflow_proto::proto::engine::{NodePrefixResult, QueryPrefixBlocksRequest};
@@ -541,19 +542,11 @@ async fn registration_loop(
         'insert: for (i, (namespace, hashes)) in insert_namespaces.iter().enumerate() {
             for (chunk_idx, chunk) in hashes.chunks(MAX_HASHES_PER_RPC).enumerate() {
                 let count = chunk.len();
-                let request = InsertBlockHashesRequest {
-                    namespace: namespace.clone(),
-                    block_hashes: chunk.to_vec(),
-                    node: advertise_addr.clone(),
-                    node_id: node_id.clone(),
-                };
-
-                match c.insert_block_hashes(request).await {
+                match send_insert_chunk(c, namespace, chunk, &advertise_addr, &node_id).await {
                     Ok(resp) => {
-                        let inner = resp.into_inner();
                         debug!(
                             "Registered {} block hashes with MetaServer (namespace={}, inserted={})",
-                            count, namespace, inner.inserted_count
+                            count, namespace, resp.inserted_count
                         );
                     }
                     Err(e) => {
@@ -604,25 +597,18 @@ async fn registration_loop(
             let mut failed = false;
             for (namespace, hashes) in batch.groups {
                 for chunk in hashes.chunks(MAX_HASHES_PER_RPC) {
-                    let request = InsertBlockHashesRequest {
-                        namespace: namespace.clone(),
-                        block_hashes: chunk.to_vec(),
-                        node: advertise_addr.clone(),
-                        node_id: node_id.clone(),
-                    };
-                    match c.insert_block_hashes(request).await {
+                    match send_insert_chunk(c, &namespace, chunk, &advertise_addr, &node_id).await {
                         Ok(resp) => {
-                            let inner = resp.into_inner();
-                            if inner.owner_counts.len() != chunk.len() {
+                            if resp.owner_counts.len() != chunk.len() {
                                 error!(
                                     "MetaServer owner hint length mismatch: expected={} got={}",
                                     chunk.len(),
-                                    inner.owner_counts.len()
+                                    resp.owner_counts.len()
                                 );
                                 failed = true;
                                 break;
                             }
-                            owner_counts.extend(inner.owner_counts);
+                            owner_counts.extend(resp.owner_counts);
                         }
                         Err(e) => {
                             error!(
@@ -652,12 +638,6 @@ async fn registration_loop(
                 hinted_insert_failed = true;
                 break 'hinted;
             }
-        }
-
-        if hinted_insert_failed {
-            client = None;
-            ack_flushes(flush_acks);
-            continue;
         }
 
         // Process removes
@@ -709,10 +689,32 @@ async fn registration_loop(
                 .add(dropped as u64, &[]);
             client = None;
         }
+        if hinted_insert_failed {
+            client = None;
+        }
         ack_flushes(flush_acks);
     }
 
     info!("MetaServer registration loop shutting down");
+}
+
+async fn send_insert_chunk(
+    client: &mut MetaServerGrpcClient<Channel>,
+    namespace: &str,
+    hashes: &[Vec<u8>],
+    advertise_addr: &str,
+    node_id: &str,
+) -> Result<InsertBlockHashesResponse, tonic::Status> {
+    let request = InsertBlockHashesRequest {
+        namespace: namespace.to_string(),
+        block_hashes: hashes.to_vec(),
+        node: advertise_addr.to_string(),
+        node_id: node_id.to_string(),
+    };
+    client
+        .insert_block_hashes(request)
+        .await
+        .map(|response| response.into_inner())
 }
 
 fn ack_flushes(acks: Vec<oneshot::Sender<()>>) {
@@ -983,6 +985,7 @@ mod tests {
         remove_count: AtomicUsize,
         unregister_count: AtomicUsize,
         fail_insert_with_stale_session: AtomicUsize,
+        malformed_owner_counts: AtomicUsize,
         insert_requests: RequestLog,
         remove_requests: RequestLog,
         heartbeat_notify: Notify,
@@ -1041,13 +1044,25 @@ mod tests {
                 .unwrap()
                 .push((request.namespace, request.block_hashes));
             self.state.insert_notify.notify_waiters();
+            let owner_counts = if self
+                .state
+                .malformed_owner_counts
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    (remaining > 0).then(|| remaining - 1)
+                })
+                .is_ok()
+            {
+                Vec::new()
+            } else {
+                vec![1; inserted_count as usize]
+            };
             Ok(Response::new(InsertBlockHashesResponse {
                 status: Some(ResponseStatus {
                     ok: true,
                     message: String::new(),
                 }),
                 inserted_count,
-                owner_counts: vec![1; inserted_count as usize],
+                owner_counts,
             }))
         }
 
@@ -1440,6 +1455,46 @@ mod tests {
         assert_eq!(
             collect_requests(&service.remove_requests),
             expected_requests(&[("ns-evicted", evicted)])
+        );
+
+        let (done_tx, done_rx) = oneshot::channel();
+        tx.send(MetaServerCommand::Shutdown(done_tx)).await.unwrap();
+        done_rx.await.unwrap();
+        loop_task.await.unwrap();
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn hinted_insert_failure_does_not_skip_remove() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        service.malformed_owner_counts.store(1, Ordering::SeqCst);
+        let (tx, rx) = mpsc::channel(16);
+        let hash = vec![0xa1];
+
+        tx.try_send(MetaServerCommand::InsertWithHint {
+            batch: BlockHashBatch::single_namespace("ns".to_string(), vec![hash.clone()]),
+            callback: Box::new(|_| panic!("failed hint must not invoke callback")),
+        })
+        .unwrap();
+        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
+            vec![("ns".to_string(), hash.clone())],
+        )))
+        .unwrap();
+        let (flush_tx, flush_rx) = oneshot::channel();
+        tx.try_send(MetaServerCommand::Flush(flush_tx)).unwrap();
+
+        let endpoint = metaserver_endpoint(addr.clone());
+        let loop_task = tokio::spawn(registration_loop(
+            rx,
+            addr,
+            endpoint,
+            "node-a:50055".to_string(),
+        ));
+        flush_rx.await.unwrap();
+
+        assert_eq!(
+            collect_requests(&service.remove_requests),
+            expected_requests(&[("ns", hash)])
         );
 
         let (done_tx, done_rx) = oneshot::channel();

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -91,6 +91,8 @@ struct BlockHashBatch {
     groups: Vec<(String, Vec<Vec<u8>>)>,
 }
 
+type InsertHintCallback = Box<dyn FnOnce(Vec<u32>) + Send + 'static>;
+
 impl BlockHashBatch {
     fn from_entries(entries: Vec<(String, Vec<u8>)>) -> Self {
         let mut groups: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
@@ -116,6 +118,10 @@ impl BlockHashBatch {
 /// Command sent to the background MetaServer loop.
 enum MetaServerCommand {
     Insert(BlockHashBatch),
+    InsertWithHint {
+        batch: BlockHashBatch,
+        callback: InsertHintCallback,
+    },
     Remove(BlockHashBatch),
     /// Barrier: acked once every insert/remove enqueued before it has been
     /// delivered to the MetaServer (or dropped after a failed attempt).
@@ -190,6 +196,51 @@ impl MetaServerClient {
             return;
         }
         self.try_send_register_batch(BlockHashBatch::single_namespace(namespace, hashes));
+    }
+
+    /// Enqueue a batched registration whose response carries owner-count
+    /// hints. The callback is best effort: it is not called when the RPC fails.
+    pub(crate) fn try_register_namespace_with_hint<F>(
+        &self,
+        namespace: String,
+        hashes: Vec<Vec<u8>>,
+        callback: F,
+    ) where
+        F: FnOnce(Vec<u32>) + Send + 'static,
+    {
+        if hashes.is_empty() {
+            return;
+        }
+        let batch = BlockHashBatch::single_namespace(namespace, hashes);
+        let count = batch.count();
+        match self.command_tx.try_send(MetaServerCommand::InsertWithHint {
+            batch,
+            callback: Box::new(callback),
+        }) {
+            Ok(()) => {
+                core_metrics()
+                    .metaserver_registration_blocks
+                    .add(count as u64, &[]);
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                warn!(
+                    "MetaServer registration queue full, dropping {} hashes",
+                    count
+                );
+                core_metrics()
+                    .metaserver_registration_queue_full
+                    .add(count as u64, &[]);
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                error!(
+                    "MetaServer registration loop has exited, dropping {} hashes",
+                    count
+                );
+                core_metrics()
+                    .metaserver_registration_queue_full
+                    .add(count as u64, &[]);
+            }
+        }
     }
 
     fn try_send_register_batch(&self, batch: BlockHashBatch) {
@@ -382,6 +433,7 @@ async fn registration_loop(
         let mut inserts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
         let mut removes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
         let mut mixed_ops: Option<HashMap<(String, Vec<u8>), bool>> = None; // true=insert
+        let mut hinted_inserts: Vec<(BlockHashBatch, InsertHintCallback)> = Vec::new();
         let mut saw_insert = false;
         let mut saw_remove = false;
         // Flush barriers drained in this batch; acked after the sends below, so
@@ -402,6 +454,9 @@ async fn registration_loop(
                     } else {
                         append_groups(&mut inserts, batch.groups);
                     }
+                }
+                MetaServerCommand::InsertWithHint { batch, callback } => {
+                    hinted_inserts.push((batch, callback));
                 }
                 MetaServerCommand::Remove(batch) => {
                     saw_remove = true;
@@ -444,6 +499,7 @@ async fn registration_loop(
         }
 
         let insert_total: usize = inserts.values().map(|v| v.len()).sum();
+        let hinted_insert_total: usize = hinted_inserts.iter().map(|(b, _)| b.count()).sum();
         let remove_total: usize = removes.values().map(|v| v.len()).sum();
         if ensure_heartbeat_registered(
             &mut client,
@@ -458,7 +514,7 @@ async fn registration_loop(
         {
             core_metrics()
                 .metaserver_registration_failures
-                .add(insert_total as u64, &[]);
+                .add((insert_total + hinted_insert_total) as u64, &[]);
             core_metrics()
                 .metaserver_removal_failures
                 .add(remove_total as u64, &[]);
@@ -523,6 +579,73 @@ async fn registration_loop(
                     .metaserver_removal_failures
                     .add(remove_total as u64, &[]);
             }
+            client = None;
+            ack_flushes(flush_acks);
+            continue;
+        }
+
+        // Hinted inserts remain separate from the fire-and-forget netting path
+        // so each callback receives counts aligned with its own hash batch.
+        // Save happens before this queue is drained, so a later eviction still
+        // safely turns an eventual callback into a no-op at the cache layer.
+        let mut hinted_insert_failed = false;
+        'hinted: for (batch, callback) in hinted_inserts {
+            let batch_count = batch.count();
+            let mut owner_counts = Vec::with_capacity(batch_count);
+            let mut failed = false;
+            for (namespace, hashes) in batch.groups {
+                for chunk in hashes.chunks(MAX_HASHES_PER_RPC) {
+                    let request = InsertBlockHashesRequest {
+                        namespace: namespace.clone(),
+                        block_hashes: chunk.to_vec(),
+                        node: advertise_addr.clone(),
+                        node_id: node_id.clone(),
+                    };
+                    match c.insert_block_hashes(request).await {
+                        Ok(resp) => {
+                            let inner = resp.into_inner();
+                            if inner.owner_counts.len() != chunk.len() {
+                                warn!(
+                                    "MetaServer owner hint length mismatch: expected={} got={}",
+                                    chunk.len(),
+                                    inner.owner_counts.len()
+                                );
+                                failed = true;
+                                break;
+                            }
+                            owner_counts.extend(inner.owner_counts);
+                        }
+                        Err(e) => {
+                            error!(
+                                "MetaServer hinted insert failed (namespace={}, count={}): {e}",
+                                namespace,
+                                chunk.len()
+                            );
+                            if e.code() == Code::FailedPrecondition {
+                                core_metrics().metaserver_session_resets.add(1, &[]);
+                                heartbeat.node_registered = false;
+                            }
+                            failed = true;
+                            break;
+                        }
+                    }
+                }
+                if failed {
+                    break;
+                }
+            }
+            if !failed {
+                callback(owner_counts);
+            } else {
+                core_metrics()
+                    .metaserver_registration_failures
+                    .add(batch_count as u64, &[]);
+                hinted_insert_failed = true;
+                break 'hinted;
+            }
+        }
+
+        if hinted_insert_failed {
             client = None;
             ack_flushes(flush_acks);
             continue;
@@ -901,6 +1024,7 @@ mod tests {
                     message: String::new(),
                 }),
                 inserted_count,
+                owner_counts: vec![1; inserted_count as usize],
             }))
         }
 
@@ -1054,6 +1178,29 @@ mod tests {
         // Flush after shutdown: loop has exited, must return, not hang.
         client.flush().await;
         let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn hinted_registration_returns_aligned_owner_counts() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        let client = MetaServerClient::new(MetaServerClientConfig::new(
+            addr,
+            "node-a:50055".to_string(),
+        ));
+        let (hint_tx, hint_rx) = oneshot::channel();
+
+        client.try_register_namespace_with_hint(
+            "ns".to_string(),
+            vec![vec![1], vec![2]],
+            move |owner_counts| {
+                let _ = hint_tx.send(owner_counts);
+            },
+        );
+
+        assert_eq!(hint_rx.await.unwrap(), vec![1, 1]);
+        client.shutdown().await;
+        let _ = shutdown_tx.send(());
+        drop(service);
     }
 
     #[tokio::test]

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -91,8 +91,6 @@ struct BlockHashBatch {
     groups: Vec<(String, Vec<Vec<u8>>)>,
 }
 
-type InsertHintCallback = Box<dyn FnOnce(Vec<u32>) + Send + 'static>;
-
 impl BlockHashBatch {
     fn from_entries(entries: Vec<(String, Vec<u8>)>) -> Self {
         let mut groups: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
@@ -118,10 +116,6 @@ impl BlockHashBatch {
 /// Command sent to the background MetaServer loop.
 enum MetaServerCommand {
     Insert(BlockHashBatch),
-    InsertWithHint {
-        batch: BlockHashBatch,
-        callback: InsertHintCallback,
-    },
     Remove(BlockHashBatch),
     /// Barrier: acked once every insert/remove enqueued before it has been
     /// delivered to the MetaServer (or dropped after a failed attempt).
@@ -196,51 +190,6 @@ impl MetaServerClient {
             return;
         }
         self.try_send_register_batch(BlockHashBatch::single_namespace(namespace, hashes));
-    }
-
-    /// Enqueue a batched registration whose response carries owner-count
-    /// hints. The callback is best effort: it is not called when the RPC fails.
-    pub(crate) fn try_register_namespace_with_hint<F>(
-        &self,
-        namespace: String,
-        hashes: Vec<Vec<u8>>,
-        callback: F,
-    ) where
-        F: FnOnce(Vec<u32>) + Send + 'static,
-    {
-        if hashes.is_empty() {
-            return;
-        }
-        let batch = BlockHashBatch::single_namespace(namespace, hashes);
-        let count = batch.count();
-        match self.command_tx.try_send(MetaServerCommand::InsertWithHint {
-            batch,
-            callback: Box::new(callback),
-        }) {
-            Ok(()) => {
-                core_metrics()
-                    .metaserver_registration_blocks
-                    .add(count as u64, &[]);
-            }
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                warn!(
-                    "MetaServer registration queue full, dropping {} hashes",
-                    count
-                );
-                core_metrics()
-                    .metaserver_registration_queue_full
-                    .add(count as u64, &[]);
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                error!(
-                    "MetaServer registration loop has exited, dropping {} hashes",
-                    count
-                );
-                core_metrics()
-                    .metaserver_registration_queue_full
-                    .add(count as u64, &[]);
-            }
-        }
     }
 
     fn try_send_register_batch(&self, batch: BlockHashBatch) {
@@ -433,7 +382,6 @@ async fn registration_loop(
         let mut inserts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
         let mut removes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
         let mut mixed_ops: Option<HashMap<(String, Vec<u8>), bool>> = None; // true=insert
-        let mut hinted_inserts: Vec<(BlockHashBatch, InsertHintCallback)> = Vec::new();
         let mut saw_insert = false;
         let mut saw_remove = false;
         // Flush barriers drained in this batch; acked after the sends below, so
@@ -454,9 +402,6 @@ async fn registration_loop(
                     } else {
                         append_groups(&mut inserts, batch.groups);
                     }
-                }
-                MetaServerCommand::InsertWithHint { batch, callback } => {
-                    hinted_inserts.push((batch, callback));
                 }
                 MetaServerCommand::Remove(batch) => {
                     saw_remove = true;
@@ -499,7 +444,6 @@ async fn registration_loop(
         }
 
         let insert_total: usize = inserts.values().map(|v| v.len()).sum();
-        let hinted_insert_total: usize = hinted_inserts.iter().map(|(b, _)| b.count()).sum();
         let remove_total: usize = removes.values().map(|v| v.len()).sum();
         if ensure_heartbeat_registered(
             &mut client,
@@ -514,7 +458,7 @@ async fn registration_loop(
         {
             core_metrics()
                 .metaserver_registration_failures
-                .add((insert_total + hinted_insert_total) as u64, &[]);
+                .add(insert_total as u64, &[]);
             core_metrics()
                 .metaserver_removal_failures
                 .add(remove_total as u64, &[]);
@@ -579,73 +523,6 @@ async fn registration_loop(
                     .metaserver_removal_failures
                     .add(remove_total as u64, &[]);
             }
-            client = None;
-            ack_flushes(flush_acks);
-            continue;
-        }
-
-        // Hinted inserts remain separate from the fire-and-forget netting path
-        // so each callback receives counts aligned with its own hash batch.
-        // Save happens before this queue is drained, so a later eviction still
-        // safely turns an eventual callback into a no-op at the cache layer.
-        let mut hinted_insert_failed = false;
-        'hinted: for (batch, callback) in hinted_inserts {
-            let batch_count = batch.count();
-            let mut owner_counts = Vec::with_capacity(batch_count);
-            let mut failed = false;
-            for (namespace, hashes) in batch.groups {
-                for chunk in hashes.chunks(MAX_HASHES_PER_RPC) {
-                    let request = InsertBlockHashesRequest {
-                        namespace: namespace.clone(),
-                        block_hashes: chunk.to_vec(),
-                        node: advertise_addr.clone(),
-                        node_id: node_id.clone(),
-                    };
-                    match c.insert_block_hashes(request).await {
-                        Ok(resp) => {
-                            let inner = resp.into_inner();
-                            if inner.owner_counts.len() != chunk.len() {
-                                warn!(
-                                    "MetaServer owner hint length mismatch: expected={} got={}",
-                                    chunk.len(),
-                                    inner.owner_counts.len()
-                                );
-                                failed = true;
-                                break;
-                            }
-                            owner_counts.extend(inner.owner_counts);
-                        }
-                        Err(e) => {
-                            error!(
-                                "MetaServer hinted insert failed (namespace={}, count={}): {e}",
-                                namespace,
-                                chunk.len()
-                            );
-                            if e.code() == Code::FailedPrecondition {
-                                core_metrics().metaserver_session_resets.add(1, &[]);
-                                heartbeat.node_registered = false;
-                            }
-                            failed = true;
-                            break;
-                        }
-                    }
-                }
-                if failed {
-                    break;
-                }
-            }
-            if !failed {
-                callback(owner_counts);
-            } else {
-                core_metrics()
-                    .metaserver_registration_failures
-                    .add(batch_count as u64, &[]);
-                hinted_insert_failed = true;
-                break 'hinted;
-            }
-        }
-
-        if hinted_insert_failed {
             client = None;
             ack_flushes(flush_acks);
             continue;
@@ -1024,7 +901,6 @@ mod tests {
                     message: String::new(),
                 }),
                 inserted_count,
-                owner_counts: vec![1; inserted_count as usize],
             }))
         }
 
@@ -1178,29 +1054,6 @@ mod tests {
         // Flush after shutdown: loop has exited, must return, not hang.
         client.flush().await;
         let _ = shutdown_tx.send(());
-    }
-
-    #[tokio::test]
-    async fn hinted_registration_returns_aligned_owner_counts() {
-        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
-        let client = MetaServerClient::new(MetaServerClientConfig::new(
-            addr,
-            "node-a:50055".to_string(),
-        ));
-        let (hint_tx, hint_rx) = oneshot::channel();
-
-        client.try_register_namespace_with_hint(
-            "ns".to_string(),
-            vec![vec![1], vec![2]],
-            move |owner_counts| {
-                let _ = hint_tx.send(owner_counts);
-            },
-        );
-
-        assert_eq!(hint_rx.await.unwrap(), vec![1, 1]);
-        client.shutdown().await;
-        let _ = shutdown_tx.send(());
-        drop(service);
     }
 
     #[tokio::test]

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -199,8 +199,8 @@ impl MetaServerClient {
     }
 
     /// Enqueue a batched registration whose response carries post-insert
-    /// owner-count hints. The callback is best effort: it is not called when
-    /// the RPC fails or returns a malformed response.
+    /// owner counts. The callback runs only after a successful, aligned
+    /// response; queue, RPC, or protocol failures leave cache class unchanged.
     pub(crate) fn try_register_namespace_with_hint<F>(
         &self,
         namespace: String,
@@ -614,7 +614,7 @@ async fn registration_loop(
                         Ok(resp) => {
                             let inner = resp.into_inner();
                             if inner.owner_counts.len() != chunk.len() {
-                                warn!(
+                                error!(
                                     "MetaServer owner hint length mismatch: expected={} got={}",
                                     chunk.len(),
                                     inner.owner_counts.len()

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -91,6 +91,8 @@ struct BlockHashBatch {
     groups: Vec<(String, Vec<Vec<u8>>)>,
 }
 
+type InsertHintCallback = Box<dyn FnOnce(Vec<u32>) + Send + 'static>;
+
 impl BlockHashBatch {
     fn from_entries(entries: Vec<(String, Vec<u8>)>) -> Self {
         let mut groups: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
@@ -116,6 +118,10 @@ impl BlockHashBatch {
 /// Command sent to the background MetaServer loop.
 enum MetaServerCommand {
     Insert(BlockHashBatch),
+    InsertWithHint {
+        batch: BlockHashBatch,
+        callback: InsertHintCallback,
+    },
     Remove(BlockHashBatch),
     /// Barrier: acked once every insert/remove enqueued before it has been
     /// delivered to the MetaServer (or dropped after a failed attempt).
@@ -190,6 +196,52 @@ impl MetaServerClient {
             return;
         }
         self.try_send_register_batch(BlockHashBatch::single_namespace(namespace, hashes));
+    }
+
+    /// Enqueue a batched registration whose response carries post-insert
+    /// owner-count hints. The callback is best effort: it is not called when
+    /// the RPC fails or returns a malformed response.
+    pub(crate) fn try_register_namespace_with_hint<F>(
+        &self,
+        namespace: String,
+        hashes: Vec<Vec<u8>>,
+        callback: F,
+    ) where
+        F: FnOnce(Vec<u32>) + Send + 'static,
+    {
+        if hashes.is_empty() {
+            return;
+        }
+        let batch = BlockHashBatch::single_namespace(namespace, hashes);
+        let count = batch.count();
+        match self.command_tx.try_send(MetaServerCommand::InsertWithHint {
+            batch,
+            callback: Box::new(callback),
+        }) {
+            Ok(()) => {
+                core_metrics()
+                    .metaserver_registration_blocks
+                    .add(count as u64, &[]);
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                warn!(
+                    "MetaServer registration queue full, dropping {} hashes",
+                    count
+                );
+                core_metrics()
+                    .metaserver_registration_queue_full
+                    .add(count as u64, &[]);
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                error!(
+                    "MetaServer registration loop has exited, dropping {} hashes",
+                    count
+                );
+                core_metrics()
+                    .metaserver_registration_queue_full
+                    .add(count as u64, &[]);
+            }
+        }
     }
 
     fn try_send_register_batch(&self, batch: BlockHashBatch) {
@@ -382,6 +434,7 @@ async fn registration_loop(
         let mut inserts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
         let mut removes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
         let mut mixed_ops: Option<HashMap<(String, Vec<u8>), bool>> = None; // true=insert
+        let mut hinted_inserts: Vec<(BlockHashBatch, InsertHintCallback)> = Vec::new();
         let mut saw_insert = false;
         let mut saw_remove = false;
         // Flush barriers drained in this batch; acked after the sends below, so
@@ -402,6 +455,16 @@ async fn registration_loop(
                     } else {
                         append_groups(&mut inserts, batch.groups);
                     }
+                }
+                MetaServerCommand::InsertWithHint { batch, callback } => {
+                    saw_insert = true;
+                    if saw_remove {
+                        let net = mixed_ops.get_or_insert_with(|| {
+                            build_net(std::mem::take(&mut inserts), std::mem::take(&mut removes))
+                        });
+                        clear_pending_removes(net, &batch.groups);
+                    }
+                    hinted_inserts.push((batch, callback));
                 }
                 MetaServerCommand::Remove(batch) => {
                     saw_remove = true;
@@ -444,6 +507,7 @@ async fn registration_loop(
         }
 
         let insert_total: usize = inserts.values().map(|v| v.len()).sum();
+        let hinted_insert_total: usize = hinted_inserts.iter().map(|(b, _)| b.count()).sum();
         let remove_total: usize = removes.values().map(|v| v.len()).sum();
         if ensure_heartbeat_registered(
             &mut client,
@@ -458,7 +522,7 @@ async fn registration_loop(
         {
             core_metrics()
                 .metaserver_registration_failures
-                .add(insert_total as u64, &[]);
+                .add((insert_total + hinted_insert_total) as u64, &[]);
             core_metrics()
                 .metaserver_removal_failures
                 .add(remove_total as u64, &[]);
@@ -523,6 +587,74 @@ async fn registration_loop(
                     .metaserver_removal_failures
                     .add(remove_total as u64, &[]);
             }
+            client = None;
+            ack_flushes(flush_acks);
+            continue;
+        }
+
+        // Hinted inserts remain separate from the fire-and-forget netting path
+        // so each callback receives counts aligned with its own hash batch.
+        // Mixed-operation netting preserves whether a remove happened before
+        // or after each hinted insert; a later eviction also turns the callback
+        // into a no-op at the cache layer.
+        let mut hinted_insert_failed = false;
+        'hinted: for (batch, callback) in hinted_inserts {
+            let batch_count = batch.count();
+            let mut owner_counts = Vec::with_capacity(batch_count);
+            let mut failed = false;
+            for (namespace, hashes) in batch.groups {
+                for chunk in hashes.chunks(MAX_HASHES_PER_RPC) {
+                    let request = InsertBlockHashesRequest {
+                        namespace: namespace.clone(),
+                        block_hashes: chunk.to_vec(),
+                        node: advertise_addr.clone(),
+                        node_id: node_id.clone(),
+                    };
+                    match c.insert_block_hashes(request).await {
+                        Ok(resp) => {
+                            let inner = resp.into_inner();
+                            if inner.owner_counts.len() != chunk.len() {
+                                warn!(
+                                    "MetaServer owner hint length mismatch: expected={} got={}",
+                                    chunk.len(),
+                                    inner.owner_counts.len()
+                                );
+                                failed = true;
+                                break;
+                            }
+                            owner_counts.extend(inner.owner_counts);
+                        }
+                        Err(e) => {
+                            error!(
+                                "MetaServer hinted insert failed (namespace={}, count={}): {e}",
+                                namespace,
+                                chunk.len()
+                            );
+                            if e.code() == Code::FailedPrecondition {
+                                core_metrics().metaserver_session_resets.add(1, &[]);
+                                heartbeat.node_registered = false;
+                            }
+                            failed = true;
+                            break;
+                        }
+                    }
+                }
+                if failed {
+                    break;
+                }
+            }
+            if !failed {
+                callback(owner_counts);
+            } else {
+                core_metrics()
+                    .metaserver_registration_failures
+                    .add(batch_count as u64, &[]);
+                hinted_insert_failed = true;
+                break 'hinted;
+            }
+        }
+
+        if hinted_insert_failed {
             client = None;
             ack_flushes(flush_acks);
             continue;
@@ -639,6 +771,20 @@ fn insert_groups_into_net(
     for (namespace, hashes) in groups {
         for hash in hashes {
             net.insert((namespace.clone(), hash), is_insert);
+        }
+    }
+}
+
+fn clear_pending_removes(
+    net: &mut HashMap<(String, Vec<u8>), bool>,
+    groups: &[(String, Vec<Vec<u8>>)],
+) {
+    for (namespace, hashes) in groups {
+        for hash in hashes {
+            let key = (namespace.clone(), hash.clone());
+            if net.get(&key) == Some(&false) {
+                net.remove(&key);
+            }
         }
     }
 }
@@ -901,6 +1047,7 @@ mod tests {
                     message: String::new(),
                 }),
                 inserted_count,
+                owner_counts: vec![1; inserted_count as usize],
             }))
         }
 
@@ -1057,6 +1204,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn hinted_registration_returns_aligned_owner_counts() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        let client = MetaServerClient::new(MetaServerClientConfig::new(
+            addr,
+            "node-a:50055".to_string(),
+        ));
+        let (hint_tx, hint_rx) = oneshot::channel();
+
+        client.try_register_namespace_with_hint(
+            "ns".to_string(),
+            vec![vec![1], vec![2]],
+            move |owner_counts| {
+                let _ = hint_tx.send(owner_counts);
+            },
+        );
+
+        assert_eq!(hint_rx.await.unwrap(), vec![1, 1]);
+        client.shutdown().await;
+        let _ = shutdown_tx.send(());
+        drop(service);
+    }
+
+    #[tokio::test]
     async fn flush_barrier_acks_even_when_insert_fails() {
         let (addr, service, shutdown_tx) = start_fake_metaserver().await;
         // Fail both the insert attempt and the session-reset retry heartbeat
@@ -1208,6 +1378,68 @@ mod tests {
         assert_eq!(
             collect_requests(&service.remove_requests),
             expected_requests(&[("ns-first", insert_then_remove), ("ns-remove", remove_only)])
+        );
+
+        let (done_tx, done_rx) = oneshot::channel();
+        tx.send(MetaServerCommand::Shutdown(done_tx)).await.unwrap();
+        done_rx.await.unwrap();
+        loop_task.await.unwrap();
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn hinted_insert_preserves_order_against_remove() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        let (tx, rx) = mpsc::channel(16);
+        let reinserted = vec![0xe0];
+        let evicted = vec![0xf0];
+
+        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
+            vec![("ns-reinserted".to_string(), reinserted.clone())],
+        )))
+        .unwrap();
+        tx.try_send(MetaServerCommand::InsertWithHint {
+            batch: BlockHashBatch::single_namespace(
+                "ns-reinserted".to_string(),
+                vec![reinserted.clone()],
+            ),
+            callback: Box::new(|_| {}),
+        })
+        .unwrap();
+        tx.try_send(MetaServerCommand::InsertWithHint {
+            batch: BlockHashBatch::single_namespace(
+                "ns-evicted".to_string(),
+                vec![evicted.clone()],
+            ),
+            callback: Box::new(|_| {}),
+        })
+        .unwrap();
+        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
+            vec![("ns-evicted".to_string(), evicted.clone())],
+        )))
+        .unwrap();
+        let (flush_tx, flush_rx) = oneshot::channel();
+        tx.try_send(MetaServerCommand::Flush(flush_tx)).unwrap();
+
+        let endpoint = metaserver_endpoint(addr.clone());
+        let loop_task = tokio::spawn(registration_loop(
+            rx,
+            addr,
+            endpoint,
+            "node-a:50055".to_string(),
+        ));
+        flush_rx.await.unwrap();
+
+        assert_eq!(
+            collect_requests(&service.insert_requests),
+            expected_requests(&[
+                ("ns-reinserted", reinserted),
+                ("ns-evicted", evicted.clone()),
+            ])
+        );
+        assert_eq!(
+            collect_requests(&service.remove_requests),
+            expected_requests(&[("ns-evicted", evicted)])
         );
 
         let (done_tx, done_rx) = oneshot::channel();

--- a/pegaflow-core/src/internode/p2p_service.rs
+++ b/pegaflow-core/src/internode/p2p_service.rs
@@ -24,9 +24,9 @@ use pegaflow_proto::proto::engine::{
     QueryBlocksForTransferResponse, QueryRequest, QueryResponse, RdmaHandshakeRequest,
     RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse, ReleaseRequest,
     ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse, ResponseStatus,
-    SaveRequest, SaveResponse, SessionEvent, SessionRequest, SetColdBlocksRequest,
-    SetColdBlocksResponse, ShutdownRequest, ShutdownResponse, TransferBlockInfo, TransferSlotInfo,
-    UnregisterRequest, UnregisterResponse,
+    SaveRequest, SaveResponse, SessionEvent, SessionRequest, SetReclaimableBlocksRequest,
+    SetReclaimableBlocksResponse, ShutdownRequest, ShutdownResponse, TransferBlockInfo,
+    TransferSlotInfo, UnregisterRequest, UnregisterResponse,
 };
 
 use crate::{LayerBlock, PegaEngine};
@@ -268,11 +268,11 @@ impl Engine for P2pTransferService {
         Self::not_served("unregister_context")
     }
 
-    async fn set_cold_blocks(
+    async fn set_reclaimable_blocks(
         &self,
-        _request: Request<SetColdBlocksRequest>,
-    ) -> Result<Response<SetColdBlocksResponse>, Status> {
-        Self::not_served("set_cold_blocks")
+        _request: Request<SetReclaimableBlocksRequest>,
+    ) -> Result<Response<SetReclaimableBlocksResponse>, Status> {
+        Self::not_served("set_reclaimable_blocks")
     }
 
     async fn shutdown(

--- a/pegaflow-core/src/internode/p2p_service.rs
+++ b/pegaflow-core/src/internode/p2p_service.rs
@@ -24,8 +24,9 @@ use pegaflow_proto::proto::engine::{
     QueryBlocksForTransferResponse, QueryRequest, QueryResponse, RdmaHandshakeRequest,
     RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse, ReleaseRequest,
     ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse, ResponseStatus,
-    SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest, ShutdownResponse,
-    TransferBlockInfo, TransferSlotInfo, UnregisterRequest, UnregisterResponse,
+    SaveRequest, SaveResponse, SessionEvent, SessionRequest, SetColdBlocksRequest,
+    SetColdBlocksResponse, ShutdownRequest, ShutdownResponse, TransferBlockInfo, TransferSlotInfo,
+    UnregisterRequest, UnregisterResponse,
 };
 
 use crate::{LayerBlock, PegaEngine};
@@ -265,6 +266,13 @@ impl Engine for P2pTransferService {
         _request: Request<UnregisterRequest>,
     ) -> Result<Response<UnregisterResponse>, Status> {
         Self::not_served("unregister_context")
+    }
+
+    async fn set_cold_blocks(
+        &self,
+        _request: Request<SetColdBlocksRequest>,
+    ) -> Result<Response<SetColdBlocksResponse>, Status> {
+        Self::not_served("set_cold_blocks")
     }
 
     async fn shutdown(

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -534,6 +534,10 @@ impl PegaEngine {
         self.storage.cleanup_memory_cache()
     }
 
+    pub fn set_cold_blocks(&self, namespace: &str, hashes: &[Vec<u8>]) {
+        self.storage.set_cold_blocks(namespace, hashes);
+    }
+
     /// Best-effort graceful unregister from MetaServer, if configured.
     pub async fn shutdown_metaserver_client(&self) {
         self.storage.shutdown_metaserver_client().await;

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -534,8 +534,8 @@ impl PegaEngine {
         self.storage.cleanup_memory_cache()
     }
 
-    pub fn set_cold_blocks(&self, namespace: &str, hashes: &[Vec<u8>]) {
-        self.storage.set_cold_blocks(namespace, hashes);
+    pub fn set_reclaimable_blocks(&self, namespace: &str, hashes: &[Vec<u8>]) {
+        self.storage.set_reclaimable_blocks(namespace, hashes);
     }
 
     /// Best-effort graceful unregister from MetaServer, if configured.

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -22,10 +22,10 @@ static TIER_RAM: LazyLock<[KeyValue; 1]> = LazyLock::new(|| [KeyValue::new("tier
 static TIER_RDMA: LazyLock<[KeyValue; 1]> = LazyLock::new(|| [KeyValue::new("tier", "rdma")]);
 static TIER_SSD: LazyLock<[KeyValue; 1]> = LazyLock::new(|| [KeyValue::new("tier", "ssd")]);
 static TIER_MISS: LazyLock<[KeyValue; 1]> = LazyLock::new(|| [KeyValue::new("tier", "miss")]);
-pub(crate) static CACHE_CLASS_COLD: LazyLock<[KeyValue; 1]> =
-    LazyLock::new(|| [KeyValue::new("class", "cold")]);
-pub(crate) static CACHE_CLASS_WARM: LazyLock<[KeyValue; 1]> =
-    LazyLock::new(|| [KeyValue::new("class", "warm")]);
+pub(crate) static CACHE_CLASS_RECLAIMABLE: LazyLock<[KeyValue; 1]> =
+    LazyLock::new(|| [KeyValue::new("class", "reclaimable")]);
+pub(crate) static CACHE_CLASS_RETAINED: LazyLock<[KeyValue; 1]> =
+    LazyLock::new(|| [KeyValue::new("class", "retained")]);
 
 pub(crate) struct CoreMetrics {
     // Pinned pool (allocator-level)
@@ -53,7 +53,6 @@ pub(crate) struct CoreMetrics {
     pub cache_block_evictions: Counter<u64>,
     pub cache_resident_blocks: UpDownCounter<i64>,
     pub cache_block_evictions_by_class: Counter<u64>,
-    pub cache_block_promotions: Counter<u64>,
     pub cache_block_demotions: Counter<u64>,
     pub cache_block_evictions_still_referenced: Counter<u64>,
     pub cache_eviction_reclaimed_bytes: Counter<u64>,
@@ -293,13 +292,9 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
                 .u64_counter("pegaflow_cache_block_evictions_by_class")
                 .with_description("Cache block evictions by replacement class")
                 .build(),
-            cache_block_promotions: meter
-                .u64_counter("pegaflow_cache_block_promotions")
-                .with_description("Cold cache blocks promoted to warm after a local hit")
-                .build(),
             cache_block_demotions: meter
                 .u64_counter("pegaflow_cache_block_demotions")
-                .with_description("Warm cache blocks demoted after external transfer completion")
+                .with_description("Retained cache blocks marked reclaimable")
                 .build(),
             cache_block_evictions_still_referenced: meter
                 .u64_counter("pegaflow_cache_block_evictions_still_referenced")

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -22,6 +22,10 @@ static TIER_RAM: LazyLock<[KeyValue; 1]> = LazyLock::new(|| [KeyValue::new("tier
 static TIER_RDMA: LazyLock<[KeyValue; 1]> = LazyLock::new(|| [KeyValue::new("tier", "rdma")]);
 static TIER_SSD: LazyLock<[KeyValue; 1]> = LazyLock::new(|| [KeyValue::new("tier", "ssd")]);
 static TIER_MISS: LazyLock<[KeyValue; 1]> = LazyLock::new(|| [KeyValue::new("tier", "miss")]);
+pub(crate) static CACHE_CLASS_COLD: LazyLock<[KeyValue; 1]> =
+    LazyLock::new(|| [KeyValue::new("class", "cold")]);
+pub(crate) static CACHE_CLASS_WARM: LazyLock<[KeyValue; 1]> =
+    LazyLock::new(|| [KeyValue::new("class", "warm")]);
 
 pub(crate) struct CoreMetrics {
     // Pinned pool (allocator-level)
@@ -47,6 +51,10 @@ pub(crate) struct CoreMetrics {
     pub cache_block_insertions: Counter<u64>,
     pub cache_block_admission_rejections: Counter<u64>,
     pub cache_block_evictions: Counter<u64>,
+    pub cache_resident_blocks: UpDownCounter<i64>,
+    pub cache_block_evictions_by_class: Counter<u64>,
+    pub cache_block_promotions: Counter<u64>,
+    pub cache_block_demotions: Counter<u64>,
     pub cache_block_evictions_still_referenced: Counter<u64>,
     pub cache_eviction_reclaimed_bytes: Counter<u64>,
 
@@ -276,6 +284,22 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
             cache_block_evictions: meter
                 .u64_counter("pegaflow_cache_block_evictions")
                 .with_description("Blocks evicted from cache due to memory pressure")
+                .build(),
+            cache_resident_blocks: meter
+                .i64_up_down_counter("pegaflow_cache_resident_blocks")
+                .with_description("Current cache blocks by replacement class")
+                .build(),
+            cache_block_evictions_by_class: meter
+                .u64_counter("pegaflow_cache_block_evictions_by_class")
+                .with_description("Cache block evictions by replacement class")
+                .build(),
+            cache_block_promotions: meter
+                .u64_counter("pegaflow_cache_block_promotions")
+                .with_description("Cold cache blocks promoted to warm after a local hit")
+                .build(),
+            cache_block_demotions: meter
+                .u64_counter("pegaflow_cache_block_demotions")
+                .with_description("Warm cache blocks demoted after external transfer completion")
                 .build(),
             cache_block_evictions_still_referenced: meter
                 .u64_counter("pegaflow_cache_block_evictions_still_referenced")

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -378,13 +378,13 @@ impl StorageEngine {
         }
     }
 
-    pub(crate) fn set_cold_blocks(&self, namespace: &str, hashes: &[Vec<u8>]) {
+    pub(crate) fn set_reclaimable_blocks(&self, namespace: &str, hashes: &[Vec<u8>]) {
         let namespace = namespace.to_string();
         let keys = hashes
             .iter()
             .map(|hash| BlockKey::new(namespace.clone(), hash.clone()))
             .collect::<Vec<_>>();
-        self.read_cache.demote(&keys);
+        self.read_cache.mark_reclaimable(&keys);
     }
 
     /// Evict all blocks from the resident in-memory read cache.

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -379,9 +379,10 @@ impl StorageEngine {
     }
 
     pub(crate) fn set_cold_blocks(&self, namespace: &str, hashes: &[Vec<u8>]) {
+        let namespace = namespace.to_string();
         let keys = hashes
             .iter()
-            .map(|hash| BlockKey::new(namespace.to_string(), hash.clone()))
+            .map(|hash| BlockKey::new(namespace.clone(), hash.clone()))
             .collect::<Vec<_>>();
         self.read_cache.demote(&keys);
     }

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -378,6 +378,14 @@ impl StorageEngine {
         }
     }
 
+    pub(crate) fn set_cold_blocks(&self, namespace: &str, hashes: &[Vec<u8>]) {
+        let keys = hashes
+            .iter()
+            .map(|hash| BlockKey::new(namespace.to_string(), hash.clone()))
+            .collect::<Vec<_>>();
+        self.read_cache.demote(&keys);
+    }
+
     /// Evict all blocks from the resident in-memory read cache.
     ///
     /// This preserves backing-store copies. Blocks with

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -93,21 +93,24 @@ impl ReadCache {
     pub(super) fn batch_insert_refs(
         &self,
         blocks: &[(BlockKey, Arc<SealedBlock>)],
-    ) -> Vec<BlockKey> {
+    ) -> Vec<(BlockKey, CacheInsertOutcome)> {
         let mut inner = self.inner.lock();
-        let mut inserted = Vec::new();
+        let mut resident = Vec::new();
         for (key, block) in blocks {
-            if insert_block(
+            let outcome = insert_block(
                 &mut inner,
                 key.clone(),
                 Arc::clone(block),
                 ResidentClass::Retained,
-            ) == CacheInsertOutcome::InsertedNew
-            {
-                inserted.push(key.clone());
+            );
+            if matches!(
+                outcome,
+                CacheInsertOutcome::InsertedNew | CacheInsertOutcome::AlreadyExists
+            ) {
+                resident.push((key.clone(), outcome));
             }
         }
-        inserted
+        resident
     }
 
     /// Look up specific blocks by key without prefix-scan semantics (does not
@@ -228,15 +231,17 @@ fn insert_block(
 }
 
 fn refresh_recency(inner: &mut ReadCacheInner, key: &BlockKey) {
-    if inner.reclaimable.contains_key(key) {
-        inner.reclaimable.get(key);
-    } else if inner.retained.contains_key(key) {
+    if inner.reclaimable.get(key).is_none() {
         inner.retained.get(key);
     }
 }
 
 fn mark_reclaimable(inner: &mut ReadCacheInner, key: &BlockKey) {
-    if inner.retained.remove(key).is_some() && inner.cache.contains_key(key) {
+    if !inner.cache.contains_key(key) {
+        return;
+    }
+
+    if inner.retained.remove(key).is_some() {
         inner.reclaimable.insert(key.clone(), ());
         let metrics = core_metrics();
         metrics
@@ -417,6 +422,18 @@ mod tests {
         cache.batch_insert(vec![(first, first_block)]);
 
         assert_eq!(cache.remove_lru_batch(1)[0].0, second);
+    }
+
+    #[test]
+    fn local_save_reports_existing_resident_for_owner_refresh() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+
+        let first = cache.batch_insert_refs(&[(key.clone(), make_block())]);
+        assert_eq!(first, vec![(key.clone(), CacheInsertOutcome::InsertedNew)]);
+
+        let second = cache.batch_insert_refs(&[(key.clone(), make_block())]);
+        assert_eq!(second, vec![(key, CacheInsertOutcome::AlreadyExists)]);
     }
 
     #[test]

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -107,7 +107,9 @@ impl ReadCache {
         let mut found = Vec::new();
         for key in keys {
             if let Some(block) = inner.cache.get(key) {
-                found.push((key.clone(), Arc::clone(&block)));
+                let block = Arc::clone(block);
+                refresh_recency(&mut inner, key);
+                found.push((key.clone(), block));
             }
         }
         found
@@ -217,6 +219,14 @@ fn promote_on_local_hit(inner: &mut ReadCacheInner, key: &BlockKey) {
     }
 }
 
+fn refresh_recency(inner: &mut ReadCacheInner, key: &BlockKey) {
+    if inner.cold.contains_key(key) {
+        inner.cold.get(key);
+    } else if inner.warm.contains_key(key) {
+        inner.warm.get(key);
+    }
+}
+
 fn promote(inner: &mut ReadCacheInner, key: &BlockKey) {
     if inner.cold.remove(key).is_some() && inner.cache.contains_key(key) {
         inner.warm.insert(key.clone(), ());
@@ -299,6 +309,19 @@ mod tests {
         assert_eq!(result1.len(), 1);
         assert_eq!(result2.len(), 1);
         assert_eq!(result1[0].0, result2[0].0);
+    }
+
+    #[test]
+    fn get_blocks_refreshes_recency_without_changing_class() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        cache.batch_insert_resident_keys(vec![(key.clone(), make_block())]);
+
+        let _ = cache.get_blocks(std::slice::from_ref(&key));
+
+        let inner = cache.inner.lock();
+        assert!(inner.cold.contains_key(&key));
+        assert!(!inner.warm.contains_key(&key));
     }
 
     #[test]

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
+use hashlink::LruCache;
 use parking_lot::Mutex;
 
 use crate::block::{BlockKey, SealedBlock};
 use crate::cache::{CacheInsertOutcome, TinyLfuCache};
-use crate::metrics::core_metrics;
+use crate::metrics::{CACHE_CLASS_COLD, CACHE_CLASS_WARM, core_metrics};
 
 pub(super) struct ReadCache {
     inner: Mutex<ReadCacheInner>,
@@ -12,6 +13,14 @@ pub(super) struct ReadCache {
 
 struct ReadCacheInner {
     cache: TinyLfuCache<BlockKey, Arc<SealedBlock>>,
+    cold: LruCache<BlockKey, ()>,
+    warm: LruCache<BlockKey, ()>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(super) enum ResidentClass {
+    Cold,
+    Warm,
 }
 
 impl ReadCache {
@@ -23,7 +32,11 @@ impl ReadCache {
         let cache =
             TinyLfuCache::new_unbounded(capacity_bytes, enable_lfu_admission, value_size_hint);
         Self {
-            inner: Mutex::new(ReadCacheInner { cache }),
+            inner: Mutex::new(ReadCacheInner {
+                cache,
+                cold: LruCache::new_unbounded(),
+                warm: LruCache::new_unbounded(),
+            }),
         }
     }
 
@@ -40,6 +53,7 @@ impl ReadCache {
             let mut inner = self.inner.lock();
             for key in keys {
                 if let Some(block) = inner.cache.get(key) {
+                    promote_on_local_hit(&mut inner, key);
                     hit += 1;
                     blocks.push(block);
                 } else {
@@ -53,7 +67,7 @@ impl ReadCache {
     pub(super) fn batch_insert(&self, blocks: Vec<(BlockKey, Arc<SealedBlock>)>) {
         let mut inner = self.inner.lock();
         for (key, block) in blocks {
-            insert_block(&mut inner, key, block);
+            insert_block(&mut inner, key, block, ResidentClass::Warm);
         }
     }
 
@@ -64,7 +78,7 @@ impl ReadCache {
         let mut inner = self.inner.lock();
         let mut resident_keys = Vec::new();
         for (key, block) in blocks {
-            match insert_block(&mut inner, key.clone(), block) {
+            match insert_block(&mut inner, key.clone(), block, ResidentClass::Cold) {
                 CacheInsertOutcome::InsertedNew | CacheInsertOutcome::AlreadyExists => {
                     resident_keys.push(key);
                 }
@@ -77,7 +91,12 @@ impl ReadCache {
     pub(super) fn batch_insert_refs(&self, blocks: &[(BlockKey, Arc<SealedBlock>)]) {
         let mut inner = self.inner.lock();
         for (key, block) in blocks {
-            insert_block(&mut inner, key.clone(), Arc::clone(block));
+            insert_block(
+                &mut inner,
+                key.clone(),
+                Arc::clone(block),
+                ResidentClass::Warm,
+            );
         }
     }
 
@@ -96,13 +115,64 @@ impl ReadCache {
 
     pub(super) fn remove_lru_batch(&self, batch_size: usize) -> Vec<(BlockKey, Arc<SealedBlock>)> {
         let mut inner = self.inner.lock();
-        (0..batch_size)
-            .map_while(|_| inner.cache.remove_lru())
-            .collect()
+        let mut evicted = Vec::with_capacity(batch_size);
+        while evicted.len() < batch_size {
+            let candidate = inner
+                .cold
+                .remove_lru()
+                .map(|(key, _)| (key, ResidentClass::Cold))
+                .or_else(|| {
+                    inner
+                        .warm
+                        .remove_lru()
+                        .map(|(key, _)| (key, ResidentClass::Warm))
+                });
+            let Some((key, class)) = candidate else {
+                break;
+            };
+            if let Some(block) = inner.cache.remove(&key) {
+                let attributes = class.attributes();
+                let metrics = core_metrics();
+                metrics.cache_resident_blocks.add(-1, attributes);
+                metrics.cache_block_evictions_by_class.add(1, attributes);
+                evicted.push((key, block));
+            }
+        }
+        evicted
     }
 
     pub(super) fn remove_all(&self) -> Vec<(BlockKey, Arc<SealedBlock>)> {
-        self.inner.lock().cache.remove_all()
+        let mut inner = self.inner.lock();
+        let cold_blocks = inner.cold.len() as i64;
+        let warm_blocks = inner.warm.len() as i64;
+        inner.cold.clear();
+        inner.warm.clear();
+        let metrics = core_metrics();
+        metrics
+            .cache_resident_blocks
+            .add(-cold_blocks, &*CACHE_CLASS_COLD);
+        metrics
+            .cache_resident_blocks
+            .add(-warm_blocks, &*CACHE_CLASS_WARM);
+        inner.cache.remove_all()
+    }
+
+    pub(super) fn demote(&self, keys: &[BlockKey]) {
+        let mut inner = self.inner.lock();
+        for key in keys {
+            if inner.cache.contains_key(key) {
+                demote(&mut inner, key);
+            }
+        }
+    }
+}
+
+impl ResidentClass {
+    fn attributes(self) -> &'static [opentelemetry::KeyValue] {
+        match self {
+            Self::Cold => &*CACHE_CLASS_COLD,
+            Self::Warm => &*CACHE_CLASS_WARM,
+        }
     }
 }
 
@@ -110,21 +180,63 @@ fn insert_block(
     inner: &mut ReadCacheInner,
     key: BlockKey,
     block: Arc<SealedBlock>,
+    class: ResidentClass,
 ) -> CacheInsertOutcome {
     let footprint_bytes = block.memory_footprint();
-    let outcome = inner.cache.insert(key, block);
+    let outcome = inner.cache.insert(key.clone(), block);
     match outcome {
         CacheInsertOutcome::InsertedNew => {
+            match class {
+                ResidentClass::Cold => {
+                    inner.cold.insert(key, ());
+                }
+                ResidentClass::Warm => {
+                    inner.warm.insert(key, ());
+                }
+            }
             let m = core_metrics();
             m.cache_block_insertions.add(1, &[]);
             m.cache_resident_bytes.add(footprint_bytes as i64, &[]);
+            m.cache_resident_blocks.add(1, class.attributes());
         }
-        CacheInsertOutcome::AlreadyExists => {}
+        CacheInsertOutcome::AlreadyExists => {
+            promote(&mut *inner, &key);
+        }
         CacheInsertOutcome::Rejected => {
             core_metrics().cache_block_admission_rejections.add(1, &[]);
         }
     }
     outcome
+}
+
+fn promote_on_local_hit(inner: &mut ReadCacheInner, key: &BlockKey) {
+    if inner.cold.contains_key(key) {
+        promote(inner, key);
+    } else if inner.warm.contains_key(key) {
+        inner.warm.get(key);
+    }
+}
+
+fn promote(inner: &mut ReadCacheInner, key: &BlockKey) {
+    if inner.cold.remove(key).is_some() && inner.cache.contains_key(key) {
+        inner.warm.insert(key.clone(), ());
+        let metrics = core_metrics();
+        metrics.cache_resident_blocks.add(-1, &*CACHE_CLASS_COLD);
+        metrics.cache_resident_blocks.add(1, &*CACHE_CLASS_WARM);
+        metrics.cache_block_promotions.add(1, &[]);
+    } else if inner.warm.contains_key(key) {
+        inner.warm.get(key);
+    }
+}
+
+fn demote(inner: &mut ReadCacheInner, key: &BlockKey) {
+    if inner.warm.remove(key).is_some() && inner.cache.contains_key(key) {
+        inner.cold.insert(key.clone(), ());
+        let metrics = core_metrics();
+        metrics.cache_resident_blocks.add(-1, &*CACHE_CLASS_WARM);
+        metrics.cache_resident_blocks.add(1, &*CACHE_CLASS_COLD);
+        metrics.cache_block_demotions.add(1, &[]);
+    }
 }
 
 #[cfg(test)]
@@ -209,6 +321,81 @@ mod tests {
         // get_prefix_blocks: stops at key 1 (first miss), returns only key 0
         let (prefix_hit, _) = cache.get_prefix_blocks(&keys);
         assert_eq!(prefix_hit, 1);
+    }
+
+    #[test]
+    fn cold_blocks_are_evicted_before_warm_blocks() {
+        let cache = make_cache();
+        let warm = BlockKey::new("ns".into(), vec![1]);
+        let cold = BlockKey::new("ns".into(), vec![2]);
+
+        cache.batch_insert(vec![(warm.clone(), make_block())]);
+        assert_eq!(
+            cache.batch_insert_resident_keys(vec![(cold.clone(), make_block())]),
+            vec![cold.clone()]
+        );
+
+        let evicted = cache.remove_lru_batch(1);
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].0, cold);
+        assert!(cache.contains_keys(&[warm])[0]);
+    }
+
+    #[test]
+    fn local_hit_promotes_cold_block_to_warm() {
+        let cache = make_cache();
+        let cold_hit = BlockKey::new("ns".into(), vec![1]);
+        let cold_miss = BlockKey::new("ns".into(), vec![2]);
+
+        cache.batch_insert_resident_keys(vec![
+            (cold_hit.clone(), make_block()),
+            (cold_miss.clone(), make_block()),
+        ]);
+        let (hit, _) = cache.get_prefix_blocks(std::slice::from_ref(&cold_hit));
+        assert_eq!(hit, 1);
+
+        let evicted = cache.remove_lru_batch(1);
+        assert_eq!(evicted[0].0, cold_miss);
+        assert!(cache.contains_keys(&[cold_hit])[0]);
+    }
+
+    #[test]
+    fn rdma_fetch_of_existing_cold_block_promotes_to_warm() {
+        let cache = make_cache();
+        let existing = BlockKey::new("ns".into(), vec![1]);
+        let other = BlockKey::new("ns".into(), vec![2]);
+
+        cache.batch_insert_resident_keys(vec![(existing.clone(), make_block())]);
+        cache.batch_insert_resident_keys(vec![(other.clone(), make_block())]);
+        cache.batch_insert_resident_keys(vec![(existing.clone(), make_block())]);
+
+        let evicted = cache.remove_lru_batch(1);
+        assert_eq!(evicted[0].0, other);
+        assert!(cache.contains_keys(&[existing])[0]);
+    }
+
+    #[test]
+    fn repeated_warm_insert_refreshes_lru_recency() {
+        let cache = make_cache();
+        let first = BlockKey::new("ns".into(), vec![1]);
+        let second = BlockKey::new("ns".into(), vec![2]);
+        let first_block = make_block();
+
+        cache.batch_insert(vec![(first.clone(), Arc::clone(&first_block))]);
+        cache.batch_insert(vec![(second.clone(), make_block())]);
+        cache.batch_insert(vec![(first, first_block)]);
+
+        assert_eq!(cache.remove_lru_batch(1)[0].0, second);
+    }
+
+    #[test]
+    fn demote_moves_warm_block_to_cold() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        cache.batch_insert(vec![(key.clone(), make_block())]);
+
+        cache.demote(std::slice::from_ref(&key));
+        assert_eq!(cache.remove_lru_batch(1)[0].0, key);
     }
 
     #[test]

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -5,7 +5,7 @@ use parking_lot::Mutex;
 
 use crate::block::{BlockKey, SealedBlock};
 use crate::cache::{CacheInsertOutcome, TinyLfuCache};
-use crate::metrics::{CACHE_CLASS_COLD, CACHE_CLASS_WARM, core_metrics};
+use crate::metrics::{CACHE_CLASS_RECLAIMABLE, CACHE_CLASS_RETAINED, core_metrics};
 
 pub(super) struct ReadCache {
     inner: Mutex<ReadCacheInner>,
@@ -13,14 +13,14 @@ pub(super) struct ReadCache {
 
 struct ReadCacheInner {
     cache: TinyLfuCache<BlockKey, Arc<SealedBlock>>,
-    cold: LruCache<BlockKey, ()>,
-    warm: LruCache<BlockKey, ()>,
+    reclaimable: LruCache<BlockKey, ()>,
+    retained: LruCache<BlockKey, ()>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(super) enum ResidentClass {
-    Cold,
-    Warm,
+    Reclaimable,
+    Retained,
 }
 
 impl ReadCache {
@@ -34,8 +34,8 @@ impl ReadCache {
         Self {
             inner: Mutex::new(ReadCacheInner {
                 cache,
-                cold: LruCache::new_unbounded(),
-                warm: LruCache::new_unbounded(),
+                reclaimable: LruCache::new_unbounded(),
+                retained: LruCache::new_unbounded(),
             }),
         }
     }
@@ -53,7 +53,7 @@ impl ReadCache {
             let mut inner = self.inner.lock();
             for key in keys {
                 if let Some(block) = inner.cache.get(key) {
-                    promote_on_local_hit(&mut inner, key);
+                    refresh_recency(&mut inner, key);
                     hit += 1;
                     blocks.push(block);
                 } else {
@@ -67,7 +67,7 @@ impl ReadCache {
     pub(super) fn batch_insert(&self, blocks: Vec<(BlockKey, Arc<SealedBlock>)>) {
         let mut inner = self.inner.lock();
         for (key, block) in blocks {
-            insert_block(&mut inner, key, block, ResidentClass::Warm);
+            insert_block(&mut inner, key, block, ResidentClass::Retained);
         }
     }
 
@@ -78,7 +78,7 @@ impl ReadCache {
         let mut inner = self.inner.lock();
         let mut resident_keys = Vec::new();
         for (key, block) in blocks {
-            match insert_block(&mut inner, key.clone(), block, ResidentClass::Cold) {
+            match insert_block(&mut inner, key.clone(), block, ResidentClass::Reclaimable) {
                 CacheInsertOutcome::InsertedNew | CacheInsertOutcome::AlreadyExists => {
                     resident_keys.push(key);
                 }
@@ -88,16 +88,24 @@ impl ReadCache {
         resident_keys
     }
 
-    pub(super) fn batch_insert_refs(&self, blocks: &[(BlockKey, Arc<SealedBlock>)]) {
+    pub(super) fn batch_insert_refs(
+        &self,
+        blocks: &[(BlockKey, Arc<SealedBlock>)],
+    ) -> Vec<BlockKey> {
         let mut inner = self.inner.lock();
+        let mut inserted = Vec::new();
         for (key, block) in blocks {
-            insert_block(
+            if insert_block(
                 &mut inner,
                 key.clone(),
                 Arc::clone(block),
-                ResidentClass::Warm,
-            );
+                ResidentClass::Retained,
+            ) == CacheInsertOutcome::InsertedNew
+            {
+                inserted.push(key.clone());
+            }
         }
+        inserted
     }
 
     /// Look up specific blocks by key without prefix-scan semantics (does not
@@ -119,14 +127,14 @@ impl ReadCache {
         let mut evicted = Vec::with_capacity(batch_size);
         while evicted.len() < batch_size {
             let candidate = inner
-                .cold
+                .reclaimable
                 .remove_lru()
-                .map(|(key, _)| (key, ResidentClass::Cold))
+                .map(|(key, _)| (key, ResidentClass::Reclaimable))
                 .or_else(|| {
                     inner
-                        .warm
+                        .retained
                         .remove_lru()
-                        .map(|(key, _)| (key, ResidentClass::Warm))
+                        .map(|(key, _)| (key, ResidentClass::Retained))
                 });
             let Some((key, class)) = candidate else {
                 break;
@@ -144,25 +152,34 @@ impl ReadCache {
 
     pub(super) fn remove_all(&self) -> Vec<(BlockKey, Arc<SealedBlock>)> {
         let mut inner = self.inner.lock();
-        let cold_blocks = inner.cold.len() as i64;
-        let warm_blocks = inner.warm.len() as i64;
-        inner.cold.clear();
-        inner.warm.clear();
+        let reclaimable_blocks = inner.reclaimable.len() as i64;
+        let retained_blocks = inner.retained.len() as i64;
+        inner.reclaimable.clear();
+        inner.retained.clear();
         let metrics = core_metrics();
         metrics
             .cache_resident_blocks
-            .add(-cold_blocks, &*CACHE_CLASS_COLD);
+            .add(-reclaimable_blocks, &*CACHE_CLASS_RECLAIMABLE);
         metrics
             .cache_resident_blocks
-            .add(-warm_blocks, &*CACHE_CLASS_WARM);
+            .add(-retained_blocks, &*CACHE_CLASS_RETAINED);
         inner.cache.remove_all()
     }
 
-    pub(super) fn demote(&self, keys: &[BlockKey]) {
+    pub(super) fn mark_reclaimable(&self, keys: &[BlockKey]) {
         let mut inner = self.inner.lock();
         for key in keys {
             if inner.cache.contains_key(key) {
-                demote(&mut inner, key);
+                mark_reclaimable(&mut inner, key);
+            }
+        }
+    }
+
+    pub(super) fn apply_owner_hints(&self, keys: &[BlockKey], owner_counts: &[u32]) {
+        let mut inner = self.inner.lock();
+        for (key, owner_count) in keys.iter().zip(owner_counts) {
+            if *owner_count > 1 && inner.cache.contains_key(key) {
+                mark_reclaimable(&mut inner, key);
             }
         }
     }
@@ -171,8 +188,8 @@ impl ReadCache {
 impl ResidentClass {
     fn attributes(self) -> &'static [opentelemetry::KeyValue] {
         match self {
-            Self::Cold => &*CACHE_CLASS_COLD,
-            Self::Warm => &*CACHE_CLASS_WARM,
+            Self::Reclaimable => &*CACHE_CLASS_RECLAIMABLE,
+            Self::Retained => &*CACHE_CLASS_RETAINED,
         }
     }
 }
@@ -188,11 +205,11 @@ fn insert_block(
     match outcome {
         CacheInsertOutcome::InsertedNew => {
             match class {
-                ResidentClass::Cold => {
-                    inner.cold.insert(key, ());
+                ResidentClass::Reclaimable => {
+                    inner.reclaimable.insert(key, ());
                 }
-                ResidentClass::Warm => {
-                    inner.warm.insert(key, ());
+                ResidentClass::Retained => {
+                    inner.retained.insert(key, ());
                 }
             }
             let m = core_metrics();
@@ -200,9 +217,7 @@ fn insert_block(
             m.cache_resident_bytes.add(footprint_bytes as i64, &[]);
             m.cache_resident_blocks.add(1, class.attributes());
         }
-        CacheInsertOutcome::AlreadyExists => {
-            promote(&mut *inner, &key);
-        }
+        CacheInsertOutcome::AlreadyExists => refresh_recency(inner, &key),
         CacheInsertOutcome::Rejected => {
             core_metrics().cache_block_admission_rejections.add(1, &[]);
         }
@@ -210,41 +225,27 @@ fn insert_block(
     outcome
 }
 
-fn promote_on_local_hit(inner: &mut ReadCacheInner, key: &BlockKey) {
-    if inner.cold.contains_key(key) {
-        promote(inner, key);
-    } else if inner.warm.contains_key(key) {
-        inner.warm.get(key);
-    }
-}
-
 fn refresh_recency(inner: &mut ReadCacheInner, key: &BlockKey) {
-    if inner.cold.contains_key(key) {
-        inner.cold.get(key);
-    } else if inner.warm.contains_key(key) {
-        inner.warm.get(key);
+    if inner.reclaimable.contains_key(key) {
+        inner.reclaimable.get(key);
+    } else if inner.retained.contains_key(key) {
+        inner.retained.get(key);
     }
 }
 
-fn promote(inner: &mut ReadCacheInner, key: &BlockKey) {
-    if inner.cold.remove(key).is_some() && inner.cache.contains_key(key) {
-        inner.warm.insert(key.clone(), ());
+fn mark_reclaimable(inner: &mut ReadCacheInner, key: &BlockKey) {
+    if inner.retained.remove(key).is_some() && inner.cache.contains_key(key) {
+        inner.reclaimable.insert(key.clone(), ());
         let metrics = core_metrics();
-        metrics.cache_resident_blocks.add(-1, &*CACHE_CLASS_COLD);
-        metrics.cache_resident_blocks.add(1, &*CACHE_CLASS_WARM);
-        metrics.cache_block_promotions.add(1, &[]);
-    } else if inner.warm.contains_key(key) {
-        inner.warm.get(key);
-    }
-}
-
-fn demote(inner: &mut ReadCacheInner, key: &BlockKey) {
-    if inner.warm.remove(key).is_some() && inner.cache.contains_key(key) {
-        inner.cold.insert(key.clone(), ());
-        let metrics = core_metrics();
-        metrics.cache_resident_blocks.add(-1, &*CACHE_CLASS_WARM);
-        metrics.cache_resident_blocks.add(1, &*CACHE_CLASS_COLD);
+        metrics
+            .cache_resident_blocks
+            .add(-1, &*CACHE_CLASS_RETAINED);
+        metrics
+            .cache_resident_blocks
+            .add(1, &*CACHE_CLASS_RECLAIMABLE);
         metrics.cache_block_demotions.add(1, &[]);
+    } else if inner.reclaimable.contains_key(key) {
+        inner.reclaimable.get(key);
     }
 }
 
@@ -319,8 +320,8 @@ mod tests {
         let _ = cache.get_blocks(std::slice::from_ref(&key));
 
         let inner = cache.inner.lock();
-        assert!(inner.cold.contains_key(&key));
-        assert!(!inner.warm.contains_key(&key));
+        assert!(inner.reclaimable.contains_key(&key));
+        assert!(!inner.retained.contains_key(&key));
     }
 
     #[test]
@@ -346,43 +347,46 @@ mod tests {
     }
 
     #[test]
-    fn cold_blocks_are_evicted_before_warm_blocks() {
+    fn reclaimable_blocks_are_evicted_before_retained_blocks() {
         let cache = make_cache();
-        let warm = BlockKey::new("ns".into(), vec![1]);
-        let cold = BlockKey::new("ns".into(), vec![2]);
+        let retained = BlockKey::new("ns".into(), vec![1]);
+        let reclaimable = BlockKey::new("ns".into(), vec![2]);
 
-        cache.batch_insert(vec![(warm.clone(), make_block())]);
+        cache.batch_insert(vec![(retained.clone(), make_block())]);
         assert_eq!(
-            cache.batch_insert_resident_keys(vec![(cold.clone(), make_block())]),
-            vec![cold.clone()]
+            cache.batch_insert_resident_keys(vec![(reclaimable.clone(), make_block())]),
+            vec![reclaimable.clone()]
         );
 
         let evicted = cache.remove_lru_batch(1);
         assert_eq!(evicted.len(), 1);
-        assert_eq!(evicted[0].0, cold);
-        assert!(cache.contains_keys(&[warm])[0]);
+        assert_eq!(evicted[0].0, reclaimable);
+        assert!(cache.contains_keys(&[retained])[0]);
     }
 
     #[test]
-    fn local_hit_promotes_cold_block_to_warm() {
+    fn local_hit_refreshes_reclaimable_without_changing_class() {
         let cache = make_cache();
-        let cold_hit = BlockKey::new("ns".into(), vec![1]);
-        let cold_miss = BlockKey::new("ns".into(), vec![2]);
+        let reclaimable_hit = BlockKey::new("ns".into(), vec![1]);
+        let reclaimable_miss = BlockKey::new("ns".into(), vec![2]);
 
         cache.batch_insert_resident_keys(vec![
-            (cold_hit.clone(), make_block()),
-            (cold_miss.clone(), make_block()),
+            (reclaimable_hit.clone(), make_block()),
+            (reclaimable_miss.clone(), make_block()),
         ]);
-        let (hit, _) = cache.get_prefix_blocks(std::slice::from_ref(&cold_hit));
+        let (hit, _) = cache.get_prefix_blocks(std::slice::from_ref(&reclaimable_hit));
         assert_eq!(hit, 1);
 
         let evicted = cache.remove_lru_batch(1);
-        assert_eq!(evicted[0].0, cold_miss);
-        assert!(cache.contains_keys(&[cold_hit])[0]);
+        assert_eq!(evicted[0].0, reclaimable_miss);
+        assert!(cache.contains_keys(&[reclaimable_hit.clone()])[0]);
+        let inner = cache.inner.lock();
+        assert!(inner.reclaimable.contains_key(&reclaimable_hit));
+        assert!(!inner.retained.contains_key(&reclaimable_hit));
     }
 
     #[test]
-    fn rdma_fetch_of_existing_cold_block_promotes_to_warm() {
+    fn rdma_fetch_of_existing_block_keeps_existing_class() {
         let cache = make_cache();
         let existing = BlockKey::new("ns".into(), vec![1]);
         let other = BlockKey::new("ns".into(), vec![2]);
@@ -393,11 +397,14 @@ mod tests {
 
         let evicted = cache.remove_lru_batch(1);
         assert_eq!(evicted[0].0, other);
-        assert!(cache.contains_keys(&[existing])[0]);
+        assert!(cache.contains_keys(&[existing.clone()])[0]);
+        let inner = cache.inner.lock();
+        assert!(inner.reclaimable.contains_key(&existing));
+        assert!(!inner.retained.contains_key(&existing));
     }
 
     #[test]
-    fn repeated_warm_insert_refreshes_lru_recency() {
+    fn repeated_retained_insert_refreshes_lru_recency() {
         let cache = make_cache();
         let first = BlockKey::new("ns".into(), vec![1]);
         let second = BlockKey::new("ns".into(), vec![2]);
@@ -411,13 +418,40 @@ mod tests {
     }
 
     #[test]
-    fn demote_moves_warm_block_to_cold() {
+    fn mark_reclaimable_moves_retained_block() {
         let cache = make_cache();
         let key = BlockKey::new("ns".into(), vec![1]);
         cache.batch_insert(vec![(key.clone(), make_block())]);
 
-        cache.demote(std::slice::from_ref(&key));
+        cache.mark_reclaimable(std::slice::from_ref(&key));
         assert_eq!(cache.remove_lru_batch(1)[0].0, key);
+    }
+
+    #[test]
+    fn owner_hint_marks_only_new_local_insert_as_reclaimable() {
+        let cache = make_cache();
+        let hinted = BlockKey::new("ns".into(), vec![1]);
+        let unique = BlockKey::new("ns".into(), vec![2]);
+
+        cache.batch_insert(vec![(hinted.clone(), make_block())]);
+        cache.batch_insert(vec![(unique.clone(), make_block())]);
+        cache.apply_owner_hints(&[hinted.clone(), unique.clone()], &[2, 1]);
+
+        let evicted = cache.remove_lru_batch(1);
+        assert_eq!(evicted[0].0, hinted);
+        assert!(cache.contains_keys(&[unique])[0]);
+    }
+
+    #[test]
+    fn already_existing_insert_does_not_change_class() {
+        let cache = make_cache();
+        let retained = BlockKey::new("ns".into(), vec![1]);
+        cache.batch_insert(vec![(retained.clone(), make_block())]);
+
+        cache.batch_insert_resident_keys(vec![(retained.clone(), make_block())]);
+        let inner = cache.inner.lock();
+        assert!(inner.retained.contains_key(&retained));
+        assert!(!inner.reclaimable.contains_key(&retained));
     }
 
     #[test]

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -174,16 +174,20 @@ impl ReadCache {
     pub(super) fn mark_reclaimable(&self, keys: &[BlockKey]) {
         let mut inner = self.inner.lock();
         for key in keys {
-            if inner.cache.contains_key(key) {
-                mark_reclaimable(&mut inner, key);
-            }
+            mark_reclaimable(&mut inner, key);
         }
     }
 
-    pub(super) fn apply_owner_hints(&self, keys: &[BlockKey], owner_counts: &[u32]) {
+    pub(super) fn apply_owner_hints(
+        &self,
+        resident_saves: &[(BlockKey, CacheInsertOutcome)],
+        owner_counts: &[u32],
+    ) {
         let mut inner = self.inner.lock();
-        for (key, owner_count) in keys.iter().zip(owner_counts) {
-            if *owner_count >= MIN_RECLAIMABLE_OWNER_COUNT && inner.cache.contains_key(key) {
+        for ((key, outcome), owner_count) in resident_saves.iter().zip(owner_counts) {
+            if *outcome == CacheInsertOutcome::InsertedNew
+                && *owner_count >= MIN_RECLAIMABLE_OWNER_COUNT
+            {
                 mark_reclaimable(&mut inner, key);
             }
         }
@@ -455,7 +459,10 @@ mod tests {
         cache.batch_insert(vec![(second_owner.clone(), make_block())]);
         cache.batch_insert(vec![(third_owner.clone(), make_block())]);
         cache.apply_owner_hints(
-            &[second_owner.clone(), third_owner.clone()],
+            &[
+                (second_owner.clone(), CacheInsertOutcome::InsertedNew),
+                (third_owner.clone(), CacheInsertOutcome::InsertedNew),
+            ],
             &[2, MIN_RECLAIMABLE_OWNER_COUNT],
         );
 
@@ -471,9 +478,28 @@ mod tests {
         cache.batch_insert(vec![(key.clone(), make_block())]);
         cache.remove_lru_batch(1);
 
-        cache.apply_owner_hints(&[key], &[MIN_RECLAIMABLE_OWNER_COUNT]);
+        cache.apply_owner_hints(
+            &[(key, CacheInsertOutcome::InsertedNew)],
+            &[MIN_RECLAIMABLE_OWNER_COUNT],
+        );
 
         assert!(cache.remove_lru_batch(1).is_empty());
+    }
+
+    #[test]
+    fn owner_hint_does_not_demote_existing_local_save() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        cache.batch_insert(vec![(key.clone(), make_block())]);
+
+        cache.apply_owner_hints(
+            &[(key.clone(), CacheInsertOutcome::AlreadyExists)],
+            &[MIN_RECLAIMABLE_OWNER_COUNT],
+        );
+
+        let inner = cache.inner.lock();
+        assert!(inner.retained.contains_key(&key));
+        assert!(!inner.reclaimable.contains_key(&key));
     }
 
     #[test]

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -174,15 +174,6 @@ impl ReadCache {
             }
         }
     }
-
-    pub(super) fn apply_owner_hints(&self, keys: &[BlockKey], owner_counts: &[u32]) {
-        let mut inner = self.inner.lock();
-        for (key, owner_count) in keys.iter().zip(owner_counts) {
-            if *owner_count > 1 && inner.cache.contains_key(key) {
-                mark_reclaimable(&mut inner, key);
-            }
-        }
-    }
 }
 
 impl ResidentClass {
@@ -425,21 +416,6 @@ mod tests {
 
         cache.mark_reclaimable(std::slice::from_ref(&key));
         assert_eq!(cache.remove_lru_batch(1)[0].0, key);
-    }
-
-    #[test]
-    fn owner_hint_marks_only_new_local_insert_as_reclaimable() {
-        let cache = make_cache();
-        let hinted = BlockKey::new("ns".into(), vec![1]);
-        let unique = BlockKey::new("ns".into(), vec![2]);
-
-        cache.batch_insert(vec![(hinted.clone(), make_block())]);
-        cache.batch_insert(vec![(unique.clone(), make_block())]);
-        cache.apply_owner_hints(&[hinted.clone(), unique.clone()], &[2, 1]);
-
-        let evicted = cache.remove_lru_batch(1);
-        assert_eq!(evicted[0].0, hinted);
-        assert!(cache.contains_keys(&[unique])[0]);
     }
 
     #[test]

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -107,7 +107,6 @@ impl ReadCache {
         let mut found = Vec::new();
         for key in keys {
             if let Some(block) = inner.cache.get(key) {
-                let block = Arc::clone(block);
                 refresh_recency(&mut inner, key);
                 found.push((key.clone(), block));
             }

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -7,6 +7,8 @@ use crate::block::{BlockKey, SealedBlock};
 use crate::cache::{CacheInsertOutcome, TinyLfuCache};
 use crate::metrics::{CACHE_CLASS_RECLAIMABLE, CACHE_CLASS_RETAINED, core_metrics};
 
+const MIN_RECLAIMABLE_OWNER_COUNT: u32 = 3;
+
 pub(super) struct ReadCache {
     inner: Mutex<ReadCacheInner>,
 }
@@ -170,6 +172,15 @@ impl ReadCache {
         let mut inner = self.inner.lock();
         for key in keys {
             if inner.cache.contains_key(key) {
+                mark_reclaimable(&mut inner, key);
+            }
+        }
+    }
+
+    pub(super) fn apply_owner_hints(&self, keys: &[BlockKey], owner_counts: &[u32]) {
+        let mut inner = self.inner.lock();
+        for (key, owner_count) in keys.iter().zip(owner_counts) {
+            if *owner_count >= MIN_RECLAIMABLE_OWNER_COUNT && inner.cache.contains_key(key) {
                 mark_reclaimable(&mut inner, key);
             }
         }
@@ -370,7 +381,7 @@ mod tests {
 
         let evicted = cache.remove_lru_batch(1);
         assert_eq!(evicted[0].0, reclaimable_miss);
-        assert!(cache.contains_keys(&[reclaimable_hit.clone()])[0]);
+        assert!(cache.contains_keys(std::slice::from_ref(&reclaimable_hit))[0]);
         let inner = cache.inner.lock();
         assert!(inner.reclaimable.contains_key(&reclaimable_hit));
         assert!(!inner.retained.contains_key(&reclaimable_hit));
@@ -388,7 +399,7 @@ mod tests {
 
         let evicted = cache.remove_lru_batch(1);
         assert_eq!(evicted[0].0, other);
-        assert!(cache.contains_keys(&[existing.clone()])[0]);
+        assert!(cache.contains_keys(std::slice::from_ref(&existing))[0]);
         let inner = cache.inner.lock();
         assert!(inner.reclaimable.contains_key(&existing));
         assert!(!inner.retained.contains_key(&existing));
@@ -416,6 +427,36 @@ mod tests {
 
         cache.mark_reclaimable(std::slice::from_ref(&key));
         assert_eq!(cache.remove_lru_batch(1)[0].0, key);
+    }
+
+    #[test]
+    fn owner_hint_marks_only_third_local_owner_as_reclaimable() {
+        let cache = make_cache();
+        let second_owner = BlockKey::new("ns".into(), vec![1]);
+        let third_owner = BlockKey::new("ns".into(), vec![2]);
+
+        cache.batch_insert(vec![(second_owner.clone(), make_block())]);
+        cache.batch_insert(vec![(third_owner.clone(), make_block())]);
+        cache.apply_owner_hints(
+            &[second_owner.clone(), third_owner.clone()],
+            &[2, MIN_RECLAIMABLE_OWNER_COUNT],
+        );
+
+        let evicted = cache.remove_lru_batch(1);
+        assert_eq!(evicted[0].0, third_owner);
+        assert!(cache.contains_keys(&[second_owner])[0]);
+    }
+
+    #[test]
+    fn owner_hint_for_evicted_block_is_noop() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        cache.batch_insert(vec![(key.clone(), make_block())]);
+        cache.remove_lru_batch(1);
+
+        cache.apply_owner_hints(&[key], &[MIN_RECLAIMABLE_OWNER_COUNT]);
+
+        assert!(cache.remove_lru_batch(1).is_empty());
     }
 
     #[test]

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -287,7 +287,7 @@ fn send_backing_batches(
     }
 
     if let Some(client) = &deps.metaserver_client {
-        register_block_hashes(client, namespace, locally_inserted, &deps.read_cache);
+        register_block_hashes(client, namespace, locally_inserted);
     }
 }
 
@@ -295,7 +295,6 @@ fn register_block_hashes(
     client: &MetaServerClient,
     namespace: &str,
     locally_inserted: Vec<BlockKey>,
-    read_cache: &Arc<ReadCache>,
 ) {
     if locally_inserted.is_empty() {
         return;
@@ -305,10 +304,7 @@ fn register_block_hashes(
         .map(|key| key.hash.clone())
         .collect();
 
-    let read_cache = Arc::clone(read_cache);
-    client.try_register_namespace_with_hint(namespace.to_string(), hashes, move |owner_counts| {
-        read_cache.apply_owner_hints(&locally_inserted, &owner_counts);
-    });
+    client.try_register_namespace(namespace.to_string(), hashes);
 }
 
 fn gc_inflight(

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -7,6 +7,7 @@ use tokio::sync::oneshot;
 
 use crate::backing::SsdBackingStore;
 use crate::block::{BlockKey, InflightBlock, SealedBlock, SlotInsertResult};
+use crate::cache::CacheInsertOutcome;
 use crate::internode::MetaServerClient;
 use crate::metrics::core_metrics;
 use crate::offload::InsertEntries;
@@ -199,8 +200,8 @@ fn process_insert_batch(
     if !sealed_blocks.is_empty()
         && let Some(deps) = &deps
     {
-        let locally_inserted = deps.read_cache.batch_insert_refs(&sealed_blocks);
-        send_backing_batches(deps, namespace, &sealed_blocks, locally_inserted);
+        let resident_saves = deps.read_cache.batch_insert_refs(&sealed_blocks);
+        send_backing_batches(deps, namespace, &sealed_blocks, resident_saves);
     }
 
     ordered_fast_path_seals
@@ -269,7 +270,7 @@ fn send_backing_batches(
     deps: &InsertDeps,
     namespace: &str,
     blocks: &[(BlockKey, Arc<SealedBlock>)],
-    locally_inserted: Vec<BlockKey>,
+    resident_saves: Vec<(BlockKey, CacheInsertOutcome)>,
 ) {
     if blocks.is_empty() {
         return;
@@ -287,27 +288,35 @@ fn send_backing_batches(
     }
 
     if let Some(client) = &deps.metaserver_client {
-        register_block_hashes(client, namespace, locally_inserted, &deps.read_cache);
+        register_block_hashes(client, namespace, resident_saves, &deps.read_cache);
     }
 }
 
 fn register_block_hashes(
     client: &MetaServerClient,
     namespace: &str,
-    locally_inserted: Vec<BlockKey>,
+    resident_saves: Vec<(BlockKey, CacheInsertOutcome)>,
     read_cache: &Arc<ReadCache>,
 ) {
-    if locally_inserted.is_empty() {
+    if resident_saves.is_empty() {
         return;
     }
-    let hashes: Vec<Vec<u8>> = locally_inserted
+    let hashes: Vec<Vec<u8>> = resident_saves
         .iter()
-        .map(|key| key.hash.clone())
+        .map(|(key, _)| key.hash.clone())
         .collect();
 
     let read_cache = Arc::clone(read_cache);
     client.try_register_namespace_with_hint(namespace.to_string(), hashes, move |owner_counts| {
-        read_cache.apply_owner_hints(&locally_inserted, &owner_counts);
+        let mut new_keys = Vec::new();
+        let mut new_owner_counts = Vec::new();
+        for ((key, outcome), owner_count) in resident_saves.iter().zip(owner_counts) {
+            if *outcome == CacheInsertOutcome::InsertedNew {
+                new_keys.push(key.clone());
+                new_owner_counts.push(owner_count);
+            }
+        }
+        read_cache.apply_owner_hints(&new_keys, &new_owner_counts);
     });
 }
 

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -199,8 +199,8 @@ fn process_insert_batch(
     if !sealed_blocks.is_empty()
         && let Some(deps) = &deps
     {
-        deps.read_cache.batch_insert_refs(&sealed_blocks);
-        send_backing_batches(deps, namespace, &sealed_blocks);
+        let locally_inserted = deps.read_cache.batch_insert_refs(&sealed_blocks);
+        send_backing_batches(deps, namespace, &sealed_blocks, locally_inserted);
     }
 
     ordered_fast_path_seals
@@ -269,6 +269,7 @@ fn send_backing_batches(
     deps: &InsertDeps,
     namespace: &str,
     blocks: &[(BlockKey, Arc<SealedBlock>)],
+    locally_inserted: Vec<BlockKey>,
 ) {
     if blocks.is_empty() {
         return;
@@ -286,17 +287,28 @@ fn send_backing_batches(
     }
 
     if let Some(client) = &deps.metaserver_client {
-        register_block_hashes(client, namespace, blocks);
+        register_block_hashes(client, namespace, locally_inserted, &deps.read_cache);
     }
 }
 
 fn register_block_hashes(
     client: &MetaServerClient,
     namespace: &str,
-    blocks: &[(BlockKey, Arc<SealedBlock>)],
+    locally_inserted: Vec<BlockKey>,
+    read_cache: &Arc<ReadCache>,
 ) {
-    let hashes: Vec<Vec<u8>> = blocks.iter().map(|(key, _)| key.hash.clone()).collect();
-    client.try_register_namespace(namespace.to_string(), hashes);
+    if locally_inserted.is_empty() {
+        return;
+    }
+    let hashes: Vec<Vec<u8>> = locally_inserted
+        .iter()
+        .map(|key| key.hash.clone())
+        .collect();
+
+    let read_cache = Arc::clone(read_cache);
+    client.try_register_namespace_with_hint(namespace.to_string(), hashes, move |owner_counts| {
+        read_cache.apply_owner_hints(&locally_inserted, &owner_counts);
+    });
 }
 
 fn gc_inflight(

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -308,15 +308,7 @@ fn register_block_hashes(
 
     let read_cache = Arc::clone(read_cache);
     client.try_register_namespace_with_hint(namespace.to_string(), hashes, move |owner_counts| {
-        let mut new_keys = Vec::new();
-        let mut new_owner_counts = Vec::new();
-        for ((key, outcome), owner_count) in resident_saves.iter().zip(owner_counts) {
-            if *outcome == CacheInsertOutcome::InsertedNew {
-                new_keys.push(key.clone());
-                new_owner_counts.push(owner_count);
-            }
-        }
-        read_cache.apply_owner_hints(&new_keys, &new_owner_counts);
+        read_cache.apply_owner_hints(&resident_saves, &owner_counts);
     });
 }
 

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -287,7 +287,7 @@ fn send_backing_batches(
     }
 
     if let Some(client) = &deps.metaserver_client {
-        register_block_hashes(client, namespace, locally_inserted);
+        register_block_hashes(client, namespace, locally_inserted, &deps.read_cache);
     }
 }
 
@@ -295,6 +295,7 @@ fn register_block_hashes(
     client: &MetaServerClient,
     namespace: &str,
     locally_inserted: Vec<BlockKey>,
+    read_cache: &Arc<ReadCache>,
 ) {
     if locally_inserted.is_empty() {
         return;
@@ -304,7 +305,10 @@ fn register_block_hashes(
         .map(|key| key.hash.clone())
         .collect();
 
-    client.try_register_namespace(namespace.to_string(), hashes);
+    let read_cache = Arc::clone(read_cache);
+    client.try_register_namespace_with_hint(namespace.to_string(), hashes, move |owner_counts| {
+        read_cache.apply_owner_hints(&locally_inserted, &owner_counts);
+    });
 }
 
 fn gc_inflight(

--- a/pegaflow-metaserver/README.md
+++ b/pegaflow-metaserver/README.md
@@ -136,8 +136,13 @@ message InsertBlockHashesRequest {
 message InsertBlockHashesResponse {
   ResponseStatus status = 1;    // Success/error status
   uint64 inserted_count = 2;    // Number of hashes inserted
+  repeated uint32 owner_counts = 3; // Post-insert owners per requested hash, including this node
 }
 ```
+
+`owner_counts` is an aligned snapshot for cache replacement hints. Clients do not use it for
+ownership correctness; Pega server and MetaServer versions carrying this contract are deployed
+together.
 
 ### 4. RemoveBlockHashes
 

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -127,7 +127,6 @@ impl MetaServer for GrpcMetaService {
                     "block_hashes cannot be empty".to_string(),
                 )),
                 inserted_count: 0,
-                owner_counts: Vec::new(),
             }));
             record_rpc_result("insert_block_hashes", &result, start);
             return result;
@@ -142,12 +141,12 @@ impl MetaServer for GrpcMetaService {
             }
         };
 
-        let owner_counts =
+        let inserted =
             match self
                 .store
                 .insert_hashes(&req.namespace, &req.block_hashes, &req.node, node_id)
             {
-                Ok(owner_counts) => owner_counts,
+                Ok(inserted) => inserted,
                 Err(err) => {
                     let result = Err(Self::store_error_status(err));
                     record_rpc_result("insert_block_hashes", &result, start);
@@ -158,16 +157,12 @@ impl MetaServer for GrpcMetaService {
         let elapsed = start.elapsed();
         debug!(
             "RPC [insert_block_hashes]: namespace={} node={} inserted={} hashes in {:?}",
-            req.namespace,
-            req.node,
-            owner_counts.len(),
-            elapsed
+            req.namespace, req.node, inserted, elapsed
         );
 
         let result = Ok(Response::new(InsertBlockHashesResponse {
             status: Some(Self::ok_status()),
-            inserted_count: owner_counts.len() as u64,
-            owner_counts,
+            inserted_count: inserted as u64,
         }));
         record_rpc_result("insert_block_hashes", &result, start);
         result

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -127,6 +127,7 @@ impl MetaServer for GrpcMetaService {
                     "block_hashes cannot be empty".to_string(),
                 )),
                 inserted_count: 0,
+                owner_counts: Vec::new(),
             }));
             record_rpc_result("insert_block_hashes", &result, start);
             return result;
@@ -141,12 +142,12 @@ impl MetaServer for GrpcMetaService {
             }
         };
 
-        let inserted =
+        let owner_counts =
             match self
                 .store
                 .insert_hashes(&req.namespace, &req.block_hashes, &req.node, node_id)
             {
-                Ok(inserted) => inserted,
+                Ok(owner_counts) => owner_counts,
                 Err(err) => {
                     let result = Err(Self::store_error_status(err));
                     record_rpc_result("insert_block_hashes", &result, start);
@@ -157,12 +158,16 @@ impl MetaServer for GrpcMetaService {
         let elapsed = start.elapsed();
         debug!(
             "RPC [insert_block_hashes]: namespace={} node={} inserted={} hashes in {:?}",
-            req.namespace, req.node, inserted, elapsed
+            req.namespace,
+            req.node,
+            owner_counts.len(),
+            elapsed
         );
 
         let result = Ok(Response::new(InsertBlockHashesResponse {
             status: Some(Self::ok_status()),
-            inserted_count: inserted as u64,
+            inserted_count: owner_counts.len() as u64,
+            owner_counts,
         }));
         record_rpc_result("insert_block_hashes", &result, start);
         result

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -205,24 +205,21 @@ impl BlockHashStore {
         hashes: &[Vec<u8>],
         node: &str,
         node_id: Uuid,
-    ) -> Result<Vec<u32>, StoreError> {
+    ) -> Result<usize, StoreError> {
         self.touch_node_session(node, node_id)?;
         let node: Arc<str> = Arc::from(node);
         let now = Instant::now();
-        let mut owner_counts = Vec::with_capacity(hashes.len());
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
-            let mut owners = self.blocks.entry(key).or_default();
-            owners.insert(
+            self.blocks.entry(key).or_default().insert(
                 Arc::clone(&node),
                 OwnerRecord {
                     node_id,
                     key_register_time: now,
                 },
             );
-            owner_counts.push(owners.len() as u32);
         }
-        Ok(owner_counts)
+        Ok(hashes.len())
     }
 
     pub fn remove_hashes(
@@ -470,7 +467,7 @@ mod tests {
         let inserted = store
             .insert_hashes(namespace, &hashes, node, node_id)
             .unwrap();
-        assert_eq!(inserted, vec![1, 1, 1]);
+        assert_eq!(inserted, 3);
 
         let existing = store.query_prefix(namespace, &hashes);
         assert_eq!(existing.len(), 3);
@@ -511,27 +508,6 @@ mod tests {
         let mut node_names: Vec<&str> = existing[0].nodes.iter().map(|n| n.as_ref()).collect();
         node_names.sort();
         assert_eq!(node_names, vec!["node-a:50055", "node-b:50055"]);
-    }
-
-    #[test]
-    fn insert_returns_owner_count_aligned_with_hashes() {
-        let store = BlockHashStore::new();
-        let node_a = heartbeat_node(&store, "node-a:50055");
-        let node_b = heartbeat_node(&store, "node-b:50055");
-        let hashes = vec![vec![1], vec![2]];
-
-        assert_eq!(
-            store
-                .insert_hashes("ns", &hashes, "node-a:50055", node_a)
-                .unwrap(),
-            vec![1, 1]
-        );
-        assert_eq!(
-            store
-                .insert_hashes("ns", &hashes, "node-b:50055", node_b)
-                .unwrap(),
-            vec![2, 2]
-        );
     }
 
     #[test]

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -205,21 +205,24 @@ impl BlockHashStore {
         hashes: &[Vec<u8>],
         node: &str,
         node_id: Uuid,
-    ) -> Result<usize, StoreError> {
+    ) -> Result<Vec<u32>, StoreError> {
         self.touch_node_session(node, node_id)?;
         let node: Arc<str> = Arc::from(node);
         let now = Instant::now();
+        let mut owner_counts = Vec::with_capacity(hashes.len());
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
-            self.blocks.entry(key).or_default().insert(
+            let mut owners = self.blocks.entry(key).or_default();
+            owners.insert(
                 Arc::clone(&node),
                 OwnerRecord {
                     node_id,
                     key_register_time: now,
                 },
             );
+            owner_counts.push(owners.len() as u32);
         }
-        Ok(hashes.len())
+        Ok(owner_counts)
     }
 
     pub fn remove_hashes(
@@ -467,7 +470,7 @@ mod tests {
         let inserted = store
             .insert_hashes(namespace, &hashes, node, node_id)
             .unwrap();
-        assert_eq!(inserted, 3);
+        assert_eq!(inserted, vec![1, 1, 1]);
 
         let existing = store.query_prefix(namespace, &hashes);
         assert_eq!(existing.len(), 3);
@@ -508,6 +511,27 @@ mod tests {
         let mut node_names: Vec<&str> = existing[0].nodes.iter().map(|n| n.as_ref()).collect();
         node_names.sort();
         assert_eq!(node_names, vec!["node-a:50055", "node-b:50055"]);
+    }
+
+    #[test]
+    fn insert_returns_owner_count_aligned_with_hashes() {
+        let store = BlockHashStore::new();
+        let node_a = heartbeat_node(&store, "node-a:50055");
+        let node_b = heartbeat_node(&store, "node-b:50055");
+        let hashes = vec![vec![1], vec![2]];
+
+        assert_eq!(
+            store
+                .insert_hashes("ns", &hashes, "node-a:50055", node_a)
+                .unwrap(),
+            vec![1, 1]
+        );
+        assert_eq!(
+            store
+                .insert_hashes("ns", &hashes, "node-b:50055", node_b)
+                .unwrap(),
+            vec![2, 2]
+        );
     }
 
     #[test]

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -205,21 +205,24 @@ impl BlockHashStore {
         hashes: &[Vec<u8>],
         node: &str,
         node_id: Uuid,
-    ) -> Result<usize, StoreError> {
+    ) -> Result<Vec<u32>, StoreError> {
         self.touch_node_session(node, node_id)?;
         let node: Arc<str> = Arc::from(node);
         let now = Instant::now();
+        let mut owner_counts = Vec::with_capacity(hashes.len());
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
-            self.blocks.entry(key).or_default().insert(
+            let mut owners = self.blocks.entry(key).or_default();
+            owners.insert(
                 Arc::clone(&node),
                 OwnerRecord {
                     node_id,
                     key_register_time: now,
                 },
             );
+            owner_counts.push(owners.len() as u32);
         }
-        Ok(hashes.len())
+        Ok(owner_counts)
     }
 
     pub fn remove_hashes(
@@ -467,7 +470,7 @@ mod tests {
         let inserted = store
             .insert_hashes(namespace, &hashes, node, node_id)
             .unwrap();
-        assert_eq!(inserted, 3);
+        assert_eq!(inserted, vec![1, 1, 1]);
 
         let existing = store.query_prefix(namespace, &hashes);
         assert_eq!(existing.len(), 3);
@@ -508,6 +511,34 @@ mod tests {
         let mut node_names: Vec<&str> = existing[0].nodes.iter().map(|n| n.as_ref()).collect();
         node_names.sort();
         assert_eq!(node_names, vec!["node-a:50055", "node-b:50055"]);
+    }
+
+    #[test]
+    fn insert_returns_owner_count_aligned_with_hashes() {
+        let store = BlockHashStore::new();
+        let node_a = heartbeat_node(&store, "node-a:50055");
+        let node_b = heartbeat_node(&store, "node-b:50055");
+        let node_c = heartbeat_node(&store, "node-c:50055");
+        let hashes = vec![vec![1], vec![2]];
+
+        assert_eq!(
+            store
+                .insert_hashes("ns", &hashes, "node-a:50055", node_a)
+                .unwrap(),
+            vec![1, 1]
+        );
+        assert_eq!(
+            store
+                .insert_hashes("ns", &hashes, "node-b:50055", node_b)
+                .unwrap(),
+            vec![2, 2]
+        );
+        assert_eq!(
+            store
+                .insert_hashes("ns", &hashes, "node-c:50055", node_c)
+                .unwrap(),
+            vec![3, 3]
+        );
     }
 
     #[test]

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -123,6 +123,15 @@ message UnregisterResponse {
   ResponseStatus status = 1;
 }
 
+message SetColdBlocksRequest {
+  string namespace = 1;
+  repeated bytes block_hashes = 2;
+}
+
+message SetColdBlocksResponse {
+  ResponseStatus status = 1;
+}
+
 message ShutdownRequest {}
 
 message ShutdownResponse {
@@ -207,6 +216,7 @@ service Engine {
   rpc QueryPrefetch(QueryRequest) returns (QueryResponse);
   rpc Release(ReleaseRequest) returns (ReleaseResponse);
   rpc UnregisterContext(UnregisterRequest) returns (UnregisterResponse);
+  rpc SetColdBlocks(SetColdBlocksRequest) returns (SetColdBlocksResponse);
   // Cross-node transfer: get RDMA metadata for specific blocks (serving side)
   rpc QueryBlocksForTransfer(QueryBlocksForTransferRequest) returns (QueryBlocksForTransferResponse);
   // Cross-node transfer: release block locks after RDMA transfer completes

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -243,9 +243,6 @@ message InsertBlockHashesRequest {
 message InsertBlockHashesResponse {
   ResponseStatus status = 1;
   uint64 inserted_count = 2;
-  // Owner count for each requested hash after this insert, aligned with
-  // InsertBlockHashesRequest.block_hashes.
-  repeated uint32 owner_counts = 3;
 }
 
 message RemoveBlockHashesRequest {

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -123,12 +123,12 @@ message UnregisterResponse {
   ResponseStatus status = 1;
 }
 
-message SetColdBlocksRequest {
+message SetReclaimableBlocksRequest {
   string namespace = 1;
   repeated bytes block_hashes = 2;
 }
 
-message SetColdBlocksResponse {
+message SetReclaimableBlocksResponse {
   ResponseStatus status = 1;
 }
 
@@ -216,7 +216,7 @@ service Engine {
   rpc QueryPrefetch(QueryRequest) returns (QueryResponse);
   rpc Release(ReleaseRequest) returns (ReleaseResponse);
   rpc UnregisterContext(UnregisterRequest) returns (UnregisterResponse);
-  rpc SetColdBlocks(SetColdBlocksRequest) returns (SetColdBlocksResponse);
+  rpc SetReclaimableBlocks(SetReclaimableBlocksRequest) returns (SetReclaimableBlocksResponse);
   // Cross-node transfer: get RDMA metadata for specific blocks (serving side)
   rpc QueryBlocksForTransfer(QueryBlocksForTransferRequest) returns (QueryBlocksForTransferResponse);
   // Cross-node transfer: release block locks after RDMA transfer completes
@@ -243,6 +243,9 @@ message InsertBlockHashesRequest {
 message InsertBlockHashesResponse {
   ResponseStatus status = 1;
   uint64 inserted_count = 2;
+  // Owner count for each requested hash after this insert, aligned with
+  // InsertBlockHashesRequest.block_hashes.
+  repeated uint32 owner_counts = 3;
 }
 
 message RemoveBlockHashesRequest {

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -243,8 +243,9 @@ message InsertBlockHashesRequest {
 message InsertBlockHashesResponse {
   ResponseStatus status = 1;
   uint64 inserted_count = 2;
-  // Post-insert owner count, including this node, aligned with
-  // InsertBlockHashesRequest.block_hashes. Clients treat this as a best-effort hint.
+  // Required post-insert owner count, including this node, aligned with
+  // InsertBlockHashesRequest.block_hashes. Pega server and MetaServer are
+  // deployed together; a missing or misaligned response is a protocol error.
   repeated uint32 owner_counts = 3;
 }
 

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -243,6 +243,9 @@ message InsertBlockHashesRequest {
 message InsertBlockHashesResponse {
   ResponseStatus status = 1;
   uint64 inserted_count = 2;
+  // Post-insert owner count, including this node, aligned with
+  // InsertBlockHashesRequest.block_hashes. Clients treat this as a best-effort hint.
+  repeated uint32 owner_counts = 3;
 }
 
 message RemoveBlockHashesRequest {

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -7,9 +7,10 @@ use crate::proto::engine::{
     QueryBlocksForTransferResponse, QueryLoading, QueryReady, QueryRequest, QueryResponse,
     RdmaHandshakeRequest, RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse,
     ReleaseRequest, ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse,
-    ResponseStatus, SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest,
-    ShutdownResponse, TransferBlockInfo, TransferMode as ProtoTransferMode, TransferSlotInfo,
-    UnregisterRequest, UnregisterResponse, query_response,
+    ResponseStatus, SaveRequest, SaveResponse, SessionEvent, SessionRequest, SetColdBlocksRequest,
+    SetColdBlocksResponse, ShutdownRequest, ShutdownResponse, TransferBlockInfo,
+    TransferMode as ProtoTransferMode, TransferSlotInfo, UnregisterRequest, UnregisterResponse,
+    query_response,
 };
 use crate::registry::RegistryHandle;
 use crate::session::SessionRegistry;
@@ -691,6 +692,21 @@ impl Engine for GrpcEngineService {
         }
         record_rpc_result("unregister_context", &result, start);
         result
+    }
+
+    async fn set_cold_blocks(
+        &self,
+        request: Request<SetColdBlocksRequest>,
+    ) -> Result<Response<SetColdBlocksResponse>, Status> {
+        let req = request.into_inner();
+        if req.namespace.is_empty() {
+            return Err(Status::invalid_argument("namespace must not be empty"));
+        }
+        self.engine
+            .set_cold_blocks(&req.namespace, &req.block_hashes);
+        Ok(Response::new(SetColdBlocksResponse {
+            status: Some(Self::build_simple_response()),
+        }))
     }
 
     async fn query_blocks_for_transfer(

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -7,10 +7,10 @@ use crate::proto::engine::{
     QueryBlocksForTransferResponse, QueryLoading, QueryReady, QueryRequest, QueryResponse,
     RdmaHandshakeRequest, RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse,
     ReleaseRequest, ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse,
-    ResponseStatus, SaveRequest, SaveResponse, SessionEvent, SessionRequest, SetColdBlocksRequest,
-    SetColdBlocksResponse, ShutdownRequest, ShutdownResponse, TransferBlockInfo,
-    TransferMode as ProtoTransferMode, TransferSlotInfo, UnregisterRequest, UnregisterResponse,
-    query_response,
+    ResponseStatus, SaveRequest, SaveResponse, SessionEvent, SessionRequest,
+    SetReclaimableBlocksRequest, SetReclaimableBlocksResponse, ShutdownRequest, ShutdownResponse,
+    TransferBlockInfo, TransferMode as ProtoTransferMode, TransferSlotInfo, UnregisterRequest,
+    UnregisterResponse, query_response,
 };
 use crate::registry::RegistryHandle;
 use crate::session::SessionRegistry;
@@ -694,17 +694,17 @@ impl Engine for GrpcEngineService {
         result
     }
 
-    async fn set_cold_blocks(
+    async fn set_reclaimable_blocks(
         &self,
-        request: Request<SetColdBlocksRequest>,
-    ) -> Result<Response<SetColdBlocksResponse>, Status> {
+        request: Request<SetReclaimableBlocksRequest>,
+    ) -> Result<Response<SetReclaimableBlocksResponse>, Status> {
         let req = request.into_inner();
         if req.namespace.is_empty() {
             return Err(Status::invalid_argument("namespace must not be empty"));
         }
         self.engine
-            .set_cold_blocks(&req.namespace, &req.block_hashes);
-        Ok(Response::new(SetColdBlocksResponse {
+            .set_reclaimable_blocks(&req.namespace, &req.block_hashes);
+        Ok(Response::new(SetReclaimableBlocksResponse {
             status: Some(Self::build_simple_response()),
         }))
     }

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -139,6 +139,7 @@ class SchedulerConnector:
 
         # Completion tracking
         self._pending_saves: set[str] = set()
+        self._pending_save_hashes: dict[str, set[bytes]] = {}
         self._held_requests: set[str] = set()
 
     def get_num_new_matched_tokens(
@@ -431,6 +432,8 @@ class SchedulerConnector:
 
         # Track requests with pending saves
         self._pending_saves.update(save_intents.keys())
+        for req_id, intent in save_intents.items():
+            self._pending_save_hashes.setdefault(req_id, set()).update(intent.block_hashes)
 
         logger.debug(
             "[PegaKVConnector] build_connector_meta: %d loads, %d saves",
@@ -554,6 +557,18 @@ class SchedulerConnector:
 
     def update_connector_output(self, connector_output: "KVConnectorOutput") -> None:
         for req_id in connector_output.finished_sending or []:
+            hashes = self._pending_save_hashes.pop(req_id, set())
+            if hashes and self._ctx.read_enabled:
+                try:
+                    self._ctx.engine_client.set_cold_blocks(
+                        self._ctx.namespace, list(hashes)
+                    )
+                except Exception as exc:  # noqa: BLE001 - demotion is best effort
+                    logger.warning(
+                        "[PegaKVConnector] Failed to demote saved blocks for request %s: %s",
+                        req_id,
+                        exc,
+                    )
             self._pending_saves.discard(req_id)
             logger.debug("[PegaKVConnector] Request %s save completed", req_id)
 
@@ -593,6 +608,7 @@ class SchedulerConnector:
         self._scheduled_tokens.pop(req_id, None)
         self._next_stored_block_idx.pop(req_id, None)
         self._pending_saves.discard(req_id)
+        self._pending_save_hashes.pop(req_id, None)
         self._tail_saved.discard(req_id)
 
     def _count_available_block_prefix(

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -560,7 +560,7 @@ class SchedulerConnector:
             hashes = self._pending_save_hashes.pop(req_id, set())
             if hashes and self._ctx.read_enabled:
                 try:
-                    self._ctx.engine_client.set_cold_blocks(
+                    self._ctx.engine_client.set_reclaimable_blocks(
                         self._ctx.namespace, list(hashes)
                     )
                 except Exception as exc:  # noqa: BLE001 - demotion is best effort

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -252,10 +252,10 @@ class EngineRpcClient:
         """
         ...
 
-    def set_cold_blocks(
+    def set_reclaimable_blocks(
         self, namespace: str, block_hashes: list[bytes]
     ) -> tuple[bool, str]:
-        """Mark resident blocks as cold for replacement."""
+        """Mark resident blocks as reclaimable for replacement."""
         ...
 
     def unregister_context(self, instance_id: str) -> tuple[bool, str]:

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -252,6 +252,12 @@ class EngineRpcClient:
         """
         ...
 
+    def set_cold_blocks(
+        self, namespace: str, block_hashes: list[bytes]
+    ) -> tuple[bool, str]:
+        """Mark resident blocks as cold for replacement."""
+        ...
+
     def unregister_context(self, instance_id: str) -> tuple[bool, str]:
         """Unregister a context/instance.
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2,8 +2,9 @@ use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_T
 use pegaflow_core::LoadState;
 use pegaflow_proto::proto::engine::{
     HealthRequest, LeaseLoad, LoadRequest, QueryRequest, RegisterContextRequest, ReleaseRequest,
-    ResponseStatus, SaveLayer, SaveRequest, SessionEvent, SessionRequest, SetColdBlocksRequest,
-    ShutdownRequest, TransferMode, UnregisterRequest, engine_client::EngineClient, query_response,
+    ResponseStatus, SaveLayer, SaveRequest, SessionEvent, SessionRequest,
+    SetReclaimableBlocksRequest, ShutdownRequest, TransferMode, UnregisterRequest,
+    engine_client::EngineClient, query_response,
 };
 use pyo3::{
     create_exception,
@@ -510,22 +511,22 @@ impl EngineRpcClient {
         })
     }
 
-    fn set_cold_blocks(
+    fn set_reclaimable_blocks(
         &self,
         py: Python<'_>,
         namespace: String,
         block_hashes: Vec<Vec<u8>>,
     ) -> PyResult<(bool, String)> {
-        self.call(py, "set_cold_blocks", |mut c| async move {
+        self.call(py, "set_reclaimable_blocks", |mut c| async move {
             let resp = c
-                .set_cold_blocks(SetColdBlocksRequest {
+                .set_reclaimable_blocks(SetReclaimableBlocksRequest {
                     namespace,
                     block_hashes,
                 })
                 .await?;
             Ok(resp.into_inner())
         })
-        .and_then(|r| status_tuple("set_cold_blocks", r.status))
+        .and_then(|r| status_tuple("set_reclaimable_blocks", r.status))
     }
 
     /// Unregister a context/instance.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2,8 +2,8 @@ use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_T
 use pegaflow_core::LoadState;
 use pegaflow_proto::proto::engine::{
     HealthRequest, LeaseLoad, LoadRequest, QueryRequest, RegisterContextRequest, ReleaseRequest,
-    ResponseStatus, SaveLayer, SaveRequest, SessionEvent, SessionRequest, ShutdownRequest,
-    TransferMode, UnregisterRequest, engine_client::EngineClient, query_response,
+    ResponseStatus, SaveLayer, SaveRequest, SessionEvent, SessionRequest, SetColdBlocksRequest,
+    ShutdownRequest, TransferMode, UnregisterRequest, engine_client::EngineClient, query_response,
 };
 use pyo3::{
     create_exception,
@@ -508,6 +508,24 @@ impl EngineRpcClient {
             .await?;
             Ok(())
         })
+    }
+
+    fn set_cold_blocks(
+        &self,
+        py: Python<'_>,
+        namespace: String,
+        block_hashes: Vec<Vec<u8>>,
+    ) -> PyResult<(bool, String)> {
+        self.call(py, "set_cold_blocks", |mut c| async move {
+            let resp = c
+                .set_cold_blocks(SetColdBlocksRequest {
+                    namespace,
+                    block_hashes,
+                })
+                .await?;
+            Ok(resp.into_inner())
+        })
+        .and_then(|r| status_tuple("set_cold_blocks", r.status))
     }
 
     /// Unregister a context/instance.

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -557,6 +557,37 @@ class TestSchedulerQueryProbeReuse:
         )
         return SchedulerConnector(ctx), engine_client
 
+    def test_finished_sending_demotes_saved_hashes_once(self):
+        sc, engine_client = self._make_connector()
+        hashes = {b"a", b"b"}
+        sc._pending_saves.add("r1")
+        sc._pending_save_hashes["r1"] = hashes
+
+        sc.update_connector_output(SimpleNamespace(finished_sending={"r1"}))
+        sc.update_connector_output(SimpleNamespace(finished_sending={"r1"}))
+
+        engine_client.set_cold_blocks.assert_called_once()
+        args = engine_client.set_cold_blocks.call_args.args
+        assert args[0] == "ns"
+        assert set(args[1]) == hashes
+
+    def test_save_only_finished_sending_keeps_saved_hashes_warm(self):
+        engine_client = MagicMock()
+        ctx = _make_ctx(
+            engine_client=engine_client,
+            state_manager=MagicMock(),
+            mode=PegaConnectorMode.SAVE_ONLY,
+        )
+        sc = SchedulerConnector(ctx)
+        sc._pending_saves.add("r1")
+        sc._pending_save_hashes["r1"] = {b"a", b"b"}
+
+        sc.update_connector_output(SimpleNamespace(finished_sending={"r1"}))
+
+        engine_client.set_cold_blocks.assert_not_called()
+        assert "r1" not in sc._pending_saves
+        assert "r1" not in sc._pending_save_hashes
+
     def test_repeated_same_probe_reuses_query_result(self):
         sc, engine_client = self._make_connector()
         req = _make_fake_request("r1", [_hash(i) for i in range(4)])

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -566,12 +566,12 @@ class TestSchedulerQueryProbeReuse:
         sc.update_connector_output(SimpleNamespace(finished_sending={"r1"}))
         sc.update_connector_output(SimpleNamespace(finished_sending={"r1"}))
 
-        engine_client.set_cold_blocks.assert_called_once()
-        args = engine_client.set_cold_blocks.call_args.args
+        engine_client.set_reclaimable_blocks.assert_called_once()
+        args = engine_client.set_reclaimable_blocks.call_args.args
         assert args[0] == "ns"
         assert set(args[1]) == hashes
 
-    def test_save_only_finished_sending_keeps_saved_hashes_warm(self):
+    def test_save_only_finished_sending_marks_saved_hashes_reclaimable(self):
         engine_client = MagicMock()
         ctx = _make_ctx(
             engine_client=engine_client,
@@ -584,7 +584,7 @@ class TestSchedulerQueryProbeReuse:
 
         sc.update_connector_output(SimpleNamespace(finished_sending={"r1"}))
 
-        engine_client.set_cold_blocks.assert_not_called()
+        engine_client.set_reclaimable_blocks.assert_not_called()
         assert "r1" not in sc._pending_saves
         assert "r1" not in sc._pending_save_hashes
 


### PR DESCRIPTION
## Summary

Related RFC: #398

Reduce redundant resident KV copies in P/D deployments with a two-class replacement policy:

- Locally saved blocks enter `retained`.
- RDMA/P2P-fetched blocks enter `reclaimable`.
- P-side `finished_sending` marks the saved blocks for that request as `reclaimable`.
- MetaServer Insert returns aligned post-insert owner counts; a newly saved local block is asynchronously marked `reclaimable` when `owners >= 3`.
- Reclaim evicts `reclaimable` blocks before `retained` blocks, with LRU order inside each class.
- Already-existing inserts, local prefix hits, and cross-node serving hits refresh recency without changing class.

The policy changes replacement priority only. It does not change NIXL, add a data-path RPC, delay registration, or introduce backpressure.

## PD E2E Validation

Baseline and feature used the same generated multi-turn corpus and seed in a single-host 2P2D deployment:

- Four independent TP2 vLLM instances: 2 prefill and 2 decode.
- P side: Pega read/write + NIXL pull through vLLM `MultiConnector`.
- D side: NIXL pull + Pega save-only.
- vLLM PD proxy with round-robin P/D selection.
- vLLM internal prefix cache disabled.
- Pega huge pages enabled; pool size `150 GB` per instance.
- Model: `DeepSeek-V2-Lite-Chat`.
- 512 conversations, 16 messages / 8 model requests per conversation, 4096 requests total.
- 8192 input tokens per generated user message and 128 output tokens per request.
- 32 clients, 32 active conversations, closed-loop with no request-rate limit, seed `0`.
- MetaServer metrics sampled every 5 seconds with no smoothing.
- The generated input corpus was identical in both runs: SHA256 `e3443b744287912e79e2de3a72cfbfade82972a9ec4eed77b94f5b94877ef0d1`.

Both runs completed all `4096/4096` requests. The pool was large enough to represent the intended deployment shape while the sustained workload still created eviction pressure.

### Results

| Metric | Baseline | Feature | Change |
| --- | ---: | ---: | ---: |
| Final average redundancy | 2.9278 | 2.1661 | -26.02% |
| Whole-run non-empty mean redundancy | 2.7939 | 2.1605 | -22.67% |
| Tail 20% mean redundancy | 2.8886 | 2.1106 | -26.93% |
| Final blocks with owners >= 4 | 106,188 | 3,635 | -96.58% |
| Final live owner records | 687,782 | 657,385 | -4.42% |
| Evicted blocks | 6,773,760 | 8,646,656 | +27.65% |
| RDMA fetch bytes | 799.00 GB | 787.09 GB | -1.49% |
| Cache-miss blocks | 2,127,355 | 2,127,355 | unchanged |
| Request throughput | 1.226 req/s | 1.223 req/s | -0.24% |
| Mean TTFT | 25,512.45 ms | 25,521.10 ms | +8.65 ms |

![PD 2P2D redundancy comparison: baseline vs replica-aware reclamation](https://gist.githubusercontent.com/GentleCold/bb4b96e83e19af011d1b52533dbb1170/raw/pd_redundancy_150gb_512conv_baseline_vs_feature.png)

The feature substantially suppresses high-replication blocks once reclaim pressure begins. It performs more evictions, but the identical cache-miss count, slightly lower RDMA volume, and effectively unchanged throughput/TTFT indicate that this run did not turn the additional eviction into extra recomputation or transfer cost.

## Scope and Tradeoffs

- Owner hints are best-effort replacement signals, not correctness state.
- The `owners >= 3` rule applies to every newly inserted local resident, including D-side save-only copies; the policy does not pin all D-side copies as `retained`.
- More aggressive reclamation increases eviction churn. Metrics for class distribution and evictions by class are included so this can be monitored after rollout.
- Pega Server and MetaServer are upgraded together; a successful Insert response with missing or misaligned `owner_counts` is treated as a protocol error.

## Checks

- Rust formatting and clippy passed with warnings denied.
- `pegaflow-core`: 139 passed, 1 ignored.
- `pegaflow-metaserver`: 31 passed.
- Python connector tests: 38 passed.
- Release server, MetaServer, and PyO3 builds passed in the remote validation environment.
- Baseline and feature both completed the 2P2D workload.
