### PR TITLE
docs: add NIXL P/D deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The warm-start path achieves **~9x faster TTFT** compared to cold-start, demonst
 ## Documentation
 
 - [Server Configuration](./docs/server.md) — full CLI options, SSD cache, multi-node setup
+- [P/D with NIXL](./docs/deployment.md) — GLM-5.2 FP8 deployment with MTP and MultiConnector
 - [Python Package](./python/README.md) — Python bindings and vLLM connector configuration
 - [P2P KV Cache Sharing](./docs/p2p.md) — cross-node RDMA setup, tuning, and troubleshooting
 - [P/D Router](./docs/pd.md) — prefill/decode disaggregation

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,69 +2,19 @@
 
 ## P/D with NIXL
 
-This example runs GLM-5.2 FP8 with prefill/decode disaggregation, MTP, and
-vLLM's `MultiConnector` on both sides.
+This GLM-5.2 FP8 example enables MTP and `MultiConnector` on both sides. NIXL
+handles P-to-D transfer; PegaFlow uses `read_write` on P and `save_only` on D
+to reuse KV produced by earlier requests without competing with NIXL loads.
 
-```text
-request -> prefill -- NIXL --> decode
-              |                   |
-              +---- PegaFlow -----+
-```
-
-NIXL transfers the current request's KV cache from prefill to decode.
-PegaFlow stores reusable KV cache across requests and nodes:
-
-- The prefill instance uses PegaFlow in `read_write` mode. It can reuse a
-  cached prefix, including output KV previously saved by a decode instance.
-- The decode instance puts NIXL first and uses PegaFlow in `save_only` mode.
-  NIXL owns the current P-to-D load, while PegaFlow persists the resulting KV
-  cache without competing for that load.
-
-### Prerequisites
-
-- Run a PegaFlow server beside each vLLM instance and connect those servers to
-  the same PegaFlow metaserver.
-- Configure NIXL networking and a P/D-aware router for the deployment
-  environment.
-- Use the same model revision, tokenizer, block size, KV cache dtype,
-  `PYTHONHASHSEED`, and compatible KV cache layout on both sides.
-- Set `PYTHONHASHSEED` explicitly. Different values produce different vLLM
-  block hashes and prevent cross-instance cache reuse.
-
-The following commands assume the local PegaFlow server listens on
-`http://127.0.0.1:50055`. Parallelism and memory limits are examples; adjust
-them together with the router configuration for the target hardware.
+Run one PegaFlow server beside each vLLM instance, backed by the same metaserver,
+and use a P/D-aware NIXL router. P and D must use compatible model, tokenizer,
+block size, KV dtype, KV layout, and `PYTHONHASHSEED`. The example uses seed 42
+and a local PegaFlow server at `http://127.0.0.1:50055`.
 
 ### Prefill
 
-The first child that advertises a cache hit owns the load. NIXL therefore stays
-first, while PegaFlow remains available for cross-request reads and saves.
-
 ```bash
-PREFILL_KV_CONFIG='{
-  "kv_connector": "MultiConnector",
-  "kv_role": "kv_both",
-  "kv_connector_extra_config": {
-    "connectors": [
-      {
-        "kv_connector": "NixlConnector",
-        "kv_role": "kv_producer"
-      },
-      {
-        "kv_connector": "PegaKVConnector",
-        "kv_role": "kv_both",
-        "kv_connector_module_path": "pegaflow.connector",
-        "kv_connector_extra_config": {
-          "pegaflow.mode": "read_write"
-        }
-      }
-    ]
-  }
-}'
-
 PYTHONHASHSEED=42 \
-PEGAFLOW_HOST=http://127.0.0.1 \
-PEGAFLOW_PORT=50055 \
 vllm serve GLM-5.2-FP8 \
   --served-model-name glm-5.2 \
   --host 0.0.0.0 \
@@ -76,42 +26,34 @@ vllm serve GLM-5.2-FP8 \
   --speculative-config.num_speculative_tokens 2 \
   --enable-prefix-caching \
   --trust-remote-code \
-  --kv-transfer-config "$PREFILL_KV_CONFIG"
+  --kv-transfer-config '{
+    "kv_connector": "MultiConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "connectors": [
+        {
+          "kv_connector": "NixlConnector",
+          "kv_role": "kv_producer"
+        },
+        {
+          "kv_connector": "PegaKVConnector",
+          "kv_role": "kv_both",
+          "kv_connector_module_path": "pegaflow.connector",
+          "kv_connector_extra_config": {
+            "pegaflow.host": "http://127.0.0.1",
+            "pegaflow.port": 50055,
+            "pegaflow.mode": "read_write"
+          }
+        }
+      ]
+    }
+  }'
 ```
 
 ### Decode
 
