### PR TITLE
feat(server): native VMM KV clients over an fd side-channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,6 +2002,7 @@ dependencies = [
  "cudarc",
  "dashmap",
  "fastrace",
+ "libc",
  "log",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/pegaflow-core/src/backing/transfer_lock_guard.rs
+++ b/pegaflow-core/src/backing/transfer_lock_guard.rs
@@ -81,11 +81,12 @@ mod tests {
 
     use pegaflow_proto::proto::engine::engine_server::{Engine, EngineServer};
     use pegaflow_proto::proto::engine::{
-        HealthRequest, HealthResponse, LoadRequest, LoadResponse, QueryBlocksForTransferRequest,
-        QueryBlocksForTransferResponse, QueryRequest, QueryResponse, RdmaHandshakeRequest,
-        RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse, ReleaseRequest,
-        ReleaseResponse, ReleaseTransferLockResponse, SaveRequest, SaveResponse, SessionEvent,
-        SessionRequest, ShutdownRequest, ShutdownResponse, UnregisterRequest, UnregisterResponse,
+        FlushRequest, FlushResponse, HealthRequest, HealthResponse, LoadRequest, LoadResponse,
+        QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, QueryRequest, QueryResponse,
+        RdmaHandshakeRequest, RdmaHandshakeResponse, RegisterContextRequest,
+        RegisterContextResponse, ReleaseRequest, ReleaseResponse, ReleaseTransferLockResponse,
+        SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest, ShutdownResponse,
+        UnregisterRequest, UnregisterResponse,
     };
     use tokio_stream::wrappers::TcpListenerStream;
     use tonic::transport::Endpoint;
@@ -153,6 +154,12 @@ mod tests {
             &self,
             _request: Request<ReleaseRequest>,
         ) -> Result<Response<ReleaseResponse>, Status> {
+            Err(Status::unimplemented("stub"))
+        }
+        async fn flush(
+            &self,
+            _request: Request<FlushRequest>,
+        ) -> Result<Response<FlushResponse>, Status> {
             Err(Status::unimplemented("stub"))
         }
         async fn unregister_context(

--- a/pegaflow-core/src/internode/p2p_service.rs
+++ b/pegaflow-core/src/internode/p2p_service.rs
@@ -6,8 +6,8 @@
 //! `pegaflow-server` binary provides them alongside the CUDA-IPC registration
 //! surface — which an in-process Rust embedder (one that registers raw device
 //! pointers and drives saves/loads through `PegaEngine` directly) has no use
-//! for. This service is that minimal serving surface: the three transfer RPCs
-//! plus `Health`, everything else answered with `unimplemented`.
+//! for. This service is that minimal serving surface: those three transfer RPCs,
+//! everything else answered with `unimplemented`.
 //!
 //! The embedder remains responsible for periodic GC of expired transfer locks
 //! (`PegaEngine::gc_expired_transfer_locks`), mirroring pegaflow-server's
@@ -220,19 +220,14 @@ impl Engine for P2pTransferService {
         }))
     }
 
+    // ── In-process embedders drive these through `PegaEngine` directly ──
+
     async fn health(
         &self,
         _request: Request<HealthRequest>,
     ) -> Result<Response<HealthResponse>, Status> {
-        Ok(Response::new(HealthResponse {
-            status: Some(Self::ok_status()),
-            // p2p peers never send fds; the fd side-channel is a server-local
-            // concern of the engine gRPC service, not this cross-node service.
-            fd_socket_path: String::new(),
-        }))
+        Self::not_served("health")
     }
