### PR TITLE
feat(server): support native CUDA IPC clients

### DIFF
--- a/pegaflow-core/src/backing/transfer_lock_guard.rs
+++ b/pegaflow-core/src/backing/transfer_lock_guard.rs
@@ -81,11 +81,12 @@ mod tests {
 
     use pegaflow_proto::proto::engine::engine_server::{Engine, EngineServer};
     use pegaflow_proto::proto::engine::{
-        HealthRequest, HealthResponse, LoadRequest, LoadResponse, QueryBlocksForTransferRequest,
-        QueryBlocksForTransferResponse, QueryRequest, QueryResponse, RdmaHandshakeRequest,
-        RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse, ReleaseRequest,
-        ReleaseResponse, ReleaseTransferLockResponse, SaveRequest, SaveResponse, SessionEvent,
-        SessionRequest, ShutdownRequest, ShutdownResponse, UnregisterRequest, UnregisterResponse,
+        FlushRequest, FlushResponse, HealthRequest, HealthResponse, LoadRequest, LoadResponse,
+        QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, QueryRequest, QueryResponse,
+        RdmaHandshakeRequest, RdmaHandshakeResponse, RegisterContextRequest,
+        RegisterContextResponse, ReleaseRequest, ReleaseResponse, ReleaseTransferLockResponse,
+        SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest, ShutdownResponse,
+        UnregisterRequest, UnregisterResponse,
     };
     use tokio_stream::wrappers::TcpListenerStream;
     use tonic::transport::Endpoint;
@@ -153,6 +154,12 @@ mod tests {
             &self,
             _request: Request<ReleaseRequest>,
         ) -> Result<Response<ReleaseResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn flush(
+            &self,
+            _request: Request<FlushRequest>,
+        ) -> Result<Response<FlushResponse>, Status> {
             Err(Status::unimplemented("stub"))
         }
         async fn unregister_context(

--- a/pegaflow-core/src/internode/p2p_service.rs
+++ b/pegaflow-core/src/internode/p2p_service.rs
@@ -20,12 +20,12 @@ use tonic::{Request, Response, Status, async_trait};
 
 use pegaflow_proto::proto::engine::engine_server::{Engine, EngineServer};
 use pegaflow_proto::proto::engine::{
-    HealthRequest, HealthResponse, LoadRequest, LoadResponse, QueryBlocksForTransferRequest,
-    QueryBlocksForTransferResponse, QueryRequest, QueryResponse, RdmaHandshakeRequest,
-    RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse, ReleaseRequest,
-    ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse, ResponseStatus,
-    SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest, ShutdownResponse,
-    TransferBlockInfo, TransferSlotInfo, UnregisterRequest, UnregisterResponse,
+    FlushRequest, FlushResponse, HealthRequest, HealthResponse, LoadRequest, LoadResponse,
+    QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, QueryRequest, QueryResponse,
+    RdmaHandshakeRequest, RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse,
+    ReleaseRequest, ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse,
+    ResponseStatus, SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest,
+    ShutdownResponse, TransferBlockInfo, TransferSlotInfo, UnregisterRequest, UnregisterResponse,
 };
 
 use crate::{LayerBlock, PegaEngine};
@@ -258,6 +258,13 @@ impl Engine for P2pTransferService {
         _request: Request<ReleaseRequest>,
     ) -> Result<Response<ReleaseResponse>, Status> {
         Self::not_served("release")
+    }
+
+    async fn flush(
+        &self,
+        _request: Request<FlushRequest>,
+    ) -> Result<Response<FlushResponse>, Status> {
+        Self::not_served("flush")
     }
 
     async fn unregister_context(

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -5,8 +5,6 @@ pub(crate) mod transfer_lock;
 mod write_path;
 
 use bytesize::ByteSize;
-#[cfg(not(feature = "rdma"))]
-use log::warn;
 use log::{debug, info, warn};
 use std::collections::HashSet;
 use std::num::NonZeroU64;

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -46,6 +46,14 @@ message RegisterContextRequest {
   // Set by the connector for MLA; the engine derives per-layer page offsets
   // from the registered layouts. See spec.md.
   bool page_first = 18;
+  repeated CudaIpcTensor cuda_ipc_tensors = 19;
+}
+
+message CudaIpcTensor {
+  bytes handle = 1;
+  uint64 offset_bytes = 2;
+  uint64 size_bytes = 3;
+  uint64 block_stride_bytes = 4;
 }
 
 message RegisterContextResponse {
@@ -77,6 +85,7 @@ message LoadRequest {
   string load_state_shm = 4;
   repeated string layer_names = 5;
   repeated LeaseLoad loads = 6;
+  bool wait_for_completion = 7;
 }
 
 message LeaseLoad {
@@ -85,6 +94,12 @@ message LeaseLoad {
 }
 
 message LoadResponse {
+  ResponseStatus status = 1;
+}
+
+message FlushRequest {}
+
+message FlushResponse {
   ResponseStatus status = 1;
 }
 
@@ -203,6 +218,7 @@ service Engine {
   rpc RegisterContextBatch(RegisterContextRequest) returns (RegisterContextResponse);
   rpc Save(SaveRequest) returns (SaveResponse);
   rpc Load(LoadRequest) returns (LoadResponse);
+  rpc Flush(FlushRequest) returns (FlushResponse);
   // Prefetch query: check memory + trigger SSD prefetch or cross-node RDMA fetch for missing blocks
   rpc QueryPrefetch(QueryRequest) returns (QueryResponse);
   rpc Release(ReleaseRequest) returns (ReleaseResponse);

--- a/pegaflow-proto/src/lib.rs
+++ b/pegaflow-proto/src/lib.rs
@@ -7,3 +7,5 @@ pub mod proto {
         tonic::include_proto!("pegaflow");
     }
 }
+
+pub const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "+native-cuda-ipc-v1");

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -1,7 +1,10 @@
-use pyo3::exceptions::PyValueError;
+use cudarc::driver::{CudaContext, result::DriverError, sys};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use std::collections::{HashMap, HashSet};
+use std::mem::MaybeUninit;
+use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug, Clone)]
@@ -11,22 +14,117 @@ pub struct TensorMetadata {
     pub device_id: i32,
 }
 
+pub(crate) enum TensorRegistration {
+    Python(Vec<u8>),
+    CudaIpc {
+        handle: Vec<u8>,
+        offset_bytes: u64,
+        size_bytes: u64,
+    },
+}
+
+#[allow(dead_code, reason = "owners keep registered CUDA addresses valid")]
+enum TensorOwner {
+    Python(Py<PyAny>),
+    CudaIpc(Arc<CudaIpcMapping>),
+}
+
 struct LayerTensor {
-    #[allow(
-        dead_code,
-        reason = "holding the Python tensor keeps CUDA IPC memory mapped"
-    )]
-    tensor: Py<PyAny>,
+    owner: TensorOwner,
     metadata: TensorMetadata,
 }
 