-The decode side keeps NIXL as the load owner. PegaFlow receives every save but
-does not query or load cache entries in `save_only` mode.
-
 ```bash
-DECODE_KV_CONFIG='{
-  "kv_connector": "MultiConnector",
-  "kv_role": "kv_both",
-  "kv_connector_extra_config": {
-    "connectors": [
-      {
-        "kv_connector": "NixlConnector",
-        "kv_role": "kv_consumer",
-        "kv_connector_extra_config": {
-          "kv_recompute_threshold": 0
-        }
-      },
-      {
-        "kv_connector": "PegaKVConnector",
-        "kv_role": "kv_both",
-        "kv_connector_module_path": "pegaflow.connector",
-        "kv_connector_extra_config": {
-          "pegaflow.mode": "save_only"
-        }
-      }
-    ]
-  }
-}'
-
 PYTHONHASHSEED=42 \
-PEGAFLOW_HOST=http://127.0.0.1 \
-PEGAFLOW_PORT=50055 \
 vllm serve GLM-5.2-FP8 \
   --served-model-name glm-5.2 \
   --host 0.0.0.0 \
@@ -123,23 +65,40 @@ vllm serve GLM-5.2-FP8 \
   --speculative-config.num_speculative_tokens 2 \
   --enable-prefix-caching \
   --trust-remote-code \
-  --kv-transfer-config "$DECODE_KV_CONFIG"
+  --kv-transfer-config '{
+    "kv_connector": "MultiConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "connectors": [
+        {
+          "kv_connector": "NixlConnector",
+          "kv_role": "kv_consumer",
+          "kv_connector_extra_config": {
+            "kv_recompute_threshold": 0
+          }
+        },
+        {
+          "kv_connector": "PegaKVConnector",
+          "kv_role": "kv_both",
+          "kv_connector_module_path": "pegaflow.connector",
+          "kv_connector_extra_config": {
+            "pegaflow.host": "http://127.0.0.1",
+            "pegaflow.port": 50055,
+            "pegaflow.mode": "save_only"
+          }
+        }
+      ]
+    }
+  }'
 ```
 
 ### Validate D-to-P reuse
 
-Use a two-turn request whose first response is long enough to span several KV
-blocks. Send the complete conversation history on the second turn. The prefill
-instance never computed the first response, so a PegaFlow hit for those blocks
-exercises the D-to-P path.
-
-Verify all of the following:
+Generate a multi-block response, then send the full history in turn two. A hit
+for the first response exercises D-to-P reuse. Verify:
 
 - `pegaflow_rdma_fetch_total_total{status="ok"}` increases on the prefill-side
-  PegaFlow server.
-- `query_blocks_for_transfer` requests increase on a decode-side PegaFlow
-  server.
-- PegaFlow reports all requested blocks as transferred, with no block-count
-  mismatch.
+  server and `query_blocks_for_transfer` increases on decode.
+- Every requested block is transferred with no block-count mismatch.
 - `vllm:pega_load_failure_total`, `vllm:pega_save_failure_total`, and non-OK