-
-    // ── In-process embedders drive these through `PegaEngine` directly ──
 
     async fn register_context_batch(
         &self,

--- a/pegaflow-core/src/internode/p2p_service.rs
+++ b/pegaflow-core/src/internode/p2p_service.rs
@@ -20,12 +20,12 @@ use tonic::{Request, Response, Status, async_trait};
 
 use pegaflow_proto::proto::engine::engine_server::{Engine, EngineServer};
 use pegaflow_proto::proto::engine::{
-    HealthRequest, HealthResponse, LoadRequest, LoadResponse, QueryBlocksForTransferRequest,
-    QueryBlocksForTransferResponse, QueryRequest, QueryResponse, RdmaHandshakeRequest,
-    RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse, ReleaseRequest,
-    ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse, ResponseStatus,
-    SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest, ShutdownResponse,
-    TransferBlockInfo, TransferSlotInfo, UnregisterRequest, UnregisterResponse,
+    FlushRequest, FlushResponse, HealthRequest, HealthResponse, LoadRequest, LoadResponse,
+    QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, QueryRequest, QueryResponse,
+    RdmaHandshakeRequest, RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse,
+    ReleaseRequest, ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse,
+    ResponseStatus, SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest,
+    ShutdownResponse, TransferBlockInfo, TransferSlotInfo, UnregisterRequest, UnregisterResponse,
 };
 
 use crate::{LayerBlock, PegaEngine};
@@ -226,6 +226,9 @@ impl Engine for P2pTransferService {
     ) -> Result<Response<HealthResponse>, Status> {
         Ok(Response::new(HealthResponse {
             status: Some(Self::ok_status()),
+            // p2p peers never send fds; the fd side-channel is a server-local
+            // concern of the engine gRPC service, not this cross-node service.
+            fd_socket_path: String::new(),
         }))
     }
 
@@ -258,6 +261,13 @@ impl Engine for P2pTransferService {
         _request: Request<ReleaseRequest>,
     ) -> Result<Response<ReleaseResponse>, Status> {
         Self::not_served("release")
+    }
+
+    async fn flush(
+        &self,
+        _request: Request<FlushRequest>,
+    ) -> Result<Response<FlushResponse>, Status> {
+        Self::not_served("flush")
     }
 
     async fn unregister_context(

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -5,8 +5,6 @@ pub(crate) mod transfer_lock;
 mod write_path;
 
 use bytesize::ByteSize;
-#[cfg(not(feature = "rdma"))]
-use log::warn;
 use log::{debug, info, warn};
 use std::collections::HashSet;
 use std::num::NonZeroU64;

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -46,26 +46,14 @@ message RegisterContextRequest {
   // Set by the connector for MLA; the engine derives per-layer page offsets
   // from the registered layouts. See spec.md.
   bool page_first = 18;
-  // Native VMM registration. Each layer is a strided view into one fused,
-  // GPU-resident VMM allocation the client exported as a POSIX file descriptor.
-  // The fd itself does NOT travel here — it is a host-local kernel object that
-  // cannot cross gRPC. The client sends it over the server's fd side-channel
-  // (Unix domain socket, SCM_RIGHTS; see HealthResponse.fd_socket_path) keyed
-  // by (instance_id, device_id) BEFORE issuing this RPC. Unlike a CUDA IPC
-  // handle, a VMM POSIX-fd allocation can be registered into the NIC for
-  // GPUDirect RDMA — which is why native clients use VMM, not cuIpcGetMemHandle.
+  // Per-layer views into the client's fused VMM allocation. Empty for Python.
+  // Allocation fd is out-of-band (see HealthResponse.fd_socket_path).
   repeated NativeKvTensor native_kv_tensors = 19;
-  // Total byte size of the fused VMM allocation the client exported, already
-  // rounded up to the CUDA VMM granularity. The server reserves and maps
-  // exactly this size; deriving it from layer extents would not be
-  // granularity-aligned and `cuMemAddressReserve` would reject it. Zero for
-  // non-native (Python) registrations.
+  // Fused VMM allocation size (granularity-aligned). Zero for Python.
   uint64 native_alloc_size = 20;
 }
 
-// One strided layer view into a client's fused VMM allocation. The backing fd
-// arrives out-of-band over the fd side-channel; all tensors of one registration
-// batch share the single allocation identified by (instance_id, device_id).
+// One layer's offset/size/stride inside a shared VMM allocation.
 message NativeKvTensor {
   uint64 offset_bytes = 1;
   uint64 size_bytes = 2;
@@ -168,10 +156,8 @@ message HealthRequest {}
 
 message HealthResponse {
   ResponseStatus status = 1;
-  // Absolute path to the server's fd side-channel (Unix domain socket). Native
-  // VMM clients connect here and send their exported allocation fd via
-  // SCM_RIGHTS, keyed by (instance_id, device_id), before register_context_batch.
-  // Empty if the server has no local fd channel (e.g. Python-only deployments).
+  // Unix socket for native clients to pass VMM allocation fds (SCM_RIGHTS).
+  // Empty when the fd channel is disabled.
   string fd_socket_path = 2;
 }
 

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -46,14 +46,13 @@ message RegisterContextRequest {
   // Set by the connector for MLA; the engine derives per-layer page offsets
   // from the registered layouts. See spec.md.
   bool page_first = 18;
-  // Per-layer views into the client's fused VMM allocation. Empty for Python.
-  // Allocation fd is out-of-band (Unix socket + SCM_RIGHTS, --fd-socket-path).
+  // Native VMM layer views; empty for Python. Fd via --fd-socket-path (SCM_RIGHTS).
   repeated NativeKvTensor native_kv_tensors = 19;
   // Fused VMM allocation size (granularity-aligned). Zero for Python.
   uint64 native_alloc_size = 20;
 }
 
-// One layer's offset/size/stride inside a shared VMM allocation.
+// Layer view into a shared VMM allocation.
 message NativeKvTensor {
   uint64 offset_bytes = 1;
   uint64 size_bytes = 2;

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -47,7 +47,7 @@ message RegisterContextRequest {
   // from the registered layouts. See spec.md.
   bool page_first = 18;
   // Per-layer views into the client's fused VMM allocation. Empty for Python.
-  // Allocation fd is out-of-band (see HealthResponse.fd_socket_path).
+  // Allocation fd is out-of-band (Unix socket + SCM_RIGHTS, --fd-socket-path).
   repeated NativeKvTensor native_kv_tensors = 19;
   // Fused VMM allocation size (granularity-aligned). Zero for Python.
   uint64 native_alloc_size = 20;
@@ -156,9 +156,6 @@ message HealthRequest {}
 
 message HealthResponse {
   ResponseStatus status = 1;
-  // Unix socket for native clients to pass VMM allocation fds (SCM_RIGHTS).
-  // Empty when the fd channel is disabled.
-  string fd_socket_path = 2;
 }
 
 // Liveness session: vllm opens a server-streaming RPC at startup and holds

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -46,6 +46,30 @@ message RegisterContextRequest {
   // Set by the connector for MLA; the engine derives per-layer page offsets
   // from the registered layouts. See spec.md.
   bool page_first = 18;
+  // Native VMM registration. Each layer is a strided view into one fused,
+  // GPU-resident VMM allocation the client exported as a POSIX file descriptor.
+  // The fd itself does NOT travel here — it is a host-local kernel object that
+  // cannot cross gRPC. The client sends it over the server's fd side-channel
+  // (Unix domain socket, SCM_RIGHTS; see HealthResponse.fd_socket_path) keyed
+  // by (instance_id, device_id) BEFORE issuing this RPC. Unlike a CUDA IPC
+  // handle, a VMM POSIX-fd allocation can be registered into the NIC for
+  // GPUDirect RDMA — which is why native clients use VMM, not cuIpcGetMemHandle.
+  repeated NativeKvTensor native_kv_tensors = 19;
+  // Total byte size of the fused VMM allocation the client exported, already
+  // rounded up to the CUDA VMM granularity. The server reserves and maps
+  // exactly this size; deriving it from layer extents would not be
+  // granularity-aligned and `cuMemAddressReserve` would reject it. Zero for
+  // non-native (Python) registrations.
+  uint64 native_alloc_size = 20;
+}
+
+// One strided layer view into a client's fused VMM allocation. The backing fd
+// arrives out-of-band over the fd side-channel; all tensors of one registration
+// batch share the single allocation identified by (instance_id, device_id).
+message NativeKvTensor {
+  uint64 offset_bytes = 1;
+  uint64 size_bytes = 2;
+  uint64 block_stride_bytes = 3;
 }
 
 message RegisterContextResponse {
@@ -77,6 +101,7 @@ message LoadRequest {
   string load_state_shm = 4;
   repeated string layer_names = 5;
   repeated LeaseLoad loads = 6;
+  bool wait_for_completion = 7;
 }
 
 message LeaseLoad {
@@ -85,6 +110,12 @@ message LeaseLoad {
 }
 
 message LoadResponse {
+  ResponseStatus status = 1;
+}
+
+message FlushRequest {}
+
+message FlushResponse {
   ResponseStatus status = 1;
 }
 
@@ -133,6 +164,11 @@ message HealthRequest {}
 
 message HealthResponse {
   ResponseStatus status = 1;
+  // Absolute path to the server's fd side-channel (Unix domain socket). Native
+  // VMM clients connect here and send their exported allocation fd via
+  // SCM_RIGHTS, keyed by (instance_id, device_id), before register_context_batch.
+  // Empty if the server has no local fd channel (e.g. Python-only deployments).
+  string fd_socket_path = 2;
 }
 
 // Liveness session: vllm opens a server-streaming RPC at startup and holds
@@ -203,6 +239,7 @@ service Engine {
   rpc RegisterContextBatch(RegisterContextRequest) returns (RegisterContextResponse);
   rpc Save(SaveRequest) returns (SaveResponse);
   rpc Load(LoadRequest) returns (LoadResponse);
+  rpc Flush(FlushRequest) returns (FlushResponse);
   // Prefetch query: check memory + trigger SSD prefetch or cross-node RDMA fetch for missing blocks
   rpc QueryPrefetch(QueryRequest) returns (QueryResponse);
   rpc Release(ReleaseRequest) returns (ReleaseResponse);

--- a/pegaflow-proto/src/lib.rs
+++ b/pegaflow-proto/src/lib.rs
@@ -7,3 +7,5 @@ pub mod proto {
         tonic::include_proto!("pegaflow");
     }
 }
+
+pub const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "+native-vmm-v1");

--- a/pegaflow-server/Cargo.toml
+++ b/pegaflow-server/Cargo.toml
@@ -40,6 +40,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio-stream.workspace = true
 uuid.workspace = true
+libc.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-otlp.workspace = true

--- a/pegaflow-server/examples/p2p_bench.rs
+++ b/pegaflow-server/examples/p2p_bench.rs
@@ -510,7 +510,8 @@ async fn run_holder(cli: &Cli, shape: &Shape, pool_bytes: usize) {
             14,
         ),
     ));
-    let service = GrpcEngineService::new(Arc::clone(&engine), registry, shutdown, hll);
+    // Bench saves in-process; no native VMM clients, so no fd side-channel.
+    let service = GrpcEngineService::new(Arc::clone(&engine), registry, shutdown, hll, None);
     let listen: SocketAddr = ([0, 0, 0, 0], cli.port).into();
     tokio::spawn(async move {
         Server::builder()

--- a/pegaflow-server/examples/p2p_bench.rs
+++ b/pegaflow-server/examples/p2p_bench.rs
@@ -510,7 +510,6 @@ async fn run_holder(cli: &Cli, shape: &Shape, pool_bytes: usize) {
             14,
         ),
     ));
-    // Bench saves in-process; no native VMM clients, so no fd side-channel.
     let service = GrpcEngineService::new(Arc::clone(&engine), registry, shutdown, hll, None);
     let listen: SocketAddr = ([0, 0, 0, 0], cli.port).into();
     tokio::spawn(async move {

--- a/pegaflow-server/src/fd_channel.rs
+++ b/pegaflow-server/src/fd_channel.rs
@@ -76,11 +76,6 @@ impl FdChannel {
         Ok(channel)
     }
 
-    /// Absolute socket path to advertise to clients (via `HealthResponse`).
-    pub fn path(&self) -> &str {
-        &self.path
-    }
-
     /// Claim the fd registered for `key`, waiting up to `timeout` for it to
     /// arrive if the registration RPC beat its fd. Returns `None` on timeout.
     pub async fn take(&self, key: FdKey, timeout: Duration) -> Option<OwnedFd> {

--- a/pegaflow-server/src/fd_channel.rs
+++ b/pegaflow-server/src/fd_channel.rs
@@ -166,7 +166,9 @@ fn recv_fd_with_key(sock: RawFd) -> std::io::Result<(FdKey, OwnedFd)> {
     // SAFETY: cmsg points into our control buffer.
     let (level, ctype) = unsafe { ((*cmsg).cmsg_level, (*cmsg).cmsg_type) };
     if level != libc::SOL_SOCKET || ctype != libc::SCM_RIGHTS {
-        return Err(std::io::Error::other("fd side-channel: unexpected control message"));
+        return Err(std::io::Error::other(
+            "fd side-channel: unexpected control message",
+        ));
     }
     // SAFETY: CMSG_DATA points at the fd payload of a SCM_RIGHTS message.
     let raw_fd = unsafe { std::ptr::read_unaligned(libc::CMSG_DATA(cmsg).cast::<RawFd>()) };

--- a/pegaflow-server/src/fd_channel.rs
+++ b/pegaflow-server/src/fd_channel.rs
@@ -16,33 +16,40 @@ pub(crate) struct RegistrationKey {
     pub(crate) device_id: i32,
 }
 
-/// Bound UDS path plus fds waiting to be claimed by `register_context_batch`.
-#[derive(Clone)]
-pub struct FdChannel {
+struct Inner {
     path: String,
-    pending: Arc<Mutex<HashMap<RegistrationKey, OwnedFd>>>,
-    arrived: Arc<Notify>,
+    pending: Mutex<HashMap<RegistrationKey, OwnedFd>>,
+    arrived: Notify,
 }
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        remove_stale_socket(&self.path);
+    }
+}
+
+/// Bound UDS path plus fds waiting to be claimed by `register_context_batch`.
+/// Cloning only bumps the `Arc`; the socket file is removed when the last clone drops.
+#[derive(Clone)]
+pub struct FdChannel(Arc<Inner>);
 
 impl FdChannel {
     pub fn bind(path: String) -> std::io::Result<Self> {
         remove_stale_socket(&path);
         let listener = UnixListener::bind(&path)?;
-        let channel = Self {
+        let channel = Self(Arc::new(Inner {
             path,
-            pending: Arc::new(Mutex::new(HashMap::new())),
-            arrived: Arc::new(Notify::new()),
-        };
-        let pending = Arc::clone(&channel.pending);
-        let arrived = Arc::clone(&channel.arrived);
+            pending: Mutex::new(HashMap::new()),
+            arrived: Notify::new(),
+        }));
+        let inner = Arc::clone(&channel.0);
         tokio::spawn(async move {
             loop {
                 match listener.accept().await {
                     Ok((stream, _)) => {
-                        let pending = Arc::clone(&pending);
-                        let arrived = Arc::clone(&arrived);
+                        let inner = Arc::clone(&inner);
                         tokio::spawn(async move {
-                            if let Err(err) = recv_one(stream, &pending, &arrived).await {
+                            if let Err(err) = recv_one(stream, &inner).await {
                                 log::warn!("fd side-channel: dropping connection: {err}");
                             }
                         });
@@ -62,24 +69,18 @@ impl FdChannel {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
             {
-                let mut pending = self.pending.lock().expect("fd pending map poisoned");
+                let mut pending = self.0.pending.lock().expect("fd pending map poisoned");
                 if let Some(fd) = pending.remove(&key) {
                     return Some(fd);
                 }
             }
-            if tokio::time::timeout_at(deadline, self.arrived.notified())
+            if tokio::time::timeout_at(deadline, self.0.arrived.notified())
                 .await
                 .is_err()
             {
                 return None;
             }
         }
-    }
-}
-
-impl Drop for FdChannel {
-    fn drop(&mut self) {
-        remove_stale_socket(&self.path);
     }
 }
 
@@ -91,11 +92,7 @@ fn remove_stale_socket(path: &str) {
     }
 }
 
-async fn recv_one(
-    stream: tokio::net::UnixStream,
-    pending: &Mutex<HashMap<RegistrationKey, OwnedFd>>,
-    arrived: &Notify,
-) -> std::io::Result<()> {
+async fn recv_one(stream: tokio::net::UnixStream, inner: &Inner) -> std::io::Result<()> {
     // SCM_RIGHTS needs recvmsg; wait until readable then use a blocking std socket.
     stream.readable().await?;
     let std_stream = stream.into_std()?;
@@ -104,11 +101,12 @@ async fn recv_one(
     let (key, fd) = recv_fd_with_key(raw)?;
     drop(std_stream);
 
-    pending
+    inner
+        .pending
         .lock()
         .expect("fd pending map poisoned")
         .insert(key, fd);
-    arrived.notify_waiters();
+    inner.arrived.notify_waiters();
     Ok(())
 }
 

--- a/pegaflow-server/src/fd_channel.rs
+++ b/pegaflow-server/src/fd_channel.rs
@@ -1,16 +1,6 @@
-//! Host-local fd side-channel for native VMM clients.
-//!
-//! A native client exports its fused KV allocation as a POSIX file descriptor
-//! (`CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`). That fd is a kernel object with
-//! process-local meaning — it cannot travel inside a gRPC message. The client
-//! sends it here over a Unix domain socket via `SCM_RIGHTS`, tagged with its
-//! `(instance_id, device_id)`, before it issues `register_context_batch`. The
-//! gRPC handler then claims the fd by the same key and imports the VMM
-//! allocation from it.
-//!
-//! This is why native clients can offer GPUDirect RDMA where CUDA IPC cannot: a
-//! VMM POSIX-fd allocation can be handed to `ibv_reg_dmabuf_mr`, an imported
-//! `cuIpcOpenMemHandle` pointer cannot.
+//! Host-local Unix socket that receives VMM allocation fds (SCM_RIGHTS) for
+//! native `register_context_batch`. Wire payload: `instance_id\0device_id` plus
+//! one fd per connection.
 
 use std::collections::HashMap;
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
@@ -20,52 +10,39 @@ use std::time::Duration;
 use tokio::net::UnixListener;
 use tokio::sync::Notify;
 
-/// Key identifying which registration an fd belongs to. Matches the
-/// `(instance_id, device_id)` the gRPC `register_context_batch` handler uses.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct FdKey {
+pub(crate) struct RegistrationKey {
     pub(crate) instance_id: String,
     pub(crate) device_id: i32,
 }
 
-/// Received fds waiting to be claimed by their registration RPC, plus a waker so
-/// a handler that arrives before its fd can await it instead of racing.
-#[derive(Default)]
-struct Inbox {
-    fds: HashMap<FdKey, OwnedFd>,
-    arrived: Arc<Notify>,
-}
-
-/// Server-side endpoint of the fd side-channel. Holds received fds until the
-/// matching registration RPC claims them.
+/// Bound UDS path plus fds waiting to be claimed by `register_context_batch`.
 #[derive(Clone)]
 pub struct FdChannel {
     path: String,
-    inbox: Arc<Mutex<Inbox>>,
+    pending: Arc<Mutex<HashMap<RegistrationKey, OwnedFd>>>,
+    arrived: Arc<Notify>,
 }
 
 impl FdChannel {
-    /// Bind the Unix socket at `path` and spawn an accept loop. Each connection
-    /// carries exactly one fd plus its `instance_id\0device_id` key.
     pub fn bind(path: String) -> std::io::Result<Self> {
-        // A stale socket file from a previous run would make bind fail with
-        // EADDRINUSE; the server owns this path exclusively, so clear it.
-        let _ = std::fs::remove_file(&path);
+        remove_stale_socket(&path);
         let listener = UnixListener::bind(&path)?;
         let channel = Self {
             path,
-            inbox: Arc::new(Mutex::new(Inbox::default())),
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            arrived: Arc::new(Notify::new()),
         };
-        let inbox = Arc::clone(&channel.inbox);
+        let pending = Arc::clone(&channel.pending);
+        let arrived = Arc::clone(&channel.arrived);
         tokio::spawn(async move {
             loop {
                 match listener.accept().await {
                     Ok((stream, _)) => {
-                        let inbox = Arc::clone(&inbox);
-                        // One fd per connection; handle concurrently so a slow
-                        // sender can't head-of-line block others.
+                        let pending = Arc::clone(&pending);
+                        let arrived = Arc::clone(&arrived);
                         tokio::spawn(async move {
-                            if let Err(err) = recv_one(stream, &inbox).await {
+                            if let Err(err) = recv_one(stream, &pending, &arrived).await {
                                 log::warn!("fd side-channel: dropping connection: {err}");
                             }
                         });
@@ -80,20 +57,17 @@ impl FdChannel {
         Ok(channel)
     }
 
-    /// Claim the fd registered for `key`, waiting up to `timeout` for it to
-    /// arrive if the registration RPC beat its fd. Returns `None` on timeout.
-    pub(crate) async fn take(&self, key: FdKey, timeout: Duration) -> Option<OwnedFd> {
+    /// Wait up to `timeout` for the fd tagged with `key`.
+    pub(crate) async fn take(&self, key: RegistrationKey, timeout: Duration) -> Option<OwnedFd> {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            let notify = {
-                let mut inbox = self.inbox.lock().expect("fd inbox poisoned");
-                if let Some(fd) = inbox.fds.remove(&key) {
+            {
+                let mut pending = self.pending.lock().expect("fd pending map poisoned");
+                if let Some(fd) = pending.remove(&key) {
                     return Some(fd);
                 }
-                Arc::clone(&inbox.arrived)
-            };
-            // Wait for the next arrival or the deadline, then re-check the map.
-            if tokio::time::timeout_at(deadline, notify.notified())
+            }
+            if tokio::time::timeout_at(deadline, self.arrived.notified())
                 .await
                 .is_err()
             {
@@ -105,49 +79,53 @@ impl FdChannel {
 
 impl Drop for FdChannel {
     fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
+        remove_stale_socket(&self.path);
     }
 }
 
-/// Read one `(key, fd)` from a connection and deposit it in the inbox.
-async fn recv_one(stream: tokio::net::UnixStream, inbox: &Mutex<Inbox>) -> std::io::Result<()> {
-    // SCM_RIGHTS requires recvmsg; tokio has no wrapper, so drive the raw fd
-    // through a std socket once it is readable. The payload is small and arrives
-    // in one datagram-sized write, so a single readable notification suffices.
+fn remove_stale_socket(path: &str) {
+    match std::fs::remove_file(path) {
+        Ok(()) => log::info!("fd side-channel: removed existing socket {path}"),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => log::warn!("fd side-channel: failed to remove socket {path}: {err}"),
+    }
+}
+
+async fn recv_one(
+    stream: tokio::net::UnixStream,
+    pending: &Mutex<HashMap<RegistrationKey, OwnedFd>>,
+    arrived: &Notify,
+) -> std::io::Result<()> {
+    // SCM_RIGHTS needs recvmsg; wait until readable then use a blocking std socket.
     stream.readable().await?;
     let std_stream = stream.into_std()?;
     std_stream.set_nonblocking(false)?;
     let raw = std::os::fd::AsRawFd::as_raw_fd(&std_stream);
     let (key, fd) = recv_fd_with_key(raw)?;
-    // std_stream owns `raw` and closes it on drop; the received `fd` is separate.
     drop(std_stream);
-    let notify = {
-        let mut guard = inbox.lock().expect("fd inbox poisoned");
-        guard.fds.insert(key, fd);
-        Arc::clone(&guard.arrived)
-    };
-    notify.notify_waiters();
+
+    pending
+        .lock()
+        .expect("fd pending map poisoned")
+        .insert(key, fd);
+    arrived.notify_waiters();
     Ok(())
 }
 
-/// Blocking `recvmsg` that pulls one fd (SCM_RIGHTS) plus a
-/// `instance_id\0device_id` payload off `sock`.
-fn recv_fd_with_key(sock: RawFd) -> std::io::Result<(FdKey, OwnedFd)> {
-    // Payload: "<instance_id>\0<device_id>", capped generously.
+fn recv_fd_with_key(sock: RawFd) -> std::io::Result<(RegistrationKey, OwnedFd)> {
     let mut buf = [0u8; 512];
     let mut iov = libc::iovec {
         iov_base: buf.as_mut_ptr().cast(),
         iov_len: buf.len(),
     };
-    // Control buffer sized for exactly one fd.
-    let mut cmsg_space = [0u8; unsafe_cmsg_space()];
+    let mut cmsg_space = [0u8; CMSG_SPACE_FOR_FD];
     let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
     msg.msg_iov = &mut iov;
     msg.msg_iovlen = 1;
     msg.msg_control = cmsg_space.as_mut_ptr().cast();
     msg.msg_controllen = cmsg_space.len();
 
-    // SAFETY: msg is fully initialized with valid iov/control buffers.
+    // SAFETY: iov and control buffers are valid for the duration of recvmsg.
     let n = unsafe { libc::recvmsg(sock, &mut msg, 0) };
     if n < 0 {
         return Err(std::io::Error::last_os_error());
@@ -156,31 +134,28 @@ fn recv_fd_with_key(sock: RawFd) -> std::io::Result<(FdKey, OwnedFd)> {
         return Err(std::io::Error::other("fd control message truncated"));
     }
 
-    // Extract the single fd from the first SCM_RIGHTS control message.
-    // SAFETY: msg has a valid control buffer populated by recvmsg above.
+    // SAFETY: control buffer was filled by recvmsg.
     let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
     if cmsg.is_null() {
         return Err(std::io::Error::other("fd side-channel: no control message"));
     }
-    // SAFETY: cmsg points into our control buffer.
+    // SAFETY: cmsg points into cmsg_space.
     let (level, ctype) = unsafe { ((*cmsg).cmsg_level, (*cmsg).cmsg_type) };
     if level != libc::SOL_SOCKET || ctype != libc::SCM_RIGHTS {
         return Err(std::io::Error::other(
             "fd side-channel: unexpected control message",
         ));
     }
-    // SAFETY: CMSG_DATA points at the fd payload of a SCM_RIGHTS message.
+    // SAFETY: SCM_RIGHTS payload is one RawFd.
     let raw_fd = unsafe { std::ptr::read_unaligned(libc::CMSG_DATA(cmsg).cast::<RawFd>()) };
-    // SAFETY: recvmsg transferred ownership of this fd to us.
+    // SAFETY: ownership transferred by recvmsg.
     let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
 
-    let payload = &buf[..n as usize];
-    let key = parse_key(payload)?;
+    let key = parse_key(&buf[..n as usize])?;
     Ok((key, fd))
 }
 
-/// Parse `"<instance_id>\0<device_id>"` into an [`FdKey`].
-fn parse_key(payload: &[u8]) -> std::io::Result<FdKey> {
+fn parse_key(payload: &[u8]) -> std::io::Result<RegistrationKey> {
     let mut parts = payload.splitn(2, |&b| b == 0);
     let instance = parts
         .next()
@@ -195,16 +170,11 @@ fn parse_key(payload: &[u8]) -> std::io::Result<FdKey> {
         .ok()
         .and_then(|s| s.trim_end_matches('\0').parse().ok())
         .ok_or_else(|| std::io::Error::other("fd side-channel: bad device_id"))?;
-    Ok(FdKey {
+    Ok(RegistrationKey {
         instance_id,
         device_id,
     })
 }
 
-/// `CMSG_SPACE(size_of::<RawFd>())` as a const for the control buffer. Wrapped
-/// in a const fn since `CMSG_SPACE` is not const in libc.
-const fn unsafe_cmsg_space() -> usize {
-    // CMSG_SPACE(4) rounds the header + 4-byte fd up to the alignment boundary;
-    // 64 bytes covers it on all supported platforms with margin.
-    64
-}
+/// Bytes for one SCM_RIGHTS fd (`CMSG_SPACE(sizeof(int))` with margin).
+const CMSG_SPACE_FOR_FD: usize = 64;

--- a/pegaflow-server/src/fd_channel.rs
+++ b/pegaflow-server/src/fd_channel.rs
@@ -111,7 +111,7 @@ async fn recv_one(stream: tokio::net::UnixStream, inner: &Inner) -> std::io::Res
 }
 
 fn recv_fd_with_key(sock: RawFd) -> std::io::Result<(RegistrationKey, OwnedFd)> {
-    let mut buf = [0u8; 512];
+    let mut buf = [0u8; MAX_KEY_PAYLOAD];
     let mut iov = libc::iovec {
         iov_base: buf.as_mut_ptr().cast(),
         iov_len: buf.len(),
@@ -174,5 +174,7 @@ fn parse_key(payload: &[u8]) -> std::io::Result<RegistrationKey> {
     })
 }
 
+/// `instance_id\0device_id` payload; generous so long instance ids do not truncate.
+const MAX_KEY_PAYLOAD: usize = 4096;
 /// Bytes for one SCM_RIGHTS fd (`CMSG_SPACE(sizeof(int))` with margin).
 const CMSG_SPACE_FOR_FD: usize = 64;

--- a/pegaflow-server/src/fd_channel.rs
+++ b/pegaflow-server/src/fd_channel.rs
@@ -3,6 +3,7 @@
 //! one fd per connection.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -12,8 +13,11 @@ use tokio::sync::Notify;
 
 /// `instance_id\0device_id` payload; generous so long instance ids do not truncate.
 const MAX_KEY_PAYLOAD: usize = 4096;
-/// Bytes for one SCM_RIGHTS fd (`CMSG_SPACE(sizeof(int))` with margin).
-const CMSG_SPACE_FOR_FD: usize = 64;
+/// Control buffer for one SCM_RIGHTS fd.
+const CMSG_SPACE_FOR_FD: usize = unsafe {
+    // SAFETY: CMSG_SPACE is a pure layout calculation from the payload length.
+    libc::CMSG_SPACE(std::mem::size_of::<RawFd>() as libc::c_uint) as usize
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct RegistrationKey {
@@ -33,8 +37,7 @@ impl Drop for Inner {
     }
 }
 
-/// Bound UDS path plus fds waiting to be claimed by `register_context_batch`.
-/// Cloning only bumps the `Arc`; the socket file is removed when the last clone drops.
+/// UDS side-channel; last `Arc` drop unlinks the socket file.
 #[derive(Clone)]
 pub struct FdChannel(Arc<Inner>);
 
@@ -106,13 +109,22 @@ async fn recv_one(stream: tokio::net::UnixStream, inner: &Inner) -> std::io::Res
     let (key, fd) = recv_fd_with_key(raw)?;
     drop(std_stream);
 
-    inner
-        .pending
-        .lock()
-        .expect("fd pending map poisoned")
-        .insert(key, fd);
-    inner.arrived.notify_waiters();
-    Ok(())
+    let mut pending = inner.pending.lock().expect("fd pending map poisoned");
+    match pending.entry(key) {
+        Entry::Vacant(slot) => {
+            slot.insert(fd);
+            drop(pending);
+            inner.arrived.notify_waiters();
+            Ok(())
+        }
+        Entry::Occupied(slot) => {
+            let key = slot.key();
+            Err(std::io::Error::other(format!(
+                "duplicate pending fd for instance_id={} device_id={}",
+                key.instance_id, key.device_id
+            )))
+        }
+    }
 }
 
 fn recv_fd_with_key(sock: RawFd) -> std::io::Result<(RegistrationKey, OwnedFd)> {
@@ -177,4 +189,170 @@ fn parse_key(payload: &[u8]) -> std::io::Result<RegistrationKey> {
         instance_id,
         device_id,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::os::fd::AsRawFd;
+    use std::os::unix::net::UnixStream as StdUnixStream;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_sock_path(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("pegaflow-fd-test-{label}-{nanos}.sock"))
+    }
+
+    fn key(instance_id: &str, device_id: i32) -> RegistrationKey {
+        RegistrationKey {
+            instance_id: instance_id.to_string(),
+            device_id,
+        }
+    }
+
+    /// Pipe whose read end carries `tag` once written on the write end.
+    /// Returns `(read_end_to_send, write_end_keep_alive)`.
+    fn tagged_pipe(tag: u8) -> (OwnedFd, std::fs::File) {
+        let mut fds = [0 as RawFd; 2];
+        // SAFETY: pipe(2) with a two-slot output array.
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        // SAFETY: pipe ends are open and owned here.
+        let (read_end, write_end) =
+            unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) };
+        let mut write_file = std::fs::File::from(write_end);
+        write_file.write_all(&[tag]).expect("write tag into pipe");
+        (read_end, write_file)
+    }
+
+    fn send_fd(sock_path: &str, reg: &RegistrationKey, pass: RawFd) {
+        let stream = StdUnixStream::connect(sock_path).expect("connect fd side-channel");
+        let payload = format!("{}\0{}", reg.instance_id, reg.device_id);
+        let mut payload_bytes = payload.into_bytes();
+        let mut iov = libc::iovec {
+            iov_base: payload_bytes.as_mut_ptr().cast(),
+            iov_len: payload_bytes.len(),
+        };
+        let mut cmsg_buf = vec![0u8; CMSG_SPACE_FOR_FD];
+        let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+        msg.msg_control = cmsg_buf.as_mut_ptr().cast();
+        msg.msg_controllen = cmsg_buf.len();
+
+        // SAFETY: msg_control points at cmsg_buf; CMSG_* walk that buffer only.
+        unsafe {
+            let cmsg = libc::CMSG_FIRSTHDR(&msg);
+            assert!(!cmsg.is_null());
+            (*cmsg).cmsg_level = libc::SOL_SOCKET;
+            (*cmsg).cmsg_type = libc::SCM_RIGHTS;
+            (*cmsg).cmsg_len = libc::CMSG_LEN(std::mem::size_of::<RawFd>() as libc::c_uint) as _;
+            std::ptr::write_unaligned(libc::CMSG_DATA(cmsg).cast::<RawFd>(), pass);
+            msg.msg_controllen = (*cmsg).cmsg_len;
+            let n = libc::sendmsg(stream.as_raw_fd(), &msg, 0);
+            assert!(n >= 0, "sendmsg: {}", std::io::Error::last_os_error());
+        }
+    }
+
+    fn read_tag(fd: &OwnedFd) -> u8 {
+        let mut buf = [0u8; 1];
+        let mut file = std::fs::File::from(fd.try_clone().expect("clone fd"));
+        file.read_exact(&mut buf).expect("read tag");
+        buf[0]
+    }
+
+    #[test]
+    fn parse_key_splits_instance_and_device() {
+        // "engine-abc" + NUL + "3" (\x00 is null; next char is '3')
+        let k = parse_key(b"engine-abc\x003").unwrap();
+        assert_eq!(k.instance_id, "engine-abc");
+        assert_eq!(k.device_id, 3);
+    }
+
+    #[test]
+    fn parse_key_rejects_missing_nul() {
+        assert!(parse_key(b"no-separator").is_err());
+    }
+
+    #[tokio::test]
+    async fn fd_before_take_delivers_tagged_pipe() {
+        let path = temp_sock_path("before");
+        let channel = FdChannel::bind(path.to_string_lossy().into_owned()).unwrap();
+        let reg = key("inst-a", 0);
+        let (pass, _hold_write) = tagged_pipe(0xA1);
+        send_fd(path.to_str().unwrap(), &reg, pass.as_raw_fd());
+
+        let got = channel
+            .take(reg, Duration::from_secs(2))
+            .await
+            .expect("fd should be pending");
+        assert_eq!(read_tag(&got), 0xA1);
+    }
+
+    #[tokio::test]
+    async fn take_waits_when_fd_arrives_later() {
+        let path = temp_sock_path("wait");
+        let channel = FdChannel::bind(path.to_string_lossy().into_owned()).unwrap();
+        let reg = key("inst-b", 1);
+        let path_str = path.to_string_lossy().into_owned();
+        let reg_send = reg.clone();
+
+        let take = tokio::spawn({
+            let channel = channel.clone();
+            async move { channel.take(reg, Duration::from_secs(2)).await }
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let (pass, _hold_write) = tagged_pipe(0xB2);
+        tokio::task::spawn_blocking(move || {
+            send_fd(&path_str, &reg_send, pass.as_raw_fd());
+            // Keep pass alive until sendmsg returns (SCM_RIGHTS dups the fd).
+            drop(pass);
+        })
+        .await
+        .unwrap();
+
+        let got = take.await.unwrap().expect("fd after wait");
+        assert_eq!(read_tag(&got), 0xB2);
+    }
+
+    #[tokio::test]
+    async fn take_times_out_without_fd() {
+        let path = temp_sock_path("timeout");
+        let channel = FdChannel::bind(path.to_string_lossy().into_owned()).unwrap();
+        let got = channel
+            .take(key("missing", 0), Duration::from_millis(80))
+            .await;
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn duplicate_key_keeps_first_fd() {
+        let path = temp_sock_path("dup");
+        let path_str = path.to_string_lossy().into_owned();
+        let channel = FdChannel::bind(path_str.clone()).unwrap();
+        let reg = key("inst-dup", 0);
+
+        let (first, _w1) = tagged_pipe(0x11);
+        let (second, _w2) = tagged_pipe(0x22);
+        send_fd(&path_str, &reg, first.as_raw_fd());
+        // Allow the first connection to be accepted and inserted.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        send_fd(&path_str, &reg, second.as_raw_fd());
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let got = channel
+            .take(reg, Duration::from_secs(1))
+            .await
+            .expect("first fd remains");
+        assert_eq!(
+            read_tag(&got),
+            0x11,
+            "duplicate must not replace pending fd"
+        );
+    }
 }

--- a/pegaflow-server/src/fd_channel.rs
+++ b/pegaflow-server/src/fd_channel.rs
@@ -86,6 +86,12 @@ impl FdChannel {
                 .await
                 .is_err()
             {
+                log::warn!(
+                    "fd side-channel: timed out waiting for fd instance_id={} device_id={}; \
+                     a late-arriving fd may stay pending until process exit",
+                    key.instance_id,
+                    key.device_id
+                );
                 return None;
             }
         }

--- a/pegaflow-server/src/fd_channel.rs
+++ b/pegaflow-server/src/fd_channel.rs
@@ -20,9 +20,13 @@ use std::time::Duration;
 use tokio::net::UnixListener;
 use tokio::sync::Notify;
 
-/// Key identifying which registration an fd belongs to. Matches the tuple the
-/// gRPC `register_context_batch` handler reconstructs from its request.
-type FdKey = (String, i32);
+/// Key identifying which registration an fd belongs to. Matches the
+/// `(instance_id, device_id)` the gRPC `register_context_batch` handler uses.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct FdKey {
+    pub(crate) instance_id: String,
+    pub(crate) device_id: i32,
+}
 
 /// Received fds waiting to be claimed by their registration RPC, plus a waker so
 /// a handler that arrives before its fd can await it instead of racing.
@@ -78,7 +82,7 @@ impl FdChannel {
 
     /// Claim the fd registered for `key`, waiting up to `timeout` for it to
     /// arrive if the registration RPC beat its fd. Returns `None` on timeout.
-    pub async fn take(&self, key: FdKey, timeout: Duration) -> Option<OwnedFd> {
+    pub(crate) async fn take(&self, key: FdKey, timeout: Duration) -> Option<OwnedFd> {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
             let notify = {
@@ -175,7 +179,7 @@ fn recv_fd_with_key(sock: RawFd) -> std::io::Result<(FdKey, OwnedFd)> {
     Ok((key, fd))
 }
 
-/// Parse `"<instance_id>\0<device_id>"` into an `(instance_id, device_id)` key.
+/// Parse `"<instance_id>\0<device_id>"` into an [`FdKey`].
 fn parse_key(payload: &[u8]) -> std::io::Result<FdKey> {
     let mut parts = payload.splitn(2, |&b| b == 0);
     let instance = parts
@@ -191,7 +195,10 @@ fn parse_key(payload: &[u8]) -> std::io::Result<FdKey> {
         .ok()
         .and_then(|s| s.trim_end_matches('\0').parse().ok())
         .ok_or_else(|| std::io::Error::other("fd side-channel: bad device_id"))?;
-    Ok((instance_id, device_id))
+    Ok(FdKey {
+        instance_id,
+        device_id,
+    })
 }
 
 /// `CMSG_SPACE(size_of::<RawFd>())` as a const for the control buffer. Wrapped

--- a/pegaflow-server/src/fd_channel.rs
+++ b/pegaflow-server/src/fd_channel.rs
@@ -10,6 +10,11 @@ use std::time::Duration;
 use tokio::net::UnixListener;
 use tokio::sync::Notify;
 
+/// `instance_id\0device_id` payload; generous so long instance ids do not truncate.
+const MAX_KEY_PAYLOAD: usize = 4096;
+/// Bytes for one SCM_RIGHTS fd (`CMSG_SPACE(sizeof(int))` with margin).
+const CMSG_SPACE_FOR_FD: usize = 64;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct RegistrationKey {
     pub(crate) instance_id: String,
@@ -173,8 +178,3 @@ fn parse_key(payload: &[u8]) -> std::io::Result<RegistrationKey> {
         device_id,
     })
 }
-
-/// `instance_id\0device_id` payload; generous so long instance ids do not truncate.
-const MAX_KEY_PAYLOAD: usize = 4096;
-/// Bytes for one SCM_RIGHTS fd (`CMSG_SPACE(sizeof(int))` with margin).
-const CMSG_SPACE_FOR_FD: usize = 64;

--- a/pegaflow-server/src/fd_channel.rs
+++ b/pegaflow-server/src/fd_channel.rs
@@ -1,0 +1,206 @@
+//! Host-local fd side-channel for native VMM clients.
+//!
+//! A native client exports its fused KV allocation as a POSIX file descriptor
+//! (`CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`). That fd is a kernel object with
+//! process-local meaning — it cannot travel inside a gRPC message. The client
+//! sends it here over a Unix domain socket via `SCM_RIGHTS`, tagged with its
+//! `(instance_id, device_id)`, before it issues `register_context_batch`. The
+//! gRPC handler then claims the fd by the same key and imports the VMM
+//! allocation from it.
+//!
+//! This is why native clients can offer GPUDirect RDMA where CUDA IPC cannot: a
+//! VMM POSIX-fd allocation can be handed to `ibv_reg_dmabuf_mr`, an imported
+//! `cuIpcOpenMemHandle` pointer cannot.
+
+use std::collections::HashMap;
+use std::os::fd::{FromRawFd, OwnedFd, RawFd};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::net::UnixListener;
+use tokio::sync::Notify;
+
+/// Key identifying which registration an fd belongs to. Matches the tuple the
+/// gRPC `register_context_batch` handler reconstructs from its request.
+type FdKey = (String, i32);
+
+/// Received fds waiting to be claimed by their registration RPC, plus a waker so
+/// a handler that arrives before its fd can await it instead of racing.
+#[derive(Default)]
+struct Inbox {
+    fds: HashMap<FdKey, OwnedFd>,
+    arrived: Arc<Notify>,
+}
+
+/// Server-side endpoint of the fd side-channel. Holds received fds until the
+/// matching registration RPC claims them.
+#[derive(Clone)]
+pub struct FdChannel {
+    path: String,
+    inbox: Arc<Mutex<Inbox>>,
+}
+
+impl FdChannel {
+    /// Bind the Unix socket at `path` and spawn an accept loop. Each connection
+    /// carries exactly one fd plus its `instance_id\0device_id` key.
+    pub fn bind(path: String) -> std::io::Result<Self> {
+        // A stale socket file from a previous run would make bind fail with
+        // EADDRINUSE; the server owns this path exclusively, so clear it.
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path)?;
+        let channel = Self {
+            path,
+            inbox: Arc::new(Mutex::new(Inbox::default())),
+        };
+        let inbox = Arc::clone(&channel.inbox);
+        tokio::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _)) => {
+                        let inbox = Arc::clone(&inbox);
+                        // One fd per connection; handle concurrently so a slow
+                        // sender can't head-of-line block others.
+                        tokio::spawn(async move {
+                            if let Err(err) = recv_one(stream, &inbox).await {
+                                log::warn!("fd side-channel: dropping connection: {err}");
+                            }
+                        });
+                    }
+                    Err(err) => {
+                        log::error!("fd side-channel accept failed: {err}");
+                        break;
+                    }
+                }
+            }
+        });
+        Ok(channel)
+    }
+
+    /// Absolute socket path to advertise to clients (via `HealthResponse`).
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Claim the fd registered for `key`, waiting up to `timeout` for it to
+    /// arrive if the registration RPC beat its fd. Returns `None` on timeout.
+    pub async fn take(&self, key: FdKey, timeout: Duration) -> Option<OwnedFd> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let notify = {
+                let mut inbox = self.inbox.lock().expect("fd inbox poisoned");
+                if let Some(fd) = inbox.fds.remove(&key) {
+                    return Some(fd);
+                }
+                Arc::clone(&inbox.arrived)
+            };
+            // Wait for the next arrival or the deadline, then re-check the map.
+            if tokio::time::timeout_at(deadline, notify.notified())
+                .await
+                .is_err()
+            {
+                return None;
+            }
+        }
+    }
+}
+
+impl Drop for FdChannel {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Read one `(key, fd)` from a connection and deposit it in the inbox.
+async fn recv_one(stream: tokio::net::UnixStream, inbox: &Mutex<Inbox>) -> std::io::Result<()> {
+    // SCM_RIGHTS requires recvmsg; tokio has no wrapper, so drive the raw fd
+    // through a std socket once it is readable. The payload is small and arrives
+    // in one datagram-sized write, so a single readable notification suffices.
+    stream.readable().await?;
+    let std_stream = stream.into_std()?;
+    std_stream.set_nonblocking(false)?;
+    let raw = std::os::fd::AsRawFd::as_raw_fd(&std_stream);
+    let (key, fd) = recv_fd_with_key(raw)?;
+    // std_stream owns `raw` and closes it on drop; the received `fd` is separate.
+    drop(std_stream);
+    let notify = {
+        let mut guard = inbox.lock().expect("fd inbox poisoned");
+        guard.fds.insert(key, fd);
+        Arc::clone(&guard.arrived)
+    };
+    notify.notify_waiters();
+    Ok(())
+}
+
+/// Blocking `recvmsg` that pulls one fd (SCM_RIGHTS) plus a
+/// `instance_id\0device_id` payload off `sock`.
+fn recv_fd_with_key(sock: RawFd) -> std::io::Result<(FdKey, OwnedFd)> {
+    // Payload: "<instance_id>\0<device_id>", capped generously.
+    let mut buf = [0u8; 512];
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr().cast(),
+        iov_len: buf.len(),
+    };
+    // Control buffer sized for exactly one fd.
+    let mut cmsg_space = [0u8; unsafe_cmsg_space()];
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg_space.as_mut_ptr().cast();
+    msg.msg_controllen = cmsg_space.len();
+
+    // SAFETY: msg is fully initialized with valid iov/control buffers.
+    let n = unsafe { libc::recvmsg(sock, &mut msg, 0) };
+    if n < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if (msg.msg_flags & libc::MSG_CTRUNC) != 0 {
+        return Err(std::io::Error::other("fd control message truncated"));
+    }
+
+    // Extract the single fd from the first SCM_RIGHTS control message.
+    // SAFETY: msg has a valid control buffer populated by recvmsg above.
+    let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+    if cmsg.is_null() {
+        return Err(std::io::Error::other("fd side-channel: no control message"));
+    }
+    // SAFETY: cmsg points into our control buffer.
+    let (level, ctype) = unsafe { ((*cmsg).cmsg_level, (*cmsg).cmsg_type) };
+    if level != libc::SOL_SOCKET || ctype != libc::SCM_RIGHTS {
+        return Err(std::io::Error::other("fd side-channel: unexpected control message"));
+    }
+    // SAFETY: CMSG_DATA points at the fd payload of a SCM_RIGHTS message.
+    let raw_fd = unsafe { std::ptr::read_unaligned(libc::CMSG_DATA(cmsg).cast::<RawFd>()) };
+    // SAFETY: recvmsg transferred ownership of this fd to us.
+    let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+
+    let payload = &buf[..n as usize];
+    let key = parse_key(payload)?;
+    Ok((key, fd))
+}
+
+/// Parse `"<instance_id>\0<device_id>"` into an `(instance_id, device_id)` key.
+fn parse_key(payload: &[u8]) -> std::io::Result<FdKey> {
+    let mut parts = payload.splitn(2, |&b| b == 0);
+    let instance = parts
+        .next()
+        .ok_or_else(|| std::io::Error::other("fd side-channel: missing instance_id"))?;
+    let device = parts
+        .next()
+        .ok_or_else(|| std::io::Error::other("fd side-channel: missing device_id"))?;
+    let instance_id = std::str::from_utf8(instance)
+        .map_err(|_| std::io::Error::other("fd side-channel: instance_id not utf-8"))?
+        .to_string();
+    let device_id: i32 = std::str::from_utf8(device)
+        .ok()
+        .and_then(|s| s.trim_end_matches('\0').parse().ok())
+        .ok_or_else(|| std::io::Error::other("fd side-channel: bad device_id"))?;
+    Ok((instance_id, device_id))
+}
+
+/// `CMSG_SPACE(size_of::<RawFd>())` as a const for the control buffer. Wrapped
+/// in a const fn since `CMSG_SPACE` is not const in libc.
+const fn unsafe_cmsg_space() -> usize {
+    // CMSG_SPACE(4) rounds the header + 4-byte fd up to the alignment boundary;
+    // 64 bytes covers it on all supported platforms with margin.
+    64
+}

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -93,16 +93,11 @@ pub struct Cli {
     #[arg(long, default_value_t = true)]
     pub enable_prometheus: bool,
 
-    /// Unix socket path for the native-VMM fd side-channel. Native clients send
-    /// their exported allocation fd here (SCM_RIGHTS) before registration.
-    /// Empty disables native VMM registration (Python clients are unaffected).
+    /// UDS path for native clients to send VMM allocation fds (SCM_RIGHTS). Empty disables.
     #[arg(long, default_value = "/tmp/pegaflow-fd.sock")]
     pub fd_socket_path: String,
 
-    /// Initialize the Python/torch CUDA registry at startup. Required for the
-    /// Python (vLLM) connector, whose tensors arrive as pickled torch wrappers.
-    /// Native VMM clients do not need it — pass `--python-registry false` for a
-    /// torch-free deployment that serves only native clients.
+    /// Init torch CUDA registry (vLLM path). False = torch-free, native VMM only.
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub python_registry: bool,
 
@@ -384,9 +379,7 @@ fn init_python_cuda(device_ids: &[i32]) -> Result<(), std::io::Error> {
     })
 }
 
-/// Create each device's primary CUDA context via cudarc — the torch-free
-/// equivalent of `init_python_cuda`, used when `--python-registry false`.
-/// Native VMM clients bind these contexts when importing their allocations.
+/// Primary CUDA contexts via cudarc when `--python-registry false`.
 fn init_cudarc_cuda(device_ids: &[i32]) -> Result<(), std::io::Error> {
     if device_ids.is_empty() {
         return Err(std::io::Error::other("no CUDA devices to initialize"));
@@ -499,8 +492,6 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     if cli.python_registry {
         init_python_cuda(&devices)?;
     } else {
-        // Torch-free path: create each device's CUDA context via cudarc instead
-        // of forcing torch to do it. Native VMM import binds these contexts.
         init_cudarc_cuda(&devices)?;
     }
     info!(
@@ -509,9 +500,6 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         devices
     );
 
-    // The Python registry initializes torch's CUDA context for the vLLM
-    // connector. Native VMM clients import their own allocations without torch,
-    // so a native-only deployment can skip it entirely (no torch dependency).
     let registry = if cli.python_registry {
         CudaTensorRegistry::new().map_err(|err| {
             let msg = format_py_err(err);
@@ -649,9 +637,6 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             storage_config,
         )?);
 
-        // Bind the native-VMM fd side-channel before serving, so a client that
-        // connects the moment gRPC comes up finds the socket ready. Empty path
-        // disables it (Python-only deployments).
         let fd_channel = if cli.fd_socket_path.is_empty() {
             None
         } else {

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -94,9 +94,8 @@ pub struct Cli {
     pub enable_prometheus: bool,
 
     /// Unix socket path for the native-VMM fd side-channel. Native clients send
-    /// their exported allocation fd here (SCM_RIGHTS) before registration; the
-    /// path is advertised back via HealthResponse. Empty disables native VMM
-    /// registration (Python clients are unaffected).
+    /// their exported allocation fd here (SCM_RIGHTS) before registration.
+    /// Empty disables native VMM registration (Python clients are unaffected).
     #[arg(long, default_value = "/tmp/pegaflow-fd.sock")]
     pub fd_socket_path: String,
 

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -395,12 +395,10 @@ fn init_cudarc_cuda(device_ids: &[i32]) -> Result<(), std::io::Error> {
     for &device_id in device_ids {
         let ordinal = usize::try_from(device_id)
             .map_err(|_| std::io::Error::other(format!("device_id {device_id} must be >= 0")))?;
-        let ctx = cudarc::driver::CudaContext::new(ordinal).map_err(|e| {
-            std::io::Error::other(format!("cudarc init device {device_id}: {e}"))
-        })?;
-        ctx.bind_to_thread().map_err(|e| {
-            std::io::Error::other(format!("cudarc bind device {device_id}: {e}"))
-        })?;
+        let ctx = cudarc::driver::CudaContext::new(ordinal)
+            .map_err(|e| std::io::Error::other(format!("cudarc init device {device_id}: {e}")))?;
+        ctx.bind_to_thread()
+            .map_err(|e| std::io::Error::other(format!("cudarc bind device {device_id}: {e}")))?;
         info!("Initialized CUDA context for device {device_id} (cudarc, torch-free)");
     }
     Ok(())

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -1,4 +1,5 @@
 mod check_cuda_version;
+pub mod fd_channel;
 pub mod http_server;
 pub mod metric;
 pub mod proto;
@@ -91,6 +92,20 @@ pub struct Cli {
     /// Enable Prometheus /metrics endpoint on the HTTP server.
     #[arg(long, default_value_t = true)]
     pub enable_prometheus: bool,
+
+    /// Unix socket path for the native-VMM fd side-channel. Native clients send
+    /// their exported allocation fd here (SCM_RIGHTS) before registration; the
+    /// path is advertised back via HealthResponse. Empty disables native VMM
+    /// registration (Python clients are unaffected).
+    #[arg(long, default_value = "/tmp/pegaflow-fd.sock")]
+    pub fd_socket_path: String,
+
+    /// Initialize the Python/torch CUDA registry at startup. Required for the
+    /// Python (vLLM) connector, whose tensors arrive as pickled torch wrappers.
+    /// Native VMM clients do not need it — pass `--python-registry false` for a
+    /// torch-free deployment that serves only native clients.
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+    pub python_registry: bool,
 
     /// Enable OTLP metrics export over gRPC (e.g. http://127.0.0.1:4317).
     #[arg(long)]
@@ -370,6 +385,27 @@ fn init_python_cuda(device_ids: &[i32]) -> Result<(), std::io::Error> {
     })
 }
 
+/// Create each device's primary CUDA context via cudarc — the torch-free
+/// equivalent of `init_python_cuda`, used when `--python-registry false`.
+/// Native VMM clients bind these contexts when importing their allocations.
+fn init_cudarc_cuda(device_ids: &[i32]) -> Result<(), std::io::Error> {
+    if device_ids.is_empty() {
+        return Err(std::io::Error::other("no CUDA devices to initialize"));
+    }
+    for &device_id in device_ids {
+        let ordinal = usize::try_from(device_id)
+            .map_err(|_| std::io::Error::other(format!("device_id {device_id} must be >= 0")))?;
+        let ctx = cudarc::driver::CudaContext::new(ordinal).map_err(|e| {
+            std::io::Error::other(format!("cudarc init device {device_id}: {e}"))
+        })?;
+        ctx.bind_to_thread().map_err(|e| {
+            std::io::Error::other(format!("cudarc bind device {device_id}: {e}"))
+        })?;
+        info!("Initialized CUDA context for device {device_id} (cudarc, torch-free)");
+    }
+    Ok(())
+}
+
 struct MetricsState {
     meter_provider: Option<SdkMeterProvider>,
     prometheus_registry: Option<Registry>,
@@ -463,17 +499,31 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         return Err("No CUDA devices available".into());
     }
 
-    init_python_cuda(&devices)?;
+    if cli.python_registry {
+        init_python_cuda(&devices)?;
+    } else {
+        // Torch-free path: create each device's CUDA context via cudarc instead
+        // of forcing torch to do it. Native VMM import binds these contexts.
+        init_cudarc_cuda(&devices)?;
+    }
     info!(
         "CUDA runtime initialized for {} device(s): {:?}",
         devices.len(),
         devices
     );
 
-    let registry = CudaTensorRegistry::new().map_err(|err| {
-        let msg = format_py_err(err);
-        std::io::Error::other(format!("failed to initialize torch CUDA context: {msg}"))
-    })?;
+    // The Python registry initializes torch's CUDA context for the vLLM
+    // connector. Native VMM clients import their own allocations without torch,
+    // so a native-only deployment can skip it entirely (no torch dependency).
+    let registry = if cli.python_registry {
+        CudaTensorRegistry::new().map_err(|err| {
+            let msg = format_py_err(err);
+            std::io::Error::other(format!("failed to initialize torch CUDA context: {msg}"))
+        })?
+    } else {
+        info!("Python/torch registry disabled; serving native VMM clients only");
+        CudaTensorRegistry::empty()
+    };
     // Confine the registry to its own thread: GIL + CUDA work now happens off
     // the async runtime, so a wedged `empty_cache` can't starve tokio workers.
     let registry = RegistryHandle::spawn(registry);
@@ -602,11 +652,24 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             storage_config,
         )?);
 
+        // Bind the native-VMM fd side-channel before serving, so a client that
+        // connects the moment gRPC comes up finds the socket ready. Empty path
+        // disables it (Python-only deployments).
+        let fd_channel = if cli.fd_socket_path.is_empty() {
+            None
+        } else {
+            Some(
+                crate::fd_channel::FdChannel::bind(cli.fd_socket_path.clone())
+                    .map_err(|e| format!("bind fd side-channel {}: {e}", cli.fd_socket_path))?,
+            )
+        };
+
         let service = GrpcEngineService::new(
             Arc::clone(&engine),
             registry.clone(),
             Arc::clone(&shutdown),
             Arc::clone(&hll_tracker),
+            fd_channel,
         );
 
         // Spawn background GC task for stale inflight blocks and expired transfer locks

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -18,7 +18,10 @@ pub(crate) enum TensorRegistration {
     /// One strided layer view into the batch's shared VMM allocation. The
     /// backing fd is not here — it arrives out-of-band on the fd side-channel
     /// and is imported once per batch (see [`CudaTensorRegistry::register_layers`]).
-    Native { offset_bytes: u64, size_bytes: u64 },
+    Native {
+        offset_bytes: u64,
+        size_bytes: u64,
+    },
 }
 
 #[allow(dead_code, reason = "owners keep registered CUDA addresses valid")]
@@ -75,9 +78,9 @@ impl VmmMapping {
         // Reserve a VA range and map the physical handle into it.
         let mut base_ptr: sys::CUdeviceptr = 0;
         // SAFETY: standard VMM reserve; outputs are valid, alignment 0 = default.
-        if let Err(e) = unsafe {
-            sys::cuMemAddressReserve(&mut base_ptr, alloc_size, 0, 0, 0).result()
-        } {
+        if let Err(e) =
+            unsafe { sys::cuMemAddressReserve(&mut base_ptr, alloc_size, 0, 0, 0).result() }
+        {
             // SAFETY: handle was successfully imported above and not yet mapped.
             unsafe { sys::cuMemRelease(handle).result().ok() };
             return Err(cuda_error("reserve VMM address range", e));
@@ -221,16 +224,9 @@ impl CudaTensorRegistry {
                     size_bytes,
                 } => {
                     let mapping = mapping.as_ref().ok_or_else(|| {
-                        PyValueError::new_err(
-                            "native tensor registration without an imported fd",
-                        )
+                        PyValueError::new_err("native tensor registration without an imported fd")
                     })?;
-                    Self::materialize_native_tensor(
-                        device_id,
-                        mapping,
-                        offset_bytes,
-                        size_bytes,
-                    )?
+                    Self::materialize_native_tensor(device_id, mapping, offset_bytes, size_bytes)?
                 }
             };
             let metadata = layer_tensor.metadata.clone();
@@ -518,9 +514,7 @@ fn registry_actor(mut registry: CudaTensorRegistry, mut rx: mpsc::Receiver<Regis
                 // Borrow the raw fd for the import; `OwnedFd` closes our copy
                 // when it drops at the end of this arm (CUDA dups it internally).
                 use std::os::fd::AsRawFd;
-                let native = native_fd
-                    .as_ref()
-                    .map(|(fd, size)| (fd.as_raw_fd(), *size));
+                let native = native_fd.as_ref().map(|(fd, size)| (fd.as_raw_fd(), *size));
                 let result = registry
                     .register_layers(&context_key, device_id, layers, native)
                     // Stringify here, on the GIL-owning thread, so the gRPC

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -1,7 +1,9 @@
-use pyo3::exceptions::PyValueError;
+use cudarc::driver::{CudaContext, result::DriverError, sys};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug, Clone)]
@@ -11,22 +13,131 @@ pub struct TensorMetadata {
     pub device_id: i32,
 }
 
+pub(crate) enum TensorRegistration {
+    Python(Vec<u8>),
+    /// One strided layer view into the batch's shared VMM allocation. The
+    /// backing fd is not here — it arrives out-of-band on the fd side-channel
+    /// and is imported once per batch (see [`CudaTensorRegistry::register_layers`]).
+    Native { offset_bytes: u64, size_bytes: u64 },
+}
+
+#[allow(dead_code, reason = "owners keep registered CUDA addresses valid")]
+enum TensorOwner {
+    Python(Py<PyAny>),
+    Vmm(Arc<VmmMapping>),
+}
+
 struct LayerTensor {
-    #[allow(
-        dead_code,
-        reason = "holding the Python tensor keeps CUDA IPC memory mapped"
-    )]
-    tensor: Py<PyAny>,
+    owner: TensorOwner,
     metadata: TensorMetadata,
 }
 
-// Note: No custom Drop impl needed for LayerTensor.
-// PyO3's Py<PyAny> will automatically:
-// 1. Acquire the GIL when dropped
-// 2. Decrement the Python object's reference count
-// 3. Let Python's garbage collector handle the actual cleanup
-// This is the correct way to release CUDA IPC tensors - the mapped memory
-// will be unmapped when the tensor's storage is garbage collected.
+/// A VMM allocation imported from a client's exported POSIX file descriptor and
+/// mapped into this process's address space. Owns the reserved VA range and the
+/// imported physical handle; `base_ptr` is the mapped device pointer other
+/// layers offset into. Unlike a CUDA IPC mapping, this pointer can be handed to
+/// `ibv_reg_dmabuf_mr` for GPUDirect RDMA (registration wiring is a follow-up).
+struct VmmMapping {
+    context: Arc<CudaContext>,
+    handle: sys::CUmemGenericAllocationHandle,
+    base_ptr: sys::CUdeviceptr,
+    size_bytes: usize,
+}
+
+impl VmmMapping {
+    /// Import `fd` (a `CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR` exported by the
+    /// client), reserve a VA range of `alloc_size`, map the physical memory in,
+    /// and grant this device read/write access. `alloc_size` must match the
+    /// client's allocation (already rounded up to the VMM granularity).
+    fn import(device_id: i32, fd: i32, alloc_size: usize) -> PyResult<Arc<Self>> {
+        let device = usize::try_from(device_id)
+            .map_err(|_| PyValueError::new_err("device_id must be non-negative"))?;
+        let context = CudaContext::new(device).map_err(|e| cuda_error("retain context", e))?;
+        context
+            .bind_to_thread()
+            .map_err(|e| cuda_error("bind context", e))?;
+
+        // Import the physical allocation from the client's fd. CUDA dups the fd
+        // internally, so the caller still owns (and closes) its own copy.
+        let mut handle: sys::CUmemGenericAllocationHandle = 0;
+        // SAFETY: `handle` is valid output storage; `fd` is a live POSIX fd for a
+        // VMM allocation the client exported; the type tag matches the export.
+        unsafe {
+            sys::cuMemImportFromShareableHandle(
+                &mut handle,
+                fd as usize as *mut std::ffi::c_void,
+                sys::CUmemAllocationHandleType_enum::CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+            )
+            .result()
+            .map_err(|e| cuda_error("import VMM shareable handle", e))?;
+        }
+
+        // Reserve a VA range and map the physical handle into it.
+        let mut base_ptr: sys::CUdeviceptr = 0;
+        // SAFETY: standard VMM reserve; outputs are valid, alignment 0 = default.
+        if let Err(e) = unsafe {
+            sys::cuMemAddressReserve(&mut base_ptr, alloc_size, 0, 0, 0).result()
+        } {
+            // SAFETY: handle was successfully imported above and not yet mapped.
+            unsafe { sys::cuMemRelease(handle).result().ok() };
+            return Err(cuda_error("reserve VMM address range", e));
+        }
+        // SAFETY: base_ptr..+alloc_size is freshly reserved; handle is imported.
+        if let Err(e) = unsafe { sys::cuMemMap(base_ptr, alloc_size, 0, handle, 0).result() } {
+            unsafe { sys::cuMemAddressFree(base_ptr, alloc_size).result().ok() };
+            unsafe { sys::cuMemRelease(handle).result().ok() };
+            return Err(cuda_error("map VMM allocation", e));
+        }
+
+        // Grant this device read/write access to the mapped range.
+        let access = sys::CUmemAccessDesc {
+            location: sys::CUmemLocation {
+                type_: sys::CUmemLocationType_enum::CU_MEM_LOCATION_TYPE_DEVICE,
+                id: device_id,
+            },
+            flags: sys::CUmemAccess_flags_enum::CU_MEM_ACCESS_FLAGS_PROT_READWRITE,
+        };
+        // SAFETY: base_ptr..+alloc_size is mapped; one access descriptor.
+        if let Err(e) = unsafe { sys::cuMemSetAccess(base_ptr, alloc_size, &access, 1).result() } {
+            unsafe { sys::cuMemUnmap(base_ptr, alloc_size).result().ok() };
+            unsafe { sys::cuMemAddressFree(base_ptr, alloc_size).result().ok() };
+            unsafe { sys::cuMemRelease(handle).result().ok() };
+            return Err(cuda_error("set VMM access", e));
+        }
+
+        Ok(Arc::new(Self {
+            context,
+            handle,
+            base_ptr,
+            size_bytes: alloc_size,
+        }))
+    }
+}
+
+impl Drop for VmmMapping {
+    fn drop(&mut self) {
+        self.context
+            .bind_to_thread()
+            .expect("bind CUDA context before releasing VMM mapping");
+        // SAFETY: this object owns one successful import+reserve+map, torn down
+        // in reverse order: unmap, free VA, release physical handle.
+        unsafe {
+            sys::cuMemUnmap(self.base_ptr, self.size_bytes)
+                .result()
+                .expect("unmap VMM allocation");
+            sys::cuMemAddressFree(self.base_ptr, self.size_bytes)
+                .result()
+                .expect("free VMM address range");
+            sys::cuMemRelease(self.handle)
+                .result()
+                .expect("release VMM handle");
+        }
+    }
+}
+
+fn cuda_error(operation: &str, error: DriverError) -> PyErr {
+    PyRuntimeError::new_err(format!("{operation}: {error}"))
+}
 
 struct ContextState {
     device_id: i32,
@@ -64,11 +175,17 @@ impl CudaTensorRegistry {
         }
     }
 
+    /// Register a batch of layers under `context_key`.
+    ///
+    /// `native_fd` is `Some((fd, alloc_size))` for native VMM clients: the whole
+    /// batch shares one fused allocation imported once from that fd. It is `None`
+    /// for Python clients, whose per-layer tensors carry their own storage.
     fn register_layers(
         &mut self,
         context_key: &str,
         device_id: i32,
-        layers: Vec<(String, Vec<u8>)>,
+        layers: Vec<(String, TensorRegistration)>,
+        native_fd: Option<(i32, usize)>,
     ) -> PyResult<Vec<TensorMetadata>> {
         if self.contexts.contains_key(context_key) {
             return Err(PyValueError::new_err(format!(
@@ -85,10 +202,37 @@ impl CudaTensorRegistry {
             }
         }
 
+        // Native batches import their one shared allocation up front; every layer
+        // is a strided view offsetting into it.
+        let mapping = match native_fd {
+            Some((fd, alloc_size)) => Some(VmmMapping::import(device_id, fd, alloc_size)?),
+            None => None,
+        };
+
         let mut context = ContextState::new(device_id);
         let mut metadatas = Vec::with_capacity(layers.len());
-        for (layer_name, wrapper_bytes) in layers {
-            let layer_tensor = Self::materialize_tensor(device_id, &wrapper_bytes)?;
+        for (layer_name, registration) in layers {
+            let layer_tensor = match registration {
+                TensorRegistration::Python(bytes) => {
+                    Self::materialize_python_tensor(device_id, &bytes)?
+                }
+                TensorRegistration::Native {
+                    offset_bytes,
+                    size_bytes,
+                } => {
+                    let mapping = mapping.as_ref().ok_or_else(|| {
+                        PyValueError::new_err(
+                            "native tensor registration without an imported fd",
+                        )
+                    })?;
+                    Self::materialize_native_tensor(
+                        device_id,
+                        mapping,
+                        offset_bytes,
+                        size_bytes,
+                    )?
+                }
+            };
             let metadata = layer_tensor.metadata.clone();
 
             if context.device_id != metadata.device_id {
@@ -150,26 +294,32 @@ impl CudaTensorRegistry {
             return 0;
         }
 
-        // Remove contexts under the GIL so each `Py<PyAny>` is dropped (decref)
-        // there, then force gc + empty_cache to actually unmap the CUDA IPC
-        // memory immediately instead of letting Python's GC defer it.
-        Python::attach(|py| {
-            for key in &keys {
-                self.contexts.remove(key);
-            }
+        let needs_python = keys
+            .iter()
+            .filter_map(|key| self.contexts.get(key))
+            .flat_map(|context| context.tensors.values())
+            .any(|tensor| matches!(&tensor.owner, TensorOwner::Python(_)));
+        let removed: Vec<_> = keys
+            .iter()
+            .filter_map(|key| self.contexts.remove(key))
+            .collect();
 
-            let gc = py.import("gc").expect("gc module");
-            let _ = gc.call_method0("collect");
+        if needs_python {
+            Python::attach(|py| {
+                drop(removed);
+                let gc = py.import("gc").expect("gc module");
+                let _ = gc.call_method0("collect");
 
-            let torch = py.import("torch").expect("torch module");
-            let cuda = torch.getattr("cuda").expect("torch.cuda");
-            let _ = cuda.call_method0("empty_cache");
-        });
+                let torch = py.import("torch").expect("torch module");
+                let cuda = torch.getattr("cuda").expect("torch.cuda");
+                let _ = cuda.call_method0("empty_cache");
+            });
+        }
 
         tensor_count
     }
 
-    fn materialize_tensor(device_id: i32, wrapper_bytes: &[u8]) -> PyResult<LayerTensor> {
+    fn materialize_python_tensor(device_id: i32, wrapper_bytes: &[u8]) -> PyResult<LayerTensor> {
         Python::attach(|py| {
             let torch = py.import("torch")?;
             let pickle = py.import("pickle")?;
@@ -192,13 +342,48 @@ impl CudaTensorRegistry {
             let tensor_owned = tensor.unbind();
 
             Ok(LayerTensor {
-                tensor: tensor_owned,
+                owner: TensorOwner::Python(tensor_owned),
                 metadata: TensorMetadata {
                     data_ptr,
                     size_bytes,
                     device_id: resolved_device,
                 },
             })
+        })
+    }
+
+    /// Build one layer view as a strided window into the batch's shared VMM
+    /// mapping. `offset_bytes`/`size_bytes` are validated against the mapping's
+    /// imported size so a malformed client can't point us outside the allocation.
+    fn materialize_native_tensor(
+        device_id: i32,
+        mapping: &Arc<VmmMapping>,
+        offset_bytes: u64,
+        size_bytes: u64,
+    ) -> PyResult<LayerTensor> {
+        let offset = usize::try_from(offset_bytes)
+            .map_err(|_| PyValueError::new_err("native view offset does not fit usize"))?;
+        let size = usize::try_from(size_bytes)
+            .map_err(|_| PyValueError::new_err("native view size does not fit usize"))?;
+        let end = offset
+            .checked_add(size)
+            .ok_or_else(|| PyValueError::new_err("native view range overflows usize"))?;
+        if size == 0 || end > mapping.size_bytes {
+            return Err(PyValueError::new_err(
+                "native view is outside its allocation",
+            ));
+        }
+        let data_ptr = mapping
+            .base_ptr
+            .checked_add(offset_bytes)
+            .ok_or_else(|| PyValueError::new_err("native view pointer overflows u64"))?;
+        Ok(LayerTensor {
+            owner: TensorOwner::Vmm(Arc::clone(mapping)),
+            metadata: TensorMetadata {
+                data_ptr,
+                size_bytes: size,
+                device_id,
+            },
         })
     }
 }
@@ -209,8 +394,10 @@ enum RegistryCommand {
     RegisterLayers {
         context_key: String,
         device_id: i32,
-        /// `(layer_name, wrapper_bytes)` for each layer in the batch.
-        layers: Vec<(String, Vec<u8>)>,
+        layers: Vec<(String, TensorRegistration)>,
+        /// `Some((fd, alloc_size))` for native VMM batches; the actor imports the
+        /// shared allocation from `fd` and closes its own fd copy afterward.
+        native_fd: Option<(std::os::fd::OwnedFd, usize)>,
         // The `PyErr` is stringified on the actor thread (which holds the GIL),
         // so callers never need to touch the GIL to read an error message.
         reply: oneshot::Sender<Result<Vec<TensorMetadata>, String>>,
@@ -262,18 +449,22 @@ impl RegistryHandle {
     /// per-layer metadata in input order. The batch is transactional with
     /// respect to the registry: an existing context is rejected before any
     /// tensor is materialized, and a materialization failure does not publish a
-    /// partial context.
-    pub async fn register_layers(
+    /// partial context. `native_fd` is `Some` for native VMM clients (the fused
+    /// allocation's fd, already received over the fd side-channel) and `None`
+    /// for Python clients.
+    pub(crate) async fn register_layers(
         &self,
         context_key: String,
         device_id: i32,
-        layers: Vec<(String, Vec<u8>)>,
+        layers: Vec<(String, TensorRegistration)>,
+        native_fd: Option<(std::os::fd::OwnedFd, usize)>,
     ) -> Result<Vec<TensorMetadata>, String> {
         let (reply, rx) = oneshot::channel();
         self.dispatch(RegistryCommand::RegisterLayers {
             context_key,
             device_id,
             layers,
+            native_fd,
             reply,
         })
         .await;
@@ -321,10 +512,17 @@ fn registry_actor(mut registry: CudaTensorRegistry, mut rx: mpsc::Receiver<Regis
                 context_key,
                 device_id,
                 layers,
+                native_fd,
                 reply,
             } => {
+                // Borrow the raw fd for the import; `OwnedFd` closes our copy
+                // when it drops at the end of this arm (CUDA dups it internally).
+                use std::os::fd::AsRawFd;
+                let native = native_fd
+                    .as_ref()
+                    .map(|(fd, size)| (fd.as_raw_fd(), *size));
                 let result = registry
-                    .register_layers(&context_key, device_id, layers)
+                    .register_layers(&context_key, device_id, layers, native)
                     // Stringify here, on the GIL-owning thread, so the gRPC
                     // handler never needs `Python::attach` just to read the message.
                     .map_err(|err| Python::attach(|py| err.value(py).to_string()));
@@ -371,7 +569,7 @@ mod tests {
             .insert("instance-a:tp0:pp0:dev0".to_string(), ContextState::new(7));
 
         let err = registry
-            .register_layers("instance-a:tp0:pp0:dev0", 0, Vec::new())
+            .register_layers("instance-a:tp0:pp0:dev0", 0, Vec::new(), None)
             .expect_err("existing context must be rejected");
 
         let message = Python::attach(|py| err.value(py).to_string());

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -15,9 +15,7 @@ pub struct TensorMetadata {
 
 pub(crate) enum TensorRegistration {
     Python(Vec<u8>),
-    /// One strided layer view into the batch's shared VMM allocation. The
-    /// backing fd is not here — it arrives out-of-band on the fd side-channel
-    /// and is imported once per batch (see [`CudaTensorRegistry::register_layers`]).
+    /// Strided view into the batch's shared VMM allocation (fd arrives out-of-band).
     Native {
         offset_bytes: u64,
         size_bytes: u64,
@@ -35,11 +33,7 @@ struct LayerTensor {
     metadata: TensorMetadata,
 }
 
-/// A VMM allocation imported from a client's exported POSIX file descriptor and
-/// mapped into this process's address space. Owns the reserved VA range and the
-/// imported physical handle; `base_ptr` is the mapped device pointer other
-/// layers offset into. Unlike a CUDA IPC mapping, this pointer can be handed to
-/// `ibv_reg_dmabuf_mr` for GPUDirect RDMA (registration wiring is a follow-up).
+/// Imported client VMM allocation mapped into this process (`base_ptr` + size).
 struct VmmMapping {
     context: Arc<CudaContext>,
     handle: sys::CUmemGenericAllocationHandle,
@@ -48,10 +42,7 @@ struct VmmMapping {
 }
 
 impl VmmMapping {
-    /// Import `fd` (a `CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR` exported by the
-    /// client), reserve a VA range of `alloc_size`, map the physical memory in,
-    /// and grant this device read/write access. `alloc_size` must match the
-    /// client's allocation (already rounded up to the VMM granularity).
+    /// Import POSIX-fd VMM handle, reserve/map `alloc_size`, set device access.
     fn import(device_id: i32, fd: i32, alloc_size: usize) -> PyResult<Arc<Self>> {
         let device = usize::try_from(device_id)
             .map_err(|_| PyValueError::new_err("device_id must be non-negative"))?;
@@ -60,11 +51,8 @@ impl VmmMapping {
             .bind_to_thread()
             .map_err(|e| cuda_error("bind context", e))?;
 
-        // Import the physical allocation from the client's fd. CUDA dups the fd
-        // internally, so the caller still owns (and closes) its own copy.
         let mut handle: sys::CUmemGenericAllocationHandle = 0;
-        // SAFETY: `handle` is valid output storage; `fd` is a live POSIX fd for a
-        // VMM allocation the client exported; the type tag matches the export.
+        // SAFETY: live VMM POSIX fd; CUDA dups it so the caller still owns `fd`.
         unsafe {
             sys::cuMemImportFromShareableHandle(
                 &mut handle,
@@ -75,24 +63,22 @@ impl VmmMapping {
             .map_err(|e| cuda_error("import VMM shareable handle", e))?;
         }
 
-        // Reserve a VA range and map the physical handle into it.
         let mut base_ptr: sys::CUdeviceptr = 0;
-        // SAFETY: standard VMM reserve; outputs are valid, alignment 0 = default.
+        // SAFETY: reserve output is written to base_ptr.
         if let Err(e) =
             unsafe { sys::cuMemAddressReserve(&mut base_ptr, alloc_size, 0, 0, 0).result() }
         {
-            // SAFETY: handle was successfully imported above and not yet mapped.
+            // SAFETY: handle imported, not yet mapped.
             unsafe { sys::cuMemRelease(handle).result().ok() };
             return Err(cuda_error("reserve VMM address range", e));
         }
-        // SAFETY: base_ptr..+alloc_size is freshly reserved; handle is imported.
+        // SAFETY: base_ptr reserved; handle imported.
         if let Err(e) = unsafe { sys::cuMemMap(base_ptr, alloc_size, 0, handle, 0).result() } {
             unsafe { sys::cuMemAddressFree(base_ptr, alloc_size).result().ok() };
             unsafe { sys::cuMemRelease(handle).result().ok() };
             return Err(cuda_error("map VMM allocation", e));
         }
 
-        // Grant this device read/write access to the mapped range.
         let access = sys::CUmemAccessDesc {
             location: sys::CUmemLocation {
                 type_: sys::CUmemLocationType_enum::CU_MEM_LOCATION_TYPE_DEVICE,
@@ -100,7 +86,7 @@ impl VmmMapping {
             },
             flags: sys::CUmemAccess_flags_enum::CU_MEM_ACCESS_FLAGS_PROT_READWRITE,
         };
-        // SAFETY: base_ptr..+alloc_size is mapped; one access descriptor.
+        // SAFETY: range is mapped; one access desc.
         if let Err(e) = unsafe { sys::cuMemSetAccess(base_ptr, alloc_size, &access, 1).result() } {
             unsafe { sys::cuMemUnmap(base_ptr, alloc_size).result().ok() };
             unsafe { sys::cuMemAddressFree(base_ptr, alloc_size).result().ok() };
@@ -122,8 +108,7 @@ impl Drop for VmmMapping {
         self.context
             .bind_to_thread()
             .expect("bind CUDA context before releasing VMM mapping");
-        // SAFETY: this object owns one successful import+reserve+map, torn down
-        // in reverse order: unmap, free VA, release physical handle.
+        // SAFETY: reverse of import: unmap, free VA, release handle.
         unsafe {
             sys::cuMemUnmap(self.base_ptr, self.size_bytes)
                 .result()
@@ -178,11 +163,6 @@ impl CudaTensorRegistry {
         }
     }
 
-    /// Register a batch of layers under `context_key`.
-    ///
-    /// `native_fd` is `Some((fd, alloc_size))` for native VMM clients: the whole
-    /// batch shares one fused allocation imported once from that fd. It is `None`
-    /// for Python clients, whose per-layer tensors carry their own storage.
     fn register_layers(
         &mut self,
         context_key: &str,
@@ -205,8 +185,6 @@ impl CudaTensorRegistry {
             }
         }
 
-        // Native batches import their one shared allocation up front; every layer
-        // is a strided view offsetting into it.
         let mapping = match native_fd {
             Some((fd, alloc_size)) => Some(VmmMapping::import(device_id, fd, alloc_size)?),
             None => None,
@@ -348,9 +326,6 @@ impl CudaTensorRegistry {
         })
     }
 
-    /// Build one layer view as a strided window into the batch's shared VMM
-    /// mapping. `offset_bytes`/`size_bytes` are validated against the mapping's
-    /// imported size so a malformed client can't point us outside the allocation.
     fn materialize_native_tensor(
         device_id: i32,
         mapping: &Arc<VmmMapping>,
@@ -384,18 +359,14 @@ impl CudaTensorRegistry {
     }
 }
 
-/// Work submitted to the dedicated registry thread. Each carries a `oneshot`
-/// the actor uses to hand the result back to the awaiting caller.
 enum RegistryCommand {
     RegisterLayers {
         context_key: String,
         device_id: i32,
         layers: Vec<(String, TensorRegistration)>,
-        /// `Some((fd, alloc_size))` for native VMM batches; the actor imports the
-        /// shared allocation from `fd` and closes its own fd copy afterward.
+        /// `Some((fd, alloc_size))` for native VMM; `None` for Python.
         native_fd: Option<(std::os::fd::OwnedFd, usize)>,
-        // The `PyErr` is stringified on the actor thread (which holds the GIL),
-        // so callers never need to touch the GIL to read an error message.
+        // Stringified on the actor thread (holds GIL).
         reply: oneshot::Sender<Result<Vec<TensorMetadata>, String>>,
     },
     DropInstance {
@@ -441,13 +412,7 @@ impl RegistryHandle {
         Self { tx }
     }
 
-    /// Materialize and register a batch of layers under `context_key`. Returns
-    /// per-layer metadata in input order. The batch is transactional with
-    /// respect to the registry: an existing context is rejected before any
-    /// tensor is materialized, and a materialization failure does not publish a
-    /// partial context. `native_fd` is `Some` for native VMM clients (the fused
-    /// allocation's fd, already received over the fd side-channel) and `None`
-    /// for Python clients.
+    /// Register layers under `context_key`. `native_fd`: VMM fd + size, or `None` for Python.
     pub(crate) async fn register_layers(
         &self,
         context_key: String,
@@ -511,14 +476,10 @@ fn registry_actor(mut registry: CudaTensorRegistry, mut rx: mpsc::Receiver<Regis
                 native_fd,
                 reply,
             } => {
-                // Borrow the raw fd for the import; `OwnedFd` closes our copy
-                // when it drops at the end of this arm (CUDA dups it internally).
                 use std::os::fd::AsRawFd;
                 let native = native_fd.as_ref().map(|(fd, size)| (fd.as_raw_fd(), *size));
                 let result = registry
                     .register_layers(&context_key, device_id, layers, native)
-                    // Stringify here, on the GIL-owning thread, so the gRPC
-                    // handler never needs `Python::attach` just to read the message.
                     .map_err(|err| Python::attach(|py| err.value(py).to_string()));
                 let _ = reply.send(result);
             }

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -309,7 +309,7 @@ impl Engine for GrpcEngineService {
                 }
                 let fd = channel
                     .take(
-                        crate::fd_channel::FdKey {
+                        crate::fd_channel::RegistrationKey {
                             instance_id: req.instance_id.clone(),
                             device_id: req.device_id,
                         },

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -309,7 +309,10 @@ impl Engine for GrpcEngineService {
                 }
                 let fd = channel
                     .take(
-                        (req.instance_id.clone(), req.device_id),
+                        crate::fd_channel::FdKey {
+                            instance_id: req.instance_id.clone(),
+                            device_id: req.device_id,
+                        },
                         std::time::Duration::from_secs(5),
                     )
                     .await

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -3,15 +3,16 @@ use pegaflow_core::{trace_in_span, trace_root};
 use crate::metric::record_rpc_result;
 use crate::proto::engine::engine_server::Engine;
 use crate::proto::engine::{
-    HealthRequest, HealthResponse, LoadRequest, LoadResponse, QueryBlocksForTransferRequest,
-    QueryBlocksForTransferResponse, QueryLoading, QueryReady, QueryRequest, QueryResponse,
-    RdmaHandshakeRequest, RdmaHandshakeResponse, RegisterContextRequest, RegisterContextResponse,
-    ReleaseRequest, ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse,
-    ResponseStatus, SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest,
-    ShutdownResponse, TransferBlockInfo, TransferMode as ProtoTransferMode, TransferSlotInfo,
-    UnregisterRequest, UnregisterResponse, query_response,
+    FlushRequest, FlushResponse, HealthRequest, HealthResponse, LoadRequest, LoadResponse,
+    QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, QueryLoading, QueryReady,
+    QueryRequest, QueryResponse, RdmaHandshakeRequest, RdmaHandshakeResponse,
+    RegisterContextRequest, RegisterContextResponse, ReleaseRequest, ReleaseResponse,
+    ReleaseTransferLockRequest, ReleaseTransferLockResponse, ResponseStatus, SaveRequest,
+    SaveResponse, SessionEvent, SessionRequest, ShutdownRequest, ShutdownResponse,
+    TransferBlockInfo, TransferMode as ProtoTransferMode, TransferSlotInfo, UnregisterRequest,
+    UnregisterResponse, query_response,
 };
-use crate::registry::RegistryHandle;
+use crate::registry::{RegistryHandle, TensorRegistration};
 use crate::session::SessionRegistry;
 use log::{debug, info, warn};
 use pegaflow_core::{EngineError, LayerSave, PegaEngine, PrefetchStatus, QueryLeaseId};
@@ -21,6 +22,8 @@ use tokio::sync::{Notify, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, async_trait};
 
+mod validation;
+
 #[derive(Clone)]
 pub struct GrpcEngineService {
     engine: Arc<PegaEngine>,
@@ -28,6 +31,9 @@ pub struct GrpcEngineService {
     shutdown: Arc<Notify>,
     hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::MultiWindowHllTracker>>,
     session_registry: Arc<SessionRegistry>,
+    /// Host-local fd side-channel for native VMM clients. `None` in Python-only
+    /// deployments (no `--fd-socket-path`).
+    fd_channel: Option<crate::fd_channel::FdChannel>,
 }
 
 impl GrpcEngineService {
@@ -36,6 +42,7 @@ impl GrpcEngineService {
         registry: RegistryHandle,
         shutdown: Arc<Notify>,
         hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::MultiWindowHllTracker>>,
+        fd_channel: Option<crate::fd_channel::FdChannel>,
     ) -> Self {
         Self {
             engine,
@@ -43,6 +50,7 @@ impl GrpcEngineService {
             shutdown,
             hll_tracker,
             session_registry: SessionRegistry::new(),
+            fd_channel,
         }
     }
 
@@ -111,34 +119,6 @@ impl GrpcEngineService {
         if device_id < 0 {
             return Err(Status::invalid_argument(format!(
                 "device_id {device_id} must be >= 0"
-            )));
-        }
-        Ok(())
-    }
-
-    fn validate_register_context_request(req: &RegisterContextRequest) -> Result<(), Status> {
-        let server_version = env!("CARGO_PKG_VERSION");
-        if req.client_version != server_version {
-            return Err(Status::failed_precondition(format!(
-                "PegaFlow version mismatch: client={} server={server_version}",
-                if req.client_version.is_empty() {
-                    "<missing>"
-                } else {
-                    &req.client_version
-                }
-            )));
-        }
-        Self::validate_device_id(req.device_id)?;
-        if req.tp_size == 0 {
-            return Err(Status::invalid_argument("tp_size must be > 0"));
-        }
-        if req.world_size == 0 {
-            return Err(Status::invalid_argument("world_size must be > 0"));
-        }
-        if req.tp_rank >= req.tp_size {
-            return Err(Status::invalid_argument(format!(
-                "tp_rank {} out of range (tp_size {})",
-                req.tp_rank, req.tp_size
             )));
         }
         Ok(())
@@ -226,7 +206,7 @@ impl Engine for GrpcEngineService {
                 req.wrapper_bytes.iter().map(|b| b.len()).collect::<Vec<_>>()
             );
 
-            Self::validate_register_context_request(&req)?;
+            validation::register_context(&req)?;
 
             // The connector picks the H2D/D2H backend per model and sends it
             // here. Read it before `req` is partially moved below.
@@ -238,7 +218,6 @@ impl Engine for GrpcEngineService {
             // Validate array lengths are consistent with each other.
             let batch_len = req.layer_names.len();
             if batch_len == 0
-                || req.wrapper_bytes.len() != batch_len
                 || req.num_blocks.len() != batch_len
                 || req.bytes_per_block.len() != batch_len
                 || req.kv_stride_bytes.len() != batch_len
@@ -278,19 +257,76 @@ impl Engine for GrpcEngineService {
             // Materialize tensors and collect data_ptr/size_bytes
             let context_key =
                 Self::context_key(&req.instance_id, req.tp_rank, req.pp_rank, req.device_id);
-            // Materialize on the dedicated registry thread (GIL + CUDA IPC) and
+            // Materialize on the dedicated registry thread (GIL + CUDA) and
             // await the result, so this RPC never blocks an async worker. Move
-            // the (large) wrapper bytes over; clone the layer names since the
+            // the registration payloads over; clone the layer names since the
             // engine call below still needs them.
-            let layers: Vec<(String, Vec<u8>)> = req
-                .layer_names
-                .iter()
-                .cloned()
-                .zip(req.wrapper_bytes)
-                .collect();
+            let native = !req.native_kv_tensors.is_empty();
+            let mut block_stride_bytes = Vec::with_capacity(batch_len);
+            let layers = if native {
+                req.layer_names
+                    .iter()
+                    .cloned()
+                    .zip(req.native_kv_tensors)
+                    .map(|(name, tensor)| {
+                        block_stride_bytes.push(Self::usize_from_u64(
+                            tensor.block_stride_bytes,
+                            "block_stride_bytes",
+                        )?);
+                        Ok((
+                            name,
+                            TensorRegistration::Native {
+                                offset_bytes: tensor.offset_bytes,
+                                size_bytes: tensor.size_bytes,
+                            },
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, Status>>()?
+            } else {
+                req.layer_names
+                    .iter()
+                    .cloned()
+                    .zip(req.wrapper_bytes)
+                    .map(|(name, bytes)| (name, TensorRegistration::Python(bytes)))
+                    .collect()
+            };
+
+            // Native clients hand us the allocation fd out-of-band on the fd
+            // side-channel; claim it by (instance_id, device_id). The client
+            // sends the fd before this RPC, but a small wait covers reordering.
+            let native_fd = if native {
+                let channel = self.fd_channel.as_ref().ok_or_else(|| {
+                    Status::failed_precondition(
+                        "native VMM registration requires --fd-socket-path on the server",
+                    )
+                })?;
+                // The client's fused allocation size, already granularity-aligned.
+                let alloc_size = Self::usize_from_u64(req.native_alloc_size, "native_alloc_size")?;
+                if alloc_size == 0 {
+                    return Err(Status::invalid_argument(
+                        "native registration requires a non-zero native_alloc_size",
+                    ));
+                }
+                let fd = channel
+                    .take(
+                        (req.instance_id.clone(), req.device_id),
+                        std::time::Duration::from_secs(5),
+                    )
+                    .await
+                    .ok_or_else(|| {
+                        Status::failed_precondition(format!(
+                            "no allocation fd received on the side-channel for instance {} device {}",
+                            req.instance_id, req.device_id
+                        ))
+                    })?;
+                Some((fd, alloc_size))
+            } else {
+                None
+            };
+
             let metadatas = self
                 .registry
-                .register_layers(context_key.clone(), req.device_id, layers)
+                .register_layers(context_key.clone(), req.device_id, layers, native_fd)
                 .await
                 .map_err(|message| Status::internal(format!("register tensor failed: {message}")))?;
             let mut data_ptrs = Vec::with_capacity(batch_len);
@@ -301,7 +337,7 @@ impl Engine for GrpcEngineService {
             }
 
             // Call engine batch registration
-            if let Err(err) = self.engine.register_context_layer_batch(
+            if let Err(err) = self.engine.register_context_layer_batch_strided(
                 &req.instance_id,
                 &req.namespace,
                 req.device_id,
@@ -316,6 +352,7 @@ impl Engine for GrpcEngineService {
                 &bytes_per_block_list,
                 &kv_stride_bytes_list,
                 &segments_list,
+                native.then_some(block_stride_bytes.as_slice()),
                 transfer_mode,
                 req.page_first,
             ) {
@@ -450,6 +487,7 @@ impl Engine for GrpcEngineService {
                 layer_names,
                 loads,
                 load_state_shm,
+                wait_for_completion,
                 ..
             } = req;
             Self::validate_device_id(device_id)?;
@@ -475,16 +513,36 @@ impl Engine for GrpcEngineService {
                 })
                 .collect::<Result<_, _>>()?;
 
-            self.engine
-                .batch_load_kv_blocks_multi_layer(
-                    &instance_id,
-                    tp_rank,
-                    device_id,
-                    &load_state_shm,
-                    &layer_refs,
-                    &loads,
-                )
-                .map_err(Self::map_engine_error)?;
+            if wait_for_completion {
+                if !load_state_shm.is_empty() {
+                    return Err(Status::invalid_argument(
+                        "synchronous load must not include load_state_shm",
+                    ));
+                }
+                self.engine
+                    .batch_load_kv_blocks_multi_layer_inproc(
+                        &instance_id,
+                        tp_rank,
+                        device_id,
+                        &layer_refs,
+                        &loads,
+                    )
+                    .map_err(Self::map_engine_error)?
+                    .await
+                    .map_err(|_| Status::internal("load worker dropped completion"))?
+                    .map_err(Self::map_engine_error)?;
+            } else {
+                self.engine
+                    .batch_load_kv_blocks_multi_layer(
+                        &instance_id,
+                        tp_rank,
+                        device_id,
+                        &load_state_shm,
+                        &layer_refs,
+                        &loads,
+                    )
+                    .map_err(Self::map_engine_error)?;
+            }
 
             Ok(Response::new(LoadResponse {
                 status: Some(Self::build_simple_response()),
@@ -648,6 +706,16 @@ impl Engine for GrpcEngineService {
         }
         record_rpc_result("release", &result, start);
         result
+    }
+
+    async fn flush(
+        &self,
+        _request: Request<FlushRequest>,
+    ) -> Result<Response<FlushResponse>, Status> {
+        self.engine.flush_saves_and_registrations().await;
+        Ok(Response::new(FlushResponse {
+            status: Some(Self::build_simple_response()),
+        }))
     }
 
     async fn unregister_context(
@@ -879,6 +947,11 @@ impl Engine for GrpcEngineService {
             debug!("RPC [health]");
             Ok(Response::new(HealthResponse {
                 status: Some(Self::build_simple_response()),
+                fd_socket_path: self
+                    .fd_channel
+                    .as_ref()
+                    .map(|c| c.path().to_string())
+                    .unwrap_or_default(),
             }))
         }
         .await;
@@ -958,110 +1031,4 @@ impl Engine for GrpcEngineService {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::proto::engine::SaveLayer;
-    use tonic::Code;
-
-    #[test]
-    fn validate_query_prefetch_rejects_empty_req_id() {
-        let err = GrpcEngineService::validate_query_prefetch_request(&QueryRequest {
-            instance_id: "instance".to_string(),
-            block_hashes: Vec::new(),
-            req_id: String::new(),
-        })
-        .expect_err("empty req_id must be rejected before engine lookup");
-
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("req_id"));
-    }
-
-    #[test]
-    fn validate_query_prefetch_allows_empty_hashes() {
-        GrpcEngineService::validate_query_prefetch_request(&QueryRequest {
-            instance_id: "instance".to_string(),
-            block_hashes: Vec::new(),
-            req_id: "request".to_string(),
-        })
-        .expect("empty block_hashes are a valid zero-hit query");
-    }
-
-    #[test]
-    fn validate_register_context_rejects_pure_argument_errors() {
-        let err = GrpcEngineService::validate_register_context_request(&RegisterContextRequest {
-            instance_id: "instance".to_string(),
-            namespace: "namespace".to_string(),
-            client_version: env!("CARGO_PKG_VERSION").to_string(),
-            tp_rank: 1,
-            tp_size: 1,
-            world_size: 1,
-            device_id: 0,
-            layer_names: Vec::new(),
-            wrapper_bytes: Vec::new(),
-            num_blocks: Vec::new(),
-            bytes_per_block: Vec::new(),
-            kv_stride_bytes: Vec::new(),
-            segments: Vec::new(),
-            pp_rank: 0,
-            transfer_mode: ProtoTransferMode::Direct as i32,
-            page_first: false,
-        })
-        .expect_err("tp_rank outside tp_size must be rejected at RPC boundary");
-
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("tp_rank"));
-    }
-
-    #[test]
-    fn validate_register_context_rejects_client_version_mismatch() {
-        let err = GrpcEngineService::validate_register_context_request(&RegisterContextRequest {
-            instance_id: "instance".to_string(),
-            namespace: "namespace".to_string(),
-            client_version: "0.0.0-test-mismatch".to_string(),
-            tp_rank: 0,
-            tp_size: 1,
-            world_size: 1,
-            device_id: 0,
-            layer_names: Vec::new(),
-            wrapper_bytes: Vec::new(),
-            num_blocks: Vec::new(),
-            bytes_per_block: Vec::new(),
-            kv_stride_bytes: Vec::new(),
-            segments: Vec::new(),
-            pp_rank: 0,
-            transfer_mode: ProtoTransferMode::Direct as i32,
-            page_first: false,
-        })
-        .expect_err("client/server version mismatch must be rejected before registration");
-
-        assert_eq!(err.code(), Code::FailedPrecondition);
-        assert!(err.message().contains("PegaFlow version mismatch"));
-        assert!(err.message().contains("client=0.0.0-test-mismatch"));
-        assert!(
-            err.message()
-                .contains(concat!("server=", env!("CARGO_PKG_VERSION")))
-        );
-    }
-
-    #[test]
-    fn validate_save_layers_rejects_mismatched_block_shapes() {
-        let err = GrpcEngineService::validate_save_layers(&[SaveLayer {
-            layer_name: "layer_0".to_string(),
-            block_ids: vec![0, 1],
-            block_hashes: vec![vec![1]],
-        }])
-        .expect_err("service must reject malformed save shape");
-
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("does not match"));
-    }
-
-    #[test]
-    fn validate_device_id_rejects_negative_values() {
-        let err = GrpcEngineService::validate_device_id(-1)
-            .expect_err("negative device_id must be rejected at RPC boundary");
-
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("device_id"));
-    }
-}
+mod tests;

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -948,11 +948,6 @@ impl Engine for GrpcEngineService {
             debug!("RPC [health]");
             Ok(Response::new(HealthResponse {
                 status: Some(Self::build_simple_response()),
-                fd_socket_path: self
-                    .fd_channel
-                    .as_ref()
-                    .map(|c| c.path().to_string())
-                    .unwrap_or_default(),
             }))
         }
         .await;

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -31,8 +31,6 @@ pub struct GrpcEngineService {
     shutdown: Arc<Notify>,
     hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::MultiWindowHllTracker>>,
     session_registry: Arc<SessionRegistry>,
-    /// Host-local fd side-channel for native VMM clients. `None` in Python-only
-    /// deployments (no `--fd-socket-path`).
     fd_channel: Option<crate::fd_channel::FdChannel>,
 }
 
@@ -254,13 +252,8 @@ impl Engine for GrpcEngineService {
             let tp_size = Self::usize_from_u32(req.tp_size, "tp_size")?;
             let world_size = Self::usize_from_u32(req.world_size, "world_size")?;
 
-            // Materialize tensors and collect data_ptr/size_bytes
             let context_key =
                 Self::context_key(&req.instance_id, req.tp_rank, req.pp_rank, req.device_id);
-            // Materialize on the dedicated registry thread (GIL + CUDA) and
-            // await the result, so this RPC never blocks an async worker. Move
-            // the registration payloads over; clone the layer names since the
-            // engine call below still needs them.
             let native = !req.native_kv_tensors.is_empty();
             let mut block_stride_bytes = Vec::with_capacity(batch_len);
             let layers = if native {
@@ -291,16 +284,12 @@ impl Engine for GrpcEngineService {
                     .collect()
             };
 
-            // Native clients hand us the allocation fd out-of-band on the fd
-            // side-channel; claim it by (instance_id, device_id). The client
-            // sends the fd before this RPC, but a small wait covers reordering.
             let native_fd = if native {
                 let channel = self.fd_channel.as_ref().ok_or_else(|| {
                     Status::failed_precondition(
                         "native VMM registration requires --fd-socket-path on the server",
                     )
                 })?;
-                // The client's fused allocation size, already granularity-aligned.
                 let alloc_size = Self::usize_from_u64(req.native_alloc_size, "native_alloc_size")?;
                 if alloc_size == 0 {
                     return Err(Status::invalid_argument(

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -302,7 +302,7 @@ impl Engine for GrpcEngineService {
                             instance_id: req.instance_id.clone(),
                             device_id: req.device_id,
                         },
-                        std::time::Duration::from_secs(5),
+                        std::time::Duration::from_secs(60),
                     )
                     .await
                     .ok_or_else(|| {

--- a/pegaflow-server/src/service/tests.rs
+++ b/pegaflow-server/src/service/tests.rs
@@ -1,0 +1,105 @@
+use super::*;
+use crate::proto::engine::SaveLayer;
+use tonic::Code;
+
+#[test]
+fn validate_query_prefetch_rejects_empty_req_id() {
+    let err = GrpcEngineService::validate_query_prefetch_request(&QueryRequest {
+        instance_id: "instance".to_string(),
+        block_hashes: Vec::new(),
+        req_id: String::new(),
+    })
+    .expect_err("empty req_id must be rejected before engine lookup");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("req_id"));
+}
+
+#[test]
+fn validate_query_prefetch_allows_empty_hashes() {
+    GrpcEngineService::validate_query_prefetch_request(&QueryRequest {
+        instance_id: "instance".to_string(),
+        block_hashes: Vec::new(),
+        req_id: "request".to_string(),
+    })
+    .expect("empty block_hashes are a valid zero-hit query");
+}
+
+#[test]
+fn validate_register_context_rejects_pure_argument_errors() {
+    let err = validation::register_context(&RegisterContextRequest {
+        instance_id: "instance".to_string(),
+        namespace: "namespace".to_string(),
+        client_version: pegaflow_proto::VERSION.to_string(),
+        tp_rank: 1,
+        tp_size: 1,
+        world_size: 1,
+        device_id: 0,
+        layer_names: Vec::new(),
+        wrapper_bytes: Vec::new(),
+        num_blocks: Vec::new(),
+        bytes_per_block: Vec::new(),
+        kv_stride_bytes: Vec::new(),
+        segments: Vec::new(),
+        pp_rank: 0,
+        transfer_mode: ProtoTransferMode::Direct as i32,
+        page_first: false,
+        native_kv_tensors: Vec::new(),
+        native_alloc_size: 0,
+    })
+    .expect_err("tp_rank outside tp_size must be rejected at RPC boundary");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("tp_rank"));
+}
+
+#[test]
+fn validate_register_context_rejects_client_version_mismatch() {
+    let err = validation::register_context(&RegisterContextRequest {
+        instance_id: "instance".to_string(),
+        namespace: "namespace".to_string(),
+        client_version: "0.0.0-test-mismatch".to_string(),
+        tp_rank: 0,
+        tp_size: 1,
+        world_size: 1,
+        device_id: 0,
+        layer_names: Vec::new(),
+        wrapper_bytes: Vec::new(),
+        num_blocks: Vec::new(),
+        bytes_per_block: Vec::new(),
+        kv_stride_bytes: Vec::new(),
+        segments: Vec::new(),
+        pp_rank: 0,
+        transfer_mode: ProtoTransferMode::Direct as i32,
+        page_first: false,
+        native_kv_tensors: Vec::new(),
+        native_alloc_size: 0,
+    })
+    .expect_err("client/server version mismatch must be rejected before registration");
+
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert!(err.message().contains("PegaFlow version mismatch"));
+    assert!(err.message().contains("client=0.0.0-test-mismatch"));
+}
+
+#[test]
+fn validate_save_layers_rejects_mismatched_block_shapes() {
+    let err = GrpcEngineService::validate_save_layers(&[SaveLayer {
+        layer_name: "layer_0".to_string(),
+        block_ids: vec![0, 1],
+        block_hashes: vec![vec![1]],
+    }])
+    .expect_err("service must reject malformed save shape");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("does not match"));
+}
+
+#[test]
+fn validate_device_id_rejects_negative_values() {
+    let err = GrpcEngineService::validate_device_id(-1)
+        .expect_err("negative device_id must be rejected at RPC boundary");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("device_id"));
+}

--- a/pegaflow-server/src/service/validation.rs
+++ b/pegaflow-server/src/service/validation.rs
@@ -1,0 +1,50 @@
+use tonic::Status;
+
+use crate::proto::engine::RegisterContextRequest;
+
+pub(super) fn register_context(req: &RegisterContextRequest) -> Result<(), Status> {
+    let server_version = pegaflow_proto::VERSION;
+    if req.client_version != server_version {
+        return Err(Status::failed_precondition(format!(
+            "PegaFlow version mismatch: client={} server={server_version}",
+            if req.client_version.is_empty() {
+                "<missing>"
+            } else {
+                &req.client_version
+            }
+        )));
+    }
+    if req.device_id < 0 {
+        return Err(Status::invalid_argument("device_id must be non-negative"));
+    }
+    if req.tp_size == 0 {
+        return Err(Status::invalid_argument("tp_size must be > 0"));
+    }
+    if req.world_size == 0 {
+        return Err(Status::invalid_argument("world_size must be > 0"));
+    }
+    if req.tp_rank >= req.tp_size {
+        return Err(Status::invalid_argument(format!(
+            "tp_rank {} out of range (tp_size {})",
+            req.tp_rank, req.tp_size
+        )));
+    }
+
+    let layers = req.layer_names.len();
+    let python = req.wrapper_bytes.len() == layers && req.native_kv_tensors.is_empty();
+    let native = req.native_kv_tensors.len() == layers && req.wrapper_bytes.is_empty();
+    if layers == 0 || (!python && !native) {
+        return Err(Status::invalid_argument(
+            "exactly one tensor payload must match layer_names",
+        ));
+    }
+    for tensor in &req.native_kv_tensors {
+        if tensor.size_bytes == 0
+            || tensor.block_stride_bytes == 0
+            || tensor.offset_bytes.checked_add(tensor.size_bytes).is_none()
+        {
+            return Err(Status::invalid_argument("invalid native KV tensor metadata"));
+        }
+    }
+    Ok(())
+}

--- a/pegaflow-server/src/service/validation.rs
+++ b/pegaflow-server/src/service/validation.rs
@@ -43,7 +43,9 @@ pub(super) fn register_context(req: &RegisterContextRequest) -> Result<(), Statu
             || tensor.block_stride_bytes == 0
             || tensor.offset_bytes.checked_add(tensor.size_bytes).is_none()
         {
-            return Err(Status::invalid_argument("invalid native KV tensor metadata"));
+            return Err(Status::invalid_argument(
+                "invalid native KV tensor metadata",
+            ));
         }
     }
     Ok(())

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -377,6 +377,7 @@ impl MockVllmRpcHarness {
                 lease,
                 block_ids: (0..block_count as u32).collect(),
             }],
+            wait_for_completion: false,
         };
         match self.worker.load(request.clone()).await {
             Ok(response) => Ok(LoadRpcExchange {
@@ -443,7 +444,7 @@ async fn spawn_engine_server(
             14,
         ),
     ));
-    let service = GrpcEngineService::new(engine, registry, shutdown, hll_tracker);
+    let service = GrpcEngineService::new(engine, registry, shutdown, hll_tracker, None);
 
     let handle = tokio::spawn(async move {
         Server::builder()

--- a/pegaflow-server/tests/http_cleanup_hang_repro.rs
+++ b/pegaflow-server/tests/http_cleanup_hang_repro.rs
@@ -235,7 +235,7 @@ fn wedge_register_request(i: usize) -> RegisterContextRequest {
     RegisterContextRequest {
         instance_id: format!("wedge-{i}"),
         namespace: "wedge".to_string(),
-        client_version: env!("CARGO_PKG_VERSION").to_string(),
+        client_version: pegaflow_proto::VERSION.to_string(),
         tp_rank: 0,
         tp_size: 1,
         world_size: 1,
@@ -249,6 +249,8 @@ fn wedge_register_request(i: usize) -> RegisterContextRequest {
         pp_rank: 0,
         transfer_mode: TransferMode::Direct as i32,
         page_first: false,
+        native_kv_tensors: Vec::new(),
+        native_alloc_size: 0,
     }
 }
 
@@ -277,6 +279,7 @@ fn start_cluster(worker_threads: usize) -> TestCluster {
         registry.clone(),
         Arc::clone(&shutdown),
         hll_tracker,
+        None,
     );
     rt.spawn(async move {
         Server::builder()

--- a/pegaflow-server/tests/native_vmm_rpc_e2e.rs
+++ b/pegaflow-server/tests/native_vmm_rpc_e2e.rs
@@ -1,0 +1,460 @@
+//! Native VMM registration + save/load over gRPC.
+//!
+//! Covers the torch-free path:
+//! VMM alloc → SCM_RIGHTS fd side-channel → `RegisterContextBatch(native_*)`
+//! → D2H save → H2D load → GPU pattern check.
+//!
+//! Run: `cargo test -p pegaflow-server --test native_vmm_rpc_e2e --features cuda-13,rdma`
+
+use std::ffi::c_void;
+use std::net::{SocketAddr, TcpListener};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixStream as StdUnixStream;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use cudarc::driver::CudaContext;
+use cudarc::driver::sys;
+use pegaflow_core::sync_state::{LOAD_STATE_ERROR, LOAD_STATE_SUCCESS};
+use pegaflow_core::{LoadState, PegaEngine, StorageConfig};
+use pegaflow_server::fd_channel::FdChannel;
+use pegaflow_server::proto::engine::engine_client::EngineClient;
+use pegaflow_server::proto::engine::engine_server::EngineServer;
+use pegaflow_server::proto::engine::{
+    LeaseLoad, LoadRequest, NativeKvTensor, QueryRequest, RegisterContextRequest, SaveLayer,
+    SaveRequest, TransferMode, query_response,
+};
+use pegaflow_server::{CudaTensorRegistry, GrpcEngineService, RegistryHandle};
+use tokio::sync::Notify;
+use tonic::transport::Server;
+
+const INSTANCE_ID: &str = "native-vmm-rpc-e2e";
+const NAMESPACE: &str = "native-vmm";
+const LAYER_NAME: &str = "layer_0";
+const BLOCK_COUNT: usize = 4;
+const BYTES_PER_BLOCK: usize = 1024;
+const TOTAL_BYTES: usize = BLOCK_COUNT * BYTES_PER_BLOCK;
+
+#[tokio::test]
+async fn native_vmm_register_save_load_roundtrip() {
+    let ctx = CudaContext::new(0).expect("CUDA device 0");
+    ctx.bind_to_thread().expect("bind CUDA context");
+
+    // Client-side fused VMM allocation (same process; side-channel still exercises SCM_RIGHTS).
+    let client_alloc = ClientVmmAlloc::create(0, TOTAL_BYTES).expect("create VMM alloc");
+    let mut expected = vec![0u8; TOTAL_BYTES];
+    fill_pattern(&mut expected);
+    client_alloc.copy_from_host(&expected);
+
+    let sock_path = temp_sock_path();
+    let fd_channel = FdChannel::bind(sock_path.clone()).expect("bind fd channel");
+
+    let engine = Arc::new(
+        PegaEngine::new_with_config(
+            16 << 20,
+            false,
+            StorageConfig {
+                enable_lfu_admission: false,
+                ..StorageConfig::default()
+            },
+        )
+        .expect("engine"),
+    );
+    // Torch-free registry: native registration only.
+    let registry = RegistryHandle::spawn(CudaTensorRegistry::empty());
+    let port = unused_port();
+    let addr: SocketAddr = ([127, 0, 0, 1], port).into();
+    let shutdown = Arc::new(Notify::new());
+    let hll = Arc::new(std::sync::Mutex::new(
+        pegaflow_common::hll::MultiWindowHllTracker::new(
+            vec![("24h".into(), Duration::from_secs(86400))],
+            14,
+        ),
+    ));
+    let service = GrpcEngineService::new(
+        Arc::clone(&engine),
+        registry,
+        Arc::clone(&shutdown),
+        hll,
+        Some(fd_channel),
+    );
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(EngineServer::new(service))
+            .serve(addr)
+            .await
+            .expect("serve");
+    });
+
+    let mut client = connect(&format!("http://127.0.0.1:{port}")).await;
+
+    // 1) fd before register
+    send_fd(
+        &sock_path,
+        INSTANCE_ID,
+        0,
+        client_alloc.export_fd().as_raw_fd(),
+    );
+
+    // 2) native RegisterContextBatch
+    let reg = client
+        .register_context_batch(RegisterContextRequest {
+            instance_id: INSTANCE_ID.to_string(),
+            namespace: NAMESPACE.to_string(),
+            client_version: pegaflow_proto::VERSION.to_string(),
+            tp_rank: 0,
+            tp_size: 1,
+            world_size: 1,
+            device_id: 0,
+            layer_names: vec![LAYER_NAME.to_string()],
+            wrapper_bytes: vec![],
+            num_blocks: vec![BLOCK_COUNT as u64],
+            bytes_per_block: vec![BYTES_PER_BLOCK as u64],
+            kv_stride_bytes: vec![0],
+            segments: vec![1],
+            pp_rank: 0,
+            transfer_mode: TransferMode::Direct as i32,
+            page_first: false,
+            native_kv_tensors: vec![NativeKvTensor {
+                offset_bytes: 0,
+                size_bytes: TOTAL_BYTES as u64,
+                block_stride_bytes: BYTES_PER_BLOCK as u64,
+            }],
+            native_alloc_size: client_alloc.alloc_size() as u64,
+        })
+        .await
+        .expect("register_context_batch")
+        .into_inner();
+    assert!(
+        reg.status.as_ref().is_some_and(|s| s.ok),
+        "register failed: {:?}",
+        reg.status
+    );
+
+    // 3) D2H save
+    let hashes: Vec<Vec<u8>> = (0..BLOCK_COUNT)
+        .map(|i| {
+            let mut h = vec![7u8];
+            h.extend_from_slice(&(i as u32).to_le_bytes());
+            h
+        })
+        .collect();
+    let save = client
+        .save(SaveRequest {
+            instance_id: INSTANCE_ID.to_string(),
+            tp_rank: 0,
+            device_id: 0,
+            pp_rank: 0,
+            saves: vec![SaveLayer {
+                layer_name: LAYER_NAME.to_string(),
+                block_ids: (0..BLOCK_COUNT as u32).collect(),
+                block_hashes: hashes.clone(),
+            }],
+        })
+        .await
+        .expect("save")
+        .into_inner();
+    assert!(
+        save.status.as_ref().is_some_and(|s| s.ok),
+        "{:?}",
+        save.status
+    );
+    engine.flush_saves().await;
+
+    // 4) query hits
+    let query = client
+        .query_prefetch(QueryRequest {
+            instance_id: INSTANCE_ID.to_string(),
+            block_hashes: hashes.clone(),
+            req_id: "native-vmm-hit".into(),
+            wait_for_full_prefix: false,
+        })
+        .await
+        .expect("query")
+        .into_inner();
+    let ready = match query.outcome {
+        Some(query_response::Outcome::Ready(r)) => r,
+        other => panic!("expected Ready, got {other:?}"),
+    };
+    assert_eq!(ready.num_hit_blocks as usize, BLOCK_COUNT);
+    assert!(!ready.lease.is_empty());
+
+    // 5) wipe GPU, H2D load, verify
+    client_alloc.zero();
+    assert!(client_alloc.copy_to_host().iter().all(|&b| b == 0));
+
+    let load_state = LoadState::new().expect("LoadState");
+    let load = client
+        .load(LoadRequest {
+            instance_id: INSTANCE_ID.to_string(),
+            tp_rank: 0,
+            device_id: 0,
+            load_state_shm: load_state.shm_name().to_string(),
+            layer_names: vec![LAYER_NAME.to_string()],
+            loads: vec![LeaseLoad {
+                lease: ready.lease,
+                block_ids: (0..BLOCK_COUNT as u32).collect(),
+            }],
+            wait_for_completion: false,
+        })
+        .await
+        .expect("load")
+        .into_inner();
+    assert!(
+        load.status.as_ref().is_some_and(|s| s.ok),
+        "{:?}",
+        load.status
+    );
+    wait_load(&load_state).await;
+
+    assert_eq!(
+        client_alloc.copy_to_host(),
+        expected,
+        "H2D restore must match pre-save GPU pattern"
+    );
+
+    server.abort();
+}
+
+// ── client VMM allocation (exportable POSIX fd) ─────────────────────────────
+
+struct ClientVmmAlloc {
+    _ctx: Arc<CudaContext>,
+    handle: sys::CUmemGenericAllocationHandle,
+    base_ptr: sys::CUdeviceptr,
+    alloc_size: usize,
+    export_fd: OwnedFd,
+}
+
+impl ClientVmmAlloc {
+    fn create(device_id: i32, size: usize) -> Result<Self, String> {
+        let ctx = CudaContext::new(device_id as usize).map_err(|e| e.to_string())?;
+        ctx.bind_to_thread().map_err(|e| e.to_string())?;
+
+        let mut props: sys::CUmemAllocationProp = unsafe { std::mem::zeroed() };
+        props.type_ = sys::CUmemAllocationType_enum::CU_MEM_ALLOCATION_TYPE_PINNED;
+        props.location.type_ = sys::CUmemLocationType_enum::CU_MEM_LOCATION_TYPE_DEVICE;
+        props.location.id = device_id;
+        props.requestedHandleTypes =
+            sys::CUmemAllocationHandleType_enum::CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+        // Consumer GPUs reject gpuDirectRDMACapable; IT only needs POSIX export.
+        props.allocFlags.gpuDirectRDMACapable = 0;
+
+        let mut granularity = 0usize;
+        check_cuda(
+            unsafe {
+                sys::cuMemGetAllocationGranularity(
+                    &mut granularity,
+                    &props,
+                    sys::CUmemAllocationGranularity_flags_enum::CU_MEM_ALLOC_GRANULARITY_MINIMUM,
+                )
+            },
+            "cuMemGetAllocationGranularity",
+        );
+        let alloc_size = size.div_ceil(granularity) * granularity;
+
+        let mut handle: sys::CUmemGenericAllocationHandle = 0;
+        check_cuda(
+            unsafe { sys::cuMemCreate(&mut handle, alloc_size, &props, 0) },
+            "cuMemCreate",
+        );
+
+        let mut base_ptr: sys::CUdeviceptr = 0;
+        check_cuda(
+            unsafe { sys::cuMemAddressReserve(&mut base_ptr, alloc_size, 0, 0, 0) },
+            "cuMemAddressReserve",
+        );
+        if let Err(e) = check_cuda_result(
+            unsafe { sys::cuMemMap(base_ptr, alloc_size, 0, handle, 0) },
+            "cuMemMap",
+        ) {
+            unsafe {
+                sys::cuMemAddressFree(base_ptr, alloc_size);
+                sys::cuMemRelease(handle);
+            }
+            return Err(e);
+        }
+
+        let access = sys::CUmemAccessDesc {
+            location: sys::CUmemLocation {
+                type_: sys::CUmemLocationType_enum::CU_MEM_LOCATION_TYPE_DEVICE,
+                id: device_id,
+            },
+            flags: sys::CUmemAccess_flags_enum::CU_MEM_ACCESS_FLAGS_PROT_READWRITE,
+        };
+        if let Err(e) = check_cuda_result(
+            unsafe { sys::cuMemSetAccess(base_ptr, alloc_size, &access, 1) },
+            "cuMemSetAccess",
+        ) {
+            unsafe {
+                sys::cuMemUnmap(base_ptr, alloc_size);
+                sys::cuMemAddressFree(base_ptr, alloc_size);
+                sys::cuMemRelease(handle);
+            }
+            return Err(e);
+        }
+
+        let mut raw_fd: i32 = -1;
+        check_cuda(
+            unsafe {
+                sys::cuMemExportToShareableHandle(
+                    &mut raw_fd as *mut i32 as *mut c_void,
+                    handle,
+                    sys::CUmemAllocationHandleType_enum::CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+                    0,
+                )
+            },
+            "cuMemExportToShareableHandle",
+        );
+        // SAFETY: export transferred a new fd to us.
+        let export_fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+
+        Ok(Self {
+            _ctx: ctx,
+            handle,
+            base_ptr,
+            alloc_size,
+            export_fd,
+        })
+    }
+
+    fn alloc_size(&self) -> usize {
+        self.alloc_size
+    }
+
+    fn export_fd(&self) -> &OwnedFd {
+        &self.export_fd
+    }
+
+    fn copy_from_host(&self, data: &[u8]) {
+        assert!(data.len() <= self.alloc_size);
+        check_cuda(
+            unsafe {
+                sys::cuMemcpyHtoD_v2(self.base_ptr, data.as_ptr() as *const c_void, data.len())
+            },
+            "cuMemcpyHtoD_v2",
+        );
+    }
+
+    fn copy_to_host(&self) -> Vec<u8> {
+        let mut out = vec![0u8; TOTAL_BYTES];
+        check_cuda(
+            unsafe {
+                sys::cuMemcpyDtoH_v2(out.as_mut_ptr() as *mut c_void, self.base_ptr, out.len())
+            },
+            "cuMemcpyDtoH_v2",
+        );
+        out
+    }
+
+    fn zero(&self) {
+        check_cuda(
+            unsafe { sys::cuMemsetD8_v2(self.base_ptr, 0, TOTAL_BYTES) },
+            "cuMemsetD8_v2",
+        );
+    }
+}
+
+impl Drop for ClientVmmAlloc {
+    fn drop(&mut self) {
+        let _ = self._ctx.bind_to_thread();
+        unsafe {
+            let _ = sys::cuMemUnmap(self.base_ptr, self.alloc_size);
+            let _ = sys::cuMemAddressFree(self.base_ptr, self.alloc_size);
+            let _ = sys::cuMemRelease(self.handle);
+        }
+    }
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+fn send_fd(sock_path: &str, instance_id: &str, device_id: i32, pass: RawFd) {
+    let stream = StdUnixStream::connect(sock_path).expect("connect fd socket");
+    let mut payload = format!("{instance_id}\0{device_id}").into_bytes();
+    let mut iov = libc::iovec {
+        iov_base: payload.as_mut_ptr().cast(),
+        iov_len: payload.len(),
+    };
+    let cmsg_space =
+        unsafe { libc::CMSG_SPACE(std::mem::size_of::<RawFd>() as libc::c_uint) as usize };
+    let mut cmsg_buf = vec![0u8; cmsg_space];
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg_buf.as_mut_ptr().cast();
+    msg.msg_controllen = cmsg_buf.len();
+    unsafe {
+        let cmsg = libc::CMSG_FIRSTHDR(&msg);
+        assert!(!cmsg.is_null());
+        (*cmsg).cmsg_level = libc::SOL_SOCKET;
+        (*cmsg).cmsg_type = libc::SCM_RIGHTS;
+        (*cmsg).cmsg_len = libc::CMSG_LEN(std::mem::size_of::<RawFd>() as libc::c_uint) as _;
+        std::ptr::write_unaligned(libc::CMSG_DATA(cmsg).cast::<RawFd>(), pass);
+        msg.msg_controllen = (*cmsg).cmsg_len;
+        let n = libc::sendmsg(stream.as_raw_fd(), &msg, 0);
+        assert!(n >= 0, "sendmsg: {}", std::io::Error::last_os_error());
+    }
+}
+
+fn fill_pattern(buf: &mut [u8]) {
+    for (i, block) in buf.chunks_exact_mut(BYTES_PER_BLOCK).enumerate() {
+        block.fill(((i % 251) + 1) as u8);
+    }
+}
+
+fn temp_sock_path() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir()
+        .join(format!("pegaflow-native-vmm-e2e-{nanos}.sock"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn unused_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+async fn connect(endpoint: &str) -> EngineClient<tonic::transport::Channel> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match EngineClient::connect(endpoint.to_string()).await {
+            Ok(c) => return c,
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            Err(e) => panic!("connect: {e}"),
+        }
+    }
+}
+
+async fn wait_load(state: &LoadState) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let s = state.get();
+        if s == LOAD_STATE_SUCCESS {
+            return;
+        }
+        assert_ne!(s, LOAD_STATE_ERROR, "load ERROR");
+        assert!(Instant::now() < deadline, "load timeout");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+fn check_cuda(result: sys::CUresult, op: &str) {
+    check_cuda_result(result, op).unwrap_or_else(|e| panic!("{e}"));
+}
+
+fn check_cuda_result(result: sys::CUresult, op: &str) -> Result<(), String> {
+    if result == sys::CUresult::CUDA_SUCCESS {
+        Ok(())
+    } else {
+        Err(format!("{op} failed: {result:?}"))
+    }
+}

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -161,7 +161,7 @@ async fn spawn_engine_server(engine: Arc<PegaEngine>, port: u16) {
             14,
         ),
     ));
-    let service = GrpcEngineService::new(engine, registry, shutdown, hll_tracker);
+    let service = GrpcEngineService::new(engine, registry, shutdown, hll_tracker, None);
     let addr: SocketAddr = ([127, 0, 0, 1], port).into();
     tokio::spawn(async move {
         Server::builder()

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -322,7 +322,8 @@ impl EngineRpcClient {
                     pp_rank,
                     transfer_mode: transfer_mode as i32,
                     page_first,
-                    cuda_ipc_tensors: Vec::new(),
+                    native_kv_tensors: Vec::new(),
+                    native_alloc_size: 0,
                 })
                 .await?;
             Ok(resp.into_inner())

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -308,7 +308,7 @@ impl EngineRpcClient {
                 .register_context_batch(RegisterContextRequest {
                     instance_id,
                     namespace,
-                    client_version: env!("CARGO_PKG_VERSION").to_string(),
+                    client_version: pegaflow_proto::VERSION.to_string(),
                     tp_rank,
                     tp_size,
                     world_size,
@@ -322,6 +322,7 @@ impl EngineRpcClient {
                     pp_rank,
                     transfer_mode: transfer_mode as i32,
                     page_first,
+                    cuda_ipc_tensors: Vec::new(),
                 })
                 .await?;
             Ok(resp.into_inner())
@@ -419,6 +420,7 @@ impl EngineRpcClient {
                     load_state_shm,
                     layer_names,
                     loads,
+                    wait_for_completion: false,
                 })
                 .await?;
             Ok(resp.into_inner())

--- a/typos.toml
+++ b/typos.toml
@@ -1,3 +1,5 @@
 [default.extend-words]
 # Rust std library path (std::f64::consts)
 consts = "consts"
+# libc msghdr field name (msg_controllen)
+controllen = "controllen"


### PR DESCRIPTION
## Summary

Adds a **native (non-Python) KV registration path** that shares GPU KV memory with the engine by **VMM POSIX file descriptor** instead of a CUDA IPC handle.

Why: a CUDA-IPC-imported pointer **cannot be registered into the NIC** — `ibv_reg_mr` on a `cuIpcOpenMemHandle` pointer fails, and no dma-buf fd can be obtained for it. It can therefore never back GPUDirect RDMA. A VMM allocation (`cuMemCreate` + POSIX-fd export) **can** be handed to `ibv_reg_dmabuf_mr`. This PR is the foundation for RDMA-capable KV offload (the RDMA registration itself is a follow-up).

A POSIX fd cannot travel inside a gRPC message (it is a host-local kernel object), so the client sends it over a **host-local Unix-domain socket via `SCM_RIGHTS`**, keyed by `(instance_id, device_id)`, before `register_context_batch`. The server advertises the socket path in `HealthResponse`.

## Changes

- **proto**: replace `CudaIpcTensor` with `NativeKvTensor` (the fd travels out of band, not in the message); add `HealthResponse.fd_socket_path` and `RegisterContextRequest.native_alloc_size`. Version tag → `+native-vmm-v1`.
- **`fd_channel.rs`**: Unix-socket listener receiving one fd per connection via `recvmsg`/`SCM_RIGHTS`, delivered to the matching registration with a short wait for reordering.
- **`registry.rs`**: `VmmMapping` imports the fd (`cuMemImportFromShareableHandle` + reserve/map/set-access) and tears it down in order; one shared allocation per batch, each layer a strided view into it.
- **`--python-registry`** (default `true`): keeps the torch/vLLM connector path. `false` runs a **torch-free** deployment that initializes device contexts via cudarc and serves only native clients.

## Testing

- Native **Qwen3-4B host-tier save/load verified end to end**: a prefix evicted from HBM is restored from the CPU tier **bit-exact** (head-logprob delta 0.0000). Verified in both `--python-registry true` and torch-free modes.
- Server unit tests: 23 passed.
- Consumer vs data-center GPU: `cuMemCreate` rejects `gpuDirectRDMACapable` on parts that don't support it, so the client sets that flag only where the device attribute reports support.

## Not in this PR

- NIC registration (`ibv_reg_dmabuf_mr`) of the imported allocation — the mapping is RDMA-ready but wiring RDMA is a follow-up.
- Multi-arena (GLM5.2) VMM export; this PR covers the single fused Qwen3 buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