-// Note: No custom Drop impl needed for LayerTensor.
-// PyO3's Py<PyAny> will automatically:
-// 1. Acquire the GIL when dropped
-// 2. Decrement the Python object's reference count
-// 3. Let Python's garbage collector handle the actual cleanup
-// This is the correct way to release CUDA IPC tensors - the mapped memory
-// will be unmapped when the tensor's storage is garbage collected.
+struct CudaIpcMapping {
+    context: Arc<CudaContext>,
+    base_ptr: u64,
+    size_bytes: usize,
+}
+
+impl CudaIpcMapping {
+    fn open(device_id: i32, bytes: &[u8]) -> PyResult<Arc<Self>> {
+        if bytes.len() != std::mem::size_of::<sys::CUipcMemHandle>() {
+            return Err(PyValueError::new_err("invalid CUDA IPC handle size"));
+        }
+        let device = usize::try_from(device_id)
+            .map_err(|_| PyValueError::new_err("device_id must be non-negative"))?;
+        let context = CudaContext::new(device).map_err(|e| cuda_error("retain context", e))?;
+        context
+            .bind_to_thread()
+            .map_err(|e| cuda_error("bind context", e))?;
+
+        let mut handle = MaybeUninit::<sys::CUipcMemHandle>::uninit();
+        // SAFETY: the length check above covers the entire opaque handle.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                handle.as_mut_ptr().cast::<u8>(),
+                bytes.len(),
+            );
+        }
+        let mut base_ptr = 0;
+        // SAFETY: CUDA initializes base_ptr from the fully copied handle.
+        unsafe {
+            sys::cuIpcOpenMemHandle_v2(
+                &mut base_ptr,
+                handle.assume_init(),
+                sys::CUipcMem_flags::CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS as u32,
+            )
+            .result()
+            .map_err(|e| cuda_error("open CUDA IPC handle", e))?;
+        }
+        let mut mapping = Self {
+            context,
+            base_ptr,
+            size_bytes: 0,
+        };
+
+        let mut actual_device = -1i32;
+        // SAFETY: base_ptr is a live CUDA mapping and output storage is valid.
+        unsafe {
+            sys::cuPointerGetAttribute(
+                (&mut actual_device as *mut i32).cast(),
+                sys::CUpointer_attribute::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
+                base_ptr,
+            )
+            .result()
+            .map_err(|e| cuda_error("query mapping device", e))?;
+        }
+        if actual_device != device_id {
+            return Err(PyValueError::new_err(format!(
+                "CUDA IPC allocation belongs to device {actual_device}, not {device_id}"
+            )));
+        }
+
+        let mut allocation_base = 0;
+        // SAFETY: base_ptr is a live CUDA mapping and output storage is valid.
+        unsafe {
+            sys::cuMemGetAddressRange_v2(&mut allocation_base, &mut mapping.size_bytes, base_ptr)
+                .result()
+                .map_err(|e| cuda_error("query mapping range", e))?;
+        }
+        if allocation_base != base_ptr {
+            return Err(PyRuntimeError::new_err(
+                "CUDA IPC mapping is not allocation-aligned",
+            ));
+        }
+        Ok(Arc::new(mapping))
+    }
+}
+
+impl Drop for CudaIpcMapping {
+    fn drop(&mut self) {
+        self.context
+            .bind_to_thread()
+            .expect("bind CUDA context before closing IPC mapping");
+        // SAFETY: this object owns one successful CUDA IPC open.
+        unsafe { sys::cuIpcCloseMemHandle(self.base_ptr).result() }
+            .expect("close CUDA IPC mapping");
+    }
+}
+
+fn cuda_error(operation: &str, error: DriverError) -> PyErr {
+    PyRuntimeError::new_err(format!("{operation}: {error}"))
+}
 
 struct ContextState {
     device_id: i32,
@@ -68,7 +166,7 @@ impl CudaTensorRegistry {
         &mut self,
         context_key: &str,
         device_id: i32,
-        layers: Vec<(String, Vec<u8>)>,
+        layers: Vec<(String, TensorRegistration)>,
     ) -> PyResult<Vec<TensorMetadata>> {
         if self.contexts.contains_key(context_key) {
             return Err(PyValueError::new_err(format!(
@@ -87,8 +185,24 @@ impl CudaTensorRegistry {
 
         let mut context = ContextState::new(device_id);
         let mut metadatas = Vec::with_capacity(layers.len());
-        for (layer_name, wrapper_bytes) in layers {
-            let layer_tensor = Self::materialize_tensor(device_id, &wrapper_bytes)?;
+        let mut mappings = HashMap::new();
+        for (layer_name, registration) in layers {
+            let layer_tensor = match registration {
+                TensorRegistration::Python(bytes) => {
+                    Self::materialize_python_tensor(device_id, &bytes)?
+                }
+                TensorRegistration::CudaIpc {
+                    handle,
+                    offset_bytes,
+                    size_bytes,
+                } => Self::materialize_cuda_ipc_tensor(
+                    device_id,
+                    handle,
+                    offset_bytes,
+                    size_bytes,
+                    &mut mappings,
+                )?,
+            };
             let metadata = layer_tensor.metadata.clone();
 
             if context.device_id != metadata.device_id {
@@ -150,26 +264,32 @@ impl CudaTensorRegistry {
             return 0;
         }
 
-        // Remove contexts under the GIL so each `Py<PyAny>` is dropped (decref)
-        // there, then force gc + empty_cache to actually unmap the CUDA IPC
-        // memory immediately instead of letting Python's GC defer it.
-        Python::attach(|py| {
-            for key in &keys {
-                self.contexts.remove(key);
-            }
+        let needs_python = keys
+            .iter()
+            .filter_map(|key| self.contexts.get(key))
+            .flat_map(|context| context.tensors.values())
+            .any(|tensor| matches!(&tensor.owner, TensorOwner::Python(_)));
+        let removed: Vec<_> = keys
+            .iter()
+            .filter_map(|key| self.contexts.remove(key))
+            .collect();
 
-            let gc = py.import("gc").expect("gc module");
-            let _ = gc.call_method0("collect");
+        if needs_python {
+            Python::attach(|py| {
+                drop(removed);
+                let gc = py.import("gc").expect("gc module");
+                let _ = gc.call_method0("collect");
 
-            let torch = py.import("torch").expect("torch module");
-            let cuda = torch.getattr("cuda").expect("torch.cuda");
-            let _ = cuda.call_method0("empty_cache");
-        });
+                let torch = py.import("torch").expect("torch module");
+                let cuda = torch.getattr("cuda").expect("torch.cuda");
+                let _ = cuda.call_method0("empty_cache");
+            });
+        }
 
         tensor_count
     }
 
-    fn materialize_tensor(device_id: i32, wrapper_bytes: &[u8]) -> PyResult<LayerTensor> {
+    fn materialize_python_tensor(device_id: i32, wrapper_bytes: &[u8]) -> PyResult<LayerTensor> {
         Python::attach(|py| {
             let torch = py.import("torch")?;
             let pickle = py.import("pickle")?;
@@ -192,13 +312,53 @@ impl CudaTensorRegistry {
             let tensor_owned = tensor.unbind();
 
             Ok(LayerTensor {
-                tensor: tensor_owned,
+                owner: TensorOwner::Python(tensor_owned),
                 metadata: TensorMetadata {
                     data_ptr,
                     size_bytes,
                     device_id: resolved_device,
                 },
             })
+        })
+    }
+
+    fn materialize_cuda_ipc_tensor(
+        device_id: i32,
+        handle: Vec<u8>,
+        offset_bytes: u64,
+        size_bytes: u64,
+        mappings: &mut HashMap<Vec<u8>, Arc<CudaIpcMapping>>,
+    ) -> PyResult<LayerTensor> {
+        let offset = usize::try_from(offset_bytes)
+            .map_err(|_| PyValueError::new_err("CUDA IPC offset does not fit usize"))?;
+        let size = usize::try_from(size_bytes)
+            .map_err(|_| PyValueError::new_err("CUDA IPC size does not fit usize"))?;
+        let mapping = if let Some(mapping) = mappings.get(&handle) {
+            Arc::clone(mapping)
+        } else {
+            let mapping = CudaIpcMapping::open(device_id, &handle)?;
+            mappings.insert(handle, Arc::clone(&mapping));
+            mapping
+        };
+        let end = offset
+            .checked_add(size)
+            .ok_or_else(|| PyValueError::new_err("CUDA IPC view range overflows usize"))?;
+        if size == 0 || end > mapping.size_bytes {
+            return Err(PyValueError::new_err(
+                "CUDA IPC view is outside its allocation",
+            ));
+        }
+        let data_ptr = mapping
+            .base_ptr
+            .checked_add(offset_bytes)
+            .ok_or_else(|| PyValueError::new_err("CUDA IPC view pointer overflows u64"))?;
+        Ok(LayerTensor {
+            owner: TensorOwner::CudaIpc(mapping),
+            metadata: TensorMetadata {
+                data_ptr,
+                size_bytes: size,
+                device_id,
+            },
         })
     }
 }
@@ -209,8 +369,7 @@ enum RegistryCommand {
     RegisterLayers {
         context_key: String,
         device_id: i32,
-        /// `(layer_name, wrapper_bytes)` for each layer in the batch.
-        layers: Vec<(String, Vec<u8>)>,
+        layers: Vec<(String, TensorRegistration)>,
         // The `PyErr` is stringified on the actor thread (which holds the GIL),
         // so callers never need to touch the GIL to read an error message.
         reply: oneshot::Sender<Result<Vec<TensorMetadata>, String>>,
@@ -263,11 +422,11 @@ impl RegistryHandle {
     /// respect to the registry: an existing context is rejected before any
     /// tensor is materialized, and a materialization failure does not publish a
     /// partial context.
-    pub async fn register_layers(
+    pub(crate) async fn register_layers(
         &self,
         context_key: String,
         device_id: i32,
-        layers: Vec<(String, Vec<u8>)>,
+        layers: Vec<(String, TensorRegistration)>,
     ) -> Result<Vec<TensorMetadata>, String> {
         let (reply, rx) = oneshot::channel();
         self.dispatch(RegistryCommand::RegisterLayers {

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -3,15 +3,16 @@ use pegaflow_core::{trace_in_span, trace_root};
 use crate::metric::record_rpc_result;
 use crate::proto::engine::engine_server::Engine;
 use crate::proto::engine::{
-    HealthRequest, HealthResponse, LoadRequest, LoadResponse, QueryBlocksForTransferRequest,
-    QueryBlocksForTransferResponse, QueryLoading, QueryReady, QueryRequest, QueryResponse,
-    RdmaHandshakeRequest, RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse,
-    ReleaseRequest, ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse,
-    ResponseStatus, SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest,
-    ShutdownResponse, TransferBlockInfo, TransferMode as ProtoTransferMode, TransferSlotInfo,
-    UnregisterRequest, UnregisterResponse, query_response,
+    FlushRequest, FlushResponse, HealthRequest, HealthResponse, LoadRequest, LoadResponse,
+    QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, QueryLoading, QueryReady,
+    QueryRequest, QueryResponse, RdmaHandshakeRequest, RdmaHandshakeResponse,
+    RegisterContextRequest, RegisterContextResponse, ReleaseRequest, ReleaseResponse,
+    ReleaseTransferLockRequest, ReleaseTransferLockResponse, ResponseStatus, SaveRequest,
+    SaveResponse, SessionEvent, SessionRequest, ShutdownRequest, ShutdownResponse,
+    TransferBlockInfo, TransferMode as ProtoTransferMode, TransferSlotInfo, UnregisterRequest,
+    UnregisterResponse, query_response,
 };
-use crate::registry::RegistryHandle;
+use crate::registry::{RegistryHandle, TensorRegistration};
 use crate::session::SessionRegistry;
 use log::{debug, info, warn};
 use pegaflow_core::{EngineError, LayerSave, PegaEngine, PrefetchStatus, QueryLeaseId};
@@ -20,6 +21,8 @@ use std::time::Instant;
 use tokio::sync::{Notify, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, async_trait};
+
+mod validation;
 
 #[derive(Clone)]
 pub struct GrpcEngineService {
@@ -116,34 +119,6 @@ impl GrpcEngineService {
         Ok(())
     }
 
-    fn validate_register_context_request(req: &RegisterContextRequest) -> Result<(), Status> {
-        let server_version = env!("CARGO_PKG_VERSION");
-        if req.client_version != server_version {
-            return Err(Status::failed_precondition(format!(
-                "PegaFlow version mismatch: client={} server={server_version}",
-                if req.client_version.is_empty() {
-                    "<missing>"
-                } else {
-                    &req.client_version
-                }
-            )));
-        }
-        Self::validate_device_id(req.device_id)?;
-        if req.tp_size == 0 {
-            return Err(Status::invalid_argument("tp_size must be > 0"));
-        }
-        if req.world_size == 0 {
-            return Err(Status::invalid_argument("world_size must be > 0"));
-        }
-        if req.tp_rank >= req.tp_size {
-            return Err(Status::invalid_argument(format!(
-                "tp_rank {} out of range (tp_size {})",
-                req.tp_rank, req.tp_size
-            )));
-        }
-        Ok(())
-    }
-
     fn validate_save_layers(saves: &[crate::proto::engine::SaveLayer]) -> Result<(), Status> {
         for layer in saves {
             if layer.block_ids.len() != layer.block_hashes.len() {
@@ -226,7 +201,7 @@ impl Engine for GrpcEngineService {
                 req.wrapper_bytes.iter().map(|b| b.len()).collect::<Vec<_>>()
             );
 
-            Self::validate_register_context_request(&req)?;
+            validation::register_context(&req)?;
 
             // The connector picks the H2D/D2H backend per model and sends it
             // here. Read it before `req` is partially moved below.
@@ -238,7 +213,6 @@ impl Engine for GrpcEngineService {
             // Validate array lengths are consistent with each other.
             let batch_len = req.layer_names.len();
             if batch_len == 0
-                || req.wrapper_bytes.len() != batch_len
                 || req.num_blocks.len() != batch_len
                 || req.bytes_per_block.len() != batch_len
                 || req.kv_stride_bytes.len() != batch_len
@@ -280,14 +254,38 @@ impl Engine for GrpcEngineService {
                 Self::context_key(&req.instance_id, req.tp_rank, req.pp_rank, req.device_id);
             // Materialize on the dedicated registry thread (GIL + CUDA IPC) and
             // await the result, so this RPC never blocks an async worker. Move
-            // the (large) wrapper bytes over; clone the layer names since the
+            // the registration payloads over; clone the layer names since the
             // engine call below still needs them.
-            let layers: Vec<(String, Vec<u8>)> = req
-                .layer_names
-                .iter()
-                .cloned()
-                .zip(req.wrapper_bytes)
-                .collect();
+            let native = !req.cuda_ipc_tensors.is_empty();
+            let mut block_stride_bytes = Vec::with_capacity(batch_len);
+            let layers = if native {
+                req.layer_names
+                    .iter()
+                    .cloned()
+                    .zip(req.cuda_ipc_tensors)
+                    .map(|(name, tensor)| {
+                        block_stride_bytes.push(Self::usize_from_u64(
+                            tensor.block_stride_bytes,
+                            "block_stride_bytes",
+                        )?);
+                        Ok((
+                            name,
+                            TensorRegistration::CudaIpc {
+                                handle: tensor.handle,
+                                offset_bytes: tensor.offset_bytes,
+                                size_bytes: tensor.size_bytes,
+                            },
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, Status>>()?
+            } else {
+                req.layer_names
+                    .iter()
+                    .cloned()
+                    .zip(req.wrapper_bytes)
+                    .map(|(name, bytes)| (name, TensorRegistration::Python(bytes)))
+                    .collect()
+            };
             let metadatas = self
                 .registry
                 .register_layers(context_key.clone(), req.device_id, layers)
@@ -301,7 +299,7 @@ impl Engine for GrpcEngineService {
             }
 
             // Call engine batch registration
-            if let Err(err) = self.engine.register_context_layer_batch(
+            if let Err(err) = self.engine.register_context_layer_batch_strided(
                 &req.instance_id,
                 &req.namespace,
                 req.device_id,
@@ -316,6 +314,7 @@ impl Engine for GrpcEngineService {
                 &bytes_per_block_list,
                 &kv_stride_bytes_list,
                 &segments_list,
+                native.then_some(block_stride_bytes.as_slice()),
                 transfer_mode,
                 req.page_first,
             ) {
@@ -450,6 +449,7 @@ impl Engine for GrpcEngineService {
                 layer_names,
                 loads,
                 load_state_shm,
+                wait_for_completion,
                 ..
             } = req;
             Self::validate_device_id(device_id)?;
@@ -475,16 +475,36 @@ impl Engine for GrpcEngineService {
                 })
                 .collect::<Result<_, _>>()?;
 
-            self.engine
-                .batch_load_kv_blocks_multi_layer(
-                    &instance_id,
-                    tp_rank,
-                    device_id,
-                    &load_state_shm,
-                    &layer_refs,
-                    &loads,
-                )
-                .map_err(Self::map_engine_error)?;
+            if wait_for_completion {
+                if !load_state_shm.is_empty() {
+                    return Err(Status::invalid_argument(
+                        "synchronous load must not include load_state_shm",
+                    ));
+                }
+                self.engine
+                    .batch_load_kv_blocks_multi_layer_inproc(
+                        &instance_id,
+                        tp_rank,
+                        device_id,
+                        &layer_refs,
+                        &loads,
+                    )
+                    .map_err(Self::map_engine_error)?
+                    .await
+                    .map_err(|_| Status::internal("load worker dropped completion"))?
+                    .map_err(Self::map_engine_error)?;
+            } else {
+                self.engine
+                    .batch_load_kv_blocks_multi_layer(
+                        &instance_id,
+                        tp_rank,
+                        device_id,
+                        &load_state_shm,
+                        &layer_refs,
+                        &loads,
+                    )
+                    .map_err(Self::map_engine_error)?;
+            }
 
             Ok(Response::new(LoadResponse {
                 status: Some(Self::build_simple_response()),
@@ -648,6 +668,16 @@ impl Engine for GrpcEngineService {
         }
         record_rpc_result("release", &result, start);
         result
+    }
+
+    async fn flush(
+        &self,
+        _request: Request<FlushRequest>,
+    ) -> Result<Response<FlushResponse>, Status> {
+        self.engine.flush_saves_and_registrations().await;
+        Ok(Response::new(FlushResponse {
+            status: Some(Self::build_simple_response()),
+        }))
     }
 
     async fn unregister_context(
@@ -958,110 +988,4 @@ impl Engine for GrpcEngineService {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::proto::engine::SaveLayer;
-    use tonic::Code;
-
-    #[test]
-    fn validate_query_prefetch_rejects_empty_req_id() {
-        let err = GrpcEngineService::validate_query_prefetch_request(&QueryRequest {
-            instance_id: "instance".to_string(),
-            block_hashes: Vec::new(),
-            req_id: String::new(),
-        })
-        .expect_err("empty req_id must be rejected before engine lookup");
-
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("req_id"));
-    }
-
-    #[test]
-    fn validate_query_prefetch_allows_empty_hashes() {
-        GrpcEngineService::validate_query_prefetch_request(&QueryRequest {
-            instance_id: "instance".to_string(),
-            block_hashes: Vec::new(),
-            req_id: "request".to_string(),
-        })
-        .expect("empty block_hashes are a valid zero-hit query");
-    }
-
-    #[test]
-    fn validate_register_context_rejects_pure_argument_errors() {
-        let err = GrpcEngineService::validate_register_context_request(&RegisterContextRequest {
-            instance_id: "instance".to_string(),
-            namespace: "namespace".to_string(),
-            client_version: env!("CARGO_PKG_VERSION").to_string(),
-            tp_rank: 1,
-            tp_size: 1,
-            world_size: 1,
-            device_id: 0,
-            layer_names: Vec::new(),
-            wrapper_bytes: Vec::new(),
-            num_blocks: Vec::new(),
-            bytes_per_block: Vec::new(),
-            kv_stride_bytes: Vec::new(),
-            segments: Vec::new(),
-            pp_rank: 0,
-            transfer_mode: ProtoTransferMode::Direct as i32,
-            page_first: false,
-        })
-        .expect_err("tp_rank outside tp_size must be rejected at RPC boundary");
-
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("tp_rank"));
-    }
-
-    #[test]
-    fn validate_register_context_rejects_client_version_mismatch() {
-        let err = GrpcEngineService::validate_register_context_request(&RegisterContextRequest {
-            instance_id: "instance".to_string(),
-            namespace: "namespace".to_string(),
-            client_version: "0.0.0-test-mismatch".to_string(),
-            tp_rank: 0,
-            tp_size: 1,
-            world_size: 1,
-            device_id: 0,
-            layer_names: Vec::new(),
-            wrapper_bytes: Vec::new(),
-            num_blocks: Vec::new(),
-            bytes_per_block: Vec::new(),
-            kv_stride_bytes: Vec::new(),
-            segments: Vec::new(),
-            pp_rank: 0,
-            transfer_mode: ProtoTransferMode::Direct as i32,
-            page_first: false,
-        })
-        .expect_err("client/server version mismatch must be rejected before registration");
-
-        assert_eq!(err.code(), Code::FailedPrecondition);
-        assert!(err.message().contains("PegaFlow version mismatch"));
-        assert!(err.message().contains("client=0.0.0-test-mismatch"));
-        assert!(
-            err.message()
-                .contains(concat!("server=", env!("CARGO_PKG_VERSION")))
-        );
-    }
-
-    #[test]
-    fn validate_save_layers_rejects_mismatched_block_shapes() {
-        let err = GrpcEngineService::validate_save_layers(&[SaveLayer {
-            layer_name: "layer_0".to_string(),
-            block_ids: vec![0, 1],
-            block_hashes: vec![vec![1]],
-        }])
-        .expect_err("service must reject malformed save shape");
-
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("does not match"));
-    }
-
-    #[test]
-    fn validate_device_id_rejects_negative_values() {
-        let err = GrpcEngineService::validate_device_id(-1)
-            .expect_err("negative device_id must be rejected at RPC boundary");
-
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("device_id"));
-    }
-}
+mod tests;

--- a/pegaflow-server/src/service/tests.rs
+++ b/pegaflow-server/src/service/tests.rs
@@ -1,0 +1,103 @@
+use super::*;
+use crate::proto::engine::SaveLayer;
+use tonic::Code;
+
+#[test]
+fn validate_query_prefetch_rejects_empty_req_id() {
+    let err = GrpcEngineService::validate_query_prefetch_request(&QueryRequest {
+        instance_id: "instance".to_string(),
+        block_hashes: Vec::new(),
+        req_id: String::new(),
+    })
+    .expect_err("empty req_id must be rejected before engine lookup");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("req_id"));
+}
+
+#[test]
+fn validate_query_prefetch_allows_empty_hashes() {
+    GrpcEngineService::validate_query_prefetch_request(&QueryRequest {
+        instance_id: "instance".to_string(),
+        block_hashes: Vec::new(),
+        req_id: "request".to_string(),
+    })
+    .expect("empty block_hashes are a valid zero-hit query");
+}
+
+#[test]
+fn validate_register_context_rejects_pure_argument_errors() {
+    let err = validation::register_context(&RegisterContextRequest {
+        instance_id: "instance".to_string(),
+        namespace: "namespace".to_string(),
+        client_version: pegaflow_proto::VERSION.to_string(),
+        tp_rank: 1,
+        tp_size: 1,
+        world_size: 1,
+        device_id: 0,
+        layer_names: Vec::new(),
+        wrapper_bytes: Vec::new(),
+        num_blocks: Vec::new(),
+        bytes_per_block: Vec::new(),
+        kv_stride_bytes: Vec::new(),
+        segments: Vec::new(),
+        pp_rank: 0,
+        transfer_mode: ProtoTransferMode::Direct as i32,
+        page_first: false,
+        cuda_ipc_tensors: Vec::new(),
+    })
+    .expect_err("tp_rank outside tp_size must be rejected at RPC boundary");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("tp_rank"));
+}
+
+#[test]
+fn validate_register_context_rejects_client_version_mismatch() {
+    let err = validation::register_context(&RegisterContextRequest {
+        instance_id: "instance".to_string(),
+        namespace: "namespace".to_string(),
+        client_version: "0.0.0-test-mismatch".to_string(),
+        tp_rank: 0,
+        tp_size: 1,
+        world_size: 1,
+        device_id: 0,
+        layer_names: Vec::new(),
+        wrapper_bytes: Vec::new(),
+        num_blocks: Vec::new(),
+        bytes_per_block: Vec::new(),
+        kv_stride_bytes: Vec::new(),
+        segments: Vec::new(),
+        pp_rank: 0,
+        transfer_mode: ProtoTransferMode::Direct as i32,
+        page_first: false,
+        cuda_ipc_tensors: Vec::new(),
+    })
+    .expect_err("client/server version mismatch must be rejected before registration");
+
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert!(err.message().contains("PegaFlow version mismatch"));
+    assert!(err.message().contains("client=0.0.0-test-mismatch"));
+}
+
+#[test]
+fn validate_save_layers_rejects_mismatched_block_shapes() {
+    let err = GrpcEngineService::validate_save_layers(&[SaveLayer {
+        layer_name: "layer_0".to_string(),
+        block_ids: vec![0, 1],
+        block_hashes: vec![vec![1]],
+    }])
+    .expect_err("service must reject malformed save shape");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("does not match"));
+}
+
+#[test]
+fn validate_device_id_rejects_negative_values() {
+    let err = GrpcEngineService::validate_device_id(-1)
+        .expect_err("negative device_id must be rejected at RPC boundary");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("device_id"));
+}

--- a/pegaflow-server/src/service/validation.rs
+++ b/pegaflow-server/src/service/validation.rs
@@ -1,0 +1,51 @@
+use tonic::Status;
+
+use crate::proto::engine::RegisterContextRequest;
+
+pub(super) fn register_context(req: &RegisterContextRequest) -> Result<(), Status> {
+    let server_version = pegaflow_proto::VERSION;
+    if req.client_version != server_version {
+        return Err(Status::failed_precondition(format!(
+            "PegaFlow version mismatch: client={} server={server_version}",
+            if req.client_version.is_empty() {
+                "<missing>"
+            } else {
+                &req.client_version
+            }
+        )));
+    }
+    if req.device_id < 0 {
+        return Err(Status::invalid_argument("device_id must be non-negative"));
+    }
+    if req.tp_size == 0 {
+        return Err(Status::invalid_argument("tp_size must be > 0"));
+    }
+    if req.world_size == 0 {
+        return Err(Status::invalid_argument("world_size must be > 0"));
+    }
+    if req.tp_rank >= req.tp_size {
+        return Err(Status::invalid_argument(format!(
+            "tp_rank {} out of range (tp_size {})",
+            req.tp_rank, req.tp_size
+        )));
+    }
+
+    let layers = req.layer_names.len();
+    let python = req.wrapper_bytes.len() == layers && req.cuda_ipc_tensors.is_empty();
+    let native = req.cuda_ipc_tensors.len() == layers && req.wrapper_bytes.is_empty();
+    if layers == 0 || (!python && !native) {
+        return Err(Status::invalid_argument(
+            "exactly one tensor payload must match layer_names",
+        ));
+    }
+    for tensor in &req.cuda_ipc_tensors {
+        if tensor.handle.len() != std::mem::size_of::<cudarc::driver::sys::CUipcMemHandle>()
+            || tensor.size_bytes == 0
+            || tensor.block_stride_bytes == 0
+            || tensor.offset_bytes.checked_add(tensor.size_bytes).is_none()
+        {
+            return Err(Status::invalid_argument("invalid CUDA IPC tensor metadata"));
+        }
+    }
+    Ok(())
+}

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -377,6 +377,7 @@ impl MockVllmRpcHarness {
                 lease,
                 block_ids: (0..block_count as u32).collect(),
             }],
+            wait_for_completion: false,
         };
         match self.worker.load(request.clone()).await {
             Ok(response) => Ok(LoadRpcExchange {

--- a/pegaflow-server/tests/http_cleanup_hang_repro.rs
+++ b/pegaflow-server/tests/http_cleanup_hang_repro.rs
@@ -235,7 +235,7 @@ fn wedge_register_request(i: usize) -> RegisterContextRequest {
     RegisterContextRequest {
         instance_id: format!("wedge-{i}"),
         namespace: "wedge".to_string(),
-        client_version: env!("CARGO_PKG_VERSION").to_string(),
+        client_version: pegaflow_proto::VERSION.to_string(),
         tp_rank: 0,
         tp_size: 1,
         world_size: 1,
@@ -249,6 +249,7 @@ fn wedge_register_request(i: usize) -> RegisterContextRequest {
         pp_rank: 0,
         transfer_mode: TransferMode::Direct as i32,
         page_first: false,
+        cuda_ipc_tensors: Vec::new(),
     }
 }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -308,7 +308,7 @@ impl EngineRpcClient {
                 .register_context_batch(RegisterContextRequest {
                     instance_id,
                     namespace,
-                    client_version: env!("CARGO_PKG_VERSION").to_string(),
+                    client_version: pegaflow_proto::VERSION.to_string(),
                     tp_rank,
                     tp_size,
                     world_size,
@@ -322,6 +322,7 @@ impl EngineRpcClient {
                     pp_rank,
                     transfer_mode: transfer_mode as i32,
                     page_first,
+                    cuda_ipc_tensors: Vec::new(),
                 })
                 .await?;
             Ok(resp.into_inner())
@@ -419,6 +420,7 @@ impl EngineRpcClient {
                     load_state_shm,
                     layer_names,
                     loads,
+                    wait_for_completion: false,
                 })
                 .await?;
             Ok(resp.into_inner())


### PR DESCRIPTION
## Summary

- Accept native CUDA IPC registrations as one `CudaIpcTensor` entry per layer, including allocation handle, view range, and block stride.
- Reuse the existing strided registration, in-process load completion, and flush APIs; the Python wrapper path remains unchanged.
- Reject old/new wire mismatches through an exact native-CUDA-IPC capability version.

## Validation

- `prek run`
- `cargo test --release -p pegaflow-server --no-default-features --features cuda-13 --lib` (23 passed)
- `cargo test --release -p pegaflow-core --lib` (124 passed, 1 ignored)
- `cargo check --release -p pegaflow-server --no-default-features --features cuda-13 --all-targets`
- `cargo check --release -p pegaflow-py --no-default-features --features cuda-13`