-  PegaFlow RPC deltas remain zero.
+  PegaFlow RPC deltas stay at zero.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,145 @@
+# Deployment
+
+## P/D with NIXL
+
+This example runs GLM-5.2 FP8 with prefill/decode disaggregation, MTP, and
+vLLM's `MultiConnector` on both sides.
+
+```text
+request -> prefill -- NIXL --> decode
+              |                   |
+              +---- PegaFlow -----+
+```
+
+NIXL transfers the current request's KV cache from prefill to decode.
+PegaFlow stores reusable KV cache across requests and nodes:
+
+- The prefill instance uses PegaFlow in `read_write` mode. It can reuse a
+  cached prefix, including output KV previously saved by a decode instance.
+- The decode instance puts NIXL first and uses PegaFlow in `save_only` mode.
+  NIXL owns the current P-to-D load, while PegaFlow persists the resulting KV
+  cache without competing for that load.
+
+### Prerequisites
+
+- Run a PegaFlow server beside each vLLM instance and connect those servers to
+  the same PegaFlow metaserver.
+- Configure NIXL networking and a P/D-aware router for the deployment
+  environment.
+- Use the same model revision, tokenizer, block size, KV cache dtype,
+  `PYTHONHASHSEED`, and compatible KV cache layout on both sides.
+- Set `PYTHONHASHSEED` explicitly. Different values produce different vLLM
+  block hashes and prevent cross-instance cache reuse.
+
+The following commands assume the local PegaFlow server listens on
+`http://127.0.0.1:50055`. Parallelism and memory limits are examples; adjust
+them together with the router configuration for the target hardware.
+
+### Prefill
+
+The first child that advertises a cache hit owns the load. NIXL therefore stays
+first, while PegaFlow remains available for cross-request reads and saves.
+
+```bash
+PREFILL_KV_CONFIG='{
+  "kv_connector": "MultiConnector",
+  "kv_role": "kv_both",
+  "kv_connector_extra_config": {
+    "connectors": [
+      {
+        "kv_connector": "NixlConnector",
+        "kv_role": "kv_producer"
+      },
+      {
+        "kv_connector": "PegaKVConnector",
+        "kv_role": "kv_both",
+        "kv_connector_module_path": "pegaflow.connector",
+        "kv_connector_extra_config": {
+          "pegaflow.mode": "read_write"
+        }
+      }
+    ]
+  }
+}'
+
+PYTHONHASHSEED=42 \
+PEGAFLOW_HOST=http://127.0.0.1 \
+PEGAFLOW_PORT=50055 \
+vllm serve GLM-5.2-FP8 \
+  --served-model-name glm-5.2 \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --tensor-parallel-size 8 \
+  --enable-expert-parallel \
+  --kv-cache-dtype fp8 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 2 \
+  --enable-prefix-caching \
+  --trust-remote-code \
+  --kv-transfer-config "$PREFILL_KV_CONFIG"
+```
+
+### Decode
+
+The decode side keeps NIXL as the load owner. PegaFlow receives every save but
+does not query or load cache entries in `save_only` mode.
+
+```bash
+DECODE_KV_CONFIG='{
+  "kv_connector": "MultiConnector",
+  "kv_role": "kv_both",
+  "kv_connector_extra_config": {
+    "connectors": [
+      {
+        "kv_connector": "NixlConnector",
+        "kv_role": "kv_consumer",
+        "kv_connector_extra_config": {
+          "kv_recompute_threshold": 0
+        }
+      },
+      {
+        "kv_connector": "PegaKVConnector",
+        "kv_role": "kv_both",
+        "kv_connector_module_path": "pegaflow.connector",
+        "kv_connector_extra_config": {
+          "pegaflow.mode": "save_only"
+        }
+      }
+    ]
+  }
+}'
+
+PYTHONHASHSEED=42 \
+PEGAFLOW_HOST=http://127.0.0.1 \
+PEGAFLOW_PORT=50055 \
+vllm serve GLM-5.2-FP8 \
+  --served-model-name glm-5.2 \
+  --host 0.0.0.0 \
+  --port 8001 \
+  --tensor-parallel-size 8 \
+  --enable-expert-parallel \
+  --kv-cache-dtype fp8 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 2 \
+  --enable-prefix-caching \
+  --trust-remote-code \
+  --kv-transfer-config "$DECODE_KV_CONFIG"
+```
+
+### Validate D-to-P reuse
+
+Use a two-turn request whose first response is long enough to span several KV
+blocks. Send the complete conversation history on the second turn. The prefill
+instance never computed the first response, so a PegaFlow hit for those blocks
+exercises the D-to-P path.
+
+Verify all of the following:
+
+- `pegaflow_rdma_fetch_total_total{status="ok"}` increases on the prefill-side
+  PegaFlow server.
+- `query_blocks_for_transfer` requests increase on a decode-side PegaFlow
+  server.
+- PegaFlow reports all requested blocks as transferred, with no block-count
+  mismatch.
+- `vllm:pega_load_failure_total`, `vllm:pega_save_failure_total`, and non-OK
+  PegaFlow RPC deltas remain zero.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,9 +14,9 @@ and `PYTHONHASHSEED`.
 
 Replace `<p_node_ip>` and `<d_node_ip>` with the addresses assigned to the P
 and D nodes. The example assumes P and D run on separate nodes; to colocate
