### PR TITLE
feat(cache): reclaim extra replicas with MetaServer hints

### DIFF
--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Weak;
 
 use log::{debug, error, info, warn};
 use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_TIMEOUT};
@@ -16,6 +17,7 @@ use tonic::transport::{Channel, Endpoint};
 use uuid::Uuid;
 
 use crate::metrics::core_metrics;
+use crate::storage::ReadCache;
 
 // Shared insert/remove command channel depth. Eviction bursts outrun the single
 // consumer's per-RPC drain, so a shallow queue silently drops removals.
@@ -92,8 +94,6 @@ struct BlockHashBatch {
     groups: Vec<(String, Vec<Vec<u8>>)>,
 }
 
-type InsertHintCallback = Box<dyn FnOnce(Vec<u32>) + Send + 'static>;
-
 impl BlockHashBatch {
     fn from_entries(entries: Vec<(String, Vec<u8>)>) -> Self {
         let mut groups: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
@@ -119,10 +119,6 @@ impl BlockHashBatch {
 /// Command sent to the background MetaServer loop.
 enum MetaServerCommand {
     Insert(BlockHashBatch),
-    InsertWithHint {
-        batch: BlockHashBatch,
-        callback: InsertHintCallback,
-    },
     Remove(BlockHashBatch),
     /// Barrier: acked once every insert/remove enqueued before it has been
     /// delivered to the MetaServer (or dropped after a failed attempt).
@@ -158,7 +154,7 @@ impl MetaServerClient {
     /// Create a new client and spawn the background registration loop.
     ///
     /// Must be called from within a tokio runtime context.
-    pub fn new(config: MetaServerClientConfig) -> Self {
+    pub(crate) fn new(config: MetaServerClientConfig, read_cache: Weak<ReadCache>) -> Self {
         let endpoint = metaserver_endpoint(config.metaserver_addr.clone());
         let (command_tx, rx) = mpsc::channel(config.queue_depth);
 
@@ -167,6 +163,7 @@ impl MetaServerClient {
             config.metaserver_addr.clone(),
             endpoint.clone(),
             config.advertise_addr,
+            read_cache,
         ));
 
         // Lazy-connect query client: connects on first RPC, not here
@@ -197,30 +194,6 @@ impl MetaServerClient {
             return;
         }
         self.try_send_register_batch(BlockHashBatch::single_namespace(namespace, hashes));
-    }
-
-    /// Enqueue a registration whose response carries post-insert owner counts.
-    /// Queue, RPC, or protocol failures leave cache classification unchanged.
-    pub(crate) fn try_register_namespace_with_hint<F>(
-        &self,
-        namespace: String,
-        hashes: Vec<Vec<u8>>,
-        callback: F,
-    ) where
-        F: FnOnce(Vec<u32>) + Send + 'static,
-    {
-        if hashes.is_empty() {
-            return;
-        }
-        let batch = BlockHashBatch::single_namespace(namespace, hashes);
-        let count = batch.count();
-        self.try_send_registration(
-            MetaServerCommand::InsertWithHint {
-                batch,
-                callback: Box::new(callback),
-            },
-            count,
-        );
     }
 
     fn try_send_register_batch(&self, batch: BlockHashBatch) {
@@ -367,6 +340,7 @@ async fn registration_loop(
     metaserver_addr: String,
     endpoint: Endpoint,
     advertise_addr: String,
+    read_cache: Weak<ReadCache>,
 ) {
     let mut client: Option<MetaServerGrpcClient<Channel>> = None;
     let node_id = Uuid::new_v4().to_string();
@@ -417,7 +391,6 @@ async fn registration_loop(
         let mut inserts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
         let mut removes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
         let mut mixed_ops: Option<HashMap<(String, Vec<u8>), bool>> = None; // true=insert
-        let mut hinted_inserts: Vec<(BlockHashBatch, InsertHintCallback)> = Vec::new();
         let mut saw_insert = false;
         let mut saw_remove = false;
         // Flush barriers drained in this batch; acked after the sends below, so
@@ -438,16 +411,6 @@ async fn registration_loop(
                     } else {
                         append_groups(&mut inserts, batch.groups);
                     }
-                }
-                MetaServerCommand::InsertWithHint { batch, callback } => {
-                    saw_insert = true;
-                    if saw_remove {
-                        let net = mixed_ops.get_or_insert_with(|| {
-                            build_net(std::mem::take(&mut inserts), std::mem::take(&mut removes))
-                        });
-                        clear_pending_removes(net, &batch.groups);
-                    }
-                    hinted_inserts.push((batch, callback));
                 }
                 MetaServerCommand::Remove(batch) => {
                     saw_remove = true;
@@ -490,7 +453,6 @@ async fn registration_loop(
         }
 
         let insert_total: usize = inserts.values().map(|v| v.len()).sum();
-        let hinted_insert_total: usize = hinted_inserts.iter().map(|(b, _)| b.count()).sum();
         let remove_total: usize = removes.values().map(|v| v.len()).sum();
         if ensure_heartbeat_registered(
             &mut client,
@@ -505,7 +467,7 @@ async fn registration_loop(
         {
             core_metrics()
                 .metaserver_registration_failures
-                .add((insert_total + hinted_insert_total) as u64, &[]);
+                .add(insert_total as u64, &[]);
             core_metrics()
                 .metaserver_removal_failures
                 .add(remove_total as u64, &[]);
@@ -526,9 +488,15 @@ async fn registration_loop(
                 let count = chunk.len();
                 match send_insert_chunk(c, namespace, chunk, &advertise_addr, &node_id).await {
                     Ok(resp) => {
+                        if let Some(cache) = read_cache.upgrade() {
+                            cache.mark_reclaimable_hashes(namespace, &resp.reclaimable_hashes);
+                        }
                         debug!(
-                            "Registered {} block hashes with MetaServer (namespace={}, inserted={})",
-                            count, namespace, resp.inserted_count
+                            "Registered {} block hashes with MetaServer (namespace={}, inserted={}, reclaimable={})",
+                            count,
+                            namespace,
+                            resp.inserted_count,
+                            resp.reclaimable_hashes.len()
                         );
                     }
                     Err(e) => {
@@ -549,8 +517,7 @@ async fn registration_loop(
         }
 
         if let Some((idx, offset)) = insert_failed_at {
-            let dropped =
-                unsent_after_failure(&insert_namespaces, idx, offset) + hinted_insert_total;
+            let dropped = unsent_after_failure(&insert_namespaces, idx, offset);
             core_metrics()
                 .metaserver_registration_failures
                 .add(dropped as u64, &[]);
@@ -563,59 +530,6 @@ async fn registration_loop(
             client = None;
             ack_flushes(flush_acks);
             continue;
-        }
-
-        // Keep hinted inserts separate so every callback receives counts
-        // aligned with its originating save batch.
-        let mut hinted_insert_failed = false;
-        let mut pending_hinted = hinted_insert_total;
-        'hinted: for (batch, callback) in hinted_inserts {
-            let batch_count = batch.count();
-            let mut owner_counts = Vec::with_capacity(batch_count);
-            let mut failed = false;
-            for (namespace, hashes) in batch.groups {
-                for chunk in hashes.chunks(MAX_HASHES_PER_RPC) {
-                    match send_insert_chunk(c, &namespace, chunk, &advertise_addr, &node_id).await {
-                        Ok(resp) => {
-                            if resp.owner_counts.len() != chunk.len() {
-                                error!(
-                                    "MetaServer owner hint length mismatch: expected={} got={}",
-                                    chunk.len(),
-                                    resp.owner_counts.len()
-                                );
-                                failed = true;
-                                break;
-                            }
-                            owner_counts.extend(resp.owner_counts);
-                        }
-                        Err(e) => {
-                            handle_insert_error(
-                                "hinted insert",
-                                &namespace,
-                                chunk.len(),
-                                &e,
-                                &advertise_addr,
-                                &node_id,
-                                &mut heartbeat,
-                            );
-                            failed = true;
-                            break;
-                        }
-                    }
-                }
-                if failed {
-                    break;
-                }
-            }
-            if failed {
-                core_metrics()
-                    .metaserver_registration_failures
-                    .add(pending_hinted as u64, &[]);
-                hinted_insert_failed = true;
-                break 'hinted;
-            }
-            callback(owner_counts);
-            pending_hinted -= batch_count;
         }
 
         // Process removes
@@ -665,9 +579,6 @@ async fn registration_loop(
             core_metrics()
                 .metaserver_removal_failures
                 .add(dropped as u64, &[]);
-            client = None;
-        }
-        if hinted_insert_failed {
             client = None;
         }
         ack_flushes(flush_acks);
@@ -771,20 +682,6 @@ fn insert_groups_into_net(
     for (namespace, hashes) in groups {
         for hash in hashes {
             net.insert((namespace.clone(), hash), is_insert);
-        }
-    }
-}
-
-fn clear_pending_removes(
-    net: &mut HashMap<(String, Vec<u8>), bool>,
-    groups: &[(String, Vec<Vec<u8>>)],
-) {
-    for (namespace, hashes) in groups {
-        for hash in hashes {
-            let key = (namespace.clone(), hash.clone());
-            if net.get(&key) == Some(&false) {
-                net.remove(&key);
-            }
         }
     }
 }
@@ -956,6 +853,7 @@ async fn unregister_current_session(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::block::{BlockKey, SealedBlock};
     use pegaflow_proto::proto::engine::meta_server_server::{MetaServer, MetaServerServer};
     use pegaflow_proto::proto::engine::{
         HeartbeatNodeResponse, InsertBlockHashesResponse, QueryPrefixBlocksRequest,
@@ -983,7 +881,7 @@ mod tests {
         remove_count: AtomicUsize,
         unregister_count: AtomicUsize,
         fail_insert_with_stale_session: AtomicUsize,
-        malformed_owner_counts: AtomicUsize,
+        reclaimable_hashes: Mutex<Vec<Vec<u8>>>,
         insert_requests: RequestLog,
         remove_requests: RequestLog,
         heartbeat_notify: Notify,
@@ -1036,31 +934,28 @@ mod tests {
                 return Err(Status::failed_precondition("stale node session"));
             }
             let inserted_count = request.block_hashes.len() as u64;
+            let reclaimable_hashes = self
+                .state
+                .reclaimable_hashes
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|hash| request.block_hashes.contains(hash))
+                .cloned()
+                .collect();
             self.state
                 .insert_requests
                 .lock()
                 .unwrap()
                 .push((request.namespace, request.block_hashes));
             self.state.insert_notify.notify_waiters();
-            let owner_counts = if self
-                .state
-                .malformed_owner_counts
-                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
-                    (remaining > 0).then(|| remaining - 1)
-                })
-                .is_ok()
-            {
-                Vec::new()
-            } else {
-                vec![1; inserted_count as usize]
-            };
             Ok(Response::new(InsertBlockHashesResponse {
                 status: Some(ResponseStatus {
                     ok: true,
                     message: String::new(),
                 }),
                 inserted_count,
-                owner_counts,
+                reclaimable_hashes,
             }))
         }
 
@@ -1159,10 +1054,10 @@ mod tests {
     #[tokio::test]
     async fn heartbeat_loop_sends_initial_heartbeat_and_unregisters_on_shutdown() {
         let (addr, service, shutdown_tx) = start_fake_metaserver().await;
-        let client = MetaServerClient::new(MetaServerClientConfig::new(
-            addr,
-            "node-a:50055".to_string(),
-        ));
+        let client = MetaServerClient::new(
+            MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
+            Weak::new(),
+        );
 
         wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
         client.shutdown().await;
@@ -1177,10 +1072,10 @@ mod tests {
         service
             .fail_insert_with_stale_session
             .store(1, Ordering::SeqCst);
-        let client = MetaServerClient::new(MetaServerClientConfig::new(
-            addr,
-            "node-a:50055".to_string(),
-        ));
+        let client = MetaServerClient::new(
+            MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
+            Weak::new(),
+        );
 
         wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
         client.try_register_namespace("ns".to_string(), vec![vec![1]]);
@@ -1193,10 +1088,10 @@ mod tests {
     #[tokio::test]
     async fn flush_barrier_waits_for_prior_registrations() {
         let (addr, service, shutdown_tx) = start_fake_metaserver().await;
-        let client = MetaServerClient::new(MetaServerClientConfig::new(
-            addr,
-            "node-a:50055".to_string(),
-        ));
+        let client = MetaServerClient::new(
+            MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
+            Weak::new(),
+        );
 
         client.try_register_namespace("ns".to_string(), vec![vec![1], vec![2]]);
         // On return, the insert enqueued above must have been delivered — no
@@ -1217,26 +1112,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hinted_registration_returns_aligned_owner_counts() {
+    async fn registration_applies_reclaimable_hashes() {
         let (addr, service, shutdown_tx) = start_fake_metaserver().await;
-        let client = MetaServerClient::new(MetaServerClientConfig::new(
-            addr,
-            "node-a:50055".to_string(),
-        ));
-        let (hint_tx, hint_rx) = oneshot::channel();
+        let read_cache = Arc::new(ReadCache::new(1 << 20, false, None));
         let hashes: Vec<Vec<u8>> = (0..=MAX_HASHES_PER_RPC as u32)
             .map(|value| value.to_le_bytes().to_vec())
             .collect();
-
-        client.try_register_namespace_with_hint(
-            "ns".to_string(),
-            hashes.clone(),
-            move |owner_counts| {
-                let _ = hint_tx.send(owner_counts);
-            },
+        let hinted_hash = hashes[0].clone();
+        let hinted_key = BlockKey::new("ns".to_string(), hinted_hash.clone());
+        read_cache.insert_retained_for_test(
+            hinted_key.clone(),
+            Arc::new(SealedBlock::from_slots(Vec::new())),
+        );
+        *service.reclaimable_hashes.lock().unwrap() = vec![hinted_hash];
+        let client = MetaServerClient::new(
+            MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
+            Arc::downgrade(&read_cache),
         );
 
-        assert_eq!(hint_rx.await.unwrap(), vec![1; hashes.len()]);
+        client.try_register_namespace("ns".to_string(), hashes);
+        client.flush().await;
+
+        assert!(read_cache.is_reclaimable_for_test(&hinted_key));
         assert_eq!(service.insert_count.load(Ordering::SeqCst), 2);
         client.shutdown().await;
         let _ = shutdown_tx.send(());
@@ -1251,10 +1148,10 @@ mod tests {
         service
             .fail_insert_with_stale_session
             .store(usize::MAX, Ordering::SeqCst);
-        let client = MetaServerClient::new(MetaServerClientConfig::new(
-            addr,
-            "node-a:50055".to_string(),
-        ));
+        let client = MetaServerClient::new(
+            MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
+            Weak::new(),
+        );
 
         client.try_register_namespace("ns".to_string(), vec![vec![1]]);
         // The contract is "delivered or dropped": a failed insert drops the
@@ -1283,10 +1180,10 @@ mod tests {
     #[tokio::test]
     async fn large_namespace_removal_splits_into_bounded_rpcs() {
         let (addr, service, shutdown_tx) = start_fake_metaserver().await;
-        let client = MetaServerClient::new(MetaServerClientConfig::new(
-            addr,
-            "node-a:50055".to_string(),
-        ));
+        let client = MetaServerClient::new(
+            MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
+            Weak::new(),
+        );
         wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
 
         // One namespace coalesced past the per-RPC cap. Use sha256-sized (32B)
@@ -1380,6 +1277,7 @@ mod tests {
             addr,
             endpoint,
             "node-a:50055".to_string(),
+            Weak::new(),
         ));
 
         wait_for_count(&service.insert_notify, &service.insert_count, 2).await;
@@ -1395,108 +1293,6 @@ mod tests {
         assert_eq!(
             collect_requests(&service.remove_requests),
             expected_requests(&[("ns-first", insert_then_remove), ("ns-remove", remove_only)])
-        );
-
-        let (done_tx, done_rx) = oneshot::channel();
-        tx.send(MetaServerCommand::Shutdown(done_tx)).await.unwrap();
-        done_rx.await.unwrap();
-        loop_task.await.unwrap();
-        let _ = shutdown_tx.send(());
-    }
-
-    #[tokio::test]
-    async fn hinted_insert_preserves_order_against_remove() {
-        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
-        let (tx, rx) = mpsc::channel(16);
-        let reinserted = vec![0xe0];
-        let evicted = vec![0xf0];
-
-        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
-            vec![("ns-reinserted".to_string(), reinserted.clone())],
-        )))
-        .unwrap();
-        tx.try_send(MetaServerCommand::InsertWithHint {
-            batch: BlockHashBatch::single_namespace(
-                "ns-reinserted".to_string(),
-                vec![reinserted.clone()],
-            ),
-            callback: Box::new(|_| {}),
-        })
-        .unwrap();
-        tx.try_send(MetaServerCommand::InsertWithHint {
-            batch: BlockHashBatch::single_namespace(
-                "ns-evicted".to_string(),
-                vec![evicted.clone()],
-            ),
-            callback: Box::new(|_| {}),
-        })
-        .unwrap();
-        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
-            vec![("ns-evicted".to_string(), evicted.clone())],
-        )))
-        .unwrap();
-        let (flush_tx, flush_rx) = oneshot::channel();
-        tx.try_send(MetaServerCommand::Flush(flush_tx)).unwrap();
-
-        let endpoint = metaserver_endpoint(addr.clone());
-        let loop_task = tokio::spawn(registration_loop(
-            rx,
-            addr,
-            endpoint,
-            "node-a:50055".to_string(),
-        ));
-        flush_rx.await.unwrap();
-
-        assert_eq!(
-            collect_requests(&service.insert_requests),
-            expected_requests(&[
-                ("ns-reinserted", reinserted),
-                ("ns-evicted", evicted.clone()),
-            ])
-        );
-        assert_eq!(
-            collect_requests(&service.remove_requests),
-            expected_requests(&[("ns-evicted", evicted)])
-        );
-
-        let (done_tx, done_rx) = oneshot::channel();
-        tx.send(MetaServerCommand::Shutdown(done_tx)).await.unwrap();
-        done_rx.await.unwrap();
-        loop_task.await.unwrap();
-        let _ = shutdown_tx.send(());
-    }
-
-    #[tokio::test]
-    async fn hinted_insert_failure_does_not_skip_remove() {
-        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
-        service.malformed_owner_counts.store(1, Ordering::SeqCst);
-        let (tx, rx) = mpsc::channel(16);
-        let hash = vec![0xa1];
-
-        tx.try_send(MetaServerCommand::InsertWithHint {
-            batch: BlockHashBatch::single_namespace("ns".to_string(), vec![hash.clone()]),
-            callback: Box::new(|_| panic!("failed hint must not invoke callback")),
-        })
-        .unwrap();
-        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
-            vec![("ns".to_string(), hash.clone())],
-        )))
-        .unwrap();
-        let (flush_tx, flush_rx) = oneshot::channel();
-        tx.try_send(MetaServerCommand::Flush(flush_tx)).unwrap();
-
-        let endpoint = metaserver_endpoint(addr.clone());
-        let loop_task = tokio::spawn(registration_loop(
-            rx,
-            addr,
-            endpoint,
-            "node-a:50055".to_string(),
-        ));
-        flush_rx.await.unwrap();
-
-        assert_eq!(
-            collect_requests(&service.remove_requests),
-            expected_requests(&[("ns", hash)])
         );
 
         let (done_tx, done_rx) = oneshot::channel();

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -488,7 +488,9 @@ async fn registration_loop(
                 match c.insert_block_hashes(request).await {
                     Ok(resp) => {
                         let inner = resp.into_inner();
-                        if let Some(cache) = read_cache.upgrade() {
+                        if !inner.reclaimable_hashes.is_empty()
+                            && let Some(cache) = read_cache.upgrade()
+                        {
                             cache.mark_reclaimable_hashes(namespace, &inner.reclaimable_hashes);
                         }
                         debug!(

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -5,8 +5,7 @@ use log::{debug, error, info, warn};
 use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_TIMEOUT};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
-    HeartbeatNodeRequest, InsertBlockHashesRequest, InsertBlockHashesResponse,
-    RemoveBlockHashesRequest, UnregisterNodeRequest,
+    HeartbeatNodeRequest, InsertBlockHashesRequest, RemoveBlockHashesRequest, UnregisterNodeRequest,
 };
 #[cfg(feature = "rdma")]
 use pegaflow_proto::proto::engine::{NodePrefixResult, QueryPrefixBlocksRequest};
@@ -193,16 +192,9 @@ impl MetaServerClient {
         if hashes.is_empty() {
             return;
         }
-        self.try_send_register_batch(BlockHashBatch::single_namespace(namespace, hashes));
-    }
-
-    fn try_send_register_batch(&self, batch: BlockHashBatch) {
+        let batch = BlockHashBatch::single_namespace(namespace, hashes);
         let count = batch.count();
-        self.try_send_registration(MetaServerCommand::Insert(batch), count);
-    }
-
-    fn try_send_registration(&self, command: MetaServerCommand, count: usize) {
-        match self.command_tx.try_send(command) {
+        match self.command_tx.try_send(MetaServerCommand::Insert(batch)) {
             Ok(()) => {
                 core_metrics()
                     .metaserver_registration_blocks
@@ -486,29 +478,40 @@ async fn registration_loop(
         'insert: for (i, (namespace, hashes)) in insert_namespaces.iter().enumerate() {
             for (chunk_idx, chunk) in hashes.chunks(MAX_HASHES_PER_RPC).enumerate() {
                 let count = chunk.len();
-                match send_insert_chunk(c, namespace, chunk, &advertise_addr, &node_id).await {
+                let request = InsertBlockHashesRequest {
+                    namespace: namespace.clone(),
+                    block_hashes: chunk.to_vec(),
+                    node: advertise_addr.clone(),
+                    node_id: node_id.clone(),
+                };
+
+                match c.insert_block_hashes(request).await {
                     Ok(resp) => {
+                        let inner = resp.into_inner();
                         if let Some(cache) = read_cache.upgrade() {
-                            cache.mark_reclaimable_hashes(namespace, &resp.reclaimable_hashes);
+                            cache.mark_reclaimable_hashes(namespace, &inner.reclaimable_hashes);
                         }
                         debug!(
                             "Registered {} block hashes with MetaServer (namespace={}, inserted={}, reclaimable={})",
                             count,
                             namespace,
-                            resp.inserted_count,
-                            resp.reclaimable_hashes.len()
+                            inner.inserted_count,
+                            inner.reclaimable_hashes.len()
                         );
                     }
                     Err(e) => {
-                        handle_insert_error(
-                            "insert_block_hashes",
-                            namespace,
-                            count,
-                            &e,
-                            &advertise_addr,
-                            &node_id,
-                            &mut heartbeat,
+                        error!(
+                            "MetaServer insert_block_hashes failed (namespace={}, count={}): {e}",
+                            namespace, count
                         );
+                        if e.code() == Code::FailedPrecondition {
+                            warn!(
+                                "MetaServer insert rejected current session; resetting node registration: node={} node_id={}",
+                                advertise_addr, node_id
+                            );
+                            core_metrics().metaserver_session_resets.add(1, &[]);
+                            heartbeat.node_registered = false;
+                        }
                         insert_failed_at = Some((i, chunk_idx * MAX_HASHES_PER_RPC));
                         break 'insert;
                     }
@@ -585,45 +588,6 @@ async fn registration_loop(
     }
 
     info!("MetaServer registration loop shutting down");
-}
-
-async fn send_insert_chunk(
-    client: &mut MetaServerGrpcClient<Channel>,
-    namespace: &str,
-    hashes: &[Vec<u8>],
-    advertise_addr: &str,
-    node_id: &str,
-) -> Result<InsertBlockHashesResponse, tonic::Status> {
-    let request = InsertBlockHashesRequest {
-        namespace: namespace.to_string(),
-        block_hashes: hashes.to_vec(),
-        node: advertise_addr.to_string(),
-        node_id: node_id.to_string(),
-    };
-    client
-        .insert_block_hashes(request)
-        .await
-        .map(|response| response.into_inner())
-}
-
-fn handle_insert_error(
-    operation: &str,
-    namespace: &str,
-    count: usize,
-    error: &tonic::Status,
-    advertise_addr: &str,
-    node_id: &str,
-    heartbeat: &mut HeartbeatState,
-) {
-    error!("MetaServer {operation} failed (namespace={namespace}, count={count}): {error}");
-    if error.code() == Code::FailedPrecondition {
-        warn!(
-            "MetaServer insert rejected current session; resetting node registration: node={} node_id={}",
-            advertise_addr, node_id
-        );
-        core_metrics().metaserver_session_resets.add(1, &[]);
-        heartbeat.node_registered = false;
-    }
 }
 
 fn ack_flushes(acks: Vec<oneshot::Sender<()>>) {

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -4,7 +4,8 @@ use log::{debug, error, info, warn};
 use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_TIMEOUT};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
-    HeartbeatNodeRequest, InsertBlockHashesRequest, RemoveBlockHashesRequest, UnregisterNodeRequest,
+    HeartbeatNodeRequest, InsertBlockHashesRequest, InsertBlockHashesResponse,
+    RemoveBlockHashesRequest, UnregisterNodeRequest,
 };
 #[cfg(feature = "rdma")]
 use pegaflow_proto::proto::engine::{NodePrefixResult, QueryPrefixBlocksRequest};
@@ -91,6 +92,8 @@ struct BlockHashBatch {
     groups: Vec<(String, Vec<Vec<u8>>)>,
 }
 
+type InsertHintCallback = Box<dyn FnOnce(Vec<u32>) + Send + 'static>;
+
 impl BlockHashBatch {
     fn from_entries(entries: Vec<(String, Vec<u8>)>) -> Self {
         let mut groups: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
@@ -116,6 +119,10 @@ impl BlockHashBatch {
 /// Command sent to the background MetaServer loop.
 enum MetaServerCommand {
     Insert(BlockHashBatch),
+    InsertWithHint {
+        batch: BlockHashBatch,
+        callback: InsertHintCallback,
+    },
     Remove(BlockHashBatch),
     /// Barrier: acked once every insert/remove enqueued before it has been
     /// delivered to the MetaServer (or dropped after a failed attempt).
@@ -192,9 +199,37 @@ impl MetaServerClient {
         self.try_send_register_batch(BlockHashBatch::single_namespace(namespace, hashes));
     }
 
+    /// Enqueue a registration whose response carries post-insert owner counts.
+    /// Queue, RPC, or protocol failures leave cache classification unchanged.
+    pub(crate) fn try_register_namespace_with_hint<F>(
+        &self,
+        namespace: String,
+        hashes: Vec<Vec<u8>>,
+        callback: F,
+    ) where
+        F: FnOnce(Vec<u32>) + Send + 'static,
+    {
+        if hashes.is_empty() {
+            return;
+        }
+        let batch = BlockHashBatch::single_namespace(namespace, hashes);
+        let count = batch.count();
+        self.try_send_registration(
+            MetaServerCommand::InsertWithHint {
+                batch,
+                callback: Box::new(callback),
+            },
+            count,
+        );
+    }
+
     fn try_send_register_batch(&self, batch: BlockHashBatch) {
         let count = batch.count();
-        match self.command_tx.try_send(MetaServerCommand::Insert(batch)) {
+        self.try_send_registration(MetaServerCommand::Insert(batch), count);
+    }
+
+    fn try_send_registration(&self, command: MetaServerCommand, count: usize) {
+        match self.command_tx.try_send(command) {
             Ok(()) => {
                 core_metrics()
                     .metaserver_registration_blocks
@@ -382,6 +417,7 @@ async fn registration_loop(
         let mut inserts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
         let mut removes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
         let mut mixed_ops: Option<HashMap<(String, Vec<u8>), bool>> = None; // true=insert
+        let mut hinted_inserts: Vec<(BlockHashBatch, InsertHintCallback)> = Vec::new();
         let mut saw_insert = false;
         let mut saw_remove = false;
         // Flush barriers drained in this batch; acked after the sends below, so
@@ -402,6 +438,16 @@ async fn registration_loop(
                     } else {
                         append_groups(&mut inserts, batch.groups);
                     }
+                }
+                MetaServerCommand::InsertWithHint { batch, callback } => {
+                    saw_insert = true;
+                    if saw_remove {
+                        let net = mixed_ops.get_or_insert_with(|| {
+                            build_net(std::mem::take(&mut inserts), std::mem::take(&mut removes))
+                        });
+                        clear_pending_removes(net, &batch.groups);
+                    }
+                    hinted_inserts.push((batch, callback));
                 }
                 MetaServerCommand::Remove(batch) => {
                     saw_remove = true;
@@ -444,6 +490,7 @@ async fn registration_loop(
         }
 
         let insert_total: usize = inserts.values().map(|v| v.len()).sum();
+        let hinted_insert_total: usize = hinted_inserts.iter().map(|(b, _)| b.count()).sum();
         let remove_total: usize = removes.values().map(|v| v.len()).sum();
         if ensure_heartbeat_registered(
             &mut client,
@@ -458,7 +505,7 @@ async fn registration_loop(
         {
             core_metrics()
                 .metaserver_registration_failures
-                .add(insert_total as u64, &[]);
+                .add((insert_total + hinted_insert_total) as u64, &[]);
             core_metrics()
                 .metaserver_removal_failures
                 .add(remove_total as u64, &[]);
@@ -477,34 +524,23 @@ async fn registration_loop(
         'insert: for (i, (namespace, hashes)) in insert_namespaces.iter().enumerate() {
             for (chunk_idx, chunk) in hashes.chunks(MAX_HASHES_PER_RPC).enumerate() {
                 let count = chunk.len();
-                let request = InsertBlockHashesRequest {
-                    namespace: namespace.clone(),
-                    block_hashes: chunk.to_vec(),
-                    node: advertise_addr.clone(),
-                    node_id: node_id.clone(),
-                };
-
-                match c.insert_block_hashes(request).await {
+                match send_insert_chunk(c, namespace, chunk, &advertise_addr, &node_id).await {
                     Ok(resp) => {
-                        let inner = resp.into_inner();
                         debug!(
                             "Registered {} block hashes with MetaServer (namespace={}, inserted={})",
-                            count, namespace, inner.inserted_count
+                            count, namespace, resp.inserted_count
                         );
                     }
                     Err(e) => {
-                        error!(
-                            "MetaServer insert_block_hashes failed (namespace={}, count={}): {e}",
-                            namespace, count
+                        handle_insert_error(
+                            "insert_block_hashes",
+                            namespace,
+                            count,
+                            &e,
+                            &advertise_addr,
+                            &node_id,
+                            &mut heartbeat,
                         );
-                        if e.code() == Code::FailedPrecondition {
-                            warn!(
-                                "MetaServer insert rejected current session; resetting node registration: node={} node_id={}",
-                                advertise_addr, node_id
-                            );
-                            core_metrics().metaserver_session_resets.add(1, &[]);
-                            heartbeat.node_registered = false;
-                        }
                         insert_failed_at = Some((i, chunk_idx * MAX_HASHES_PER_RPC));
                         break 'insert;
                     }
@@ -513,7 +549,8 @@ async fn registration_loop(
         }
 
         if let Some((idx, offset)) = insert_failed_at {
-            let dropped = unsent_after_failure(&insert_namespaces, idx, offset);
+            let dropped =
+                unsent_after_failure(&insert_namespaces, idx, offset) + hinted_insert_total;
             core_metrics()
                 .metaserver_registration_failures
                 .add(dropped as u64, &[]);
@@ -526,6 +563,59 @@ async fn registration_loop(
             client = None;
             ack_flushes(flush_acks);
             continue;
+        }
+
+        // Keep hinted inserts separate so every callback receives counts
+        // aligned with its originating save batch.
+        let mut hinted_insert_failed = false;
+        let mut pending_hinted = hinted_insert_total;
+        'hinted: for (batch, callback) in hinted_inserts {
+            let batch_count = batch.count();
+            let mut owner_counts = Vec::with_capacity(batch_count);
+            let mut failed = false;
+            for (namespace, hashes) in batch.groups {
+                for chunk in hashes.chunks(MAX_HASHES_PER_RPC) {
+                    match send_insert_chunk(c, &namespace, chunk, &advertise_addr, &node_id).await {
+                        Ok(resp) => {
+                            if resp.owner_counts.len() != chunk.len() {
+                                error!(
+                                    "MetaServer owner hint length mismatch: expected={} got={}",
+                                    chunk.len(),
+                                    resp.owner_counts.len()
+                                );
+                                failed = true;
+                                break;
+                            }
+                            owner_counts.extend(resp.owner_counts);
+                        }
+                        Err(e) => {
+                            handle_insert_error(
+                                "hinted insert",
+                                &namespace,
+                                chunk.len(),
+                                &e,
+                                &advertise_addr,
+                                &node_id,
+                                &mut heartbeat,
+                            );
+                            failed = true;
+                            break;
+                        }
+                    }
+                }
+                if failed {
+                    break;
+                }
+            }
+            if failed {
+                core_metrics()
+                    .metaserver_registration_failures
+                    .add(pending_hinted as u64, &[]);
+                hinted_insert_failed = true;
+                break 'hinted;
+            }
+            callback(owner_counts);
+            pending_hinted -= batch_count;
         }
 
         // Process removes
@@ -577,10 +667,52 @@ async fn registration_loop(
                 .add(dropped as u64, &[]);
             client = None;
         }
+        if hinted_insert_failed {
+            client = None;
+        }
         ack_flushes(flush_acks);
     }
 
     info!("MetaServer registration loop shutting down");
+}
+
+async fn send_insert_chunk(
+    client: &mut MetaServerGrpcClient<Channel>,
+    namespace: &str,
+    hashes: &[Vec<u8>],
+    advertise_addr: &str,
+    node_id: &str,
+) -> Result<InsertBlockHashesResponse, tonic::Status> {
+    let request = InsertBlockHashesRequest {
+        namespace: namespace.to_string(),
+        block_hashes: hashes.to_vec(),
+        node: advertise_addr.to_string(),
+        node_id: node_id.to_string(),
+    };
+    client
+        .insert_block_hashes(request)
+        .await
+        .map(|response| response.into_inner())
+}
+
+fn handle_insert_error(
+    operation: &str,
+    namespace: &str,
+    count: usize,
+    error: &tonic::Status,
+    advertise_addr: &str,
+    node_id: &str,
+    heartbeat: &mut HeartbeatState,
+) {
+    error!("MetaServer {operation} failed (namespace={namespace}, count={count}): {error}");
+    if error.code() == Code::FailedPrecondition {
+        warn!(
+            "MetaServer insert rejected current session; resetting node registration: node={} node_id={}",
+            advertise_addr, node_id
+        );
+        core_metrics().metaserver_session_resets.add(1, &[]);
+        heartbeat.node_registered = false;
+    }
 }
 
 fn ack_flushes(acks: Vec<oneshot::Sender<()>>) {
@@ -639,6 +771,20 @@ fn insert_groups_into_net(
     for (namespace, hashes) in groups {
         for hash in hashes {
             net.insert((namespace.clone(), hash), is_insert);
+        }
+    }
+}
+
+fn clear_pending_removes(
+    net: &mut HashMap<(String, Vec<u8>), bool>,
+    groups: &[(String, Vec<Vec<u8>>)],
+) {
+    for (namespace, hashes) in groups {
+        for hash in hashes {
+            let key = (namespace.clone(), hash.clone());
+            if net.get(&key) == Some(&false) {
+                net.remove(&key);
+            }
         }
     }
 }
@@ -837,6 +983,7 @@ mod tests {
         remove_count: AtomicUsize,
         unregister_count: AtomicUsize,
         fail_insert_with_stale_session: AtomicUsize,
+        malformed_owner_counts: AtomicUsize,
         insert_requests: RequestLog,
         remove_requests: RequestLog,
         heartbeat_notify: Notify,
@@ -895,12 +1042,25 @@ mod tests {
                 .unwrap()
                 .push((request.namespace, request.block_hashes));
             self.state.insert_notify.notify_waiters();
+            let owner_counts = if self
+                .state
+                .malformed_owner_counts
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    (remaining > 0).then(|| remaining - 1)
+                })
+                .is_ok()
+            {
+                Vec::new()
+            } else {
+                vec![1; inserted_count as usize]
+            };
             Ok(Response::new(InsertBlockHashesResponse {
                 status: Some(ResponseStatus {
                     ok: true,
                     message: String::new(),
                 }),
                 inserted_count,
+                owner_counts,
             }))
         }
 
@@ -1057,6 +1217,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn hinted_registration_returns_aligned_owner_counts() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        let client = MetaServerClient::new(MetaServerClientConfig::new(
+            addr,
+            "node-a:50055".to_string(),
+        ));
+        let (hint_tx, hint_rx) = oneshot::channel();
+        let hashes: Vec<Vec<u8>> = (0..=MAX_HASHES_PER_RPC as u32)
+            .map(|value| value.to_le_bytes().to_vec())
+            .collect();
+
+        client.try_register_namespace_with_hint(
+            "ns".to_string(),
+            hashes.clone(),
+            move |owner_counts| {
+                let _ = hint_tx.send(owner_counts);
+            },
+        );
+
+        assert_eq!(hint_rx.await.unwrap(), vec![1; hashes.len()]);
+        assert_eq!(service.insert_count.load(Ordering::SeqCst), 2);
+        client.shutdown().await;
+        let _ = shutdown_tx.send(());
+        drop(service);
+    }
+
+    #[tokio::test]
     async fn flush_barrier_acks_even_when_insert_fails() {
         let (addr, service, shutdown_tx) = start_fake_metaserver().await;
         // Fail both the insert attempt and the session-reset retry heartbeat
@@ -1208,6 +1395,108 @@ mod tests {
         assert_eq!(
             collect_requests(&service.remove_requests),
             expected_requests(&[("ns-first", insert_then_remove), ("ns-remove", remove_only)])
+        );
+
+        let (done_tx, done_rx) = oneshot::channel();
+        tx.send(MetaServerCommand::Shutdown(done_tx)).await.unwrap();
+        done_rx.await.unwrap();
+        loop_task.await.unwrap();
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn hinted_insert_preserves_order_against_remove() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        let (tx, rx) = mpsc::channel(16);
+        let reinserted = vec![0xe0];
+        let evicted = vec![0xf0];
+
+        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
+            vec![("ns-reinserted".to_string(), reinserted.clone())],
+        )))
+        .unwrap();
+        tx.try_send(MetaServerCommand::InsertWithHint {
+            batch: BlockHashBatch::single_namespace(
+                "ns-reinserted".to_string(),
+                vec![reinserted.clone()],
+            ),
+            callback: Box::new(|_| {}),
+        })
+        .unwrap();
+        tx.try_send(MetaServerCommand::InsertWithHint {
+            batch: BlockHashBatch::single_namespace(
+                "ns-evicted".to_string(),
+                vec![evicted.clone()],
+            ),
+            callback: Box::new(|_| {}),
+        })
+        .unwrap();
+        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
+            vec![("ns-evicted".to_string(), evicted.clone())],
+        )))
+        .unwrap();
+        let (flush_tx, flush_rx) = oneshot::channel();
+        tx.try_send(MetaServerCommand::Flush(flush_tx)).unwrap();
+
+        let endpoint = metaserver_endpoint(addr.clone());
+        let loop_task = tokio::spawn(registration_loop(
+            rx,
+            addr,
+            endpoint,
+            "node-a:50055".to_string(),
+        ));
+        flush_rx.await.unwrap();
+
+        assert_eq!(
+            collect_requests(&service.insert_requests),
+            expected_requests(&[
+                ("ns-reinserted", reinserted),
+                ("ns-evicted", evicted.clone()),
+            ])
+        );
+        assert_eq!(
+            collect_requests(&service.remove_requests),
+            expected_requests(&[("ns-evicted", evicted)])
+        );
+
+        let (done_tx, done_rx) = oneshot::channel();
+        tx.send(MetaServerCommand::Shutdown(done_tx)).await.unwrap();
+        done_rx.await.unwrap();
+        loop_task.await.unwrap();
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn hinted_insert_failure_does_not_skip_remove() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        service.malformed_owner_counts.store(1, Ordering::SeqCst);
+        let (tx, rx) = mpsc::channel(16);
+        let hash = vec![0xa1];
+
+        tx.try_send(MetaServerCommand::InsertWithHint {
+            batch: BlockHashBatch::single_namespace("ns".to_string(), vec![hash.clone()]),
+            callback: Box::new(|_| panic!("failed hint must not invoke callback")),
+        })
+        .unwrap();
+        tx.try_send(MetaServerCommand::Remove(BlockHashBatch::from_entries(
+            vec![("ns".to_string(), hash.clone())],
+        )))
+        .unwrap();
+        let (flush_tx, flush_rx) = oneshot::channel();
+        tx.try_send(MetaServerCommand::Flush(flush_tx)).unwrap();
+
+        let endpoint = metaserver_endpoint(addr.clone());
+        let loop_task = tokio::spawn(registration_loop(
+            rx,
+            addr,
+            endpoint,
+            "node-a:50055".to_string(),
+        ));
+        flush_rx.await.unwrap();
+
+        assert_eq!(
+            collect_requests(&service.remove_requests),
+            expected_requests(&[("ns", hash)])
         );
 
         let (done_tx, done_rx) = oneshot::channel();

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -26,7 +26,7 @@ use pegaflow_common::NumaNode;
 use prefetch::PrefetchScheduler;
 #[cfg(feature = "rdma")]
 use prefetch::RdmaFetch;
-use read_cache::ReadCache;
+pub(crate) use read_cache::ReadCache;
 use write_path::{InsertDeps, WritePipeline};
 
 // Each reclaim iteration emits one MetaServer removal command; a small batch
@@ -123,21 +123,6 @@ impl StorageEngine {
         let blockwise_alloc = config.blockwise_alloc;
         let transfer_lock_timeout = config.transfer_lock_timeout;
 
-        // Create MetaServer client if configured
-        let metaserver_client = config.metaserver_addr.as_ref().map(|addr| {
-            let advertise = config
-                .advertise_addr
-                .clone()
-                .unwrap_or_else(|| "127.0.0.1:50055".to_string());
-            info!(
-                "MetaServer client enabled: metaserver={}, advertise={}, queue_depth={}",
-                addr, advertise, config.metaserver_queue_depth
-            );
-            let ms_config = MetaServerClientConfig::new(addr.clone(), advertise)
-                .with_queue_depth(config.metaserver_queue_depth);
-            Arc::new(MetaServerClient::new(ms_config))
-        });
-
         if blockwise_alloc {
             info!("Blockwise allocation enabled for batch_save");
         }
@@ -176,6 +161,23 @@ impl StorageEngine {
             config.enable_lfu_admission,
             value_size_hint,
         ));
+
+        let metaserver_client = config.metaserver_addr.as_ref().map(|addr| {
+            let advertise = config
+                .advertise_addr
+                .clone()
+                .unwrap_or_else(|| "127.0.0.1:50055".to_string());
+            info!(
+                "MetaServer client enabled: metaserver={}, advertise={}, queue_depth={}",
+                addr, advertise, config.metaserver_queue_depth
+            );
+            let ms_config = MetaServerClientConfig::new(addr.clone(), advertise)
+                .with_queue_depth(config.metaserver_queue_depth);
+            Arc::new(MetaServerClient::new(
+                ms_config,
+                Arc::downgrade(&read_cache),
+            ))
+        });
 
         let (write_pipeline, insert_rx) = WritePipeline::new();
         let write_pipeline = Arc::new(write_pipeline);

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -7,9 +7,7 @@ use crate::block::{BlockKey, SealedBlock};
 use crate::cache::{CacheInsertOutcome, TinyLfuCache};
 use crate::metrics::{CACHE_CLASS_RECLAIMABLE, CACHE_CLASS_RETAINED, core_metrics};
 
-const MIN_RECLAIMABLE_OWNER_COUNT: u32 = 3;
-
-pub(super) struct ReadCache {
+pub(crate) struct ReadCache {
     inner: Mutex<ReadCacheInner>,
 }
 
@@ -26,7 +24,7 @@ enum ResidentClass {
 }
 
 impl ReadCache {
-    pub(super) fn new(
+    pub(crate) fn new(
         capacity_bytes: usize,
         enable_lfu_admission: bool,
         value_size_hint: Option<usize>,
@@ -93,9 +91,9 @@ impl ReadCache {
     pub(super) fn batch_insert_refs(
         &self,
         blocks: &[(BlockKey, Arc<SealedBlock>)],
-    ) -> Vec<(BlockKey, CacheInsertOutcome)> {
+    ) -> Vec<BlockKey> {
         let mut inner = self.inner.lock();
-        let mut resident = Vec::new();
+        let mut resident_keys = Vec::new();
         for (key, block) in blocks {
             let outcome = insert_block(
                 &mut inner,
@@ -107,10 +105,10 @@ impl ReadCache {
                 outcome,
                 CacheInsertOutcome::InsertedNew | CacheInsertOutcome::AlreadyExists
             ) {
-                resident.push((key.clone(), outcome));
+                resident_keys.push(key.clone());
             }
         }
-        resident
+        resident_keys
     }
 
     /// Look up specific blocks by key without prefix-scan semantics (does not
@@ -163,20 +161,23 @@ impl ReadCache {
         removed
     }
 
-    pub(super) fn apply_owner_hints(
-        &self,
-        resident_saves: &[(BlockKey, CacheInsertOutcome)],
-        owner_counts: &[u32],
-    ) {
-        debug_assert_eq!(resident_saves.len(), owner_counts.len());
+    pub(crate) fn mark_reclaimable_hashes(&self, namespace: &str, hashes: &[Vec<u8>]) {
         let mut inner = self.inner.lock();
-        for ((key, outcome), owner_count) in resident_saves.iter().zip(owner_counts) {
-            if *outcome == CacheInsertOutcome::InsertedNew
-                && *owner_count >= MIN_RECLAIMABLE_OWNER_COUNT
-            {
-                mark_reclaimable(&mut inner, key);
-            }
+        for hash in hashes {
+            let key = BlockKey::new(namespace.to_string(), hash.clone());
+            mark_reclaimable(&mut inner, &key);
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert_retained_for_test(&self, key: BlockKey, block: Arc<SealedBlock>) {
+        let mut inner = self.inner.lock();
+        insert_block(&mut inner, key, block, ResidentClass::Retained);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_reclaimable_for_test(&self, key: &BlockKey) -> bool {
+        self.inner.lock().reclaimable.contains_key(key)
     }
 }
 
@@ -387,58 +388,47 @@ mod tests {
     }
 
     #[test]
-    fn local_save_reports_resident_insert_outcomes() {
+    fn local_save_reports_resident_keys() {
         let cache = make_cache();
         let key = BlockKey::new("ns".into(), vec![1]);
 
         assert_eq!(
             cache.batch_insert_refs(&[(key.clone(), make_block())]),
-            vec![(key.clone(), CacheInsertOutcome::InsertedNew)]
+            vec![key.clone()]
         );
         assert_eq!(
             cache.batch_insert_refs(&[(key.clone(), make_block())]),
-            vec![(key, CacheInsertOutcome::AlreadyExists)]
+            vec![key]
         );
     }
 
     #[test]
-    fn owner_hint_marks_only_new_third_owner_as_reclaimable() {
+    fn reclaimable_hashes_move_only_matching_residents() {
         let cache = make_cache();
-        let second_owner = BlockKey::new("ns".into(), vec![1]);
-        let third_owner = BlockKey::new("ns".into(), vec![2]);
-        let existing = BlockKey::new("ns".into(), vec![3]);
+        let retained = BlockKey::new("ns".into(), vec![1]);
+        let reclaimable = BlockKey::new("ns".into(), vec![2]);
+        let other_namespace = BlockKey::new("other".into(), vec![1]);
 
         cache.batch_insert(vec![
-            (second_owner.clone(), make_block()),
-            (third_owner.clone(), make_block()),
-            (existing.clone(), make_block()),
+            (retained.clone(), make_block()),
+            (other_namespace.clone(), make_block()),
         ]);
-        cache.apply_owner_hints(
-            &[
-                (second_owner.clone(), CacheInsertOutcome::InsertedNew),
-                (third_owner.clone(), CacheInsertOutcome::InsertedNew),
-                (existing.clone(), CacheInsertOutcome::AlreadyExists),
-            ],
-            &[2, MIN_RECLAIMABLE_OWNER_COUNT, MIN_RECLAIMABLE_OWNER_COUNT],
-        );
+        cache.batch_insert_resident_keys(vec![(reclaimable.clone(), make_block())]);
+        cache.mark_reclaimable_hashes("ns", &[vec![1], vec![2], vec![3]]);
 
-        assert_class(&cache, &second_owner, ResidentClass::Retained);
-        assert_class(&cache, &third_owner, ResidentClass::Reclaimable);
-        assert_class(&cache, &existing, ResidentClass::Retained);
-        assert_eq!(cache.remove_lru_batch(1)[0].0, third_owner);
+        assert_class(&cache, &retained, ResidentClass::Reclaimable);
+        assert_class(&cache, &reclaimable, ResidentClass::Reclaimable);
+        assert_class(&cache, &other_namespace, ResidentClass::Retained);
     }
 
     #[test]
-    fn owner_hint_for_evicted_block_is_noop() {
+    fn reclaimable_hash_for_evicted_block_is_noop() {
         let cache = make_cache();
         let key = BlockKey::new("ns".into(), vec![1]);
         cache.batch_insert(vec![(key.clone(), make_block())]);
         cache.remove_lru_batch(1);
 
-        cache.apply_owner_hints(
-            &[(key, CacheInsertOutcome::InsertedNew)],
-            &[MIN_RECLAIMABLE_OWNER_COUNT],
-        );
+        cache.mark_reclaimable_hashes("ns", &[key.hash]);
 
         assert!(cache.remove_lru_batch(1).is_empty());
     }

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -162,10 +162,26 @@ impl ReadCache {
     }
 
     pub(crate) fn mark_reclaimable_hashes(&self, namespace: &str, hashes: &[Vec<u8>]) {
+        if hashes.is_empty() {
+            return;
+        }
+
         let mut inner = self.inner.lock();
+        let mut moved = 0;
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
-            mark_reclaimable(&mut inner, &key);
+            if mark_reclaimable(&mut inner, &key) {
+                moved += 1;
+            }
+        }
+        if moved > 0 {
+            let metrics = core_metrics();
+            metrics
+                .cache_resident_blocks
+                .add(-moved, &*CACHE_CLASS_RETAINED);
+            metrics
+                .cache_resident_blocks
+                .add(moved, &*CACHE_CLASS_RECLAIMABLE);
         }
     }
 
@@ -229,24 +245,19 @@ fn refresh_recency(inner: &mut ReadCacheInner, key: &BlockKey) {
     );
 }
 
-fn mark_reclaimable(inner: &mut ReadCacheInner, key: &BlockKey) {
+fn mark_reclaimable(inner: &mut ReadCacheInner, key: &BlockKey) -> bool {
     if !inner.cache.contains_key(key) {
-        return;
+        return false;
     }
     if inner.retained.remove(key).is_some() {
         inner.reclaimable.insert(key.clone(), ());
-        let metrics = core_metrics();
-        metrics
-            .cache_resident_blocks
-            .add(-1, &*CACHE_CLASS_RETAINED);
-        metrics
-            .cache_resident_blocks
-            .add(1, &*CACHE_CLASS_RECLAIMABLE);
+        true
     } else {
         debug_assert!(
             inner.reclaimable.contains_key(key),
             "resident block is missing its replacement class"
         );
+        false
     }
 }
 

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -7,6 +7,8 @@ use crate::block::{BlockKey, SealedBlock};
 use crate::cache::{CacheInsertOutcome, TinyLfuCache};
 use crate::metrics::{CACHE_CLASS_RECLAIMABLE, CACHE_CLASS_RETAINED, core_metrics};
 
+const MIN_RECLAIMABLE_OWNER_COUNT: u32 = 3;
+
 pub(super) struct ReadCache {
     inner: Mutex<ReadCacheInner>,
 }
@@ -88,16 +90,27 @@ impl ReadCache {
         resident_keys
     }
 
-    pub(super) fn batch_insert_refs(&self, blocks: &[(BlockKey, Arc<SealedBlock>)]) {
+    pub(super) fn batch_insert_refs(
+        &self,
+        blocks: &[(BlockKey, Arc<SealedBlock>)],
+    ) -> Vec<(BlockKey, CacheInsertOutcome)> {
         let mut inner = self.inner.lock();
+        let mut resident = Vec::new();
         for (key, block) in blocks {
-            insert_block(
+            let outcome = insert_block(
                 &mut inner,
                 key.clone(),
                 Arc::clone(block),
                 ResidentClass::Retained,
             );
+            if matches!(
+                outcome,
+                CacheInsertOutcome::InsertedNew | CacheInsertOutcome::AlreadyExists
+            ) {
+                resident.push((key.clone(), outcome));
+            }
         }
+        resident
     }
 
     /// Look up specific blocks by key without prefix-scan semantics (does not
@@ -149,6 +162,22 @@ impl ReadCache {
             .add(-retained_blocks, &*CACHE_CLASS_RETAINED);
         removed
     }
+
+    pub(super) fn apply_owner_hints(
+        &self,
+        resident_saves: &[(BlockKey, CacheInsertOutcome)],
+        owner_counts: &[u32],
+    ) {
+        debug_assert_eq!(resident_saves.len(), owner_counts.len());
+        let mut inner = self.inner.lock();
+        for ((key, outcome), owner_count) in resident_saves.iter().zip(owner_counts) {
+            if *outcome == CacheInsertOutcome::InsertedNew
+                && *owner_count >= MIN_RECLAIMABLE_OWNER_COUNT
+            {
+                mark_reclaimable(&mut inner, key);
+            }
+        }
+    }
 }
 
 impl ResidentClass {
@@ -197,6 +226,27 @@ fn refresh_recency(inner: &mut ReadCacheInner, key: &BlockKey) {
         classified || !inner.cache.contains_key(key),
         "resident block is missing its replacement class"
     );
+}
+
+fn mark_reclaimable(inner: &mut ReadCacheInner, key: &BlockKey) {
+    if !inner.cache.contains_key(key) {
+        return;
+    }
+    if inner.retained.remove(key).is_some() {
+        inner.reclaimable.insert(key.clone(), ());
+        let metrics = core_metrics();
+        metrics
+            .cache_resident_blocks
+            .add(-1, &*CACHE_CLASS_RETAINED);
+        metrics
+            .cache_resident_blocks
+            .add(1, &*CACHE_CLASS_RECLAIMABLE);
+    } else {
+        debug_assert!(
+            inner.reclaimable.contains_key(key),
+            "resident block is missing its replacement class"
+        );
+    }
 }
 
 fn remove_lru(
@@ -334,6 +384,63 @@ mod tests {
         assert_eq!(cache.remove_lru_batch(1)[0].0, remote_first);
         assert_eq!(cache.remove_lru_batch(1)[0].0, local_other);
         assert_class(&cache, &local_first, ResidentClass::Retained);
+    }
+
+    #[test]
+    fn local_save_reports_resident_insert_outcomes() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+
+        assert_eq!(
+            cache.batch_insert_refs(&[(key.clone(), make_block())]),
+            vec![(key.clone(), CacheInsertOutcome::InsertedNew)]
+        );
+        assert_eq!(
+            cache.batch_insert_refs(&[(key.clone(), make_block())]),
+            vec![(key, CacheInsertOutcome::AlreadyExists)]
+        );
+    }
+
+    #[test]
+    fn owner_hint_marks_only_new_third_owner_as_reclaimable() {
+        let cache = make_cache();
+        let second_owner = BlockKey::new("ns".into(), vec![1]);
+        let third_owner = BlockKey::new("ns".into(), vec![2]);
+        let existing = BlockKey::new("ns".into(), vec![3]);
+
+        cache.batch_insert(vec![
+            (second_owner.clone(), make_block()),
+            (third_owner.clone(), make_block()),
+            (existing.clone(), make_block()),
+        ]);
+        cache.apply_owner_hints(
+            &[
+                (second_owner.clone(), CacheInsertOutcome::InsertedNew),
+                (third_owner.clone(), CacheInsertOutcome::InsertedNew),
+                (existing.clone(), CacheInsertOutcome::AlreadyExists),
+            ],
+            &[2, MIN_RECLAIMABLE_OWNER_COUNT, MIN_RECLAIMABLE_OWNER_COUNT],
+        );
+
+        assert_class(&cache, &second_owner, ResidentClass::Retained);
+        assert_class(&cache, &third_owner, ResidentClass::Reclaimable);
+        assert_class(&cache, &existing, ResidentClass::Retained);
+        assert_eq!(cache.remove_lru_batch(1)[0].0, third_owner);
+    }
+
+    #[test]
+    fn owner_hint_for_evicted_block_is_noop() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        cache.batch_insert(vec![(key.clone(), make_block())]);
+        cache.remove_lru_batch(1);
+
+        cache.apply_owner_hints(
+            &[(key, CacheInsertOutcome::InsertedNew)],
+            &[MIN_RECLAIMABLE_OWNER_COUNT],
+        );
+
+        assert!(cache.remove_lru_batch(1).is_empty());
     }
 
     #[test]

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -7,7 +7,6 @@ use tokio::sync::oneshot;
 
 use crate::backing::SsdBackingStore;
 use crate::block::{BlockKey, InflightBlock, SealedBlock, SlotInsertResult};
-use crate::cache::CacheInsertOutcome;
 use crate::internode::MetaServerClient;
 use crate::metrics::core_metrics;
 use crate::offload::InsertEntries;
@@ -200,8 +199,8 @@ fn process_insert_batch(
     if !sealed_blocks.is_empty()
         && let Some(deps) = &deps
     {
-        let resident_saves = deps.read_cache.batch_insert_refs(&sealed_blocks);
-        send_backing_batches(deps, namespace, &sealed_blocks, resident_saves);
+        let resident_keys = deps.read_cache.batch_insert_refs(&sealed_blocks);
+        send_backing_batches(deps, namespace, &sealed_blocks, resident_keys);
     }
 
     ordered_fast_path_seals
@@ -270,7 +269,7 @@ fn send_backing_batches(
     deps: &InsertDeps,
     namespace: &str,
     blocks: &[(BlockKey, Arc<SealedBlock>)],
-    resident_saves: Vec<(BlockKey, CacheInsertOutcome)>,
+    resident_keys: Vec<BlockKey>,
 ) {
     if blocks.is_empty() {
         return;
@@ -288,28 +287,16 @@ fn send_backing_batches(
     }
 
     if let Some(client) = &deps.metaserver_client {
-        register_block_hashes(client, namespace, resident_saves, &deps.read_cache);
+        register_block_hashes(client, namespace, resident_keys);
     }
 }
 
-fn register_block_hashes(
-    client: &MetaServerClient,
-    namespace: &str,
-    resident_saves: Vec<(BlockKey, CacheInsertOutcome)>,
-    read_cache: &Arc<ReadCache>,
-) {
-    if resident_saves.is_empty() {
+fn register_block_hashes(client: &MetaServerClient, namespace: &str, resident_keys: Vec<BlockKey>) {
+    if resident_keys.is_empty() {
         return;
     }
-    let hashes: Vec<Vec<u8>> = resident_saves
-        .iter()
-        .map(|(key, _)| key.hash.clone())
-        .collect();
-
-    let read_cache = Arc::clone(read_cache);
-    client.try_register_namespace_with_hint(namespace.to_string(), hashes, move |owner_counts| {
-        read_cache.apply_owner_hints(&resident_saves, &owner_counts);
-    });
+    let hashes = resident_keys.into_iter().map(|key| key.hash).collect();
+    client.try_register_namespace(namespace.to_string(), hashes);
 }
 
 fn gc_inflight(

--- a/pegaflow-core/src/storage/write_path.rs
+++ b/pegaflow-core/src/storage/write_path.rs
@@ -7,6 +7,7 @@ use tokio::sync::oneshot;
 
 use crate::backing::SsdBackingStore;
 use crate::block::{BlockKey, InflightBlock, SealedBlock, SlotInsertResult};
+use crate::cache::CacheInsertOutcome;
 use crate::internode::MetaServerClient;
 use crate::metrics::core_metrics;
 use crate::offload::InsertEntries;
@@ -199,8 +200,8 @@ fn process_insert_batch(
     if !sealed_blocks.is_empty()
         && let Some(deps) = &deps
     {
-        deps.read_cache.batch_insert_refs(&sealed_blocks);
-        send_backing_batches(deps, namespace, &sealed_blocks);
+        let resident_saves = deps.read_cache.batch_insert_refs(&sealed_blocks);
+        send_backing_batches(deps, namespace, &sealed_blocks, resident_saves);
     }
 
     ordered_fast_path_seals
@@ -269,6 +270,7 @@ fn send_backing_batches(
     deps: &InsertDeps,
     namespace: &str,
     blocks: &[(BlockKey, Arc<SealedBlock>)],
+    resident_saves: Vec<(BlockKey, CacheInsertOutcome)>,
 ) {
     if blocks.is_empty() {
         return;
@@ -286,17 +288,28 @@ fn send_backing_batches(
     }
 
     if let Some(client) = &deps.metaserver_client {
-        register_block_hashes(client, namespace, blocks);
+        register_block_hashes(client, namespace, resident_saves, &deps.read_cache);
     }
 }
 
 fn register_block_hashes(
     client: &MetaServerClient,
     namespace: &str,
-    blocks: &[(BlockKey, Arc<SealedBlock>)],
+    resident_saves: Vec<(BlockKey, CacheInsertOutcome)>,
+    read_cache: &Arc<ReadCache>,
 ) {
-    let hashes: Vec<Vec<u8>> = blocks.iter().map(|(key, _)| key.hash.clone()).collect();
-    client.try_register_namespace(namespace.to_string(), hashes);
+    if resident_saves.is_empty() {
+        return;
+    }
+    let hashes: Vec<Vec<u8>> = resident_saves
+        .iter()
+        .map(|(key, _)| key.hash.clone())
+        .collect();
+
+    let read_cache = Arc::clone(read_cache);
+    client.try_register_namespace_with_hint(namespace.to_string(), hashes, move |owner_counts| {
+        read_cache.apply_owner_hints(&resident_saves, &owner_counts);
+    });
 }
 
 fn gc_inflight(

--- a/pegaflow-metaserver/README.md
+++ b/pegaflow-metaserver/README.md
@@ -136,7 +136,7 @@ message InsertBlockHashesRequest {
 message InsertBlockHashesResponse {
   ResponseStatus status = 1;    // Success/error status
   uint64 inserted_count = 2;    // Number of hashes inserted
-  repeated uint32 owner_counts = 3; // Post-insert counts aligned with block_hashes
+  repeated bytes reclaimable_hashes = 3; // New third-or-later owner hashes
 }
 ```
 

--- a/pegaflow-metaserver/README.md
+++ b/pegaflow-metaserver/README.md
@@ -136,6 +136,7 @@ message InsertBlockHashesRequest {
 message InsertBlockHashesResponse {
   ResponseStatus status = 1;    // Success/error status
   uint64 inserted_count = 2;    // Number of hashes inserted
+  repeated uint32 owner_counts = 3; // Post-insert counts aligned with block_hashes
 }
 ```
 

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -127,7 +127,7 @@ impl MetaServer for GrpcMetaService {
                     "block_hashes cannot be empty".to_string(),
                 )),
                 inserted_count: 0,
-                owner_counts: Vec::new(),
+                reclaimable_hashes: Vec::new(),
             }));
             record_rpc_result("insert_block_hashes", &result, start);
             return result;
@@ -142,12 +142,13 @@ impl MetaServer for GrpcMetaService {
             }
         };
 
-        let owner_counts =
+        let inserted_count = req.block_hashes.len() as u64;
+        let reclaimable_hashes =
             match self
                 .store
                 .insert_hashes(&req.namespace, &req.block_hashes, &req.node, node_id)
             {
-                Ok(owner_counts) => owner_counts,
+                Ok(reclaimable_hashes) => reclaimable_hashes,
                 Err(err) => {
                     let result = Err(Self::store_error_status(err));
                     record_rpc_result("insert_block_hashes", &result, start);
@@ -157,17 +158,18 @@ impl MetaServer for GrpcMetaService {
 
         let elapsed = start.elapsed();
         debug!(
-            "RPC [insert_block_hashes]: namespace={} node={} inserted={} hashes in {:?}",
+            "RPC [insert_block_hashes]: namespace={} node={} inserted={} reclaimable={} in {:?}",
             req.namespace,
             req.node,
-            owner_counts.len(),
+            inserted_count,
+            reclaimable_hashes.len(),
             elapsed
         );
 
         let result = Ok(Response::new(InsertBlockHashesResponse {
             status: Some(Self::ok_status()),
-            inserted_count: owner_counts.len() as u64,
-            owner_counts,
+            inserted_count,
+            reclaimable_hashes,
         }));
         record_rpc_result("insert_block_hashes", &result, start);
         result
@@ -318,11 +320,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_insert_block_hashes_returns_aligned_post_insert_owner_counts() {
+    async fn test_insert_block_hashes_returns_new_third_owner_hashes() {
         let svc = make_service();
         let hashes = vec![vec![1], vec![2], vec![1]];
 
-        for (node, expected) in [("node-a", 1), ("node-b", 2), ("node-c", 3)] {
+        for (node, expected) in [
+            ("node-a", vec![]),
+            ("node-b", vec![]),
+            ("node-c", vec![vec![1], vec![2]]),
+        ] {
             let node_id = heartbeat_node(&svc, node).await;
             let response = svc
                 .insert_block_hashes(Request::new(InsertBlockHashesRequest {
@@ -336,7 +342,7 @@ mod tests {
                 .into_inner();
 
             assert_eq!(response.inserted_count, hashes.len() as u64);
-            assert_eq!(response.owner_counts, vec![expected; hashes.len()]);
+            assert_eq!(response.reclaimable_hashes, expected);
         }
     }
 

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -127,6 +127,7 @@ impl MetaServer for GrpcMetaService {
                     "block_hashes cannot be empty".to_string(),
                 )),
                 inserted_count: 0,
+                owner_counts: Vec::new(),
             }));
             record_rpc_result("insert_block_hashes", &result, start);
             return result;
@@ -141,12 +142,12 @@ impl MetaServer for GrpcMetaService {
             }
         };
 
-        let inserted =
+        let owner_counts =
             match self
                 .store
                 .insert_hashes(&req.namespace, &req.block_hashes, &req.node, node_id)
             {
-                Ok(inserted) => inserted,
+                Ok(owner_counts) => owner_counts,
                 Err(err) => {
                     let result = Err(Self::store_error_status(err));
                     record_rpc_result("insert_block_hashes", &result, start);
@@ -157,12 +158,16 @@ impl MetaServer for GrpcMetaService {
         let elapsed = start.elapsed();
         debug!(
             "RPC [insert_block_hashes]: namespace={} node={} inserted={} hashes in {:?}",
-            req.namespace, req.node, inserted, elapsed
+            req.namespace,
+            req.node,
+            owner_counts.len(),
+            elapsed
         );
 
         let result = Ok(Response::new(InsertBlockHashesResponse {
             status: Some(Self::ok_status()),
-            inserted_count: inserted as u64,
+            inserted_count: owner_counts.len() as u64,
+            owner_counts,
         }));
         record_rpc_result("insert_block_hashes", &result, start);
         result
@@ -310,6 +315,29 @@ mod tests {
         .await
         .unwrap();
         node_id
+    }
+
+    #[tokio::test]
+    async fn test_insert_block_hashes_returns_aligned_post_insert_owner_counts() {
+        let svc = make_service();
+        let hashes = vec![vec![1], vec![2], vec![1]];
+
+        for (node, expected) in [("node-a", 1), ("node-b", 2), ("node-c", 3)] {
+            let node_id = heartbeat_node(&svc, node).await;
+            let response = svc
+                .insert_block_hashes(Request::new(InsertBlockHashesRequest {
+                    namespace: "ns".into(),
+                    block_hashes: hashes.clone(),
+                    node: node.into(),
+                    node_id,
+                }))
+                .await
+                .unwrap()
+                .into_inner();
+
+            assert_eq!(response.inserted_count, hashes.len() as u64);
+            assert_eq!(response.owner_counts, vec![expected; hashes.len()]);
+        }
     }
 
     #[tokio::test]

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -227,8 +227,9 @@ impl BlockHashStore {
                 && owners
                     .iter()
                     .filter(|(node, owner)| self.is_owner_visible(node, owner, now))
+                    .take(MIN_RECLAIMABLE_OWNER_COUNT)
                     .count()
-                    >= MIN_RECLAIMABLE_OWNER_COUNT
+                    == MIN_RECLAIMABLE_OWNER_COUNT
             {
                 reclaimable_hashes.push(hash.clone());
             }

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -6,6 +6,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
+const MIN_RECLAIMABLE_OWNER_COUNT: usize = 3;
+
 pub const DEFAULT_NODE_STALE_SECS: u64 = 30;
 pub const DEFAULT_TTL_MINUTES: u64 = 120;
 
@@ -205,24 +207,26 @@ impl BlockHashStore {
         hashes: &[Vec<u8>],
         node: &str,
         node_id: Uuid,
-    ) -> Result<Vec<u32>, StoreError> {
+    ) -> Result<Vec<Vec<u8>>, StoreError> {
         self.touch_node_session(node, node_id)?;
         let node: Arc<str> = Arc::from(node);
         let now = Instant::now();
-        let mut owner_counts = Vec::with_capacity(hashes.len());
+        let mut reclaimable_hashes = Vec::new();
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
             let mut owners = self.blocks.entry(key).or_default();
-            owners.insert(
+            let previous = owners.insert(
                 Arc::clone(&node),
                 OwnerRecord {
                     node_id,
                     key_register_time: now,
                 },
             );
-            owner_counts.push(owners.len() as u32);
+            if previous.is_none() && owners.len() >= MIN_RECLAIMABLE_OWNER_COUNT {
+                reclaimable_hashes.push(hash.clone());
+            }
         }
-        Ok(owner_counts)
+        Ok(reclaimable_hashes)
     }
 
     pub fn remove_hashes(
@@ -467,10 +471,10 @@ mod tests {
 
         let hashes = vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11, 12]];
 
-        let inserted = store
+        let reclaimable = store
             .insert_hashes(namespace, &hashes, node, node_id)
             .unwrap();
-        assert_eq!(inserted, vec![1, 1, 1]);
+        assert!(reclaimable.is_empty());
 
         let existing = store.query_prefix(namespace, &hashes);
         assert_eq!(existing.len(), 3);
@@ -514,30 +518,43 @@ mod tests {
     }
 
     #[test]
-    fn insert_returns_owner_counts_aligned_with_hashes() {
+    fn insert_returns_only_new_third_owner_hashes() {
         let store = BlockHashStore::new();
         let node_a = heartbeat_node(&store, "node-a:50055");
         let node_b = heartbeat_node(&store, "node-b:50055");
         let node_c = heartbeat_node(&store, "node-c:50055");
+        let node_d = heartbeat_node(&store, "node-d:50055");
         let hashes = vec![vec![1], vec![2], vec![1]];
 
         assert_eq!(
             store
                 .insert_hashes("ns", &hashes, "node-a:50055", node_a)
                 .unwrap(),
-            vec![1, 1, 1]
+            Vec::<Vec<u8>>::new()
         );
         assert_eq!(
             store
                 .insert_hashes("ns", &hashes, "node-b:50055", node_b)
                 .unwrap(),
-            vec![2, 2, 2]
+            Vec::<Vec<u8>>::new()
         );
         assert_eq!(
             store
                 .insert_hashes("ns", &hashes, "node-c:50055", node_c)
                 .unwrap(),
-            vec![3, 3, 3]
+            vec![vec![1], vec![2]]
+        );
+        assert_eq!(
+            store
+                .insert_hashes("ns", &hashes, "node-c:50055", node_c)
+                .unwrap(),
+            Vec::<Vec<u8>>::new()
+        );
+        assert_eq!(
+            store
+                .insert_hashes("ns", &hashes, "node-d:50055", node_d)
+                .unwrap(),
+            vec![vec![1], vec![2]]
         );
     }
 

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -205,21 +205,24 @@ impl BlockHashStore {
         hashes: &[Vec<u8>],
         node: &str,
         node_id: Uuid,
-    ) -> Result<usize, StoreError> {
+    ) -> Result<Vec<u32>, StoreError> {
         self.touch_node_session(node, node_id)?;
         let node: Arc<str> = Arc::from(node);
         let now = Instant::now();
+        let mut owner_counts = Vec::with_capacity(hashes.len());
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
-            self.blocks.entry(key).or_default().insert(
+            let mut owners = self.blocks.entry(key).or_default();
+            owners.insert(
                 Arc::clone(&node),
                 OwnerRecord {
                     node_id,
                     key_register_time: now,
                 },
             );
+            owner_counts.push(owners.len() as u32);
         }
-        Ok(hashes.len())
+        Ok(owner_counts)
     }
 
     pub fn remove_hashes(
@@ -467,7 +470,7 @@ mod tests {
         let inserted = store
             .insert_hashes(namespace, &hashes, node, node_id)
             .unwrap();
-        assert_eq!(inserted, 3);
+        assert_eq!(inserted, vec![1, 1, 1]);
 
         let existing = store.query_prefix(namespace, &hashes);
         assert_eq!(existing.len(), 3);
@@ -508,6 +511,34 @@ mod tests {
         let mut node_names: Vec<&str> = existing[0].nodes.iter().map(|n| n.as_ref()).collect();
         node_names.sort();
         assert_eq!(node_names, vec!["node-a:50055", "node-b:50055"]);
+    }
+
+    #[test]
+    fn insert_returns_owner_counts_aligned_with_hashes() {
+        let store = BlockHashStore::new();
+        let node_a = heartbeat_node(&store, "node-a:50055");
+        let node_b = heartbeat_node(&store, "node-b:50055");
+        let node_c = heartbeat_node(&store, "node-c:50055");
+        let hashes = vec![vec![1], vec![2], vec![1]];
+
+        assert_eq!(
+            store
+                .insert_hashes("ns", &hashes, "node-a:50055", node_a)
+                .unwrap(),
+            vec![1, 1, 1]
+        );
+        assert_eq!(
+            store
+                .insert_hashes("ns", &hashes, "node-b:50055", node_b)
+                .unwrap(),
+            vec![2, 2, 2]
+        );
+        assert_eq!(
+            store
+                .insert_hashes("ns", &hashes, "node-c:50055", node_c)
+                .unwrap(),
+            vec![3, 3, 3]
+        );
     }
 
     #[test]

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -222,7 +222,14 @@ impl BlockHashStore {
                     key_register_time: now,
                 },
             );
-            if previous.is_none() && owners.len() >= MIN_RECLAIMABLE_OWNER_COUNT {
+            let is_new_owner = previous.is_none_or(|owner| owner.node_id != node_id);
+            if is_new_owner
+                && owners
+                    .iter()
+                    .filter(|(node, owner)| self.is_owner_visible(node, owner, now))
+                    .count()
+                    >= MIN_RECLAIMABLE_OWNER_COUNT
+            {
                 reclaimable_hashes.push(hash.clone());
             }
         }
@@ -555,6 +562,74 @@ mod tests {
                 .insert_hashes("ns", &hashes, "node-d:50055", node_d)
                 .unwrap(),
             vec![vec![1], vec![2]]
+        );
+    }
+
+    #[test]
+    fn stale_owner_does_not_count_toward_reclaim_hint() {
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::from_secs(30),
+            ttl: Duration::from_secs(60),
+        });
+        let hash = vec![1];
+        let node_a = heartbeat_node(&store, "node-a");
+        let node_b = heartbeat_node(&store, "node-b");
+        let node_c = heartbeat_node(&store, "node-c");
+        let node_d = heartbeat_node(&store, "node-d");
+
+        store
+            .insert_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a)
+            .unwrap();
+        store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(31);
+
+        store
+            .insert_hashes("ns", std::slice::from_ref(&hash), "node-b", node_b)
+            .unwrap();
+        assert!(
+            store
+                .insert_hashes("ns", std::slice::from_ref(&hash), "node-c", node_c)
+                .unwrap()
+                .is_empty(),
+            "the stale owner must not make node-c the third live owner"
+        );
+        assert_eq!(
+            store
+                .insert_hashes("ns", std::slice::from_ref(&hash), "node-d", node_d)
+                .unwrap(),
+            vec![hash]
+        );
+    }
+
+    #[test]
+    fn new_session_at_same_address_counts_as_new_owner() {
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::from_secs(30),
+            ttl: Duration::from_secs(60),
+        });
+        let hash = vec![1];
+        let old_node_a = heartbeat_node(&store, "node-a");
+        let node_b = heartbeat_node(&store, "node-b");
+        let node_c = heartbeat_node(&store, "node-c");
+
+        for (node, node_id) in [
+            ("node-a", old_node_a),
+            ("node-b", node_b),
+            ("node-c", node_c),
+        ] {
+            store
+                .insert_hashes("ns", std::slice::from_ref(&hash), node, node_id)
+                .unwrap();
+        }
+
+        store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(31);
+        let new_node_a = heartbeat_node(&store, "node-a");
+        assert_ne!(old_node_a, new_node_a);
+
+        assert_eq!(
+            store
+                .insert_hashes("ns", std::slice::from_ref(&hash), "node-a", new_node_a,)
+                .unwrap(),
+            vec![hash]
         );
     }
 

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -233,10 +233,9 @@ message InsertBlockHashesRequest {
 message InsertBlockHashesResponse {
   ResponseStatus status = 1;
   uint64 inserted_count = 2;
-  // Required post-insert owner count, including this node, aligned with
-  // InsertBlockHashesRequest.block_hashes. Pega server and MetaServer are
-  // deployed together; a missing or misaligned response is a protocol error.
-  repeated uint32 owner_counts = 3;
+  // Hashes for which this node became the third or later owner. The caller
+  // should classify matching local residents as reclaimable.
+  repeated bytes reclaimable_hashes = 3;
 }
 
 message RemoveBlockHashesRequest {

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -233,6 +233,10 @@ message InsertBlockHashesRequest {
 message InsertBlockHashesResponse {
   ResponseStatus status = 1;
   uint64 inserted_count = 2;
+  // Required post-insert owner count, including this node, aligned with
+  // InsertBlockHashesRequest.block_hashes. Pega server and MetaServer are
+  // deployed together; a missing or misaligned response is a protocol error.
+  repeated uint32 owner_counts = 3;
 }
 
 message RemoveBlockHashesRequest {


### PR DESCRIPTION
## Summary

- make MetaServer decide which newly registered replicas are reclaimable: a hash is returned only when this node becomes a new third-or-later owner
- return self-describing `reclaimable_hashes` from ordinary insert RPCs instead of aligned `owner_counts`
- apply insert hints in the shared registration loop through `Weak<ReadCache>`, moving matching retained residents to the reclaimable LRU
- remove `InsertWithHint`, per-batch callbacks, owner-count alignment checks, and compatibility handling for the old response contract
- preserve the source policy from #412: RDMA/P2P residents are reclaimable, local/SSD residents start retained, and `AlreadyExists` does not otherwise change class

This builds on #412. Related design/background: #398 and #389.

## Policy

```text
Local/SSD insert -> retained
RDMA/P2P fetch   -> reclaimable

MetaServer insert:
  existing owner                 -> no hint
  new owner, post-insert count <3 -> no hint
  new owner, post-insert count >=3 -> return hash in reclaimable_hashes

Pega registration loop:
  matching retained resident -> reclaimable
  missing/already reclaimable -> no-op

Eviction order: reclaimable LRU -> retained LRU
```

`reclaimable_hashes` is an insert-time signal, not a continuously synchronized replica count. Pega server and MetaServer are deployed at the same version, so the protobuf field is replaced directly without a legacy compatibility path. Registration remains best effort; a lost hint can only affect replacement pressure, not KV correctness or owner registration/removal.

## 2P6D Benchmark

The latest run uses the same workload and result files for all three policies.

| Setting | Value |
| --- | --- |
| Model | DeepSeek-V2-Lite-Chat |
| Topology | 2 prefill + 6 decode, all TP1; 8 independent Pega servers |
| Connectors | P: Pega read/write + NIXL producer; D: NIXL consumer + Pega save-only |
| Proxy | official vLLM non-stream multi-turn P/D proxy |
| Pega pool | 75 GB per server, hugepages enabled |
| Workload | 256 conversations, 16 turns, 2048 completed requests |
| Clients | 32 closed-loop clients, 32 active conversations |
| Tokens | 8192 input per turn / 1024 output; max model length 81920 |
| Sampling | round-robin conversations, seed 0, request rate 0 |
| Metrics | 5-second raw sampling |

vLLM prefix caching and the proxy conversation-metadata cache were disabled, matching the previous baseline/source-tiered runs. This keeps conversation-history reuse on the Pega P2P path.

### Redundancy and performance

| Policy | Mean redundancy | Tail 20% | Final | Runtime | Req/s | Mean TTFT |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Baseline | 2.961 | 2.890 | 3.143 | 3923 s | 0.522 | 58453 ms |
| Two-tier source policy | 3.029 | 3.089 | 3.574 | 3875 s | 0.529 | 58208 ms |
| **Two-tier + MetaServer hint** | **1.736** | **1.359** | **1.409** | **3901 s** | **0.525** | **58451 ms** |

Relative to baseline, MetaServer hints reduced mean redundancy by **41.4%**, the tail-20% mean by **53.0%**, and final redundancy by **55.2%**. Throughput and mean TTFT remained effectively unchanged.

### Final owner distribution

| Policy | Owner=1 | Owner=2 | Owner=3 | Owner>=4 |
| --- | ---: | ---: | ---: | ---: |
| Baseline | 59,146 | 31,837 | 23,677 | 90,188 |
| Two-tier source policy | 31,963 | 25,633 | 26,705 | 94,386 |
| **Two-tier + MetaServer hint** | **293,918** | **138,022** | **9,051** | **8,008** |

The high-owner population collapses after reclaim starts: final owner>=4 blocks fall by 91.1% relative to baseline. The larger owner=1/2 populations are the expected result of preferentially reclaiming third-or-later replicas.

### Reclamation cost

| Policy | Evictions | RDMA fetches | RDMA bytes | Cache miss blocks |
| --- | ---: | ---: | ---: | ---: |
| Baseline | 5,386,752 | 902 | 615,231,645,696 | 1,164,029 |
| Two-tier source policy | 6,294,016 | 1,452 | 1,453,582,485,504 | 1,164,605 |
| **Two-tier + MetaServer hint** | **6,893,568** | **1,463** | **925,819,269,120** | **2,349,885** |

The reduction is not free: versus baseline, evictions increased 28.0%, RDMA bytes increased 50.5%, and cache-miss blocks increased 101.9%. The result demonstrates that the policy can trade additional refetch pressure for substantially lower redundancy; production adoption should therefore consider network and latency budgets alongside the redundancy metric.

![2P6D baseline, source-tiered, and MetaServer-hint redundancy comparison](https://gist.githubusercontent.com/GentleCold/15084fca0973eafe12e5b8fc550d5b1c/raw/pd_2p6d_metaserver_hint_redundancy.png)

## Previous Topology Results

The earlier 2P2D and 4-mixed runs used 150 GB/server, TP2, 512 conversations, 16 turns, 8192 input / 128 output, 32 clients, seed 0, and 5-second sampling.

| Topology / policy | Mean redundancy | Tail 20% | Final | Runtime | Req/s |
| --- | ---: | ---: | ---: | ---: | ---: |
| 2P2D baseline | 2.798 | 2.889 | 2.928 | 3342 s | 1.226 |
| 2P2D two-tier source policy | 2.215 | 2.185 | 2.136 | 3386 s | 1.210 |
| **2P2D two-tier + owner hint** | **1.961** | **1.814** | **1.884** | **3324 s** | **1.232** |
| 4 mixed baseline | 2.443 | 2.449 | 2.473 | 1847 s | 2.217 |
| 4 mixed two-tier source policy | 1.571 | 1.435 | 1.486 | 2402 s | 1.705 |
| **4 mixed two-tier + owner hint** | **1.531** | **1.406** | **1.436** | **2422 s** | **1.691** |

### 2P2D

![2P2D baseline, two-tier source policy, and owner-hint redundancy comparison](https://gist.githubusercontent.com/GentleCold/15084fca0973eafe12e5b8fc550d5b1c/raw/pd_2p2d_three_policy_redundancy.png)

### 4 mixed

![4 mixed baseline, two-tier source policy, and owner-hint redundancy comparison](https://gist.githubusercontent.com/GentleCold/15084fca0973eafe12e5b8fc550d5b1c/raw/mixed4_three_policy_redundancy.png)

Charts and private benchmark/plotting helpers are not committed to the PR.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p pegaflow-metaserver` (32 passed)
- `cargo test -p pegaflow-core --no-default-features --features cuda-13,rdma` (134 passed, 1 ignored; integration and doc tests passed)
- `cargo clippy -p pegaflow-metaserver --all-targets -- -D warnings`
- `cargo clippy -p pegaflow-core --all-targets --no-default-features --features cuda-13,rdma -- -D warnings`
- `cargo check -p pegaflow-server --no-default-features --features cuda-13,rdma`
- release workspace build and `maturin develop --release`
- latest 2P6D E2E: 2048/2048 requests completed
- previous 2P2D and 4-mixed E2E: 4096/4096 requests completed in each topology

The E2E host runs CUDA 12.8, so runtime binaries/native bindings used CUDA 12. Rust test and clippy validation also covered the CUDA 13 + RDMA feature set.
## Review follow-up (`dc26c86`)

- Reclaim hints now count post-insert **visible/live owners**, matching `query_prefix` and redundancy metrics. Stale, superseded, and missing-node owner records do not satisfy the `>= 3` threshold.
- A new session at an existing node address is treated as a new owner session; repeated inserts from the same session remain idempotent and do not emit duplicate hints. Added regression coverage for stale owners and session takeover.
- Removed the four single-call Insert helpers left behind after `InsertWithHint` was removed. Request construction, response handling, and `FailedPrecondition` session reset now follow the existing Remove loop shape without changing queue-drop, failure-count, client-reset, or flush-ack behavior.
- Kept the internal `MetaServerClient(config, Weak<ReadCache>)` construction path and did not add an unused compatibility wrapper or change the RPC contract.

### Review validation

- `cargo fmt --all -- --check` passed.
- `cargo test -p pegaflow-metaserver` passed: 34 tests.
- `cargo clippy -p pegaflow-metaserver --all-targets -- -D warnings` passed.
- Core CUDA/RDMA test and clippy commands were attempted locally but are blocked by the macOS environment: `rdma-mummy-sys` requires Linux headers, and `io-uring` requires Linux APIs. The existing Linux CI jobs remain the validation path for those feature combinations.

## Review follow-up (88dfc7f)

Addressed the three batch-path nits without changing hint semantics:

- Skip the `Weak<ReadCache>` upgrade and cache lock when an Insert response contains no `reclaimable_hashes`; the batch API also short-circuits empty input.
- Aggregate resident-class gauge updates by the number of blocks that actually moved, producing at most one decrement and one increment per batch. Missing, already-reclaimable, duplicate, and cross-namespace hashes remain no-ops.
- Stop the visible-owner scan once the `>= 3` threshold is reached; stale/superseded/session handling is unchanged.

Validation on the remote Linux environment:

- `cargo fmt --all -- --check`
- `cargo test -p pegaflow-metaserver`: 34 passed
- `cargo test -p pegaflow-core --lib storage::read_cache::tests`: 16 passed
- `cargo clippy -p pegaflow-metaserver --all-targets -- -D warnings`
- `cargo clippy -p pegaflow-core --all-targets -- -D warnings`
