### PR TITLE
feat: complete remote prefetch with partial tail blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 *.egg-info/
 .venv/
 venv/
+python/uv.lock
 .pytest_cache/
 examples/bench_results/
 examples/pd_logs/

--- a/docs/pd.md
+++ b/docs/pd.md
@@ -86,6 +86,11 @@ The P/D setup trades higher TTFT for **significantly more stable decode latency*
 
 ## Limitations
 
+- Decode's `query_prefetch` may race prefill's async save. The
+  `wait_for_full_prefix` option does not cover this topology: it only waits
+  on remote producers discovered via MetaServer + RDMA, and a shared
+  engine's own blocks are never remote. It is also a no-op when RDMA is not
+  configured.
 - Router uses synchronous P→D handoff (no async KV-ready callback yet)
 - No built-in timeout/retry for P or D node failures
 - No Prometheus metrics for P/D latency breakdown

--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -186,7 +186,7 @@ impl BenchFixture {
     async fn query_lease(&self, req_id: &str, hashes: &[Vec<u8>]) -> QueryLeaseId {
         match self
             .engine
-            .count_prefix_hit_blocks_with_prefetch(INSTANCE_ID, req_id, hashes)
+            .count_prefix_hit_blocks_with_prefetch(INSTANCE_ID, req_id, hashes, false)
             .await
             .expect("query")
         {

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -483,14 +483,14 @@ impl PegaEngine {
         instance_id: &str,
         req_id: &str,
         block_hashes: &[Vec<u8>],
-        wait_for_remote: bool,
+        wait_for_full_prefix: bool,
     ) -> Result<PrefetchStatus, EngineError> {
         let instance = self.get_instance(instance_id)?;
         let namespace = instance.namespace();
 
         let status = self
             .storage
-            .check_prefix_and_prefetch(req_id, namespace, block_hashes, wait_for_remote)
+            .check_prefix_and_prefetch(req_id, namespace, block_hashes, wait_for_full_prefix)
             .await;
 
         match &status {

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -483,13 +483,14 @@ impl PegaEngine {
         instance_id: &str,
         req_id: &str,
         block_hashes: &[Vec<u8>],
+        wait_for_remote: bool,
     ) -> Result<PrefetchStatus, EngineError> {
         let instance = self.get_instance(instance_id)?;
         let namespace = instance.namespace();
 
         let status = self
             .storage
-            .check_prefix_and_prefetch(req_id, namespace, block_hashes)
+            .check_prefix_and_prefetch(req_id, namespace, block_hashes, wait_for_remote)
             .await;
 
         match &status {

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -451,9 +451,10 @@ impl StorageEngine {
         req_id: &str,
         namespace: &str,
         hashes: &[Vec<u8>],
+        wait_for_remote: bool,
     ) -> PrefetchStatus {
         self.prefetch
-            .check_and_prefetch(&self.read_cache, req_id, namespace, hashes)
+            .check_and_prefetch(&self.read_cache, req_id, namespace, hashes, wait_for_remote)
             .await
     }
 

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -451,10 +451,16 @@ impl StorageEngine {
         req_id: &str,
         namespace: &str,
         hashes: &[Vec<u8>],
-        wait_for_remote: bool,
+        wait_for_full_prefix: bool,
     ) -> PrefetchStatus {
         self.prefetch
-            .check_and_prefetch(&self.read_cache, req_id, namespace, hashes, wait_for_remote)
+            .check_and_prefetch(
+                &self.read_cache,
+                req_id,
+                namespace,
+                hashes,
+                wait_for_full_prefix,
+            )
             .await
     }
 

--- a/pegaflow-core/src/storage/prefetch.rs
+++ b/pegaflow-core/src/storage/prefetch.rs
@@ -53,7 +53,17 @@ impl RdmaFetch {
             .fetch_blocks(&node, req_id, namespace, &remaining_hashes[..found])
             .await;
         if require_full_prefix && blocks.len() != found {
-            return None;
+            // The advertised owner served fewer blocks than the MetaServer
+            // promised (stale advertisement or failed fetch). Keep the partial
+            // result so poll_existing blacklists RDMA for this request instead
+            // of the wait loop retrying the same fetch until timeout.
+            warn!(
+                "RDMA fetch returned fewer blocks than advertised: req_id={} node={} returned={} advertised={}",
+                req_id,
+                node,
+                blocks.len(),
+                found
+            );
         }
         Some((found, blocks))
     }
@@ -141,8 +151,9 @@ struct PrefetchState {
     active: HashMap<String, PrefetchEntry>,
     /// Reserved SSD prefetch budget for active background tasks.
     reserved_ssd_prefetch_blocks: usize,
-    /// req_ids where RDMA remote fetch returned zero blocks (remote evicted).
-    /// Prevents re-triggering RDMA on every subsequent poll for the same request.
+    /// req_ids where the advertised RDMA owner served fewer blocks than the
+    /// MetaServer promised (stale advertisement or failed fetch). Prevents
+    /// re-triggering RDMA on every subsequent poll for the same request.
     failed_remote: HashMap<String, Instant>,
 }
 
@@ -464,6 +475,7 @@ fn reserve_ssd_prefetch_slots(
     state: Arc<Mutex<PrefetchState>>,
     max_prefetch_blocks: usize,
     requested: usize,
+    require_full: bool,
 ) -> Option<(usize, SsdPrefetchReservation)> {
     if requested == 0 {
         return None;
@@ -472,7 +484,7 @@ fn reserve_ssd_prefetch_slots(
     let mut guard = state.lock();
     let available = max_prefetch_blocks.saturating_sub(guard.reserved_ssd_prefetch_blocks);
 
-    if available == 0 {
+    if available == 0 || (require_full && available < requested) {
         core_metrics()
             .ssd_prefetch_backpressure_blocks
             .add(requested as u64, &[]);
@@ -582,11 +594,15 @@ async fn run_prefetch_task(deps: PrefetchTaskDeps, input: PrefetchTaskInput) -> 
                 Arc::clone(&deps.prefetch_state),
                 deps.max_prefetch_blocks,
                 found,
+                wait_for_full_prefix,
             )
         {
             let keys = remaining_keys[..reserved].to_vec();
             let (found, blocks) = ssd.prefetch_prefix(keys).await;
-            if found > 0 {
+            // wait_for_full_prefix is all-or-nothing: a partial SSD result
+            // (backpressured reservation or short read) must not let the
+            // caller proceed with a partial prefix.
+            if found > 0 && (!wait_for_full_prefix || found == remaining_keys.len()) {
                 record_tier_attribution(
                     total,
                     hit,
@@ -735,5 +751,99 @@ mod tests {
         assert!(rdma_registration_from_resident_keys(Some(PrefetchSource::Ssd), &[k1]).is_none());
         assert!(rdma_registration_from_resident_keys(Some(PrefetchSource::Rdma), &[]).is_none());
         assert!(rdma_registration_from_resident_keys(None, &[]).is_none());
+    }
+
+    /// Feed a finished prefetch task with the given outcome through
+    /// `poll_existing` and report whether the request got blacklisted.
+    async fn poll_outcome_blacklists_req(
+        source: Option<PrefetchSource>,
+        found: usize,
+        inserts: usize,
+    ) -> bool {
+        let scheduler = PrefetchScheduler::new(None, None, None, 16);
+        let read_cache = ReadCache::new(1 << 20, false, None);
+        let result = PrefetchTaskResult {
+            source,
+            found,
+            cache_inserts: (0..inserts).map(|i| (key(i as u8), block())).collect(),
+            ready_blocks: Vec::new(),
+            missing: 0,
+        };
+        let handle = tokio::spawn(async move { result });
+        while !handle.is_finished() {
+            tokio::task::yield_now().await;
+        }
+        scheduler.state.lock().active.insert(
+            "req".to_string(),
+            PrefetchEntry {
+                handle,
+                started_at: Instant::now(),
+            },
+        );
+
+        let _ = scheduler.poll_existing(&read_cache, "req").await;
+
+        scheduler.state.lock().failed_remote.contains_key("req")
+    }
+
+    #[tokio::test]
+    async fn short_rdma_result_blacklists_request() {
+        // Partial prefix and total failure both mean the advertised owner
+        // could not serve what the MetaServer promised.
+        assert!(poll_outcome_blacklists_req(Some(PrefetchSource::Rdma), 3, 2).await);
+        assert!(poll_outcome_blacklists_req(Some(PrefetchSource::Rdma), 3, 0).await);
+    }
+
+    #[tokio::test]
+    async fn full_or_non_rdma_result_does_not_blacklist() {
+        assert!(!poll_outcome_blacklists_req(Some(PrefetchSource::Rdma), 3, 3).await);
+        assert!(!poll_outcome_blacklists_req(Some(PrefetchSource::Ssd), 3, 2).await);
+        assert!(!poll_outcome_blacklists_req(None, 0, 0).await);
+    }
+
+    #[test]
+    fn gc_sweeps_only_expired_failed_remote_entries() {
+        let scheduler = PrefetchScheduler::new(None, None, None, 16);
+        scheduler
+            .state
+            .lock()
+            .failed_remote
+            .insert("req".to_string(), Instant::now());
+
+        let (_, swept) = scheduler.gc_stale_entries(Duration::ZERO, Duration::from_secs(60));
+        assert_eq!(swept, 0);
+
+        let (_, swept) = scheduler.gc_stale_entries(Duration::ZERO, Duration::ZERO);
+        assert_eq!(swept, 1);
+        assert!(scheduler.state.lock().failed_remote.is_empty());
+    }
+
+    #[test]
+    fn strict_ssd_reservation_is_all_or_nothing() {
+        let state = Arc::new(Mutex::new(PrefetchState {
+            active: HashMap::new(),
+            reserved_ssd_prefetch_blocks: 0,
+            failed_remote: HashMap::new(),
+        }));
+        let (_n, hold) = reserve_ssd_prefetch_slots(Arc::clone(&state), 10, 6, false)
+            .expect("reservation within capacity should succeed");
+        // 4 of 10 slots remain.
+
+        // Strict request above availability is denied and reserves nothing.
+        assert!(reserve_ssd_prefetch_slots(Arc::clone(&state), 10, 5, true).is_none());
+        assert_eq!(state.lock().reserved_ssd_prefetch_blocks, 6);
+
+        // Strict request within availability reserves the full amount.
+        let (reserved, hold2) = reserve_ssd_prefetch_slots(Arc::clone(&state), 10, 4, true)
+            .expect("exact reservation should succeed");
+        assert_eq!(reserved, 4);
+        assert_eq!(state.lock().reserved_ssd_prefetch_blocks, 10);
+        drop(hold2);
+
+        // Non-strict still reserves partially when the full amount is denied.
+        let (reserved, _hold3) = reserve_ssd_prefetch_slots(Arc::clone(&state), 10, 5, false)
+            .expect("partial reservation should succeed");
+        assert_eq!(reserved, 4);
+        drop(hold);
     }
 }

--- a/pegaflow-core/src/storage/prefetch.rs
+++ b/pegaflow-core/src/storage/prefetch.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use log::{info, warn};
 use parking_lot::Mutex;
@@ -20,6 +20,9 @@ use super::read_cache::ReadCache;
 use super::tier_attribution::{
     AttributionSource, TierAttribution, record_cache_tier_block_requests,
 };
+
+const REMOTE_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const REMOTE_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[cfg(feature = "rdma")]
 #[derive(Clone)]
@@ -39,12 +42,19 @@ impl RdmaFetch {
         req_id: &str,
         namespace: &str,
         remaining_hashes: &[Vec<u8>],
+        require_full_prefix: bool,
     ) -> Option<(usize, PrefetchResult)> {
         let (node, found) = self.0.query_prefix(namespace, remaining_hashes).await?;
+        if require_full_prefix && found != remaining_hashes.len() {
+            return None;
+        }
         let blocks = self
             .0
             .fetch_blocks(&node, req_id, namespace, &remaining_hashes[..found])
             .await;
+        if require_full_prefix && blocks.len() != found {
+            return None;
+        }
         Some((found, blocks))
     }
 }
@@ -56,6 +66,7 @@ impl RdmaFetch {
         _req_id: &str,
         _namespace: &str,
         _remaining_hashes: &[Vec<u8>],
+        _require_full_prefix: bool,
     ) -> Option<(usize, PrefetchResult)> {
         None
     }
@@ -94,6 +105,7 @@ struct PrefixScan<'a> {
     namespace: &'a str,
     hashes: &'a [Vec<u8>],
     emit_tier_metrics: bool,
+    wait_for_remote: bool,
 }
 
 struct PrefetchStart<'a> {
@@ -104,6 +116,7 @@ struct PrefetchStart<'a> {
     total: usize,
     hit: usize,
     emit_tier_metrics: bool,
+    wait_for_remote: bool,
 }
 
 struct PrefetchTaskDeps {
@@ -121,6 +134,7 @@ struct PrefetchTaskInput {
     total: usize,
     hit: usize,
     emit_tier_metrics: bool,
+    wait_for_remote: bool,
 }
 
 struct PrefetchState {
@@ -186,6 +200,7 @@ impl PrefetchScheduler {
         req_id: &str,
         namespace: &str,
         hashes: &[Vec<u8>],
+        wait_for_remote: bool,
     ) -> PrefetchStatus {
         // Default: this call may be the first decision and should attribute.
         match self.poll_existing(read_cache, req_id).await {
@@ -203,6 +218,7 @@ impl PrefetchScheduler {
                 namespace,
                 hashes,
                 emit_tier_metrics: true,
+                wait_for_remote,
             },
         )
         .await
@@ -309,6 +325,7 @@ impl PrefetchScheduler {
                 total: keys.len(),
                 hit,
                 emit_tier_metrics: scan.emit_tier_metrics,
+                wait_for_remote: scan.wait_for_remote,
             });
         let task_schedule = task_start.elapsed();
 
@@ -387,6 +404,7 @@ impl PrefetchScheduler {
             total: start.total,
             hit: start.hit,
             emit_tier_metrics: start.emit_tier_metrics,
+            wait_for_remote: start.wait_for_remote,
         };
 
         let handle = tokio::spawn(async move { run_prefetch_task(deps, input).await });
@@ -447,6 +465,10 @@ fn reserve_ssd_prefetch_slots(
     max_prefetch_blocks: usize,
     requested: usize,
 ) -> Option<(usize, SsdPrefetchReservation)> {
+    if requested == 0 {
+        return None;
+    }
+
     let mut guard = state.lock();
     let available = max_prefetch_blocks.saturating_sub(guard.reserved_ssd_prefetch_blocks);
 
@@ -527,12 +549,13 @@ async fn run_prefetch_task(deps: PrefetchTaskDeps, input: PrefetchTaskInput) -> 
         total,
         hit,
         emit_tier_metrics,
+        wait_for_remote,
     } = input;
     let remaining_hashes: Vec<Vec<u8>> = remaining_keys.iter().map(|k| k.hash.clone()).collect();
 
-    if let Some(rdma) = deps.rdma_fetch
+    if let Some(rdma) = deps.rdma_fetch.as_ref()
         && let Some((found, blocks)) = rdma
-            .try_fetch_prefix(&req_id, &namespace, &remaining_hashes)
+            .try_fetch_prefix(&req_id, &namespace, &remaining_hashes, wait_for_remote)
             .await
     {
         record_tier_attribution(
@@ -552,37 +575,67 @@ async fn run_prefetch_task(deps: PrefetchTaskDeps, input: PrefetchTaskInput) -> 
         );
     }
 
-    if let Some(ssd) = deps.ssd_store {
+    if let Some(ssd) = deps.ssd_store.as_ref() {
         let found = ssd.prefix_len(&remaining_keys);
-        if found == 0 {
-            record_tier_attribution(total, hit, 0, None, emit_tier_metrics);
-            return build_ready_result(prefix_blocks, total, None, 0, &[], Vec::new());
-        }
-        let Some((reserved, _reservation)) =
-            reserve_ssd_prefetch_slots(deps.prefetch_state, deps.max_prefetch_blocks, found)
-        else {
-            record_tier_attribution(total, hit, 0, None, emit_tier_metrics);
-            return build_ready_result(prefix_blocks, total, None, 0, &[], Vec::new());
-        };
-        let keys = remaining_keys[..reserved].to_vec();
-        let (found, blocks) = ssd.prefetch_prefix(keys).await;
-        if found > 0 {
-            record_tier_attribution(
-                total,
-                hit,
+        if (!wait_for_remote || found == remaining_keys.len())
+            && let Some((reserved, _reservation)) = reserve_ssd_prefetch_slots(
+                Arc::clone(&deps.prefetch_state),
+                deps.max_prefetch_blocks,
                 found,
-                Some(PrefetchSource::Ssd.as_attribution()),
-                emit_tier_metrics,
-            );
-            return build_ready_result(
-                prefix_blocks,
-                total,
-                Some(PrefetchSource::Ssd),
-                found,
-                &remaining_keys[..found],
-                blocks,
-            );
+            )
+        {
+            let keys = remaining_keys[..reserved].to_vec();
+            let (found, blocks) = ssd.prefetch_prefix(keys).await;
+            if found > 0 {
+                record_tier_attribution(
+                    total,
+                    hit,
+                    found,
+                    Some(PrefetchSource::Ssd.as_attribution()),
+                    emit_tier_metrics,
+                );
+                return build_ready_result(
+                    prefix_blocks,
+                    total,
+                    Some(PrefetchSource::Ssd),
+                    found,
+                    &remaining_keys[..found],
+                    blocks,
+                );
+            }
         }
+    }
+
+    if wait_for_remote && let Some(rdma) = deps.rdma_fetch {
+        let started_at = Instant::now();
+        while started_at.elapsed() < REMOTE_WAIT_TIMEOUT {
+            tokio::time::sleep(REMOTE_WAIT_POLL_INTERVAL).await;
+            if let Some((found, blocks)) = rdma
+                .try_fetch_prefix(&req_id, &namespace, &remaining_hashes, true)
+                .await
+            {
+                record_tier_attribution(
+                    total,
+                    hit,
+                    found,
+                    Some(PrefetchSource::Rdma.as_attribution()),
+                    emit_tier_metrics,
+                );
+                return build_ready_result(
+                    prefix_blocks,
+                    total,
+                    Some(PrefetchSource::Rdma),
+                    found,
+                    &remaining_keys[..found],
+                    blocks,
+                );
+            }
+        }
+        warn!(
+            "Timed out waiting for remote prefix: req_id={} timeout_secs={}",
+            req_id,
+            REMOTE_WAIT_TIMEOUT.as_secs()
+        );
     }
 
     record_tier_attribution(total, hit, 0, None, emit_tier_metrics);

--- a/pegaflow-core/src/storage/prefetch.rs
+++ b/pegaflow-core/src/storage/prefetch.rs
@@ -105,7 +105,7 @@ struct PrefixScan<'a> {
     namespace: &'a str,
     hashes: &'a [Vec<u8>],
     emit_tier_metrics: bool,
-    wait_for_remote: bool,
+    wait_for_full_prefix: bool,
 }
 
 struct PrefetchStart<'a> {
@@ -116,7 +116,7 @@ struct PrefetchStart<'a> {
     total: usize,
     hit: usize,
     emit_tier_metrics: bool,
-    wait_for_remote: bool,
+    wait_for_full_prefix: bool,
 }
 
 struct PrefetchTaskDeps {
@@ -134,7 +134,7 @@ struct PrefetchTaskInput {
     total: usize,
     hit: usize,
     emit_tier_metrics: bool,
-    wait_for_remote: bool,
+    wait_for_full_prefix: bool,
 }
 
 struct PrefetchState {
@@ -200,7 +200,7 @@ impl PrefetchScheduler {
         req_id: &str,
         namespace: &str,
         hashes: &[Vec<u8>],
-        wait_for_remote: bool,
+        wait_for_full_prefix: bool,
     ) -> PrefetchStatus {
         // Default: this call may be the first decision and should attribute.
         match self.poll_existing(read_cache, req_id).await {
@@ -218,7 +218,7 @@ impl PrefetchScheduler {
                 namespace,
                 hashes,
                 emit_tier_metrics: true,
-                wait_for_remote,
+                wait_for_full_prefix,
             },
         )
         .await
@@ -325,7 +325,7 @@ impl PrefetchScheduler {
                 total: keys.len(),
                 hit,
                 emit_tier_metrics: scan.emit_tier_metrics,
-                wait_for_remote: scan.wait_for_remote,
+                wait_for_full_prefix: scan.wait_for_full_prefix,
             });
         let task_schedule = task_start.elapsed();
 
@@ -404,7 +404,7 @@ impl PrefetchScheduler {
             total: start.total,
             hit: start.hit,
             emit_tier_metrics: start.emit_tier_metrics,
-            wait_for_remote: start.wait_for_remote,
+            wait_for_full_prefix: start.wait_for_full_prefix,
         };
 
         let handle = tokio::spawn(async move { run_prefetch_task(deps, input).await });
@@ -549,13 +549,13 @@ async fn run_prefetch_task(deps: PrefetchTaskDeps, input: PrefetchTaskInput) -> 
         total,
         hit,
         emit_tier_metrics,
-        wait_for_remote,
+        wait_for_full_prefix,
     } = input;
     let remaining_hashes: Vec<Vec<u8>> = remaining_keys.iter().map(|k| k.hash.clone()).collect();
 
     if let Some(rdma) = deps.rdma_fetch.as_ref()
         && let Some((found, blocks)) = rdma
-            .try_fetch_prefix(&req_id, &namespace, &remaining_hashes, wait_for_remote)
+            .try_fetch_prefix(&req_id, &namespace, &remaining_hashes, wait_for_full_prefix)
             .await
     {
         record_tier_attribution(
@@ -577,7 +577,7 @@ async fn run_prefetch_task(deps: PrefetchTaskDeps, input: PrefetchTaskInput) -> 
 
     if let Some(ssd) = deps.ssd_store.as_ref() {
         let found = ssd.prefix_len(&remaining_keys);
-        if (!wait_for_remote || found == remaining_keys.len())
+        if (!wait_for_full_prefix || found == remaining_keys.len())
             && let Some((reserved, _reservation)) = reserve_ssd_prefetch_slots(
                 Arc::clone(&deps.prefetch_state),
                 deps.max_prefetch_blocks,
@@ -606,7 +606,7 @@ async fn run_prefetch_task(deps: PrefetchTaskDeps, input: PrefetchTaskInput) -> 
         }
     }
 
-    if wait_for_remote && let Some(rdma) = deps.rdma_fetch {
+    if wait_for_full_prefix && let Some(rdma) = deps.rdma_fetch {
         let started_at = Instant::now();
         while started_at.elapsed() < REMOTE_WAIT_TIMEOUT {
             tokio::time::sleep(REMOTE_WAIT_POLL_INTERVAL).await;

--- a/pegaflow-core/tests/common/harness.rs
+++ b/pegaflow-core/tests/common/harness.rs
@@ -383,7 +383,7 @@ impl TestEnv {
     /// Query prefix hits. Returns raw PrefetchStatus.
     pub async fn query(&self, hashes: &[Vec<u8>]) -> PrefetchStatus {
         self.engine
-            .count_prefix_hit_blocks_with_prefetch(&self.instance_id, "test", hashes)
+            .count_prefix_hit_blocks_with_prefetch(&self.instance_id, "test", hashes, false)
             .await
             .expect("query")
     }

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -92,6 +92,7 @@ message QueryRequest {
   string instance_id = 1;
   repeated bytes block_hashes = 2;
   string req_id = 3;
+  bool wait_for_remote = 4;
 }
 
 message QueryResponse {

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -92,6 +92,9 @@ message QueryRequest {
   string instance_id = 1;
   repeated bytes block_hashes = 2;
   string req_id = 3;
+  // Keep the query in Loading until the full remaining prefix is fetchable
+  // from a remote node via MetaServer + RDMA. Does not observe saves landing
+  // in the local engine; no effect when RDMA is not configured.
   bool wait_for_full_prefix = 4;
 }
 

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -92,7 +92,7 @@ message QueryRequest {
   string instance_id = 1;
   repeated bytes block_hashes = 2;
   string req_id = 3;
-  bool wait_for_remote = 4;
+  bool wait_for_full_prefix = 4;
 }
 
 message QueryResponse {

--- a/pegaflow-server/examples/p2p_bench.rs
+++ b/pegaflow-server/examples/p2p_bench.rs
@@ -444,7 +444,7 @@ async fn wait_until<F: FnMut() -> Option<usize>>(
 
 async fn cached_blocks(engine: &PegaEngine, req_id: &str, hashes: &[Vec<u8>]) -> usize {
     match engine
-        .count_prefix_hit_blocks_with_prefetch(INSTANCE, req_id, hashes)
+        .count_prefix_hit_blocks_with_prefetch(INSTANCE, req_id, hashes, false)
         .await
         .expect("count_prefix_hit_blocks_with_prefetch")
     {
@@ -676,7 +676,7 @@ async fn verify_set(
     ranks: &[RankBuffers],
 ) {
     let blocks = match engine
-        .count_prefix_hit_blocks_with_prefetch(INSTANCE, &format!("verify-{set}"), hashes)
+        .count_prefix_hit_blocks_with_prefetch(INSTANCE, &format!("verify-{set}"), hashes, false)
         .await
         .expect("verify query")
     {

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -1,9 +1,7 @@
-use log::warn;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use std::collections::{HashMap, HashSet};
-use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug, Clone)]
@@ -179,7 +177,8 @@ impl CudaTensorRegistry {
 
             cuda.call_method1("set_device", (device_id,))?;
 
-            let wrapper = pickle.call_method1("loads", (PyBytes::new(py, wrapper_bytes),))?;
+            let py_bytes = PyBytes::new(py, wrapper_bytes);
+            let wrapper = pickle.call_method1("loads", (py_bytes,))?;
             let tensor = wrapper.call_method0("to_tensor")?;
 
             let data_ptr: u64 = tensor.call_method0("data_ptr")?.extract()?;
@@ -265,34 +264,6 @@ impl RegistryHandle {
     /// tensor is materialized, and a materialization failure does not publish a
     /// partial context.
     pub async fn register_layers(
-        &self,
-        context_key: String,
-        device_id: i32,
-        layers: Vec<(String, Vec<u8>)>,
-    ) -> Result<Vec<TensorMetadata>, String> {
-        let retry_context_key = context_key.clone();
-        let retry_layers = layers.clone();
-        let result = self
-            .register_layers_once(context_key, device_id, layers)
-            .await;
-
-        match result {
-            Err(message)
-                if message.contains("invalid device context")
-                    || message.contains("cudaErrorDeviceUninitialized") =>
-            {
-                warn!(
-                    "Retrying CUDA IPC tensor registration after initialization backoff: device={device_id}"
-                );
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                self.register_layers_once(retry_context_key, device_id, retry_layers)
-                    .await
-            }
-            result => result,
-        }
-    }
-
-    async fn register_layers_once(
         &self,
         context_key: String,
         device_id: i32,

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -179,26 +179,7 @@ impl CudaTensorRegistry {
             cuda.call_method1("set_device", (device_id,))?;
 
             let wrapper = pickle.call_method1("loads", (PyBytes::new(py, wrapper_bytes),))?;
-            let tensor = match wrapper.call_method0("to_tensor") {
-                Ok(tensor) => tensor,
-                Err(err) => {
-                    let message = err.value(py).to_string();
-                    if !message.contains("invalid device context")
-                        && !message.contains("cudaErrorDeviceUninitialized")
-                    {
-                        return Err(err);
-                    }
-
-                    warn!(
-                        "Retrying CUDA IPC tensor materialization after device context initialization failed: device={device_id}"
-                    );
-                    drop(wrapper);
-                    cuda.call_method1("set_device", (device_id,))?;
-                    let wrapper =
-                        pickle.call_method1("loads", (PyBytes::new(py, wrapper_bytes),))?;
-                    wrapper.call_method0("to_tensor")?
-                }
-            };
+            let tensor = wrapper.call_method0("to_tensor")?;
 
             let data_ptr: u64 = tensor.call_method0("data_ptr")?.extract()?;
             let device_attr = tensor.getattr("device")?;
@@ -283,6 +264,33 @@ impl RegistryHandle {
     /// tensor is materialized, and a materialization failure does not publish a
     /// partial context.
     pub async fn register_layers(
+        &self,
+        context_key: String,
+        device_id: i32,
+        layers: Vec<(String, Vec<u8>)>,
+    ) -> Result<Vec<TensorMetadata>, String> {
+        let retry_context_key = context_key.clone();
+        let retry_layers = layers.clone();
+        let result = self
+            .register_layers_once(context_key, device_id, layers)
+            .await;
+
+        match result {
+            Err(message)
+                if message.contains("invalid device context")
+                    || message.contains("cudaErrorDeviceUninitialized") =>
+            {
+                warn!(
+                    "Retrying CUDA IPC tensor registration after yielding to queued contexts: device={device_id}"
+                );
+                self.register_layers_once(retry_context_key, device_id, retry_layers)
+                    .await
+            }
+            result => result,
+        }
+    }
+
+    async fn register_layers_once(
         &self,
         context_key: String,
         device_id: i32,

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -1,6 +1,7 @@
+use log::warn;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict};
+use pyo3::types::PyBytes;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::{mpsc, oneshot};
 
@@ -85,8 +86,6 @@ impl CudaTensorRegistry {
             }
         }
 
-        Self::activate_device(device_id)?;
-
         let mut context = ContextState::new(device_id);
         let mut metadatas = Vec::with_capacity(layers.len());
         for (layer_name, wrapper_bytes) in layers {
@@ -106,19 +105,6 @@ impl CudaTensorRegistry {
 
         self.contexts.insert(context_key.to_string(), context);
         Ok(metadatas)
-    }
-
-    fn activate_device(device_id: i32) -> PyResult<()> {
-        Python::attach(|py| {
-            let torch = py.import("torch")?;
-            let cuda = torch.getattr("cuda")?;
-            cuda.call_method1("set_device", (device_id,))?;
-
-            let kwargs = PyDict::new(py);
-            kwargs.set_item("device", format!("cuda:{device_id}"))?;
-            torch.call_method("empty", ([1],), Some(&kwargs))?;
-            Ok(())
-        })
     }
 
     fn drop_context(&mut self, context_key: &str) -> usize {
@@ -192,9 +178,27 @@ impl CudaTensorRegistry {
 
             cuda.call_method1("set_device", (device_id,))?;
 
-            let py_bytes = PyBytes::new(py, wrapper_bytes);
-            let wrapper = pickle.call_method1("loads", (py_bytes,))?;
-            let tensor = wrapper.call_method0("to_tensor")?;
+            let wrapper = pickle.call_method1("loads", (PyBytes::new(py, wrapper_bytes),))?;
+            let tensor = match wrapper.call_method0("to_tensor") {
+                Ok(tensor) => tensor,
+                Err(err) => {
+                    let message = err.value(py).to_string();
+                    if !message.contains("invalid device context")
+                        && !message.contains("cudaErrorDeviceUninitialized")
+                    {
+                        return Err(err);
+                    }
+
+                    warn!(
+                        "Retrying CUDA IPC tensor materialization after device context initialization failed: device={device_id}"
+                    );
+                    drop(wrapper);
+                    cuda.call_method1("set_device", (device_id,))?;
+                    let wrapper =
+                        pickle.call_method1("loads", (PyBytes::new(py, wrapper_bytes),))?;
+                    wrapper.call_method0("to_tensor")?
+                }
+            };
 
             let data_ptr: u64 = tensor.call_method0("data_ptr")?.extract()?;
             let device_attr = tensor.getattr("device")?;

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -3,6 +3,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug, Clone)]
@@ -281,8 +282,9 @@ impl RegistryHandle {
                     || message.contains("cudaErrorDeviceUninitialized") =>
             {
                 warn!(
-                    "Retrying CUDA IPC tensor registration after yielding to queued contexts: device={device_id}"
+                    "Retrying CUDA IPC tensor registration after initialization backoff: device={device_id}"
                 );
+                tokio::time::sleep(Duration::from_millis(100)).await;
                 self.register_layers_once(retry_context_key, device_id, retry_layers)
                     .await
             }

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -1,6 +1,6 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::PyBytes;
+use pyo3::types::{PyBytes, PyDict};
 use std::collections::{HashMap, HashSet};
 use tokio::sync::{mpsc, oneshot};
 
@@ -85,6 +85,8 @@ impl CudaTensorRegistry {
             }
         }
 
+        Self::activate_device(device_id)?;
+
         let mut context = ContextState::new(device_id);
         let mut metadatas = Vec::with_capacity(layers.len());
         for (layer_name, wrapper_bytes) in layers {
@@ -104,6 +106,19 @@ impl CudaTensorRegistry {
 
         self.contexts.insert(context_key.to_string(), context);
         Ok(metadatas)
+    }
+
+    fn activate_device(device_id: i32) -> PyResult<()> {
+        Python::attach(|py| {
+            let torch = py.import("torch")?;
+            let cuda = torch.getattr("cuda")?;
+            cuda.call_method1("set_device", (device_id,))?;
+
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("device", format!("cuda:{device_id}"))?;
+            torch.call_method("empty", ([1],), Some(&kwargs))?;
+            Ok(())
+        })
     }
 
     fn drop_context(&mut self, context_key: &str) -> usize {

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -1,6 +1,6 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict};
+use pyo3::types::PyBytes;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::{mpsc, oneshot};
 
@@ -85,8 +85,6 @@ impl CudaTensorRegistry {
             }
         }
 
-        Self::activate_device(device_id)?;
-
         let mut context = ContextState::new(device_id);
         let mut metadatas = Vec::with_capacity(layers.len());
         for (layer_name, wrapper_bytes) in layers {
@@ -106,19 +104,6 @@ impl CudaTensorRegistry {
 
         self.contexts.insert(context_key.to_string(), context);
         Ok(metadatas)
-    }
-
-    fn activate_device(device_id: i32) -> PyResult<()> {
-        Python::attach(|py| {
-            let torch = py.import("torch")?;
-            let cuda = torch.getattr("cuda")?;
-            cuda.call_method1("set_device", (device_id,))?;
-
-            let kwargs = PyDict::new(py);
-            kwargs.set_item("device", format!("cuda:{device_id}"))?;
-            torch.call_method("empty", ([1],), Some(&kwargs))?;
-            Ok(())
-        })
     }
 
     fn drop_context(&mut self, context_key: &str) -> usize {

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -538,6 +538,7 @@ impl Engine for GrpcEngineService {
                     &req.instance_id,
                     &req.req_id,
                     &req.block_hashes,
+                    req.wait_for_remote,
                 )
                 .await
                 .map_err(Self::map_engine_error)?;
@@ -969,6 +970,7 @@ mod tests {
             instance_id: "instance".to_string(),
             block_hashes: Vec::new(),
             req_id: String::new(),
+            wait_for_remote: false,
         })
         .expect_err("empty req_id must be rejected before engine lookup");
 
@@ -982,6 +984,7 @@ mod tests {
             instance_id: "instance".to_string(),
             block_hashes: Vec::new(),
             req_id: "request".to_string(),
+            wait_for_remote: false,
         })
         .expect("empty block_hashes are a valid zero-hit query");
     }

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -538,7 +538,7 @@ impl Engine for GrpcEngineService {
                     &req.instance_id,
                     &req.req_id,
                     &req.block_hashes,
-                    req.wait_for_remote,
+                    req.wait_for_full_prefix,
                 )
                 .await
                 .map_err(Self::map_engine_error)?;
@@ -970,7 +970,7 @@ mod tests {
             instance_id: "instance".to_string(),
             block_hashes: Vec::new(),
             req_id: String::new(),
-            wait_for_remote: false,
+            wait_for_full_prefix: false,
         })
         .expect_err("empty req_id must be rejected before engine lookup");
 
@@ -984,7 +984,7 @@ mod tests {
             instance_id: "instance".to_string(),
             block_hashes: Vec::new(),
             req_id: "request".to_string(),
-            wait_for_remote: false,
+            wait_for_full_prefix: false,
         })
         .expect("empty block_hashes are a valid zero-hit query");
     }

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -260,6 +260,7 @@ impl MockVllmRpcHarness {
             instance_id: instance_id.to_string(),
             block_hashes: hashes.to_vec(),
             req_id: req_id.to_string(),
+            wait_for_remote: false,
         };
         match self.scheduler.query_prefetch(request.clone()).await {
             Ok(response) => Ok(RpcExchange {
@@ -402,7 +403,7 @@ impl MockVllmRpcHarness {
         loop {
             match self
                 ._engine
-                .count_prefix_hit_blocks_with_prefetch(INSTANCE_ID, &req_id, hashes)
+                .count_prefix_hit_blocks_with_prefetch(INSTANCE_ID, &req_id, hashes, false)
                 .await
                 .expect("direct save visibility query")
             {

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -260,7 +260,7 @@ impl MockVllmRpcHarness {
             instance_id: instance_id.to_string(),
             block_hashes: hashes.to_vec(),
             req_id: req_id.to_string(),
-            wait_for_remote: false,
+            wait_for_full_prefix: false,
         };
         match self.scheduler.query_prefetch(request.clone()).await {
             Ok(response) => Ok(RpcExchange {

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -183,7 +183,12 @@ async fn wait_for_cache(
     let deadline = Instant::now() + timeout;
     loop {
         let status = engine
-            .count_prefix_hit_blocks_with_prefetch(instance_id, "wait-for-cache", block_hashes)
+            .count_prefix_hit_blocks_with_prefetch(
+                instance_id,
+                "wait-for-cache",
+                block_hashes,
+                false,
+            )
             .await
             .expect("count_prefix_hit_blocks_with_prefetch");
         let hit = match status {
@@ -257,11 +262,17 @@ async fn wait_for_prefetch_done(
     block_hashes: &[Vec<u8>],
     expected_hit: usize,
     timeout: Duration,
+    wait_for_remote: bool,
 ) -> QueryLeaseId {
     let deadline = Instant::now() + timeout;
     loop {
         let status = engine
-            .count_prefix_hit_blocks_with_prefetch(instance_id, req_id, block_hashes)
+            .count_prefix_hit_blocks_with_prefetch(
+                instance_id,
+                req_id,
+                block_hashes,
+                wait_for_remote,
+            )
             .await
             .expect("count_prefix_hit_blocks_with_prefetch");
         match status {
@@ -430,31 +441,69 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
         )
         .expect("register layer on engine B");
 
-    // ── 8. Remote fetch: Engine B discovers blocks via MetaServer → RDMA READ ──
-    let lease = wait_for_prefetch_done(
-        &engine_b,
-        "inst-b",
-        "req-1",
-        &block_hashes,
+    // ── 8. Start the remote query before the producer registers the blocks ──
+    let delayed_hashes = make_block_hashes(NUM_BLOCKS, 43);
+    let status = engine_b
+        .count_prefix_hit_blocks_with_prefetch(
+            "inst-b",
+            "req-wait-for-producer",
+            &delayed_hashes,
+            true,
+        )
+        .await
+        .expect("start producer wait");
+    assert!(matches!(status, PrefetchStatus::Loading));
+
+    engine_a
+        .batch_save_kv_blocks_from_ipc(
+            "inst-a",
+            0,
+            0,
+            DEVICE_ID,
+            vec![LayerSave {
+                layer_name: LAYER.to_string(),
+                block_ids: block_ids.clone(),
+                block_hashes: delayed_hashes.clone(),
+            }],
+        )
+        .await
+        .expect("save delayed blocks on engine A");
+
+    wait_for_metaserver_registration(
+        &meta_store,
+        NAMESPACE,
+        &delayed_hashes,
         NUM_BLOCKS,
-        Duration::from_secs(30),
+        Duration::from_secs(10),
     )
     .await;
 
-    // ── 8b. Verify Engine B re-registered fetched blocks to MetaServer ──
+    // ── 9. Engine B observes the producer and fetches via RDMA READ ──
+    let lease = wait_for_prefetch_done(
+        &engine_b,
+        "inst-b",
+        "req-wait-for-producer",
+        &delayed_hashes,
+        NUM_BLOCKS,
+        Duration::from_secs(30),
+        true,
+    )
+    .await;
+
+    // ── 9b. Verify Engine B re-registered fetched blocks to MetaServer ──
     // RDMA-fetched blocks are now resident on B, so B must advertise them so
     // other nodes can discover and fetch from B (not just from A).
     wait_for_metaserver_ownership(
         &meta_store,
         NAMESPACE,
-        &block_hashes,
+        &delayed_hashes,
         &format!("127.0.0.1:{port_b}"),
         NUM_BLOCKS,
         Duration::from_secs(10),
     )
     .await;
 
-    // ── 9. Load from Engine B cache → GPU ──
+    // ── 10. Load from Engine B cache → GPU ──
     let load_state = LoadState::new().expect("create LoadState");
     let shm_name = load_state.shm_name().to_string();
 
@@ -480,7 +529,7 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
-    // ── 10. Verify data integrity ──
+    // ── 11. Verify data integrity ──
     let loaded = gpu_b.copy_to_host();
     assert_eq!(
         loaded, host_data,

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -262,7 +262,7 @@ async fn wait_for_prefetch_done(
     block_hashes: &[Vec<u8>],
     expected_hit: usize,
     timeout: Duration,
-    wait_for_remote: bool,
+    wait_for_full_prefix: bool,
 ) -> QueryLeaseId {
     let deadline = Instant::now() + timeout;
     loop {
@@ -271,7 +271,7 @@ async fn wait_for_prefetch_done(
                 instance_id,
                 req_id,
                 block_hashes,
-                wait_for_remote,
+                wait_for_full_prefix,
             )
             .await
             .expect("count_prefix_hit_blocks_with_prefetch");

--- a/python/README.md
+++ b/python/README.md
@@ -109,6 +109,17 @@ vllm serve Qwen/Qwen3-0.6B \
 
 Valid values are `read_write` and `save_only`.
 
+#### P/D Partial Tail Blocks
+
+vLLM normally exposes hashes only for complete KV blocks. In a P/D deployment,
+enable `pegaflow.pd_tail_save` on prefill and `pegaflow.pd_tail_load` on decode
+to reuse the final partial prompt block as well. Start both vLLM processes with
+the same explicit `PYTHONHASHSEED` and `--prefix-caching-hash-algo xxhash_cbor`.
+
+Prefill: `{"pegaflow.pd_tail_save": true}`
+
+Decode: `{"pegaflow.pd_tail_load": true, "pegaflow.wait_for_remote": true}`
+
 ## Development
 
 See the [examples](../examples/) directory for more usage examples.

--- a/python/README.md
+++ b/python/README.md
@@ -118,7 +118,7 @@ the same explicit `PYTHONHASHSEED` and `--prefix-caching-hash-algo xxhash_cbor`.
 
 Prefill: `{"pegaflow.pd_tail_save": true}`
 
-Decode: `{"pegaflow.pd_tail_load": true, "pegaflow.wait_for_remote": true}`
+Decode: `{"pegaflow.pd_tail_load": true, "pegaflow.wait_for_full_prefix": true}`
 
 ## Development
 

--- a/python/README.md
+++ b/python/README.md
@@ -120,6 +120,12 @@ Prefill: `{"pegaflow.pd_tail_save": true}`
 
 Decode: `{"pegaflow.pd_tail_load": true, "pegaflow.wait_for_full_prefix": true}`
 
+`pegaflow.wait_for_full_prefix` makes decode wait (up to 30s) until the full
+prompt prefix is fetchable from a remote node via MetaServer + RDMA. It only
+applies when prefill and decode run separate engines; it does not observe
+saves landing in a shared/local engine and has no effect when RDMA is not
+configured.
+
 ## Development
 
 See the [examples](../examples/) directory for more usage examples.

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -155,8 +155,14 @@ class PegaKVConnector(KVConnectorBase_V1):
             pd_tail_save = bool(
                 vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.pd_tail_save", False)
             )
+            pd_tail_load = bool(
+                vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.pd_tail_load", False)
+            )
             self._scheduler = SchedulerConnector(
-                self._ctx, pd_tail_save=pd_tail_save, vllm_config=vllm_config
+                self._ctx,
+                pd_tail_save=pd_tail_save,
+                pd_tail_load=pd_tail_load,
+                vllm_config=vllm_config,
             )
             # Open the liveness stream from the scheduler process only. One
             # stream per vllm replica is enough — if any tp worker crashes,

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -106,6 +106,9 @@ class PegaKVConnector(KVConnectorBase_V1):
             is_mla,
             vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.transfer_backend", None),
         )
+        wait_for_remote = bool(
+            vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.wait_for_remote", False)
+        )
         self._engine_endpoint = f"{server_host}:{server_port}"
         engine_client = EngineRpcClient(self._engine_endpoint)
         logger.debug("[PegaKVConnector] Connected to engine server at %s", self._engine_endpoint)
@@ -130,6 +133,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             pp_rank=pp_rank,
             pp_size=pp_size,
             mode=mode,
+            wait_for_remote=wait_for_remote,
         )
 
         # MLA attention backends expose no num-layers stride dimension, so vLLM
@@ -169,7 +173,8 @@ class PegaKVConnector(KVConnectorBase_V1):
         logger.debug(
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
             "tp_rank=%s tp_size=%d pp_rank=%d pp_size=%d world_size=%d namespace=%s "
-            "is_mla=%s transfer_backend=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d mode=%s",
+            "is_mla=%s transfer_backend=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d "
+            "mode=%s wait_for_remote=%s",
             role.name,
             instance_id,
             device_id if device_id is not None else "cpu",
@@ -185,6 +190,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             pcp_world_size,
             dcp_rank,
             mode.value,
+            wait_for_remote,
         )
 
     # ==============================

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -106,8 +106,10 @@ class PegaKVConnector(KVConnectorBase_V1):
             is_mla,
             vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.transfer_backend", None),
         )
-        wait_for_remote = bool(
-            vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.wait_for_remote", False)
+        wait_for_full_prefix = bool(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "pegaflow.wait_for_full_prefix", False
+            )
         )
         self._engine_endpoint = f"{server_host}:{server_port}"
         engine_client = EngineRpcClient(self._engine_endpoint)
@@ -133,7 +135,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             pp_rank=pp_rank,
             pp_size=pp_size,
             mode=mode,
-            wait_for_remote=wait_for_remote,
+            wait_for_full_prefix=wait_for_full_prefix,
         )
 
         # MLA attention backends expose no num-layers stride dimension, so vLLM
@@ -180,7 +182,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
             "tp_rank=%s tp_size=%d pp_rank=%d pp_size=%d world_size=%d namespace=%s "
             "is_mla=%s transfer_backend=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d "
-            "mode=%s wait_for_remote=%s",
+            "mode=%s wait_for_full_prefix=%s",
             role.name,
             instance_id,
             device_id if device_id is not None else "cpu",
@@ -196,7 +198,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             pcp_world_size,
             dcp_rank,
             mode.value,
-            wait_for_remote,
+            wait_for_full_prefix,
         )
 
     # ==============================

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -61,7 +61,7 @@ class ConnectorContext:
     pp_rank: int = 0
     pp_size: int = 1
     mode: PegaConnectorMode = PegaConnectorMode.READ_WRITE
-    wait_for_remote: bool = False
+    wait_for_full_prefix: bool = False
 
     @property
     def read_enabled(self) -> bool:

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -61,6 +61,7 @@ class ConnectorContext:
     pp_rank: int = 0
     pp_size: int = 1
     mode: PegaConnectorMode = PegaConnectorMode.READ_WRITE
+    wait_for_remote: bool = False
 
     @property
     def read_enabled(self) -> bool:

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -609,6 +609,7 @@ class SchedulerConnector:
             self._ctx.instance_id,
             block_hash_list,
             req_id=req_id,
+            wait_for_remote=self._ctx.wait_for_remote,
         )
 
         if isinstance(result, QueryLoading):

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -42,6 +42,7 @@ class _QueryProbe:
 
     computed_blocks: int
     query_hashes: tuple[bytes, ...]
+    tail_tokens: int = 0
 
     # ``None`` means the backend is still loading.
     hit_blocks: int | None = None
@@ -51,8 +52,17 @@ class _QueryProbe:
     def is_ready(self) -> bool:
         return self.hit_blocks is not None
 
-    def matches(self, computed_blocks: int, query_hashes: tuple[bytes, ...]) -> bool:
-        return self.computed_blocks == computed_blocks and self.query_hashes == query_hashes
+    def matches(
+        self,
+        computed_blocks: int,
+        query_hashes: tuple[bytes, ...],
+        tail_tokens: int,
+    ) -> bool:
+        return (
+            self.computed_blocks == computed_blocks
+            and self.query_hashes == query_hashes
+            and self.tail_tokens == tail_tokens
+        )
 
     def mark_ready(self, ready: QueryReady) -> None:
         hit_blocks = ready.num_hit_blocks
@@ -82,6 +92,7 @@ class SchedulerConnector:
         self,
         context: ConnectorContext,
         pd_tail_save: bool = False,
+        pd_tail_load: bool = False,
         vllm_config=None,
     ):
         self._ctx = context
@@ -95,13 +106,18 @@ class SchedulerConnector:
         # well-defined, and independently derivable by the decode peer.
         # Only xxhash_cbor is validated cross-engine; everything else is
         # rejected (the pickle-based algos aren't even derivable elsewhere).
+        self._tail_save_enabled = pd_tail_save
+        self._tail_load_enabled = pd_tail_load
         self._tail_hash_fn = None
-        if pd_tail_save:
+        if pd_tail_save or pd_tail_load:
             assert vllm_config is not None
             algo = vllm_config.cache_config.prefix_caching_hash_algo
             if algo != "xxhash_cbor":
+                enabled_option = (
+                    "pegaflow.pd_tail_save" if pd_tail_save else "pegaflow.pd_tail_load"
+                )
                 raise ValueError(
-                    f"pegaflow.pd_tail_save requires prefix_caching_hash_algo "
+                    f"{enabled_option} requires prefix_caching_hash_algo "
                     f"'xxhash_cbor' (cross-engine derivable, validated); got {algo!r} — "
                     f"run vLLM with --prefix-caching-hash-algo xxhash_cbor"
                 )
@@ -114,7 +130,12 @@ class SchedulerConnector:
             # runs after connector construction — it must be read lazily
             # through the module, never imported by name here.
             self._kv_cache_utils = kv_cache_utils
-            logger.info("[PegaKVConnector] P/D tail-block save enabled (algo=%s)", algo)
+            logger.info(
+                "[PegaKVConnector] P/D tail-block cache enabled (save=%s load=%s algo=%s)",
+                pd_tail_save,
+                pd_tail_load,
+                algo,
+            )
         self._tail_saved: set[str] = set()
 
         # Load state
@@ -157,7 +178,7 @@ class SchedulerConnector:
             return (0, False)
 
         computed_blocks = num_computed_tokens // self._ctx.virtual_block_size
-        query_hashes = tuple(request.block_hashes[computed_blocks:])
+        query_hashes, tail_tokens = self._build_query(request, computed_blocks)
 
         # Everything is already computed locally.
         if not query_hashes:
@@ -170,7 +191,7 @@ class SchedulerConnector:
         # Ready result already cached.  Reuse it only if the request identity
         # has not drifted since the query was issued.
         if probe is not None and probe.is_ready:
-            if probe.matches(computed_blocks, query_hashes):
+            if probe.matches(computed_blocks, query_hashes, tail_tokens):
                 return self._finish_cache_lookup(
                     req_id=req_id,
                     num_tokens=request.num_tokens,
@@ -194,12 +215,13 @@ class SchedulerConnector:
                 self._pending_query_probes[req_id] = _QueryProbe(
                     computed_blocks=computed_blocks,
                     query_hashes=query_hashes,
+                    tail_tokens=tail_tokens,
                 )
             return (None, False)
 
         # A previous Loading probe exists, but the request has moved on.
         # This Ready belongs to the old query.  Do not consume it.
-        if probe is not None and not probe.matches(computed_blocks, query_hashes):
+        if probe is not None and not probe.matches(computed_blocks, query_hashes, tail_tokens):
             logger.warning(
                 "[PegaKVConnector] req=%s query identity drifted: "
                 "snapshot computed=%d/%d hashes, current computed=%d/%d hashes "
@@ -222,6 +244,7 @@ class SchedulerConnector:
             probe = _QueryProbe(
                 computed_blocks=computed_blocks,
                 query_hashes=query_hashes,
+                tail_tokens=tail_tokens,
             )
             self._pending_query_probes[req_id] = probe
 
@@ -245,25 +268,38 @@ class SchedulerConnector:
     ) -> tuple[int, bool]:
         hit_blocks = probe.require_hit_blocks()
         computed_blocks = probe.computed_blocks
-        hit_tokens = hit_blocks * self._ctx.virtual_block_size
+        vbs = self._ctx.virtual_block_size
+        tail_hit = probe.tail_tokens > 0 and hit_blocks == len(probe.query_hashes)
+        hit_tokens = (hit_blocks - 1) * vbs + probe.tail_tokens if tail_hit else hit_blocks * vbs
 
-        self._external_matched_blocks[req_id] = computed_blocks + hit_blocks
+        # A request still needs one forward token to produce logits. The last
+        # loaded page may contain that token's KV, but vLLM must recompute and
+        # overwrite it unless a P/D router supplied a separate decode token.
+        locally_computed_tokens = computed_blocks * vbs
+        hit_tokens = min(hit_tokens, max(0, num_tokens - locally_computed_tokens - 1))
+
+        loaded_blocks = (hit_tokens + vbs - 1) // vbs
+        self._external_matched_blocks[req_id] = computed_blocks + loaded_blocks
 
         if reused:
             logger.debug(
                 "[PegaKVConnector] req=%s cache_lookup_reuse: hit_blocks=%d "
-                "computed_blocks=%d hit_tokens=%d num_tokens=%d total_query_hashes=%d",
+                "computed_blocks=%d hit_tokens=%d num_tokens=%d total_query_hashes=%d "
+                "tail_hit=%s tail_tokens=%d",
                 req_id,
                 hit_blocks,
                 computed_blocks,
                 hit_tokens,
                 num_tokens,
                 len(probe.query_hashes),
+                tail_hit,
+                probe.tail_tokens,
             )
         else:
             logger.info(
                 "[PegaKVConnector] req=%s cache_lookup: hit_blocks=%d computed_blocks=%d "
-                "hit_tokens=%d num_tokens=%d lookup_us=%.0f total_query_hashes=%d",
+                "hit_tokens=%d num_tokens=%d lookup_us=%.0f total_query_hashes=%d "
+                "tail_hit=%s tail_tokens=%d",
                 req_id,
                 hit_blocks,
                 computed_blocks,
@@ -271,6 +307,8 @@ class SchedulerConnector:
                 num_tokens,
                 lookup_us or 0.0,
                 len(probe.query_hashes),
+                tail_hit,
+                probe.tail_tokens,
             )
 
         if hit_tokens <= 0:
@@ -312,12 +350,10 @@ class SchedulerConnector:
                 sum(block.block_hash is not None for block in blocks.blocks[0]) if blocks else 0
             )
             start_block_idx = num_computed_blocks
-            num_load_blocks = num_external_tokens // self._ctx.virtual_block_size
+            vbs = self._ctx.virtual_block_size
+            num_load_blocks = (num_external_tokens + vbs - 1) // vbs
             expected_load_blocks = len(block_ids) - num_computed_blocks
-            if (
-                num_external_tokens % self._ctx.virtual_block_size != 0
-                or num_load_blocks != expected_load_blocks
-            ):
+            if num_load_blocks != expected_load_blocks:
                 self._release_pending_query_probe(req_id)
                 raise RuntimeError(
                     f"req {req_id} load block mismatch: external={num_load_blocks} "
@@ -330,15 +366,14 @@ class SchedulerConnector:
                 lease=pending_probe.lease if pending_probe is not None else b"",
                 num_tokens=num_external_tokens,
             )
-            if (
-                pending_probe is not None
-                and tuple(
-                    self._block_hashes[req_id][start_block_idx : start_block_idx + num_load_blocks]
-                )
-                != pending_probe.leased_hashes
-            ):
-                self._release_pending_query_probe(req_id)
-                raise RuntimeError(f"req {req_id} load hashes do not match pending query probe")
+            if pending_probe is not None:
+                query_hashes, tail_tokens = self._build_query(request, num_computed_blocks)
+                if (
+                    not pending_probe.matches(num_computed_blocks, query_hashes, tail_tokens)
+                    or pending_probe.leased_hashes != query_hashes[:num_load_blocks]
+                ):
+                    self._release_pending_query_probe(req_id)
+                    raise RuntimeError(f"req {req_id} load hashes do not match pending query probe")
             if not load_intent.lease:
                 raise RuntimeError(f"req {req_id} missing query lease for external load")
             self._pending_load_intents[req_id] = load_intent
@@ -470,22 +505,17 @@ class SchedulerConnector:
         the key covers only the tail *prompt* tokens, and the decode peer
         recomputes every position past them anyway.
         """
-        if self._tail_hash_fn is None or req_id in self._tail_saved:
+        if not self._tail_save_enabled or req_id in self._tail_saved:
             return None
         req = self._requests.get(req_id)
         if req is None:
             return None
-        # The tail key is derived from (parent hash, token ids) alone; the
-        # decode peer cannot know lora / cache_salt / multimodal dimensions
-        # that vLLM folds into block 0's extra_keys. Saving would alias
-        # differently-salted prompts onto one key — refuse instead.
-        if req.lora_request is not None or req.cache_salt or req.mm_features:
-            return None
         vbs = self._ctx.virtual_block_size
         prompt_len = req.num_prompt_tokens
-        tail_len = prompt_len % vbs
-        if tail_len == 0:
+        tail = self._derive_tail_block(req)
+        if tail is None:
             return None
+        tail_key, tail_len = tail
         if written < prompt_len:
             return None  # tail prompt rows not written yet
         tail_idx = prompt_len // vbs
@@ -493,9 +523,6 @@ class SchedulerConnector:
         block_hashes = self._block_hashes.get(req_id) or ()
         if tail_idx >= len(allocated) or tail_idx > len(block_hashes):
             return None  # tail block not allocated / full-block hashes lagging
-        parent = block_hashes[tail_idx - 1] if tail_idx > 0 else self._kv_cache_utils.NONE_HASH
-        tail_tokens = list(req.prompt_token_ids[tail_idx * vbs : prompt_len])
-        tail_key = bytes(self._hash_block_tokens(self._tail_hash_fn, parent, tail_tokens, None))
         self._tail_saved.add(req_id)
         logger.info(
             "[PegaKVConnector] req=%s pd_tail_save: block_id=%d tail_tokens=%d key=%s",
@@ -505,6 +532,44 @@ class SchedulerConnector:
             tail_key.hex(),
         )
         return SaveIntent(block_ids=(allocated[tail_idx],), block_hashes=(tail_key,))
+
+    def _derive_tail_block(self, request: "Request") -> tuple[bytes, int] | None:
+        if self._tail_hash_fn is None:
+            return None
+        # The tail key carries no extra_keys. Reusing it for salted, LoRA, or
+        # multimodal requests would alias distinct vLLM cache identities.
+        if request.lora_request is not None or request.cache_salt or request.mm_features:
+            return None
+        vbs = self._ctx.virtual_block_size
+        prompt_len = request.num_prompt_tokens
+        tail_len = prompt_len % vbs
+        if tail_len == 0:
+            return None
+        tail_idx = prompt_len // vbs
+        block_hashes = tuple(request.block_hashes)
+        if tail_idx > len(block_hashes):
+            raise RuntimeError(
+                f"req {request.request_id} missing parent hash for tail block: "
+                f"tail_idx={tail_idx} full_hashes={len(block_hashes)}"
+            )
+        parent = block_hashes[tail_idx - 1] if tail_idx > 0 else self._kv_cache_utils.NONE_HASH
+        tail_tokens = list(request.prompt_token_ids[tail_idx * vbs : prompt_len])
+        tail_key = bytes(self._hash_block_tokens(self._tail_hash_fn, parent, tail_tokens, None))
+        return tail_key, tail_len
+
+    def _build_query(
+        self, request: "Request", computed_blocks: int
+    ) -> tuple[tuple[bytes, ...], int]:
+        query_hashes = tuple(request.block_hashes[computed_blocks:])
+        if not self._tail_load_enabled:
+            return query_hashes, 0
+
+        tail = self._derive_tail_block(request)
+        # Loading a one-token tail cannot reduce local work: vLLM must always
+        # execute at least the final prompt token to produce logits.
+        if tail is None or tail[1] <= 1:
+            return query_hashes, 0
+        return query_hashes + (tail[0],), tail[1]
 
     def _consume_full_block_saves(self, req_id: str) -> SaveIntent | None:
         # block_hashes are at virtual_block_size granularity, 1-to-1 with block_ids.

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -674,7 +674,7 @@ class SchedulerConnector:
             self._ctx.instance_id,
             block_hash_list,
             req_id=req_id,
-            wait_for_remote=self._ctx.wait_for_remote,
+            wait_for_full_prefix=self._ctx.wait_for_full_prefix,
         )
 
         if isinstance(result, QueryLoading):

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -29,11 +29,14 @@ if TYPE_CHECKING:
 class _QueryProbe:
     """One remote prefix-query snapshot.
 
-    A probe is keyed by:
+    A probe snapshots:
 
     * ``computed_blocks`` — blocks already computed locally when the query was
       issued
-    * ``query_hashes`` — remaining block hashes sent to the backend
+    * ``query_hashes`` — remaining full-block hashes plus at most one derived
+      tail key sent to the backend
+    * ``tail_tokens`` — valid rows in that tail block, used for token accounting
+      and request-drift validation
 
     If the request keeps making local progress while the backend is loading,
     the current query key may drift.  A *Ready* result is accepted only if the
@@ -79,11 +82,6 @@ class _QueryProbe:
             raise RuntimeError("query probe is still loading")
         return self.hit_blocks
 
-    @property
-    def leased_hashes(self) -> tuple[bytes, ...]:
-        """Hashes covered by the lease. Only valid after Ready."""
-        return self.query_hashes[: self.require_hit_blocks()]
-
 
 class SchedulerConnector:
     """Holds scheduler-only state and behaviors."""
@@ -113,12 +111,18 @@ class SchedulerConnector:
             assert vllm_config is not None
             algo = vllm_config.cache_config.prefix_caching_hash_algo
             if algo != "xxhash_cbor":
-                enabled_option = (
-                    "pegaflow.pd_tail_save" if pd_tail_save else "pegaflow.pd_tail_load"
+                enabled_options = ", ".join(
+                    option
+                    for enabled, option in (
+                        (pd_tail_save, "pegaflow.pd_tail_save"),
+                        (pd_tail_load, "pegaflow.pd_tail_load"),
+                    )
+                    if enabled
                 )
                 raise ValueError(
-                    f"{enabled_option} requires prefix_caching_hash_algo "
+                    "P/D tail-block caching requires prefix_caching_hash_algo "
                     f"'xxhash_cbor' (cross-engine derivable, validated); got {algo!r} — "
+                    f"enabled options: {enabled_options}; "
                     f"run vLLM with --prefix-caching-hash-algo xxhash_cbor"
                 )
             from vllm.utils.hashing import get_hash_fn_by_name
@@ -180,7 +184,7 @@ class SchedulerConnector:
         computed_blocks = num_computed_tokens // self._ctx.virtual_block_size
         query_hashes, tail_tokens = self._build_query(request, computed_blocks)
 
-        # Everything is already computed locally.
+        # Nothing remains to query remotely.
         if not query_hashes:
             self._release_pending_query_probe(req_id)
             self._external_matched_blocks[req_id] = computed_blocks
@@ -270,7 +274,10 @@ class SchedulerConnector:
         computed_blocks = probe.computed_blocks
         vbs = self._ctx.virtual_block_size
         tail_hit = probe.tail_tokens > 0 and hit_blocks == len(probe.query_hashes)
-        hit_tokens = (hit_blocks - 1) * vbs + probe.tail_tokens if tail_hit else hit_blocks * vbs
+        # _build_query appends the tail key last and the backend reports prefix
+        # hits, so a full query hit makes the final block the partial tail.
+        last_block_tokens = probe.tail_tokens if tail_hit else vbs
+        hit_tokens = (hit_blocks - 1) * vbs + last_block_tokens
 
         # A request still needs one forward token to produce logits. The last
         # loaded page may contain that token's KV, but vLLM must recompute and
@@ -278,6 +285,8 @@ class SchedulerConnector:
         locally_computed_tokens = computed_blocks * vbs
         hit_tokens = min(hit_tokens, max(0, num_tokens - locally_computed_tokens - 1))
 
+        # Cacheable tails contain at least two tokens, so recomputing the final
+        # prompt token cannot remove the last leased block from the load.
         loaded_blocks = (hit_tokens + vbs - 1) // vbs
         self._external_matched_blocks[req_id] = computed_blocks + loaded_blocks
 
@@ -368,12 +377,16 @@ class SchedulerConnector:
             )
             if pending_probe is not None:
                 query_hashes, tail_tokens = self._build_query(request, num_computed_blocks)
-                if (
-                    not pending_probe.matches(num_computed_blocks, query_hashes, tail_tokens)
-                    or pending_probe.leased_hashes != query_hashes[:num_load_blocks]
-                ):
+                if not pending_probe.matches(num_computed_blocks, query_hashes, tail_tokens):
                     self._release_pending_query_probe(req_id)
-                    raise RuntimeError(f"req {req_id} load hashes do not match pending query probe")
+                    raise RuntimeError(f"req {req_id} query identity changed before external load")
+                leased_blocks = pending_probe.require_hit_blocks()
+                if leased_blocks != num_load_blocks:
+                    self._release_pending_query_probe(req_id)
+                    raise RuntimeError(
+                        f"req {req_id} leased block mismatch: "
+                        f"leased={leased_blocks} load={num_load_blocks}"
+                    )
             if not load_intent.lease:
                 raise RuntimeError(f"req {req_id} missing query lease for external load")
             self._pending_load_intents[req_id] = load_intent
@@ -543,7 +556,10 @@ class SchedulerConnector:
         vbs = self._ctx.virtual_block_size
         prompt_len = request.num_prompt_tokens
         tail_len = prompt_len % vbs
-        if tail_len == 0:
+        # vLLM must recompute the final prompt token to produce logits. A
+        # one-token tail therefore cannot reduce local work; treating it as a
+        # hit would also lease one more hash than vLLM allocates load blocks.
+        if tail_len <= 1:
             return None
         tail_idx = prompt_len // vbs
         block_hashes = tuple(request.block_hashes)
@@ -565,9 +581,7 @@ class SchedulerConnector:
             return query_hashes, 0
 
         tail = self._derive_tail_block(request)
-        # Loading a one-token tail cannot reduce local work: vLLM must always
-        # execute at least the final prompt token to produce logits.
-        if tail is None or tail[1] <= 1:
+        if tail is None:
             return query_hashes, 0
         return query_hashes + (tail[0],), tail[1]
 

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -318,7 +318,6 @@ class WorkerConnector:
                     registration.num_blocks,
                 )
 
-        torch.cuda.synchronize(self._torch_device)
         ok, message = self._ctx.engine_client.register_context_batch(
             self._ctx.instance_id,
             self._ctx.namespace,

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -318,6 +318,7 @@ class WorkerConnector:
                     registration.num_blocks,
                 )
 
+        torch.cuda.synchronize(self._torch_device)
         ok, message = self._ctx.engine_client.register_context_batch(
             self._ctx.instance_id,
             self._ctx.namespace,

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -215,6 +215,7 @@ class EngineRpcClient:
         instance_id: str,
         block_hashes: list[bytes],
         req_id: str,
+        wait_for_remote: bool = False,
     ) -> QueryLoading | QueryReady:
         """Query prefix cache hits with SSD prefetch support.
 
@@ -228,6 +229,7 @@ class EngineRpcClient:
             instance_id: Model instance ID.
             block_hashes: List of block hashes to check.
             req_id: Request ID for tracking and prefetch correlation.
+            wait_for_remote: Keep the query loading while waiting for a remote producer.
 
         Returns:
             QueryLoading while backing fetch is in progress, otherwise QueryReady.

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -215,7 +215,7 @@ class EngineRpcClient:
         instance_id: str,
         block_hashes: list[bytes],
         req_id: str,
-        wait_for_remote: bool = False,
+        wait_for_full_prefix: bool = False,
     ) -> QueryLoading | QueryReady:
         """Query prefix cache hits with SSD prefetch support.
 
@@ -229,7 +229,7 @@ class EngineRpcClient:
             instance_id: Model instance ID.
             block_hashes: List of block hashes to check.
             req_id: Request ID for tracking and prefetch correlation.
-            wait_for_remote: Keep the query loading while waiting for a remote producer.
+            wait_for_full_prefix: Keep the query loading until the remaining prefix is complete.
 
         Returns:
             QueryLoading while backing fetch is in progress, otherwise QueryReady.

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -229,7 +229,11 @@ class EngineRpcClient:
             instance_id: Model instance ID.
             block_hashes: List of block hashes to check.
             req_id: Request ID for tracking and prefetch correlation.
-            wait_for_full_prefix: Keep the query loading until the remaining prefix is complete.
+            wait_for_full_prefix: Keep the query loading until the remaining
+                prefix is fetchable in full from a remote node. Only waits on
+                remote producers discovered via MetaServer (RDMA fetch); does
+                not observe saves landing in the local/shared engine, and has
+                no effect when RDMA is not configured.
 
         Returns:
             QueryLoading while backing fetch is in progress, otherwise QueryReady.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -443,12 +443,14 @@ impl EngineRpcClient {
     ///
     /// Returns:
     ///     QueryLoading while backing fetch is in progress, otherwise QueryReady.
+    #[pyo3(signature = (instance_id, block_hashes, req_id, wait_for_remote=false))]
     fn query_prefetch(
         &self,
         py: Python<'_>,
         instance_id: String,
         block_hashes: Vec<Vec<u8>>,
         req_id: String,
+        wait_for_remote: bool,
     ) -> PyResult<Py<PyAny>> {
         let result = py.detach(|| {
             self.rt_handle.block_on(async {
@@ -458,6 +460,7 @@ impl EngineRpcClient {
                         instance_id,
                         block_hashes,
                         req_id,
+                        wait_for_remote,
                     })
                     .await
                     .map(|resp| resp.into_inner())

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -443,14 +443,14 @@ impl EngineRpcClient {
     ///
     /// Returns:
     ///     QueryLoading while backing fetch is in progress, otherwise QueryReady.
-    #[pyo3(signature = (instance_id, block_hashes, req_id, wait_for_remote=false))]
+    #[pyo3(signature = (instance_id, block_hashes, req_id, wait_for_full_prefix=false))]
     fn query_prefetch(
         &self,
         py: Python<'_>,
         instance_id: String,
         block_hashes: Vec<Vec<u8>>,
         req_id: String,
-        wait_for_remote: bool,
+        wait_for_full_prefix: bool,
     ) -> PyResult<Py<PyAny>> {
         let result = py.detach(|| {
             self.rt_handle.block_on(async {
@@ -460,7 +460,7 @@ impl EngineRpcClient {
                         instance_id,
                         block_hashes,
                         req_id,
-                        wait_for_remote,
+                        wait_for_full_prefix,
                     })
                     .await
                     .map(|resp| resp.into_inner())

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -272,6 +272,7 @@ class ClientContext:
             kv_stride_bytes_list,
             segments_list,
             "direct",
+            False,
         )
 
         if not ok:

--- a/python/tests/session_crash_helper.py
+++ b/python/tests/session_crash_helper.py
@@ -52,6 +52,7 @@ def main() -> int:
         [kv_stride_bytes],
         [segments],
         "direct",
+        False,
     )
     if not ok:
         print(f"register_context_batch failed: {msg}", file=sys.stderr)

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -572,8 +572,29 @@ class TestSchedulerQueryProbeReuse:
     def test_query_loading_returns_retry(self):
         sc, engine_client = self._make_connector()
         engine_client.query_prefetch.return_value = QueryLoading()
+        hashes = [_hash(i) for i in range(4)]
 
-        assert sc._count_available_block_prefix([_hash(i) for i in range(4)], "r1") is None
+        assert sc._count_available_block_prefix(hashes, "r1") is None
+        engine_client.query_prefetch.assert_called_once_with(
+            sc._ctx.instance_id,
+            hashes,
+            req_id="r1",
+            wait_for_remote=False,
+        )
+
+    def test_wait_for_remote_is_forwarded(self):
+        engine_client = MagicMock()
+        engine_client.query_prefetch.return_value = QueryLoading()
+        sc = SchedulerConnector(_make_ctx(engine_client=engine_client, wait_for_remote=True))
+        hashes = [_hash(i) for i in range(4)]
+
+        assert sc._count_available_block_prefix(hashes, "r1") is None
+        engine_client.query_prefetch.assert_called_once_with(
+            sc._ctx.instance_id,
+            hashes,
+            req_id="r1",
+            wait_for_remote=True,
+        )
 
     def test_prefetch_loading_cancelled_on_request_cleanup(self):
         sc, engine_client = self._make_connector()

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -579,13 +579,13 @@ class TestSchedulerQueryProbeReuse:
             sc._ctx.instance_id,
             hashes,
             req_id="r1",
-            wait_for_remote=False,
+            wait_for_full_prefix=False,
         )
 
-    def test_wait_for_remote_is_forwarded(self):
+    def test_wait_for_full_prefix_is_forwarded(self):
         engine_client = MagicMock()
         engine_client.query_prefetch.return_value = QueryLoading()
-        sc = SchedulerConnector(_make_ctx(engine_client=engine_client, wait_for_remote=True))
+        sc = SchedulerConnector(_make_ctx(engine_client=engine_client, wait_for_full_prefix=True))
         hashes = [_hash(i) for i in range(4)]
 
         assert sc._count_available_block_prefix(hashes, "r1") is None
@@ -593,7 +593,7 @@ class TestSchedulerQueryProbeReuse:
             sc._ctx.instance_id,
             hashes,
             req_id="r1",
-            wait_for_remote=True,
+            wait_for_full_prefix=True,
         )
 
     def test_prefetch_loading_cancelled_on_request_cleanup(self):

--- a/python/tests/test_pd_tail_save.py
+++ b/python/tests/test_pd_tail_save.py
@@ -20,6 +20,7 @@ install_connector_unit_stubs()
 
 from pegaflow.connector.common import ConnectorContext
 from pegaflow.connector.scheduler import SchedulerConnector
+from pegaflow.pegaflow import QueryReady
 
 VBS = 16  # virtual block size for these tests
 
@@ -67,6 +68,7 @@ def _make_connector(req, allocated: list[int]) -> SchedulerConnector:
     sc = SchedulerConnector(_make_ctx())
     # Inject the tail machinery directly: these tests pin the TRIGGER, not
     # vLLM's hash function (covered by the cross-engine e2e gates).
+    sc._tail_save_enabled = True
     sc._tail_hash_fn = object()
     sc._kv_cache_utils = SimpleNamespace(NONE_HASH=b"\x00" * 32)
     sc._hash_block_tokens = lambda fn, parent, tokens, extra: b"tail:%d" % len(tokens)
@@ -76,6 +78,17 @@ def _make_connector(req, allocated: list[int]) -> SchedulerConnector:
     sc._scheduled_tokens[req.request_id] = 0
     sc._block_index_offsets[req.request_id] = 0
     sc._next_stored_block_idx[req.request_id] = 0
+    return sc
+
+
+def _make_load_connector(req, hit_blocks: int) -> SchedulerConnector:
+    ctx = _make_ctx()
+    ctx.engine_client.query_prefetch.return_value = QueryReady(hit_blocks, b"lease")
+    sc = SchedulerConnector(ctx)
+    sc._tail_load_enabled = True
+    sc._tail_hash_fn = object()
+    sc._kv_cache_utils = SimpleNamespace(NONE_HASH=b"\x00" * 32)
+    sc._hash_block_tokens = lambda fn, parent, tokens, extra: b"tail:%d" % len(tokens)
     return sc
 
 
@@ -196,3 +209,78 @@ class TestTailSaveThroughBuildConnectorMeta:
         intent = meta.save_intents.get("r1")
         assert intent is not None
         assert 13 in intent.block_ids
+
+
+class TestTailLoad:
+    def test_tail_hit_returns_prompt_minus_one_tokens(self):
+        req = _make_request("r1", prompt_len=50, full_hashes=3)
+        sc = _make_load_connector(req, hit_blocks=4)
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (49, True)
+        sc._ctx.engine_client.query_prefetch.assert_called_once_with(
+            "test",
+            [*req.block_hashes, b"tail:2"],
+            req_id="r1",
+            wait_for_remote=False,
+        )
+
+    def test_tail_hit_allocates_and_loads_the_partial_page(self):
+        req = _make_request("r1", prompt_len=50, full_hashes=3)
+        sc = _make_load_connector(req, hit_blocks=4)
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (49, True)
+        blocks = SimpleNamespace(
+            get_block_ids=lambda: ([10, 11, 12, 13],),
+            blocks=[[SimpleNamespace(block_hash=None) for _ in range(4)]],
+        )
+
+        sc.update_state_after_alloc(req, blocks, num_external_tokens=49)
+
+        intent = sc._pending_load_intents["r1"]
+        assert intent.block_ids == (10, 11, 12, 13)
+        assert intent.num_tokens == 49
+        assert intent.lease == b"lease"
+
+    def test_tail_hit_starts_after_the_local_block_prefix(self):
+        req = _make_request("r1", prompt_len=50, full_hashes=3)
+        sc = _make_load_connector(req, hit_blocks=3)
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=16) == (33, True)
+        blocks = SimpleNamespace(
+            get_block_ids=lambda: ([10, 11, 12, 13],),
+            blocks=[
+                [SimpleNamespace(block_hash=b"local")]
+                + [SimpleNamespace(block_hash=None) for _ in range(3)]
+            ],
+        )
+
+        sc.update_state_after_alloc(req, blocks, num_external_tokens=33)
+
+        intent = sc._pending_load_intents["r1"]
+        assert intent.block_ids == (11, 12, 13)
+        assert intent.num_tokens == 33
+
+    def test_missing_tail_keeps_the_full_block_prefix(self):
+        req = _make_request("r1", prompt_len=50, full_hashes=3)
+        sc = _make_load_connector(req, hit_blocks=3)
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (48, True)
+
+    def test_one_token_tail_is_not_queried(self):
+        req = _make_request("r1", prompt_len=49, full_hashes=3)
+        sc = _make_load_connector(req, hit_blocks=3)
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (48, True)
+        queried_hashes = sc._ctx.engine_client.query_prefetch.call_args.args[1]
+        assert queried_hashes == req.block_hashes
+
+    def test_sub_block_prompt_loads_one_page_and_recomputes_last_token(self):
+        req = _make_request("r1", prompt_len=10, full_hashes=0)
+        sc = _make_load_connector(req, hit_blocks=1)
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (9, True)
+
+    def test_block_aligned_full_hit_recomputes_last_token(self):
+        req = _make_request("r1", prompt_len=48, full_hashes=3)
+        sc = _make_load_connector(req, hit_blocks=3)
+
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (47, True)

--- a/python/tests/test_pd_tail_save.py
+++ b/python/tests/test_pd_tail_save.py
@@ -221,7 +221,7 @@ class TestTailLoad:
             "test",
             [*req.block_hashes, b"tail:2"],
             req_id="r1",
-            wait_for_remote=False,
+            wait_for_full_prefix=False,
         )
 
     def test_tail_hit_allocates_and_loads_the_partial_page(self):

--- a/python/tests/test_pd_tail_save.py
+++ b/python/tests/test_pd_tail_save.py
@@ -14,6 +14,8 @@ import hashlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from .unit_stubs import install_connector_unit_stubs
 
 install_connector_unit_stubs()
@@ -110,6 +112,11 @@ class TestTailSaveTrigger:
         req = _make_request("r1", prompt_len=48, full_hashes=3)
         sc = _make_connector(req, allocated=[10, 11, 12])
         assert sc._consume_tail_save("r1", written=48) is None
+
+    def test_one_token_tail_is_not_saved(self):
+        req = _make_request("r1", prompt_len=49, full_hashes=3)
+        sc = _make_connector(req, allocated=[10, 11, 12, 13])
+        assert sc._consume_tail_save("r1", written=49) is None
 
     def test_sub_block_prompt_uses_none_hash_parent(self):
         req = _make_request("r1", prompt_len=10, full_hashes=0)
@@ -258,6 +265,31 @@ class TestTailLoad:
         intent = sc._pending_load_intents["r1"]
         assert intent.block_ids == (11, 12, 13)
         assert intent.num_tokens == 33
+
+    def test_request_drift_is_reported_separately_from_lease_count(self):
+        req = _make_request("r1", prompt_len=50, full_hashes=3)
+        sc = _make_load_connector(req, hit_blocks=4)
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (49, True)
+        req.block_hashes[0] = _hash(99)
+        blocks = SimpleNamespace(
+            get_block_ids=lambda: ([10, 11, 12, 13],),
+            blocks=[[SimpleNamespace(block_hash=None) for _ in range(4)]],
+        )
+
+        with pytest.raises(RuntimeError, match="query identity changed before external load"):
+            sc.update_state_after_alloc(req, blocks, num_external_tokens=49)
+
+    def test_lease_count_must_match_allocated_load_blocks(self):
+        req = _make_request("r1", prompt_len=50, full_hashes=3)
+        sc = _make_load_connector(req, hit_blocks=4)
+        assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (49, True)
+        blocks = SimpleNamespace(
+            get_block_ids=lambda: ([10, 11, 12],),
+            blocks=[[SimpleNamespace(block_hash=None) for _ in range(3)]],
+        )
+
+        with pytest.raises(RuntimeError, match="leased block mismatch: leased=4 load=3"):
+            sc.update_state_after_alloc(req, blocks, num_external_tokens=33)
 
     def test_missing_tail_keeps_the_full_block_prefix(self):
         req = _make_request("r1", prompt_len=50, full_hashes=3)


### PR DESCRIPTION
## Summary

- add `pegaflow.wait_for_full_prefix` so a query stays in PegaFlow's prefetch state until the remaining prefix is complete
- load prefill-saved partial prompt blocks on decode while recomputing the logits token
- make CUDA IPC registration select and synchronize the correct device
- document the P/D hash seed, hash algorithm, and connector settings

## Validation

- `prek run`
- `cd python && uv run --extra test pytest` (199 passed, 11 deselected)
- source-only Python gate (199 passed, 11 deselected)
- GLM-5.2 FP8 on H200 x8: a new 12,020-token prompt had zero cold hits; after prefill saved it, decode loaded 188 blocks through PegaFlow, reported `tail_hit=True`, reused 12,019/12,020 prompt tokens, and produced the same greedy next token as the cold baseline
- four 4-turn conversations completed 16/16 requests; PegaFlow recorded 2,836 block hits, zero new misses, and 16/16 partial-tail hits as context grew from about 8K to 14K tokens
- eight random 7K-10K prompts completed 8/8 requests with 1,056 block hits, zero new misses, and 8/8 partial-tail hits

## Performance Work

- scheduler-side cache lookup was 0.43-0.71 ms in the multi-turn run
- no TTFT improvement is claimed: the correctness harness serializes a complete prefill request before decode, so its end-to-end TTFT is not representative of a production P/D router

## Known Behavior

- cancelling a connector probe does not cancel an already-running server-side remote wait; that task is bounded by the existing 30-second timeout and stale-entry GC