-them on one host, keep the distinct NIXL side-channel ports and also give the
-decode-side PegaFlow server and connector a different port, since one PegaFlow
-server runs beside each vLLM instance.
+them on one host, keep the distinct NIXL side-channel ports and point both
+connectors at a single shared PegaFlow server — each vLLM instance registers
+with its own instance id, so one server can serve both.
 
 ### Prefill
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,15 +12,17 @@ and use a P/D-aware NIXL router. Configure each server's routable `--addr`,
 P and D must use compatible model, tokenizer, block size, KV dtype, KV layout,
 and `PYTHONHASHSEED`.
 
-The commands use the documentation addresses `192.0.2.10` for P and
-`192.0.2.11` for D; replace them with addresses assigned to the target nodes.
-The distinct NIXL ports also avoid a collision if P and D are colocated.
+Replace `<p_node_ip>` and `<d_node_ip>` with the addresses assigned to the P
+and D nodes. The example assumes P and D run on separate nodes; to colocate
+them on one host, keep the distinct NIXL side-channel ports and also give the
+decode-side PegaFlow server and connector a different port, since one PegaFlow
+server runs beside each vLLM instance.
 
 ### Prefill
 
 ```bash
 PYTHONHASHSEED=42 \
-VLLM_NIXL_SIDE_CHANNEL_HOST=192.0.2.10 \
+VLLM_NIXL_SIDE_CHANNEL_HOST=<p_node_ip> \
 VLLM_NIXL_SIDE_CHANNEL_PORT=5600 \
 vllm serve GLM-5.2-FP8 \
   --served-model-name glm-5.2 \
@@ -47,7 +49,7 @@ vllm serve GLM-5.2-FP8 \
           "kv_role": "kv_both",
           "kv_connector_module_path": "pegaflow.connector",
           "kv_connector_extra_config": {
-            "pegaflow.host": "http://192.0.2.10",
+            "pegaflow.host": "http://<p_node_ip>",
             "pegaflow.port": 50055,
             "pegaflow.mode": "read_write"
           }
@@ -61,7 +63,7 @@ vllm serve GLM-5.2-FP8 \
 
 ```bash
 PYTHONHASHSEED=42 \
