### PR TITLE
feat(router): prefix-affinity P/D node selection for multi-P multi-D topologies

### DIFF
--- a/pegaflow-server/src/bin/pegaflow-router.rs
+++ b/pegaflow-server/src/bin/pegaflow-router.rs
@@ -17,6 +17,8 @@
 //! landed) retries the whole P→D flow — content-addressed KV makes the P leg
 //! idempotent.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
@@ -103,9 +105,16 @@ impl RouterState {
         }
     }
 
-    fn get_next_p(&self) -> (Client, String, usize) {
-        let idx = self.p_index.fetch_add(1, Ordering::Relaxed);
-        let idx = idx % self.prefill_clients.len();
+    fn get_next_p(&self, body: &Value) -> (Client, String, usize) {
+        let n = self.prefill_clients.len();
+        let idx = match Self::prefix_affinity_key(body) {
+            Some(key) if n > 1 => {
+                let mut h = DefaultHasher::new();
+                key.hash(&mut h);
+                (h.finish() as usize) % n
+            }
+            _ => self.p_index.fetch_add(1, Ordering::Relaxed) % n,
+        };
         self.p_inflight[idx].fetch_add(1, Ordering::Relaxed);
         (
             self.prefill_clients[idx].clone(),
@@ -114,9 +123,45 @@ impl RouterState {
         )
     }
 
-    fn get_next_d(&self) -> (Client, String, usize) {
-        let idx = self.d_index.fetch_add(1, Ordering::Relaxed);
-        let idx = idx % self.decode_clients.len();
+    /// Turn-stable routing key so every turn of a conversation lands on the
+    /// P that already holds its prefix KV. Without this, multi-P routing
+    /// degrades into cross-node full-context prefix transfers on most turns.
+    /// Chat keys on the first message; completions keys on a fixed-length
+    /// prompt prefix (multi-turn contexts grow by appending, so the prefix
+    /// is stable across turns). Returns None (round-robin) otherwise.
+    fn prefix_affinity_key(body: &Value) -> Option<String> {
+        if let Some(first) = body
+            .get("messages")
+            .and_then(|m| m.as_array())
+            .and_then(|a| a.first())
+        {
+            return Some(first.to_string());
+        }
+        match body.get("prompt") {
+            Some(Value::String(s)) => Some(s.chars().take(512).collect()),
+            Some(Value::Array(a)) => {
+                let head: Vec<&Value> = a.iter().take(64).collect();
+                Some(format!("{head:?}"))
+            }
+            _ => None,
+        }
+    }
+
+    /// Same affinity rule as `get_next_p`: a conversation must revisit the D
+    /// whose HBM/host tier already holds its KV, or every turn re-pulls the
+    /// full context over RDMA instead of just the fresh suffix.
+    fn get_next_d(&self, body: &Value) -> (Client, String, usize) {
+        let n = self.decode_clients.len();
+        let idx = match Self::prefix_affinity_key(body) {
+            Some(key) if n > 1 => {
+                let mut h = DefaultHasher::new();
+                key.hash(&mut h);
+                // Independent spread from the P mapping (avoid P_i => D_i lockstep).
+                1usize.hash(&mut h);
+                (h.finish() as usize) % n
+            }
+            _ => self.d_index.fetch_add(1, Ordering::Relaxed) % n,
+        };
         self.d_inflight[idx].fetch_add(1, Ordering::Relaxed);
         (
             self.decode_clients[idx].clone(),
@@ -219,7 +264,7 @@ async fn pd_first_token_flow(
         obj.remove("stream_options");
     }
 
-    let (p_client, p_url, p_idx) = state.get_next_p();
+    let (p_client, p_url, p_idx) = state.get_next_p(body);
     let p_url = format!("{}{}", p_url, api_path);
     let p_response = p_client
         .post(&p_url)
@@ -296,7 +341,7 @@ async fn pd_first_token_flow(
         d_body["stream_options"] = json!({"include_usage": true});
     }
 
-    let (d_client, d_url, d_idx) = state.get_next_d();
+    let (d_client, d_url, d_idx) = state.get_next_d(&d_body);
     let d_url = format!("{}/v1/completions", d_url);
     let d_response = match d_client
         .post(&d_url)
@@ -759,7 +804,7 @@ async fn handle_completion(
         p_body["min_tokens"] = json!(0);
     }
 
-    let (p_client, p_url, p_idx) = state.get_next_p();
+    let (p_client, p_url, p_idx) = state.get_next_p(&p_body);
     let p_url = format!("{}{}", p_url, api_path);
 
     // Send to P node
@@ -827,7 +872,7 @@ async fn handle_completion(
         d_body["stream_options"] = stream_opts;
     }
 
-    let (d_client, d_url, d_idx) = state.get_next_d();
+    let (d_client, d_url, d_idx) = state.get_next_d(&d_body);
     let d_url = format!("{}{}", d_url, api_path);
 
     if org_stream {


### PR DESCRIPTION
## Problem

`pegaflow-router` picks P and D nodes round-robin. In an xP+yD topology this breaks prefix locality for multi-turn traffic: each turn of a conversation lands on a different P (and D), so most turns miss the node-local prefix KV and fall back to cross-node full-context RDMA transfers — P nodes pull multi-GiB prefixes from other P nodes (and even from D nodes, since the mesh is content-addressed and fully bidirectional), and D nodes re-pull the whole context instead of just the fresh suffix. Those transfers collide with decode and blow up the ITL tail.

## Fix

Route by a turn-stable affinity key, falling back to round-robin when no key exists:

- chat API: the conversation's first message
- `/v1/completions`: a fixed-length prompt prefix (512 chars / 64 token ids) — multi-turn contexts grow by appending, so the prefix is stable across turns
- the D mapping hashes an extra discriminator so conversations spread across D nodes independently of the P mapping

This is the same policy family as the consistent-hash mode in vllm-project/router, kept dependency-free (std `DefaultHasher`).

## Measured (2P+2D, 4x H200, per-GPU 400G IB, Qwen3-14B bf16, OpenInfer engines)

Multi-turn chat load: 60 conversations x 5 turns, first turn 8192 tokens + 2048/turn, 128 out/turn, concurrency 12, temperature 0:

| selection | out tok/s | TPOT p99 | ITL p99 |
|---|---|---|---|
| round-robin (before) | 437 | 38.9 ms | 85.2 ms |
| P affinity | 465 | 30.8 ms | 49.2 ms |
| P + D affinity (this PR) | **495** | **22.8 ms** | **23.0 ms** |

P-side cross-node prefix fetches drop 30 → 1; D-side full-context re-pulls halve (93 → 60, the rest are post-eviction restores that no longer collide with decode). ITL p99 matches the 1P+1D isolation baseline (23.6 ms) at 2.5x its output throughput.

Single-P/single-D deployments are unaffected (affinity only engages when `len > 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)