### PR TITLE
fix(core): drain GPU workers before unregister

### DIFF
--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, mpsc as std_mpsc};
 use cudarc::driver::{CudaContext, CudaStream};
 use log::{debug, error, info, warn};
 use logforth::diagnostic::ThreadLocalDiagnostic;
+use parking_lot::Mutex;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::EngineError;
@@ -112,11 +113,38 @@ pub(crate) struct SaveTask {
     pub trace_ctx: Option<::fastrace::prelude::SpanContext>,
 }
 
+enum LoadCommand {
+    Run(LoadTask),
+    Drain(oneshot::Sender<()>),
+}
+
+enum SaveCommand {
+    Run(SaveTask),
+    Drain(oneshot::Sender<()>),
+}
+
+pub(crate) struct WorkerDrain {
+    load: oneshot::Receiver<()>,
+    save: oneshot::Receiver<()>,
+}
+
+impl WorkerDrain {
+    pub(crate) async fn wait(self) {
+        self.load
+            .await
+            .unwrap_or_else(|_| panic!("load worker exited before acknowledging drain barrier"));
+        self.save
+            .await
+            .unwrap_or_else(|_| panic!("save worker exited before acknowledging drain barrier"));
+    }
+}
+
 /// Per-GPU worker pool with dedicated load and save threads
 pub(crate) struct GpuWorkerPool {
     device_id: i32,
-    load_tx: mpsc::UnboundedSender<LoadTask>,
-    save_tx: mpsc::UnboundedSender<SaveTask>,
+    load_tx: mpsc::UnboundedSender<LoadCommand>,
+    save_tx: mpsc::UnboundedSender<SaveCommand>,
+    closed: Mutex<bool>,
 }
 
 impl GpuWorkerPool {
@@ -197,12 +225,20 @@ impl GpuWorkerPool {
             device_id,
             load_tx,
             save_tx,
+            closed: Mutex::new(false),
         })
     }
 
     /// Submit a load task (CPU -> GPU) - fire and forget
     pub(crate) fn submit_load(&self, task: LoadTask) -> Result<(), EngineError> {
-        self.load_tx.send(task).map_err(|_| {
+        let closed = self.closed.lock();
+        if *closed {
+            return Err(EngineError::Storage(format!(
+                "GPU worker pool is closing for device {}",
+                self.device_id
+            )));
+        }
+        self.load_tx.send(LoadCommand::Run(task)).map_err(|_| {
             EngineError::Storage(format!(
                 "Load worker channel closed for device {}",
                 self.device_id
@@ -225,12 +261,21 @@ impl GpuWorkerPool {
             trace_ctx: ::fastrace::prelude::SpanContext::current_local_parent(),
         };
 
-        self.save_tx.send(task).map_err(|_| {
-            EngineError::Storage(format!(
-                "Save worker channel closed for device {}",
-                self.device_id
-            ))
-        })?;
+        {
+            let closed = self.closed.lock();
+            if *closed {
+                return Err(EngineError::Storage(format!(
+                    "GPU worker pool is closing for device {}",
+                    self.device_id
+                )));
+            }
+            self.save_tx.send(SaveCommand::Run(task)).map_err(|_| {
+                EngineError::Storage(format!(
+                    "Save worker channel closed for device {}",
+                    self.device_id
+                ))
+            })?;
+        }
 
         // Await the result (this is async, won't block tokio runtime)
         reply_rx.await.map_err(|_| {
@@ -239,6 +284,31 @@ impl GpuWorkerPool {
                 self.device_id
             ))
         })?
+    }
+
+    /// Reject new transfers and place one barrier behind every transfer that
+    /// was accepted before this call.
+    pub(crate) fn close_and_drain(&self) -> WorkerDrain {
+        let mut closed = self.closed.lock();
+        assert!(!*closed, "GPU worker pool closed twice");
+        *closed = true;
+
+        let (load_tx, load_rx) = oneshot::channel();
+        let (save_tx, save_rx) = oneshot::channel();
+        let load_send = self.load_tx.send(LoadCommand::Drain(load_tx));
+        let save_send = self.save_tx.send(SaveCommand::Drain(save_tx));
+        assert!(
+            load_send.is_ok(),
+            "load worker exited before accepting drain barrier"
+        );
+        assert!(
+            save_send.is_ok(),
+            "save worker exited before accepting drain barrier"
+        );
+        WorkerDrain {
+            load: load_rx,
+            save: save_rx,
+        }
     }
 }
 
@@ -300,18 +370,28 @@ fn init_worker(device_id: i32, transfer_mode: TransferMode) -> Result<WorkerRunt
 /// Load worker thread main loop
 fn load_worker_loop(
     device_id: i32,
-    mut rx: mpsc::UnboundedReceiver<LoadTask>,
+    mut rx: mpsc::UnboundedReceiver<LoadCommand>,
     runtime: WorkerRuntime,
 ) {
-    while let Some(task) = rx.blocking_recv() {
-        let LoadTask { layers, completion } = task;
-        let result = process_load_task(&layers, &runtime.stream, runtime.backend.as_ref());
+    while let Some(command) = rx.blocking_recv() {
+        match command {
+            LoadCommand::Run(task) => {
+                let LoadTask { layers, completion } = task;
+                let result = process_load_task(&layers, &runtime.stream, runtime.backend.as_ref());
 
-        if let Err(ref e) = result {
-            error!("Load task failed: device={device_id} error={e:?}");
-            core_metrics().load_failures.add(1, &[]);
+                if let Err(ref e) = result {
+                    error!("Load task failed: device={device_id} error={e:?}");
+                    core_metrics().load_failures.add(1, &[]);
+                }
+                completion.signal(result);
+            }
+            LoadCommand::Drain(done) => {
+                runtime.stream.synchronize().unwrap_or_else(|err| {
+                    panic!("load stream drain failed for device {device_id}: {err:?}")
+                });
+                let _ = done.send(());
+            }
         }
-        completion.signal(result);
     }
 
     info!("Load worker shutting down: device={}", device_id);
@@ -320,25 +400,35 @@ fn load_worker_loop(
 /// Save worker thread main loop
 fn save_worker_loop(
     device_id: i32,
-    mut rx: mpsc::UnboundedReceiver<SaveTask>,
+    mut rx: mpsc::UnboundedReceiver<SaveCommand>,
     runtime: WorkerRuntime,
 ) {
-    while let Some(task) = rx.blocking_recv() {
-        let SaveTask {
-            layers,
-            reply,
-            #[cfg(feature = "tracing")]
-            trace_ctx,
-        } = task;
-        let result = process_save_task(
-            &layers,
-            &runtime.stream,
-            runtime.backend.as_ref(),
-            #[cfg(feature = "tracing")]
-            trace_ctx,
-        )
-        .map(|()| layers);
-        let _ = reply.send(result);
+    while let Some(command) = rx.blocking_recv() {
+        match command {
+            SaveCommand::Run(task) => {
+                let SaveTask {
+                    layers,
+                    reply,
+                    #[cfg(feature = "tracing")]
+                    trace_ctx,
+                } = task;
+                let result = process_save_task(
+                    &layers,
+                    &runtime.stream,
+                    runtime.backend.as_ref(),
+                    #[cfg(feature = "tracing")]
+                    trace_ctx,
+                )
+                .map(|()| layers);
+                let _ = reply.send(result);
+            }
+            SaveCommand::Drain(done) => {
+                runtime.stream.synchronize().unwrap_or_else(|err| {
+                    panic!("save stream drain failed for device {device_id}: {err:?}")
+                });
+                let _ = done.send(());
+            }
+        }
     }
 
     info!("Save worker shutting down: device={}", device_id);
@@ -414,6 +504,46 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
     Ok((copies, total_bytes))
 }
 
+fn wait_for_transfer(
+    stream: &Arc<CudaStream>,
+    submitted: Result<(), String>,
+) -> Result<(), EngineError> {
+    if let Err(submit_error) = submitted {
+        stream.synchronize().map_err(|sync_error| {
+            EngineError::Storage(format!(
+                "Failed to synchronize after transfer submission error ({submit_error}): {sync_error:?}"
+            ))
+        })?;
+        return Err(EngineError::Storage(submit_error));
+    }
+
+    match stream.record_event(None) {
+        Ok(event) => match event.synchronize() {
+            Ok(()) => Ok(()),
+            Err(event_error) => {
+                stream.synchronize().map_err(|stream_error| {
+                    EngineError::Storage(format!(
+                        "Event synchronization failed ({event_error:?}); stream synchronization also failed: {stream_error:?}"
+                    ))
+                })?;
+                Err(EngineError::Storage(format!(
+                    "Failed to synchronize event: {event_error:?}"
+                )))
+            }
+        },
+        Err(record_error) => {
+            stream.synchronize().map_err(|sync_error| {
+                EngineError::Storage(format!(
+                    "Failed to synchronize after event record failure ({record_error:?}): {sync_error:?}"
+                ))
+            })?;
+            Err(EngineError::Storage(format!(
+                "Failed to record event: {record_error:?}"
+            )))
+        }
+    }
+}
+
 /// Process a load task: copy blocks from CPU pinned memory to GPU for multiple
 /// layers. All layers and segments are collected into one descriptor batch,
 /// handed to a single backend (memcpy or kernel), then synchronized once.
@@ -430,15 +560,7 @@ fn process_load_task(
 
     let (copies, total_bytes) = build_copy_descs(layers)?;
 
-    backend.h2d(&copies, stream).map_err(EngineError::Storage)?;
-
-    // Wait for all transfers to complete
-    let event = stream
-        .record_event(None)
-        .map_err(|e| EngineError::Storage(format!("Failed to record event: {e:?}")))?;
-    event
-        .synchronize()
-        .map_err(|e| EngineError::Storage(format!("Failed to synchronize: {e:?}")))?;
+    wait_for_transfer(stream, backend.h2d(&copies, stream))?;
 
     let elapsed = start.elapsed();
     let bandwidth_gbps = if elapsed.as_secs_f64() > 0.0 {
@@ -483,15 +605,7 @@ fn process_save_task(
 
     let (copies, total_bytes) = build_copy_descs(layers)?;
 
-    backend.d2h(&copies, stream).map_err(EngineError::Storage)?;
-
-    // Single synchronization for all layers
-    let event = stream
-        .record_event(None)
-        .map_err(|e| EngineError::Storage(format!("Failed to record event: {e:?}")))?;
-    event
-        .synchronize()
-        .map_err(|e| EngineError::Storage(format!("Failed to synchronize: {e:?}")))?;
+    wait_for_transfer(stream, backend.d2h(&copies, stream))?;
 
     let elapsed = start.elapsed();
     let bandwidth_gbps = if elapsed.as_secs_f64() > 0.0 {

--- a/pegaflow-core/src/instance.rs
+++ b/pegaflow-core/src/instance.rs
@@ -31,10 +31,18 @@ use std::{
 
 use cudarc::driver::CudaContext;
 use log::info;
+use tokio::sync::Notify;
 
 use crate::layout::KVCacheLayout;
 use crate::{EngineError, TransferMode, gpu_worker::GpuWorkerPool};
 use pegaflow_common::NumaNode;
+
+#[derive(PartialEq, Eq)]
+enum InstanceLifecycle {
+    Open,
+    Draining,
+    Drained,
+}
 
 /// Registration state protected by a single mutex.
 struct RegistrationState {
@@ -43,6 +51,8 @@ struct RegistrationState {
 
     /// Sealed layer-id space. `None` while workers are still registering.
     topology: Option<Arc<LayerTopology>>,
+
+    lifecycle: InstanceLifecycle,
 }
 
 /// Dense layer-id space sealed from the union of registered layers.
@@ -347,6 +357,10 @@ pub struct InstanceContext {
 
     /// Registration state and GPU contexts protected by a single mutex.
     state: Mutex<RegistrationState>,
+
+    /// Wakes concurrent unregister callers after the elected closer drains all
+    /// GPU queues.
+    drain_complete: Notify,
 }
 
 impl InstanceContext {
@@ -374,8 +388,32 @@ impl InstanceContext {
             state: Mutex::new(RegistrationState {
                 gpu_contexts: HashMap::new(),
                 topology: None,
+                lifecycle: InstanceLifecycle::Open,
             }),
+            drain_complete: Notify::new(),
         })
+    }
+
+    /// Reject new work after unregister has started.
+    pub(crate) fn ensure_open(&self) -> Result<(), EngineError> {
+        if self.state.lock().lifecycle != InstanceLifecycle::Open {
+            return Err(EngineError::InvalidArgument(format!(
+                "instance {} is closing",
+                self.id
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn run_if_open<T>(&self, operation: impl FnOnce() -> T) -> Result<T, EngineError> {
+        let state = self.state.lock();
+        if state.lifecycle != InstanceLifecycle::Open {
+            return Err(EngineError::InvalidArgument(format!(
+                "instance {} is closing",
+                self.id
+            )));
+        }
+        Ok(operation())
     }
 
     /// Access the sealed layer topology.
@@ -400,6 +438,12 @@ impl InstanceContext {
         state: &RegistrationState,
         device_id: i32,
     ) -> Result<(), EngineError> {
+        if state.lifecycle != InstanceLifecycle::Open {
+            return Err(EngineError::InvalidArgument(format!(
+                "instance {} is closing",
+                self.id
+            )));
+        }
         // Check the duplicate device first: a restarted worker re-registering
         // against a stale sealed instance should hear "device already exists"
         // (the instance must be unregistered first), not a generic "fully
@@ -589,6 +633,51 @@ impl InstanceContext {
     pub(crate) fn get_gpu(&self, device_id: i32) -> Option<Arc<GpuContext>> {
         let state = self.state.lock();
         state.gpu_contexts.get(&device_id).cloned()
+    }
+
+    /// Reject new transfers and queue a barrier after every accepted task.
+    pub(crate) fn begin_close(&self) -> Option<Vec<crate::gpu_worker::WorkerDrain>> {
+        let mut state = self.state.lock();
+        match state.lifecycle {
+            InstanceLifecycle::Drained | InstanceLifecycle::Draining => None,
+            InstanceLifecycle::Open => {
+                state.lifecycle = InstanceLifecycle::Draining;
+                Some(
+                    state
+                        .gpu_contexts
+                        .values()
+                        .map(|gpu| gpu.worker_pool().close_and_drain())
+                        .collect(),
+                )
+            }
+        }
+    }
+
+    /// Wait for this instance's elected drain, or for the caller that elected
+    /// it to publish completion.
+    pub(crate) async fn finish_close(&self, drains: Option<Vec<crate::gpu_worker::WorkerDrain>>) {
+        if let Some(drains) = drains {
+            for drain in drains {
+                drain.wait().await;
+            }
+            self.state.lock().lifecycle = InstanceLifecycle::Drained;
+            self.drain_complete.notify_waiters();
+            return;
+        }
+
+        loop {
+            let notified = self.drain_complete.notified();
+            if self.state.lock().lifecycle == InstanceLifecycle::Drained {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn close_and_drain(&self) {
+        let drains = self.begin_close();
+        self.finish_close(drains).await;
     }
 
     /// Get a GPU context and verify it belongs to the requested save group.

--- a/pegaflow-core/src/instance/tests.rs
+++ b/pegaflow-core/src/instance/tests.rs
@@ -448,3 +448,21 @@ fn seal_rejects_inconsistent_layer_geometry() {
         .expect_err("same name with different geometry must fail the seal");
     assert!(err.to_string().contains("inconsistent geometry"));
 }
+
+#[tokio::test]
+async fn concurrent_close_waits_for_one_shared_drain() {
+    let instance =
+        Arc::new(InstanceContext::new("closing".into(), "namespace".into(), 1, 1, false).unwrap());
+    let first = {
+        let instance = Arc::clone(&instance);
+        tokio::spawn(async move { instance.close_and_drain().await })
+    };
+    let second = {
+        let instance = Arc::clone(&instance);
+        tokio::spawn(async move { instance.close_and_drain().await })
+    };
+
+    first.await.unwrap();
+    second.await.unwrap();
+    assert!(instance.ensure_open().is_err());
+}

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -28,6 +28,7 @@ mod seal_offload;
 mod storage;
 pub mod sync_state;
 pub mod transfer;
+mod unregister;
 
 pub use backing::{
     DEFAULT_SSD_PREFETCH_INFLIGHT, DEFAULT_SSD_PREFETCH_QUEUE_DEPTH, DEFAULT_SSD_WRITE_INFLIGHT,
@@ -127,7 +128,7 @@ pub struct PegaEngine {
     /// GPU-NUMA topology for memory allocation decisions.
     topology: Arc<NumaTopology>,
     /// Query-ready blocks owned by opaque scheduler leases.
-    query_leases: QueryLeaseManager,
+    query_leases: Arc<QueryLeaseManager>,
 }
 
 impl PegaEngine {
@@ -171,7 +172,7 @@ impl PegaEngine {
             instances: Arc::new(RwLock::new(HashMap::new())),
             storage,
             topology,
-            query_leases: QueryLeaseManager::default(),
+            query_leases: Arc::new(QueryLeaseManager::default()),
         })
     }
 
@@ -220,10 +221,12 @@ impl PegaEngine {
     /// Look up an instance by ID.
     fn get_instance(&self, instance_id: &str) -> Result<Arc<InstanceContext>, EngineError> {
         let instances = self.instances.read().expect("instances read lock poisoned");
-        instances
+        let instance = instances
             .get(instance_id)
             .cloned()
-            .ok_or_else(|| EngineError::InstanceMissing(instance_id.to_string()))
+            .ok_or_else(|| EngineError::InstanceMissing(instance_id.to_string()))?;
+        instance.ensure_open()?;
+        Ok(instance)
     }
 
     /// Batch register multiple KV cache layers for a single GPU.
@@ -419,40 +422,6 @@ impl PegaEngine {
         Ok(())
     }
 
-    /// Unregister an instance and release all associated resources.
-    pub fn unregister_instance(&self, instance_id: &str) -> Result<(), EngineError> {
-        let removed = self
-            .instances
-            .write()
-            .expect("instances write lock poisoned")
-            .remove(instance_id);
-
-        if removed.is_none() {
-            return Err(EngineError::InstanceMissing(instance_id.to_string()));
-        }
-        self.query_leases.release_instance(instance_id);
-        info!("Unregistered instance: {}", instance_id);
-        Ok(())
-    }
-
-    /// Unregister all instances, returning the IDs that were removed.
-    pub fn unregister_all_instances(&self) -> Vec<String> {
-        let mut instances = self
-            .instances
-            .write()
-            .expect("instances write lock poisoned");
-        let ids: Vec<String> = instances.keys().cloned().collect();
-        instances.clear();
-        drop(instances);
-        for id in &ids {
-            self.query_leases.release_instance(id);
-        }
-        if !ids.is_empty() {
-            info!("Unregistered all instances: {:?}", ids);
-        }
-        ids
-    }
-
     /// List all registered instance IDs.
     pub fn list_instance_ids(&self) -> Vec<String> {
         self.instances
@@ -518,9 +487,10 @@ impl PegaEngine {
                 "query lease requires at least one block".to_string(),
             ));
         }
-        Ok(self
-            .query_leases
-            .create(instance_id, blocks, instance.world_size()))
+        instance.run_if_open(|| {
+            self.query_leases
+                .create(instance_id, blocks, instance.world_size())
+        })
     }
 
     /// Release a query lease. Returns false when the lease is unknown or expired.
@@ -901,6 +871,71 @@ impl PegaEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn canceled_drained_unregister_finishes_owned_cleanup() {
+        let engine = Arc::new(
+            PegaEngine::new_with_config(1 << 20, false, storage::StorageConfig::default())
+                .expect("create engine"),
+        );
+        let instance = engine
+            .get_or_create_instance("cancel-cleanup", "namespace", 1, 1, false)
+            .expect("create instance");
+        let elected = instance.begin_close().expect("elect test drain");
+
+        let caller = {
+            let engine = Arc::clone(&engine);
+            tokio::spawn(async move { engine.unregister_instance_drained("cancel-cleanup").await })
+        };
+        while Arc::strong_count(&instance) < 3 {
+            tokio::task::yield_now().await;
+        }
+        caller.abort();
+        let _ = caller.await;
+
+        instance.finish_close(Some(elected)).await;
+        for _ in 0..100 {
+            if engine.list_instance_ids().is_empty() {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("owned cleanup did not remove the drained instance");
+    }
+
+    #[test]
+    fn stale_unregister_cannot_release_new_generation_lease() {
+        let engine = PegaEngine::new_with_config(1 << 20, false, storage::StorageConfig::default())
+            .expect("create engine");
+        let old = engine
+            .get_or_create_instance("reused", "old", 1, 1, false)
+            .expect("create old generation");
+
+        engine
+            .unregister_instance("reused")
+            .expect("remove old generation");
+        assert!(old.run_if_open(|| ()).is_err());
+
+        engine
+            .get_or_create_instance("reused", "new", 1, 1, false)
+            .expect("create new generation");
+        let lease = engine
+            .create_query_lease(
+                "reused",
+                vec![Arc::new(SealedBlock::from_slots(Vec::new()))],
+            )
+            .expect("create new generation lease");
+
+        let mut instances = engine.instances.write().expect("instances lock");
+        assert!(!unregister::remove_generation(
+            &mut instances,
+            &engine.query_leases,
+            "reused",
+            &old,
+        ));
+        drop(instances);
+        assert!(engine.release_query_lease(&lease));
+    }
 
     #[cfg(feature = "rdma")]
     #[test]

--- a/pegaflow-core/src/unregister.rs
+++ b/pegaflow-core/src/unregister.rs
@@ -1,0 +1,156 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use log::info;
+
+use crate::instance::InstanceContext;
+use crate::lease::QueryLeaseManager;
+use crate::{EngineError, PegaEngine};
+
+pub(super) fn remove_generation(
+    instances: &mut HashMap<String, Arc<InstanceContext>>,
+    query_leases: &QueryLeaseManager,
+    instance_id: &str,
+    expected: &Arc<InstanceContext>,
+) -> bool {
+    if !instances
+        .get(instance_id)
+        .is_some_and(|current| Arc::ptr_eq(current, expected))
+    {
+        return false;
+    }
+
+    query_leases.release_instance(instance_id);
+    instances.remove(instance_id);
+    true
+}
+
+impl PegaEngine {
+    /// Unregister an instance immediately without draining accepted transfers.
+    /// Allocation owners must use [`Self::unregister_instance_drained`] before
+    /// releasing memory that GPU workers may still reference.
+    pub fn unregister_instance(&self, instance_id: &str) -> Result<(), EngineError> {
+        let mut instances = self
+            .instances
+            .write()
+            .expect("instances write lock poisoned");
+        let instance = instances
+            .get(instance_id)
+            .cloned()
+            .ok_or_else(|| EngineError::InstanceMissing(instance_id.to_string()))?;
+        instance.ensure_open()?;
+        drop(
+            instance
+                .begin_close()
+                .expect("open instance must elect its close"),
+        );
+        assert!(remove_generation(
+            &mut instances,
+            &self.query_leases,
+            instance_id,
+            &instance,
+        ));
+        info!("Unregistered instance: {}", instance_id);
+        Ok(())
+    }
+
+    /// Drain accepted GPU transfers before unregistering an instance.
+    ///
+    /// Once this future starts, cleanup continues in an owned task even if the
+    /// caller is canceled.
+    pub async fn unregister_instance_drained(&self, instance_id: &str) -> Result<(), EngineError> {
+        let (instance, drains) = {
+            let instances = self.instances.read().expect("instances read lock poisoned");
+            let instance = instances
+                .get(instance_id)
+                .cloned()
+                .ok_or_else(|| EngineError::InstanceMissing(instance_id.to_string()))?;
+            let drains = instance.begin_close();
+            (instance, drains)
+        };
+        let instances = Arc::clone(&self.instances);
+        let query_leases = Arc::clone(&self.query_leases);
+        let instance_id = instance_id.to_string();
+        tokio::spawn(async move {
+            instance.finish_close(drains).await;
+            let mut instances = instances.write().expect("instances write lock poisoned");
+            if remove_generation(&mut instances, &query_leases, &instance_id, &instance) {
+                info!("Unregistered drained instance: {}", instance_id);
+            }
+        })
+        .await
+        .expect("instance cleanup task panicked");
+        Ok(())
+    }
+
+    /// Unregister all instances immediately without draining accepted transfers.
+    /// Allocation owners must use [`Self::unregister_all_instances_drained`]
+    /// before releasing memory that GPU workers may still reference.
+    pub fn unregister_all_instances(&self) -> Vec<String> {
+        let mut instances = self
+            .instances
+            .write()
+            .expect("instances write lock poisoned");
+        let targets = instances
+            .iter()
+            .filter(|(_, instance)| instance.ensure_open().is_ok())
+            .map(|(id, instance)| (id.clone(), Arc::clone(instance)))
+            .collect::<Vec<_>>();
+        let mut ids = Vec::with_capacity(targets.len());
+        for (id, instance) in targets {
+            drop(
+                instance
+                    .begin_close()
+                    .expect("open instance must elect its close"),
+            );
+            if remove_generation(&mut instances, &self.query_leases, &id, &instance) {
+                ids.push(id);
+            }
+        }
+        if !ids.is_empty() {
+            info!("Unregistered all instances: {:?}", ids);
+        }
+        ids
+    }
+
+    /// Drain accepted GPU transfers before unregistering every instance.
+    ///
+    /// Once this future starts, cleanup continues in an owned task even if the
+    /// caller is canceled.
+    pub async fn unregister_all_instances_drained(&self) -> Vec<String> {
+        let instances = {
+            let instances = self
+                .instances
+                .read()
+                .expect("instances write lock poisoned");
+            instances
+                .iter()
+                .map(|(id, instance)| (id.clone(), Arc::clone(instance), instance.begin_close()))
+                .collect::<Vec<_>>()
+        };
+        let current = Arc::clone(&self.instances);
+        let query_leases = Arc::clone(&self.query_leases);
+        tokio::spawn(async move {
+            let mut instances = instances;
+            futures::future::join_all(
+                instances
+                    .iter_mut()
+                    .map(|(_, instance, drains)| instance.finish_close(drains.take())),
+            )
+            .await;
+            let mut current = current.write().expect("instances write lock poisoned");
+            let mut ids = Vec::with_capacity(instances.len());
+            for (id, instance, _) in instances {
+                if remove_generation(&mut current, &query_leases, &id, &instance) {
+                    ids.push(id);
+                }
+            }
+            if !ids.is_empty() {
+                info!("Unregistered all drained instances: {:?}", ids);
+            }
+            ids
+        })
+        .await
+        .expect("all-instance cleanup task panicked")
+    }
+}

--- a/pegaflow-server/src/http_server.rs
+++ b/pegaflow-server/src/http_server.rs
@@ -10,12 +10,14 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 
+use crate::lifecycle::InstanceCoordinator;
 use crate::registry::RegistryHandle;
 
 #[derive(Clone)]
 struct AppState {
     engine: Arc<PegaEngine>,
     registry: RegistryHandle,
+    instances: InstanceCoordinator,
     prometheus_registry: Option<Registry>,
 }
 
@@ -82,8 +84,10 @@ async fn cleanup_handler(
 ) -> impl IntoResponse {
     match query.id {
         None => {
-            let removed_tensors = state.registry.clear().await;
-            let removed_instances = state.engine.unregister_all_instances();
+            let (removed_instances, removed_tensors) = state
+                .instances
+                .cleanup_all(Arc::clone(&state.engine), state.registry.clone())
+                .await;
 
             if !removed_instances.is_empty() || removed_tensors > 0 {
                 warn!(
@@ -104,23 +108,40 @@ async fn cleanup_handler(
             )
         }
         Some(instance_id) => {
-            let removed_tensors = state.registry.drop_instance(instance_id.clone()).await;
-            match state.engine.unregister_instance(&instance_id) {
-                Ok(()) => {
+            match state
+                .instances
+                .cleanup_instance(
+                    Arc::clone(&state.engine),
+                    state.registry.clone(),
+                    instance_id.clone(),
+                )
+                .await
+            {
+                Ok(cleanup) if cleanup.engine_found => {
                     warn!(
                         "Cleanup instance {}: {} CUDA tensor(s) released",
-                        instance_id, removed_tensors
+                        instance_id, cleanup.removed_tensors
                     );
-                    cleanup_ok_response(instance_id, removed_tensors)
+                    cleanup_ok_response(instance_id, cleanup.removed_tensors)
                 }
-                Err(_) if removed_tensors > 0 => {
-                    warn!(
-                        "Instance {} not in engine but cleaned {} CUDA tensor(s)",
-                        instance_id, removed_tensors
-                    );
-                    cleanup_ok_response(instance_id, removed_tensors)
+                Ok(cleanup) => {
+                    if cleanup.removed_tensors == 0 {
+                        (
+                            StatusCode::NOT_FOUND,
+                            format!("instance {instance_id} not found").into_response(),
+                        )
+                    } else {
+                        warn!(
+                            "Instance {} not in engine but cleaned {} CUDA tensor(s)",
+                            instance_id, cleanup.removed_tensors
+                        );
+                        cleanup_ok_response(instance_id, cleanup.removed_tensors)
+                    }
                 }
-                Err(e) => (StatusCode::NOT_FOUND, format!("{e}").into_response()),
+                Err(err) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("failed to clean instance {instance_id}: {err}").into_response(),
+                ),
             }
         }
     }
@@ -160,6 +181,7 @@ pub async fn start_http_server(
     addr: std::net::SocketAddr,
     engine: Arc<PegaEngine>,
     registry: RegistryHandle,
+    instances: InstanceCoordinator,
     enable_prometheus: bool,
     prometheus_registry: Option<Registry>,
     shutdown: Arc<Notify>,
@@ -169,6 +191,7 @@ pub async fn start_http_server(
     let state = AppState {
         engine,
         registry,
+        instances,
         prometheus_registry: if enable_prometheus {
             prometheus_registry
         } else {

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -1,5 +1,6 @@
 mod check_cuda_version;
 pub mod http_server;
+pub mod lifecycle;
 pub mod metric;
 pub mod proto;
 pub mod registry;
@@ -608,6 +609,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             Arc::clone(&shutdown),
             Arc::clone(&hll_tracker),
         );
+        let instance_coordinator = service.instance_coordinator();
 
         // Spawn background GC task for stale inflight blocks and expired transfer locks
         {
@@ -653,6 +655,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             cli.http_addr,
             Arc::clone(&engine),
             registry,
+            instance_coordinator,
             cli.enable_prometheus,
             metrics_state.prometheus_registry.clone(),
             Arc::clone(&shutdown),

--- a/pegaflow-server/src/lifecycle.rs
+++ b/pegaflow-server/src/lifecycle.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+
+use pegaflow_core::{EngineError, PegaEngine};
+use tokio::sync::{RwLock, RwLockReadGuard};
+
+use crate::registry::RegistryHandle;
+use crate::session::SessionRegistry;
+
+#[derive(Debug)]
+pub(crate) struct CleanupResult {
+    pub(crate) engine_found: bool,
+    pub(crate) removed_tensors: usize,
+}
+
+/// Keeps registration and session creation out of cleanup transactions.
+#[derive(Clone, Default)]
+pub struct InstanceCoordinator {
+    gate: Arc<RwLock<()>>,
+    sessions: Arc<SessionRegistry>,
+}
+
+impl InstanceCoordinator {
+    pub(crate) async fn registration(&self) -> RwLockReadGuard<'_, ()> {
+        self.gate.read().await
+    }
+
+    pub(crate) async fn open_session(
+        &self,
+        instance_id: String,
+        namespace: String,
+        tp_size: u32,
+        world_size: u32,
+    ) -> u64 {
+        let _registration = self.registration().await;
+        self.sessions
+            .install(instance_id, namespace, tp_size, world_size)
+    }
+
+    pub(crate) async fn cleanup_instance(
+        &self,
+        engine: Arc<PegaEngine>,
+        registry: RegistryHandle,
+        instance_id: String,
+    ) -> Result<CleanupResult, EngineError> {
+        let coordinator = self.clone();
+        tokio::spawn(async move {
+            let _cleanup = coordinator.gate.write().await;
+            let engine_found = match engine.unregister_instance_drained(&instance_id).await {
+                Ok(()) => true,
+                Err(EngineError::InstanceMissing(_)) => false,
+                Err(err) => return Err(err),
+            };
+            let removed_tensors = registry.drop_instance(instance_id.clone()).await;
+            coordinator.sessions.remove(&instance_id);
+            Ok(CleanupResult {
+                engine_found,
+                removed_tensors,
+            })
+        })
+        .await
+        .expect("instance cleanup task panicked")
+    }
+
+    pub(crate) async fn cleanup_all(
+        &self,
+        engine: Arc<PegaEngine>,
+        registry: RegistryHandle,
+    ) -> (Vec<String>, usize) {
+        let coordinator = self.clone();
+        tokio::spawn(async move {
+            let _cleanup = coordinator.gate.write().await;
+            let removed_instances = engine.unregister_all_instances_drained().await;
+            let removed_tensors = registry.clear().await;
+            coordinator.sessions.clear();
+            (removed_instances, removed_tensors)
+        })
+        .await
+        .expect("all-instance cleanup task panicked")
+    }
+
+    pub(crate) async fn cleanup_session(
+        &self,
+        engine: Arc<PegaEngine>,
+        registry: RegistryHandle,
+        instance_id: String,
+        token: u64,
+    ) -> Result<Option<usize>, EngineError> {
+        let coordinator = self.clone();
+        tokio::spawn(async move {
+            let _cleanup = coordinator.gate.write().await;
+            if !coordinator.sessions.take(&instance_id, token) {
+                return Ok(None);
+            }
+            match engine.unregister_instance_drained(&instance_id).await {
+                Ok(()) | Err(EngineError::InstanceMissing(_)) => {}
+                Err(err) => return Err(err),
+            }
+            Ok(Some(registry.drop_instance(instance_id).await))
+        })
+        .await
+        .expect("session cleanup task panicked")
+    }
+}

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -1,5 +1,6 @@
 use pegaflow_core::{trace_in_span, trace_root};
 
+use crate::lifecycle::InstanceCoordinator;
 use crate::metric::record_rpc_result;
 use crate::proto::engine::engine_server::Engine;
 use crate::proto::engine::{
@@ -12,7 +13,6 @@ use crate::proto::engine::{
     UnregisterRequest, UnregisterResponse, query_response,
 };
 use crate::registry::RegistryHandle;
-use crate::session::SessionRegistry;
 use log::{debug, info, warn};
 use pegaflow_core::{EngineError, LayerSave, PegaEngine, PrefetchStatus, QueryLeaseId};
 use std::sync::Arc;
@@ -27,7 +27,7 @@ pub struct GrpcEngineService {
     registry: RegistryHandle,
     shutdown: Arc<Notify>,
     hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::MultiWindowHllTracker>>,
-    session_registry: Arc<SessionRegistry>,
+    instances: InstanceCoordinator,
 }
 
 impl GrpcEngineService {
@@ -42,33 +42,12 @@ impl GrpcEngineService {
             registry,
             shutdown,
             hll_tracker,
-            session_registry: SessionRegistry::new(),
+            instances: InstanceCoordinator::default(),
         }
     }
 
-    /// Drop CUDA IPC tensors and engine-side instance state for `instance_id`.
-    /// Idempotent — safe to call after the instance is already gone.
-    async fn cleanup_instance(
-        engine: &PegaEngine,
-        registry: &RegistryHandle,
-        instance_id: &str,
-        reason: &'static str,
-    ) {
-        let removed = registry.drop_instance(instance_id.to_string()).await;
-        if removed > 0 {
-            info!(
-                "Session cleanup ({}): dropped {} CUDA tensors for instance {}",
-                reason, removed, instance_id
-            );
-        }
-        if let Err(err) = engine.unregister_instance(instance_id) {
-            // `InstanceMissing` is normal if the instance was never registered
-            // (vllm died before any register_context_batch). Log at debug.
-            debug!(
-                "Session cleanup ({}): engine.unregister_instance({}) returned {}",
-                reason, instance_id, err
-            );
-        }
+    pub fn instance_coordinator(&self) -> InstanceCoordinator {
+        self.instances.clone()
     }
 
     fn context_key(instance_id: &str, tp_rank: u32, pp_rank: u32, device_id: i32) -> String {
@@ -274,6 +253,8 @@ impl Engine for GrpcEngineService {
             let pp_rank = Self::usize_from_u32(req.pp_rank, "pp_rank")?;
             let tp_size = Self::usize_from_u32(req.tp_size, "tp_size")?;
             let world_size = Self::usize_from_u32(req.world_size, "world_size")?;
+
+            let _registration = self.instances.registration().await;
 
             // Materialize tensors and collect data_ptr/size_bytes
             let context_key =
@@ -658,17 +639,26 @@ impl Engine for GrpcEngineService {
         let result: Result<Response<UnregisterResponse>, Status> = async {
             let req = request.into_inner();
             debug!("RPC [unregister_context]: instance_id={}", req.instance_id);
-            let removed = self.registry.drop_instance(req.instance_id.clone()).await;
-            if removed > 0 {
+            let cleanup = self
+                .instances
+                .cleanup_instance(
+                    Arc::clone(&self.engine),
+                    self.registry.clone(),
+                    req.instance_id.clone(),
+                )
+                .await
+                .map_err(Self::map_engine_error)?;
+            if cleanup.removed_tensors > 0 {
                 info!(
                     "Dropped {} CUDA tensors for instance {}",
-                    removed, req.instance_id
+                    cleanup.removed_tensors, req.instance_id
                 );
             }
-
-            self.engine
-                .unregister_instance(&req.instance_id)
-                .map_err(Self::map_engine_error)?;
+            if !cleanup.engine_found {
+                return Err(Self::map_engine_error(EngineError::InstanceMissing(
+                    req.instance_id,
+                )));
+            }
 
             Ok(Response::new(UnregisterResponse {
                 status: Some(Self::build_simple_response()),
@@ -909,12 +899,15 @@ impl Engine for GrpcEngineService {
             return Err(Status::invalid_argument("instance_id must not be empty"));
         }
 
-        let token = self.session_registry.install(
-            instance_id.clone(),
-            req.namespace.clone(),
-            req.tp_size,
-            req.world_size,
-        );
+        let token = self
+            .instances
+            .open_session(
+                instance_id.clone(),
+                req.namespace.clone(),
+                req.tp_size,
+                req.world_size,
+            )
+            .await;
         info!(
             "Session opened: instance_id={} namespace={} tp_size={} world_size={} token={}",
             instance_id, req.namespace, req.tp_size, req.world_size, token
@@ -931,25 +924,31 @@ impl Engine for GrpcEngineService {
         // `rx` are dropped → `cleanup_tx.closed()` resolves.
         let cleanup_tx = tx.clone();
 
-        let session_registry = Arc::clone(&self.session_registry);
         let engine = Arc::clone(&self.engine);
         let cuda_registry = self.registry.clone();
+        let instances = self.instances.clone();
         let id_for_watcher = instance_id.clone();
 
         tokio::spawn(async move {
             cleanup_tx.closed().await;
-            if session_registry.take(&id_for_watcher, token) {
-                info!(
-                    "Session closed: instance_id={} token={} — running cleanup",
-                    id_for_watcher, token
-                );
-                Self::cleanup_instance(&engine, &cuda_registry, &id_for_watcher, "stream closed")
-                    .await;
-            } else {
-                debug!(
+            match instances
+                .cleanup_session(engine, cuda_registry, id_for_watcher.clone(), token)
+                .await
+            {
+                Ok(Some(removed)) => {
+                    info!(
+                        "Session closed: instance_id={} token={} — cleanup removed {} CUDA tensors",
+                        id_for_watcher, token, removed
+                    );
+                }
+                Ok(None) => debug!(
                     "Session closed: instance_id={} token={} superseded — skip cleanup",
                     id_for_watcher, token
-                );
+                ),
+                Err(err) => warn!(
+                    "Session cleanup failed: instance_id={} token={} error={}",
+                    id_for_watcher, token, err
+                ),
             }
         });
 

--- a/pegaflow-server/src/session.rs
+++ b/pegaflow-server/src/session.rs
@@ -63,6 +63,14 @@ impl SessionRegistry {
             .map(|entry| entry.topology.clone())
     }
 
+    pub(crate) fn remove(&self, instance_id: &str) {
+        self.sessions.remove(instance_id);
+    }
+
+    pub(crate) fn clear(&self) {
+        self.sessions.clear();
+    }
+
     /// CAS-remove: only removes if `token` is still the current one.
     /// Returns true if this caller owns the cleanup.
     pub fn take(&self, instance_id: &str, token: u64) -> bool {

--- a/pegaflow-server/tests/http_cleanup_hang_repro.rs
+++ b/pegaflow-server/tests/http_cleanup_hang_repro.rs
@@ -278,6 +278,7 @@ fn start_cluster(worker_threads: usize) -> TestCluster {
         Arc::clone(&shutdown),
         hll_tracker,
     );
+    let instance_coordinator = service.instance_coordinator();
     rt.spawn(async move {
         Server::builder()
             .add_service(EngineServer::new(service))
@@ -291,6 +292,7 @@ fn start_cluster(worker_threads: usize) -> TestCluster {
             http_addr,
             Arc::clone(&engine),
             registry.clone(),
+            instance_coordinator,
             true,
             Some(Registry::new()),
             Arc::clone(&shutdown),


### PR DESCRIPTION
## Summary

- reject new GPU transfers and drain both worker streams before removing an instance
- synchronize CUDA streams at the drain barrier, including transfer error paths
- make server cleanup wait for the engine drain before releasing registered CUDA tensors
- serialize cleanup against registration and session creation, and keep cleanup running after caller cancellation
- preserve the synchronous unregister APIs while adding drained variants for allocation owners

## Testing

- `prek run`
- core unit tests: 127 passed, 1 ignored
- server unit tests: 23 passed
- HTTP cleanup integration test: 1 passed