-VLLM_NIXL_SIDE_CHANNEL_HOST=192.0.2.11 \
+VLLM_NIXL_SIDE_CHANNEL_HOST=<d_node_ip> \
 VLLM_NIXL_SIDE_CHANNEL_PORT=5601 \
 vllm serve GLM-5.2-FP8 \
   --served-model-name glm-5.2 \
@@ -91,7 +93,7 @@ vllm serve GLM-5.2-FP8 \
           "kv_role": "kv_both",
           "kv_connector_module_path": "pegaflow.connector",
           "kv_connector_extra_config": {
-            "pegaflow.host": "http://192.0.2.11",
+            "pegaflow.host": "http://<d_node_ip>",
             "pegaflow.port": 50055,
             "pegaflow.mode": "save_only"
           }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,14 +7,21 @@ handles P-to-D transfer; PegaFlow uses `read_write` on P and `save_only` on D
 to reuse KV produced by earlier requests without competing with NIXL loads.
 
 Run one PegaFlow server beside each vLLM instance, backed by the same metaserver,
-and use a P/D-aware NIXL router. P and D must use compatible model, tokenizer,
-block size, KV dtype, KV layout, and `PYTHONHASHSEED`. The example uses seed 42
-and a local PegaFlow server at `http://127.0.0.1:50055`.
+and use a P/D-aware NIXL router. Configure each server's routable `--addr`,
+`--nics`, and `--metaserver-addr` as described in the [P2P guide](./p2p.md).
+P and D must use compatible model, tokenizer, block size, KV dtype, KV layout,
+and `PYTHONHASHSEED`.
+
+The commands use the documentation addresses `192.0.2.10` for P and
+`192.0.2.11` for D; replace them with addresses assigned to the target nodes.
+The distinct NIXL ports also avoid a collision if P and D are colocated.
 
 ### Prefill
 
 ```bash
 PYTHONHASHSEED=42 \
+VLLM_NIXL_SIDE_CHANNEL_HOST=192.0.2.10 \
+VLLM_NIXL_SIDE_CHANNEL_PORT=5600 \
 vllm serve GLM-5.2-FP8 \
   --served-model-name glm-5.2 \
   --host 0.0.0.0 \
@@ -40,7 +47,7 @@ vllm serve GLM-5.2-FP8 \
           "kv_role": "kv_both",
           "kv_connector_module_path": "pegaflow.connector",
           "kv_connector_extra_config": {
-            "pegaflow.host": "http://127.0.0.1",
+            "pegaflow.host": "http://192.0.2.10",
             "pegaflow.port": 50055,
             "pegaflow.mode": "read_write"
           }
@@ -54,6 +61,8 @@ vllm serve GLM-5.2-FP8 \
 
 ```bash
 PYTHONHASHSEED=42 \
+VLLM_NIXL_SIDE_CHANNEL_HOST=192.0.2.11 \
+VLLM_NIXL_SIDE_CHANNEL_PORT=5601 \
 vllm serve GLM-5.2-FP8 \
   --served-model-name glm-5.2 \
   --host 0.0.0.0 \
@@ -82,7 +91,7 @@ vllm serve GLM-5.2-FP8 \
           "kv_role": "kv_both",
           "kv_connector_module_path": "pegaflow.connector",
           "kv_connector_extra_config": {
-            "pegaflow.host": "http://127.0.0.1",
+            "pegaflow.host": "http://192.0.2.11",
             "pegaflow.port": 50055,
             "pegaflow.mode": "save_only"
           }


### PR DESCRIPTION
## Summary

- add a GLM-5.2 FP8 P/D deployment example using MTP and MultiConnector on both sides
- configure NIXL as the P-to-D transport and PegaFlow as read/write on prefill and save-only on decode
- document shared hash/layout invariants and D-to-P reuse validation
- link the guide from the main README

## Validation

- `prek run --files README.md docs/deployment.md`
- parsed both connector examples as JSON
- validated child connector configurations with vLLM `KVTransferConfig`
- checked embedded shell snippets with `bash -n`