### PR TITLE
fix(server): make native VMM registration ownership explicit

### DIFF
--- a/pegaflow-server/src/fd_channel.rs
+++ b/pegaflow-server/src/fd_channel.rs
@@ -1,22 +1,30 @@
 //! Host-local Unix socket that receives VMM allocation fds (SCM_RIGHTS) for
 //! native `register_context_batch`. Wire payload: `instance_id\0device_id` plus
-//! one fd per connection.
+//! exactly one fd per connection.
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::os::unix::net::UnixStream as ProbeUnixStream;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::net::UnixListener;
-use tokio::sync::Notify;
+use tokio::sync::{Notify, Semaphore, watch};
 
-/// `instance_id\0device_id` payload; generous so long instance ids do not truncate.
-const MAX_KEY_PAYLOAD: usize = 4096;
-/// Control buffer for one SCM_RIGHTS fd.
-const CMSG_SPACE_FOR_FD: usize = unsafe {
+const MAX_KEY_PAYLOAD: usize = 256;
+const MAX_PENDING_FDS: usize = 1024;
+const MAX_CONNECTIONS: usize = 64;
+const PENDING_FD_TTL: Duration = Duration::from_secs(60);
+#[cfg(not(test))]
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const RECEIVE_TIMEOUT: Duration = Duration::from_millis(100);
+const MAX_RECEIVED_FDS: usize = 16;
+const CMSG_SPACE_FOR_FDS: usize = unsafe {
     // SAFETY: CMSG_SPACE is a pure layout calculation from the payload length.
-    libc::CMSG_SPACE(std::mem::size_of::<RawFd>() as libc::c_uint) as usize
+    libc::CMSG_SPACE((MAX_RECEIVED_FDS * std::mem::size_of::<RawFd>()) as libc::c_uint) as usize
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -25,39 +33,89 @@ pub(crate) struct RegistrationKey {
     pub(crate) device_id: i32,
 }
 
+struct PendingFd {
+    fd: OwnedFd,
+    inserted_at: Instant,
+}
+
 struct Inner {
     path: String,
-    pending: Mutex<HashMap<RegistrationKey, OwnedFd>>,
+    socket_identity: (u64, u64),
+    pending: Mutex<HashMap<RegistrationKey, PendingFd>>,
     arrived: Notify,
+    shutdown: watch::Sender<()>,
 }
 
 impl Drop for Inner {
     fn drop(&mut self) {
-        remove_stale_socket(&self.path);
+        let _ = self.shutdown.send(());
+        match std::fs::symlink_metadata(&self.path) {
+            Ok(metadata)
+                if metadata.file_type().is_socket()
+                    && (metadata.dev(), metadata.ino()) == self.socket_identity =>
+            {
+                if let Err(err) = std::fs::remove_file(&self.path) {
+                    log::warn!(
+                        "fd side-channel: failed to remove socket {}: {err}",
+                        self.path
+                    );
+                }
+            }
+            Ok(_) => log::warn!(
+                "fd side-channel: refusing to remove replaced path {}",
+                self.path
+            ),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => log::warn!(
+                "fd side-channel: failed to inspect socket {}: {err}",
+                self.path
+            ),
+        }
     }
 }
 
-/// UDS side-channel; last `Arc` drop unlinks the socket file.
+/// UDS side-channel; the last handle stops the listener and unlinks the socket.
 #[derive(Clone)]
 pub struct FdChannel(Arc<Inner>);
 
 impl FdChannel {
     pub fn bind(path: String) -> std::io::Result<Self> {
-        remove_stale_socket(&path);
-        let listener = UnixListener::bind(&path)?;
+        let listener = match UnixListener::bind(&path) {
+            Ok(listener) => listener,
+            Err(err) if err.kind() == std::io::ErrorKind::AddrInUse => {
+                remove_stale_socket(&path)?;
+                UnixListener::bind(&path)?
+            }
+            Err(err) => return Err(err),
+        };
+        let metadata = std::fs::symlink_metadata(&path)?;
+        let (shutdown, mut shutdown_rx) = watch::channel(());
+        let connection_slots = Arc::new(Semaphore::new(MAX_CONNECTIONS));
         let channel = Self(Arc::new(Inner {
             path,
+            socket_identity: (metadata.dev(), metadata.ino()),
             pending: Mutex::new(HashMap::new()),
             arrived: Notify::new(),
+            shutdown,
         }));
-        let inner = Arc::clone(&channel.0);
+        let inner = Arc::downgrade(&channel.0);
         tokio::spawn(async move {
             loop {
-                match listener.accept().await {
+                let accepted = tokio::select! {
+                    accepted = listener.accept() => accepted,
+                    _ = shutdown_rx.changed() => break,
+                };
+                match accepted {
                     Ok((stream, _)) => {
-                        let inner = Arc::clone(&inner);
+                        let Ok(slot) = Arc::clone(&connection_slots).try_acquire_owned() else {
+                            log::warn!("fd side-channel: connection capacity reached");
+                            continue;
+                        };
+                        let inner = inner.clone();
+                        let shutdown = shutdown_rx.clone();
                         tokio::spawn(async move {
-                            if let Err(err) = recv_one(stream, &inner).await {
+                            let _slot = slot;
+                            if let Err(err) = recv_one(stream, inner, shutdown).await {
                                 log::warn!("fd side-channel: dropping connection: {err}");
                             }
                         });
@@ -72,23 +130,22 @@ impl FdChannel {
         Ok(channel)
     }
 
-    /// Wait up to `timeout` for the fd tagged with `key`.
     pub(crate) async fn take(&self, key: RegistrationKey, timeout: Duration) -> Option<OwnedFd> {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
+            // Create the notification future before checking the map so an
+            // arrival cannot land between the check and subscription.
+            let notified = self.0.arrived.notified();
             {
                 let mut pending = self.0.pending.lock().expect("fd pending map poisoned");
-                if let Some(fd) = pending.remove(&key) {
-                    return Some(fd);
+                pending.retain(|_, entry| entry.inserted_at.elapsed() < PENDING_FD_TTL);
+                if let Some(entry) = pending.remove(&key) {
+                    return Some(entry.fd);
                 }
             }
-            if tokio::time::timeout_at(deadline, self.0.arrived.notified())
-                .await
-                .is_err()
-            {
+            if tokio::time::timeout_at(deadline, notified).await.is_err() {
                 log::warn!(
-                    "fd side-channel: timed out waiting for fd instance_id={} device_id={}; \
-                     a late-arriving fd may stay pending until process exit",
+                    "fd side-channel: timed out waiting for fd instance_id={} device_id={}",
                     key.instance_id,
                     key.device_id
                 );
@@ -98,27 +155,72 @@ impl FdChannel {
     }
 }
 
-fn remove_stale_socket(path: &str) {
-    match std::fs::remove_file(path) {
-        Ok(()) => log::info!("fd side-channel: removed existing socket {path}"),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) => log::warn!("fd side-channel: failed to remove socket {path}: {err}"),
+fn remove_stale_socket(path: &str) -> std::io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_socket() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AddrInUse,
+            format!("fd side-channel path is not a socket: {path}"),
+        ));
+    }
+    let identity = (metadata.dev(), metadata.ino());
+    match ProbeUnixStream::connect(path) {
+        Ok(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::AddrInUse,
+            format!("fd side-channel already has a live listener: {path}"),
+        )),
+        Err(err) if err.kind() == std::io::ErrorKind::ConnectionRefused => {
+            let current = std::fs::symlink_metadata(path)?;
+            if !current.file_type().is_socket() || (current.dev(), current.ino()) != identity {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AddrInUse,
+                    format!("fd side-channel path changed while probing: {path}"),
+                ));
+            }
+            std::fs::remove_file(path)
+        }
+        Err(err) => Err(err),
     }
 }
 
-async fn recv_one(stream: tokio::net::UnixStream, inner: &Inner) -> std::io::Result<()> {
-    // SCM_RIGHTS needs recvmsg; wait until readable then use a blocking std socket.
-    stream.readable().await?;
+async fn recv_one(
+    stream: tokio::net::UnixStream,
+    inner: std::sync::Weak<Inner>,
+    mut shutdown: watch::Receiver<()>,
+) -> std::io::Result<()> {
+    tokio::select! {
+        result = tokio::time::timeout(RECEIVE_TIMEOUT, stream.readable()) => {
+            result.map_err(|_| std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "fd side-channel receive timed out",
+            ))??;
+        },
+        _ = shutdown.changed() => {
+            return Err(std::io::Error::other("fd side-channel closed"));
+        }
+    }
     let std_stream = stream.into_std()?;
     std_stream.set_nonblocking(false)?;
     let raw = std::os::fd::AsRawFd::as_raw_fd(&std_stream);
     let (key, fd) = recv_fd_with_key(raw)?;
     drop(std_stream);
 
+    let inner = inner
+        .upgrade()
+        .ok_or_else(|| std::io::Error::other("fd side-channel closed"))?;
     let mut pending = inner.pending.lock().expect("fd pending map poisoned");
+    pending.retain(|_, entry| entry.inserted_at.elapsed() < PENDING_FD_TTL);
+    if pending.len() >= MAX_PENDING_FDS {
+        return Err(std::io::Error::other(
+            "fd side-channel: pending fd capacity reached",
+        ));
+    }
     match pending.entry(key) {
         Entry::Vacant(slot) => {
-            slot.insert(fd);
+            slot.insert(PendingFd {
+                fd,
+                inserted_at: Instant::now(),
+            });
             drop(pending);
             inner.arrived.notify_waiters();
             Ok(())
@@ -139,7 +241,7 @@ fn recv_fd_with_key(sock: RawFd) -> std::io::Result<(RegistrationKey, OwnedFd)> 
         iov_base: buf.as_mut_ptr().cast(),
         iov_len: buf.len(),
     };
-    let mut cmsg_space = [0u8; CMSG_SPACE_FOR_FD];
+    let mut cmsg_space = [0u8; CMSG_SPACE_FOR_FDS];
     let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
     msg.msg_iov = &mut iov;
     msg.msg_iovlen = 1;
@@ -147,54 +249,82 @@ fn recv_fd_with_key(sock: RawFd) -> std::io::Result<(RegistrationKey, OwnedFd)> 
     msg.msg_controllen = cmsg_space.len();
 
     // SAFETY: iov and control buffers are valid for the duration of recvmsg.
-    let n = unsafe { libc::recvmsg(sock, &mut msg, 0) };
+    let n = unsafe { libc::recvmsg(sock, &mut msg, libc::MSG_CMSG_CLOEXEC) };
     if n < 0 {
         return Err(std::io::Error::last_os_error());
     }
-    if (msg.msg_flags & libc::MSG_CTRUNC) != 0 {
-        return Err(std::io::Error::other("fd control message truncated"));
+    let mut received_fds = Vec::new();
+    let mut unexpected_control = false;
+    // SAFETY: CMSG_FIRSTHDR/CMSG_NXTHDR only walk the kernel-populated buffer.
+    let mut cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+    while !cmsg.is_null() {
+        // SAFETY: cmsg points inside msg_control.
+        let header = unsafe { &*cmsg };
+        if header.cmsg_level == libc::SOL_SOCKET && header.cmsg_type == libc::SCM_RIGHTS {
+            let header_len = unsafe { libc::CMSG_LEN(0) as usize };
+            if header.cmsg_len < header_len {
+                return Err(std::io::Error::other(
+                    "fd side-channel: malformed SCM_RIGHTS message",
+                ));
+            }
+            let payload_len = header.cmsg_len - header_len;
+            if payload_len % std::mem::size_of::<RawFd>() != 0 {
+                return Err(std::io::Error::other(
+                    "fd side-channel: malformed SCM_RIGHTS payload",
+                ));
+            }
+            for index in 0..payload_len / std::mem::size_of::<RawFd>() {
+                // SAFETY: the kernel reported a complete RawFd at this index.
+                let raw_fd = unsafe {
+                    std::ptr::read_unaligned(libc::CMSG_DATA(cmsg).cast::<RawFd>().add(index))
+                };
+                // SAFETY: ownership of every received descriptor transferred to us.
+                received_fds.push(unsafe { OwnedFd::from_raw_fd(raw_fd) });
+            }
+        } else {
+            unexpected_control = true;
+        }
+        // SAFETY: msg and the control buffer remain valid.
+        cmsg = unsafe { libc::CMSG_NXTHDR(&msg, cmsg) };
     }
-
-    // SAFETY: control buffer was filled by recvmsg.
-    let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
-    if cmsg.is_null() {
-        return Err(std::io::Error::other("fd side-channel: no control message"));
-    }
-    // SAFETY: cmsg points into cmsg_space.
-    let (level, ctype) = unsafe { ((*cmsg).cmsg_level, (*cmsg).cmsg_type) };
-    if level != libc::SOL_SOCKET || ctype != libc::SCM_RIGHTS {
+    if (msg.msg_flags & (libc::MSG_CTRUNC | libc::MSG_TRUNC)) != 0
+        || unexpected_control
+        || received_fds.len() != 1
+    {
         return Err(std::io::Error::other(
-            "fd side-channel: unexpected control message",
+            "fd side-channel: expected exactly one complete fd message",
         ));
     }
-    // SAFETY: SCM_RIGHTS payload is one RawFd.
-    let raw_fd = unsafe { std::ptr::read_unaligned(libc::CMSG_DATA(cmsg).cast::<RawFd>()) };
-    // SAFETY: ownership transferred by recvmsg.
-    let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
-
-    let key = parse_key(&buf[..n as usize])?;
-    Ok((key, fd))
+    let fd = received_fds.pop().expect("one fd checked above");
+    Ok((parse_key(&buf[..n as usize])?, fd))
 }
 
 fn parse_key(payload: &[u8]) -> std::io::Result<RegistrationKey> {
-    let mut parts = payload.splitn(2, |&b| b == 0);
-    let instance = parts
+    let mut parts = payload.splitn(2, |&byte| byte == 0);
+    let instance_id = std::str::from_utf8(parts.next().unwrap_or_default())
+        .map_err(|_| std::io::Error::other("fd side-channel: instance_id not utf-8"))?;
+    if !valid_instance_id(instance_id) {
+        return Err(std::io::Error::other(
+            "fd side-channel: invalid instance_id",
+        ));
+    }
+    let device_id = parts
         .next()
-        .ok_or_else(|| std::io::Error::other("fd side-channel: missing instance_id"))?;
-    let device = parts
-        .next()
-        .ok_or_else(|| std::io::Error::other("fd side-channel: missing device_id"))?;
-    let instance_id = std::str::from_utf8(instance)
-        .map_err(|_| std::io::Error::other("fd side-channel: instance_id not utf-8"))?
-        .to_string();
-    let device_id: i32 = std::str::from_utf8(device)
-        .ok()
-        .and_then(|s| s.trim_end_matches('\0').parse().ok())
+        .and_then(|bytes| std::str::from_utf8(bytes).ok())
+        .and_then(|text| text.trim_end_matches('\0').parse().ok())
         .ok_or_else(|| std::io::Error::other("fd side-channel: bad device_id"))?;
     Ok(RegistrationKey {
-        instance_id,
+        instance_id: instance_id.to_string(),
         device_id,
     })
+}
+
+pub(crate) fn valid_instance_id(instance_id: &str) -> bool {
+    !instance_id.is_empty()
+        && instance_id.len() <= 128
+        && instance_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
 #[cfg(test)]
@@ -202,7 +332,7 @@ mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::os::fd::AsRawFd;
-    use std::os::unix::net::UnixStream as StdUnixStream;
+    use std::os::unix::net::{UnixListener as StdUnixListener, UnixStream as StdUnixStream};
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -221,144 +351,170 @@ mod tests {
         }
     }
 
-    /// Pipe whose read end carries `tag` once written on the write end.
-    /// Returns `(read_end_to_send, write_end_keep_alive)`.
     fn tagged_pipe(tag: u8) -> (OwnedFd, std::fs::File) {
         let mut fds = [0 as RawFd; 2];
-        // SAFETY: pipe(2) with a two-slot output array.
+        // SAFETY: pipe(2) writes two owned descriptors into fds.
         assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
-        // SAFETY: pipe ends are open and owned here.
+        // SAFETY: both descriptors are open and uniquely owned here.
         let (read_end, write_end) =
             unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) };
         let mut write_file = std::fs::File::from(write_end);
-        write_file.write_all(&[tag]).expect("write tag into pipe");
+        write_file.write_all(&[tag]).unwrap();
         (read_end, write_file)
     }
 
-    fn send_fd(sock_path: &str, reg: &RegistrationKey, pass: RawFd) {
-        let stream = StdUnixStream::connect(sock_path).expect("connect fd side-channel");
-        let payload = format!("{}\0{}", reg.instance_id, reg.device_id);
-        let mut payload_bytes = payload.into_bytes();
+    fn send_fds(path: &str, key: &RegistrationKey, fds: &[RawFd]) {
+        let stream = StdUnixStream::connect(path).unwrap();
+        let mut payload = format!("{}\0{}", key.instance_id, key.device_id).into_bytes();
         let mut iov = libc::iovec {
-            iov_base: payload_bytes.as_mut_ptr().cast(),
-            iov_len: payload_bytes.len(),
+            iov_base: payload.as_mut_ptr().cast(),
+            iov_len: payload.len(),
         };
-        let mut cmsg_buf = vec![0u8; CMSG_SPACE_FOR_FD];
+        let rights_bytes = std::mem::size_of_val(fds);
+        let mut control =
+            vec![0u8; unsafe { libc::CMSG_SPACE(rights_bytes as libc::c_uint) as usize }];
         let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
         msg.msg_iov = &mut iov;
         msg.msg_iovlen = 1;
-        msg.msg_control = cmsg_buf.as_mut_ptr().cast();
-        msg.msg_controllen = cmsg_buf.len();
-
-        // SAFETY: msg_control points at cmsg_buf; CMSG_* walk that buffer only.
+        msg.msg_control = control.as_mut_ptr().cast();
+        msg.msg_controllen = control.len();
+        // SAFETY: control and iov remain live for sendmsg.
         unsafe {
             let cmsg = libc::CMSG_FIRSTHDR(&msg);
-            assert!(!cmsg.is_null());
             (*cmsg).cmsg_level = libc::SOL_SOCKET;
             (*cmsg).cmsg_type = libc::SCM_RIGHTS;
-            (*cmsg).cmsg_len = libc::CMSG_LEN(std::mem::size_of::<RawFd>() as libc::c_uint) as _;
-            std::ptr::write_unaligned(libc::CMSG_DATA(cmsg).cast::<RawFd>(), pass);
+            (*cmsg).cmsg_len = libc::CMSG_LEN(rights_bytes as libc::c_uint) as _;
+            for (index, fd) in fds.iter().enumerate() {
+                std::ptr::write_unaligned(libc::CMSG_DATA(cmsg).cast::<RawFd>().add(index), *fd);
+            }
             msg.msg_controllen = (*cmsg).cmsg_len;
-            let n = libc::sendmsg(stream.as_raw_fd(), &msg, 0);
-            assert!(n >= 0, "sendmsg: {}", std::io::Error::last_os_error());
+            assert!(libc::sendmsg(stream.as_raw_fd(), &msg, 0) >= 0);
         }
     }
 
     fn read_tag(fd: &OwnedFd) -> u8 {
-        let mut buf = [0u8; 1];
-        let mut file = std::fs::File::from(fd.try_clone().expect("clone fd"));
-        file.read_exact(&mut buf).expect("read tag");
-        buf[0]
+        let mut tag = [0];
+        std::fs::File::from(fd.try_clone().unwrap())
+            .read_exact(&mut tag)
+            .unwrap();
+        tag[0]
     }
 
     #[test]
-    fn parse_key_splits_instance_and_device() {
-        // "engine-abc" + NUL + "3" (\x00 is null; next char is '3')
-        let k = parse_key(b"engine-abc\x003").unwrap();
-        assert_eq!(k.instance_id, "engine-abc");
-        assert_eq!(k.device_id, 3);
-    }
-
-    #[test]
-    fn parse_key_rejects_missing_nul() {
-        assert!(parse_key(b"no-separator").is_err());
+    fn key_uses_uuid_instance_and_device() {
+        assert_eq!(
+            parse_key(b"018f8f75-b82e-7c10-a7d4-01abc2345678\x003").unwrap(),
+            key("018f8f75-b82e-7c10-a7d4-01abc2345678", 3)
+        );
+        assert!(parse_key(b"bad id\x000").is_err());
     }
 
     #[tokio::test]
-    async fn fd_before_take_delivers_tagged_pipe() {
+    async fn fd_before_take_is_delivered() {
         let path = temp_sock_path("before");
         let channel = FdChannel::bind(path.to_string_lossy().into_owned()).unwrap();
-        let reg = key("inst-a", 0);
-        let (pass, _hold_write) = tagged_pipe(0xA1);
-        send_fd(path.to_str().unwrap(), &reg, pass.as_raw_fd());
+        let registration = key("instance-a", 0);
+        let (fd, _writer) = tagged_pipe(0xA1);
+        send_fds(path.to_str().unwrap(), &registration, &[fd.as_raw_fd()]);
 
-        let got = channel
-            .take(reg, Duration::from_secs(2))
+        let received = channel
+            .take(registration, Duration::from_secs(1))
             .await
-            .expect("fd should be pending");
-        assert_eq!(read_tag(&got), 0xA1);
+            .unwrap();
+        assert_eq!(read_tag(&received), 0xA1);
     }
 
     #[tokio::test]
-    async fn take_waits_when_fd_arrives_later() {
-        let path = temp_sock_path("wait");
-        let channel = FdChannel::bind(path.to_string_lossy().into_owned()).unwrap();
-        let reg = key("inst-b", 1);
-        let path_str = path.to_string_lossy().into_owned();
-        let reg_send = reg.clone();
-
-        let take = tokio::spawn({
+    async fn take_waits_for_later_fd() {
+        let path = temp_sock_path("after");
+        let path_string = path.to_string_lossy().into_owned();
+        let channel = FdChannel::bind(path_string.clone()).unwrap();
+        let registration = key("instance-b", 0);
+        let waiter = tokio::spawn({
             let channel = channel.clone();
-            async move { channel.take(reg, Duration::from_secs(2)).await }
+            let registration = registration.clone();
+            async move { channel.take(registration, Duration::from_secs(1)).await }
         });
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::task::yield_now().await;
+        let (fd, _writer) = tagged_pipe(0xB2);
+        send_fds(&path_string, &registration, &[fd.as_raw_fd()]);
 
-        let (pass, _hold_write) = tagged_pipe(0xB2);
-        tokio::task::spawn_blocking(move || {
-            send_fd(&path_str, &reg_send, pass.as_raw_fd());
-            // Keep pass alive until sendmsg returns (SCM_RIGHTS dups the fd).
-            drop(pass);
+        assert_eq!(read_tag(&waiter.await.unwrap().unwrap()), 0xB2);
+    }
+
+    #[tokio::test]
+    async fn duplicate_and_multi_fd_messages_do_not_replace_first() {
+        let path = temp_sock_path("duplicate");
+        let path_string = path.to_string_lossy().into_owned();
+        let channel = FdChannel::bind(path_string.clone()).unwrap();
+        let registration = key("instance-c", 0);
+        let (first, mut first_writer) = tagged_pipe(0xC3);
+        let (second, mut second_writer) = tagged_pipe(0xD4);
+        send_fds(&path_string, &registration, &[first.as_raw_fd()]);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        send_fds(
+            &path_string,
+            &registration,
+            &[first.as_raw_fd(), second.as_raw_fd()],
+        );
+
+        let received = channel
+            .take(registration, Duration::from_secs(1))
+            .await
+            .unwrap();
+        assert_eq!(read_tag(&received), 0xC3);
+        drop(first);
+        drop(second);
+        drop(received);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(first_writer.write_all(&[1]).is_err());
+        assert!(second_writer.write_all(&[1]).is_err());
+    }
+
+    #[tokio::test]
+    async fn last_handle_stops_listener_and_removes_path() {
+        let path = temp_sock_path("drop");
+        let channel = FdChannel::bind(path.to_string_lossy().into_owned()).unwrap();
+        let mut idle = StdUnixStream::connect(&path).unwrap();
+        tokio::time::sleep(RECEIVE_TIMEOUT + Duration::from_millis(20)).await;
+        let mut byte = [0];
+        assert_eq!(
+            idle.read(&mut byte).unwrap(),
+            0,
+            "idle connection must close"
+        );
+        drop(channel);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while path.exists() {
+                tokio::task::yield_now().await;
+            }
         })
         .await
         .unwrap();
-
-        let got = take.await.unwrap().expect("fd after wait");
-        assert_eq!(read_tag(&got), 0xB2);
     }
 
     #[tokio::test]
-    async fn take_times_out_without_fd() {
-        let path = temp_sock_path("timeout");
-        let channel = FdChannel::bind(path.to_string_lossy().into_owned()).unwrap();
-        let got = channel
-            .take(key("missing", 0), Duration::from_millis(80))
-            .await;
-        assert!(got.is_none());
-    }
+    async fn bind_recovers_only_stale_socket_paths() {
+        let stale_path = temp_sock_path("stale");
+        drop(StdUnixListener::bind(&stale_path).unwrap());
+        drop(FdChannel::bind(stale_path.to_string_lossy().into_owned()).unwrap());
 
-    #[tokio::test]
-    async fn duplicate_key_keeps_first_fd() {
-        let path = temp_sock_path("dup");
-        let path_str = path.to_string_lossy().into_owned();
-        let channel = FdChannel::bind(path_str.clone()).unwrap();
-        let reg = key("inst-dup", 0);
-
-        let (first, _w1) = tagged_pipe(0x11);
-        let (second, _w2) = tagged_pipe(0x22);
-        send_fd(&path_str, &reg, first.as_raw_fd());
-        // Allow the first connection to be accepted and inserted.
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        send_fd(&path_str, &reg, second.as_raw_fd());
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        let got = channel
-            .take(reg, Duration::from_secs(1))
-            .await
-            .expect("first fd remains");
+        let live_path = temp_sock_path("live");
+        let live = StdUnixListener::bind(&live_path).unwrap();
         assert_eq!(
-            read_tag(&got),
-            0x11,
-            "duplicate must not replace pending fd"
+            FdChannel::bind(live_path.to_string_lossy().into_owned())
+                .err()
+                .unwrap()
+                .kind(),
+            std::io::ErrorKind::AddrInUse
         );
+        drop(live);
+        std::fs::remove_file(live_path).unwrap();
+
+        let file_path = temp_sock_path("file");
+        std::fs::write(&file_path, b"keep").unwrap();
+        assert!(FdChannel::bind(file_path.to_string_lossy().into_owned()).is_err());
+        assert_eq!(std::fs::read(&file_path).unwrap(), b"keep");
+        std::fs::remove_file(file_path).unwrap();
     }
 }

--- a/pegaflow-server/src/http_server.rs
+++ b/pegaflow-server/src/http_server.rs
@@ -82,8 +82,17 @@ async fn cleanup_handler(
 ) -> impl IntoResponse {
     match query.id {
         None => {
-            let removed_tensors = state.registry.clear().await;
-            let removed_instances = state.engine.unregister_all_instances();
+            let engine = Arc::clone(&state.engine);
+            let registry = state.registry.clone();
+            let (removed_instances, removed_tensors) = tokio::spawn(async move {
+                let cleanup = registry.clear().await;
+                let removed_instances = engine.unregister_all_instances();
+                let removed_tensors = cleanup.tensor_count();
+                registry.finish_cleanup(cleanup).await;
+                (removed_instances, removed_tensors)
+            })
+            .await
+            .expect("cleanup-all task failed");
 
             if !removed_instances.is_empty() || removed_tensors > 0 {
                 warn!(
@@ -104,8 +113,19 @@ async fn cleanup_handler(
             )
         }
         Some(instance_id) => {
-            let removed_tensors = state.registry.drop_instance(instance_id.clone()).await;
-            match state.engine.unregister_instance(&instance_id) {
+            let engine = Arc::clone(&state.engine);
+            let registry = state.registry.clone();
+            let cleanup_id = instance_id.clone();
+            let (removed_tensors, unregister) = tokio::spawn(async move {
+                let cleanup = registry.drop_instance(cleanup_id.clone()).await;
+                let removed_tensors = cleanup.tensor_count();
+                let unregister = engine.unregister_instance(&cleanup_id);
+                registry.finish_cleanup(cleanup).await;
+                (removed_tensors, unregister)
+            })
+            .await
+            .expect("instance cleanup task failed");
+            match unregister {
                 Ok(()) => {
                     warn!(
                         "Cleanup instance {}: {} CUDA tensor(s) released",

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -94,7 +94,7 @@ pub struct Cli {
     pub enable_prometheus: bool,
 
     /// UDS path for native clients to send VMM allocation fds (SCM_RIGHTS). Empty disables.
-    #[arg(long, default_value = "/tmp/pegaflow-fd.sock")]
+    #[arg(long, default_value = "")]
     pub fd_socket_path: String,
 
     /// Init torch CUDA registry (vLLM path). False = torch-free, native VMM only.
@@ -306,7 +306,7 @@ fn init_cuda_driver() -> Result<(), std::io::Error> {
         .map_err(|err| std::io::Error::other(format!("failed to initialize CUDA driver: {err}")))
 }
 
-fn detect_cuda_devices() -> Result<Vec<i32>, std::io::Error> {
+fn detect_python_cuda_devices() -> Result<Vec<i32>, std::io::Error> {
     Python::attach(|py| -> pyo3::PyResult<Vec<i32>> {
         let torch = py.import("torch")?;
         let cuda = torch.getattr("cuda")?;
@@ -329,6 +329,15 @@ fn detect_cuda_devices() -> Result<Vec<i32>, std::io::Error> {
             format_py_err(err)
         ))
     })
+}
+
+fn detect_native_cuda_devices() -> Result<Vec<i32>, std::io::Error> {
+    let device_count = cudarc::driver::CudaContext::device_count().map_err(|err| {
+        std::io::Error::other(format!(
+            "failed to detect CUDA devices with the CUDA driver: {err}"
+        ))
+    })?;
+    Ok((0..device_count).collect())
 }
 
 fn init_python_cuda(device_ids: &[i32]) -> Result<(), std::io::Error> {
@@ -473,7 +482,11 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     // Determine which devices to initialize
     let devices = if cli.devices.is_empty() {
         // Auto-detect all available devices
-        let detected = detect_cuda_devices()?;
+        let detected = if cli.python_registry {
+            detect_python_cuda_devices()?
+        } else {
+            detect_native_cuda_devices()?
+        };
         info!(
             "Auto-detected {} CUDA device(s): {:?}",
             detected.len(),
@@ -777,6 +790,13 @@ mod tests {
             parse_hll_windows(&cli.metric_hll_windows).unwrap(),
             expected_hll_windows()
         );
+    }
+
+    #[test]
+    fn cli_defaults_native_fd_side_channel_off() {
+        let cli = Cli::try_parse_from(["pegaflow-server"]).unwrap();
+
+        assert!(cli.fd_socket_path.is_empty());
     }
 
     #[test]

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -4,7 +4,11 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock, mpsc, oneshot};
+
+mod cleanup;
+pub(crate) use cleanup::RegistryCleanup;
+use cleanup::RemovedContexts;
 
 #[derive(Debug, Clone)]
 pub struct TensorMetadata {
@@ -25,7 +29,7 @@ pub(crate) enum TensorRegistration {
 #[allow(dead_code, reason = "owners keep registered CUDA addresses valid")]
 enum TensorOwner {
     Python(Py<PyAny>),
-    Vmm(Arc<VmmMapping>),
+    Vmm(Arc<VmmRegistration>),
 }
 
 struct LayerTensor {
@@ -43,7 +47,7 @@ struct VmmMapping {
 
 impl VmmMapping {
     /// Import POSIX-fd VMM handle, reserve/map `alloc_size`, set device access.
-    fn import(device_id: i32, fd: i32, alloc_size: usize) -> PyResult<Arc<Self>> {
+    fn import(device_id: i32, fd: i32, alloc_size: usize) -> PyResult<Self> {
         let device = usize::try_from(device_id)
             .map_err(|_| PyValueError::new_err("device_id must be non-negative"))?;
         let context = CudaContext::new(device).map_err(|e| cuda_error("retain context", e))?;
@@ -94,12 +98,12 @@ impl VmmMapping {
             return Err(cuda_error("set VMM access", e));
         }
 
-        Ok(Arc::new(Self {
+        Ok(Self {
             context,
             handle,
             base_ptr,
             size_bytes: alloc_size,
-        }))
+        })
     }
 }
 
@@ -123,6 +127,93 @@ impl Drop for VmmMapping {
     }
 }
 
+struct VmmRegistration {
+    instance_id: String,
+    device_id: i32,
+    mapping: VmmMappingOwner,
+    operations: OperationGate,
+}
+
+enum VmmMappingOwner {
+    Cuda(VmmMapping),
+    #[cfg(test)]
+    Stub,
+}
+
+impl VmmMappingOwner {
+    fn cuda(&self) -> &VmmMapping {
+        match self {
+            Self::Cuda(mapping) => mapping,
+            #[cfg(test)]
+            Self::Stub => panic!("test-only VMM registration has no CUDA mapping"),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct OperationGate(Arc<RwLock<()>>);
+
+impl OperationGate {
+    fn enter(&self) -> Result<OwnedRwLockReadGuard<()>, ()> {
+        Arc::clone(&self.0).try_read_owned().map_err(|_| ())
+    }
+
+    async fn close(&self) -> OwnedRwLockWriteGuard<()> {
+        Arc::clone(&self.0).write_owned().await
+    }
+}
+
+impl VmmRegistration {
+    fn new(instance_id: String, device_id: i32, mapping: VmmMapping) -> Self {
+        Self {
+            instance_id,
+            device_id,
+            mapping: VmmMappingOwner::Cuda(mapping),
+            operations: OperationGate::default(),
+        }
+    }
+
+    #[cfg(test)]
+    fn stub(instance_id: &str, device_id: i32) -> Self {
+        Self {
+            instance_id: instance_id.to_string(),
+            device_id,
+            mapping: VmmMappingOwner::Stub,
+            operations: OperationGate::default(),
+        }
+    }
+
+    fn acquire(
+        self: &Arc<Self>,
+        instance_id: &str,
+        device_id: i32,
+    ) -> Result<RegistrationGuard, String> {
+        if self.instance_id != instance_id || self.device_id != device_id {
+            return Err(format!(
+                "native mapping belongs to instance {} device {}, not instance {instance_id} device {device_id}",
+                self.instance_id, self.device_id
+            ));
+        }
+        let active = self
+            .operations
+            .enter()
+            .map_err(|_| format!("native instance {} is closing", self.instance_id))?;
+        Ok(RegistrationGuard {
+            _active: active,
+            _registration: Arc::clone(self),
+        })
+    }
+
+    async fn drain(&self) -> OwnedRwLockWriteGuard<()> {
+        self.operations.close().await
+    }
+}
+
+pub(crate) struct RegistrationGuard {
+    _active: OwnedRwLockReadGuard<()>,
+    _registration: Arc<VmmRegistration>,
+}
+
 fn cuda_error(operation: &str, error: DriverError) -> PyErr {
     PyRuntimeError::new_err(format!("{operation}: {error}"))
 }
@@ -130,6 +221,7 @@ fn cuda_error(operation: &str, error: DriverError) -> PyErr {
 struct ContextState {
     device_id: i32,
     tensors: HashMap<String, LayerTensor>,
+    native_registration: Option<Arc<VmmRegistration>>,
 }
 
 impl ContextState {
@@ -137,12 +229,15 @@ impl ContextState {
         Self {
             device_id,
             tensors: HashMap::new(),
+            native_registration: None,
         }
     }
 }
 
 pub struct CudaTensorRegistry {
     contexts: HashMap<String, ContextState>,
+    native_instances: HashMap<String, Arc<VmmRegistration>>,
+    closing_native_instances: HashSet<String>,
 }
 
 impl CudaTensorRegistry {
@@ -153,6 +248,8 @@ impl CudaTensorRegistry {
             cuda.call_method0("init")?;
             Ok(Self {
                 contexts: HashMap::new(),
+                native_instances: HashMap::new(),
+                closing_native_instances: HashSet::new(),
             })
         })
     }
@@ -160,16 +257,19 @@ impl CudaTensorRegistry {
     pub fn empty() -> Self {
         Self {
             contexts: HashMap::new(),
+            native_instances: HashMap::new(),
+            closing_native_instances: HashSet::new(),
         }
     }
 
     fn register_layers(
         &mut self,
         context_key: &str,
+        instance_id: &str,
         device_id: i32,
         layers: Vec<(String, TensorRegistration)>,
         native_fd: Option<(i32, usize)>,
-    ) -> PyResult<Vec<TensorMetadata>> {
+    ) -> PyResult<(Vec<TensorMetadata>, Option<RegistrationGuard>)> {
         if self.contexts.contains_key(context_key) {
             return Err(PyValueError::new_err(format!(
                 "context {context_key} is already registered"
@@ -185,15 +285,46 @@ impl CudaTensorRegistry {
             }
         }
 
-        let mapping = match native_fd {
-            Some((fd, alloc_size)) => Some(VmmMapping::import(device_id, fd, alloc_size)?),
-            None => None,
+        let instance_prefix = format!("{instance_id}:");
+        let has_instance_context = self
+            .contexts
+            .keys()
+            .any(|key| key.starts_with(&instance_prefix));
+        let registration = match native_fd {
+            Some((fd, alloc_size)) => {
+                if self.native_instances.contains_key(instance_id)
+                    || self.closing_native_instances.contains(instance_id)
+                {
+                    return Err(PyValueError::new_err(format!(
+                        "native instance {instance_id} is already registered"
+                    )));
+                }
+                if has_instance_context {
+                    return Err(PyValueError::new_err(format!(
+                        "instance {instance_id} already has Python contexts"
+                    )));
+                }
+                let mapping = VmmMapping::import(device_id, fd, alloc_size)?;
+                Some(Arc::new(VmmRegistration::new(
+                    instance_id.to_string(),
+                    device_id,
+                    mapping,
+                )))
+            }
+            None => {
+                if self.native_instances.contains_key(instance_id) {
+                    return Err(PyValueError::new_err(format!(
+                        "instance {instance_id} is registered through native VMM"
+                    )));
+                }
+                None
+            }
         };
 
         let mut context = ContextState::new(device_id);
         let mut metadatas = Vec::with_capacity(layers.len());
-        for (layer_name, registration) in layers {
-            let layer_tensor = match registration {
+        for (layer_name, layer_registration) in layers {
+            let layer_tensor = match layer_registration {
                 TensorRegistration::Python(bytes) => {
                     Self::materialize_python_tensor(device_id, &bytes)?
                 }
@@ -201,10 +332,15 @@ impl CudaTensorRegistry {
                     offset_bytes,
                     size_bytes,
                 } => {
-                    let mapping = mapping.as_ref().ok_or_else(|| {
+                    let registration = registration.as_ref().ok_or_else(|| {
                         PyValueError::new_err("native tensor registration without an imported fd")
                     })?;
-                    Self::materialize_native_tensor(device_id, mapping, offset_bytes, size_bytes)?
+                    Self::materialize_native_tensor(
+                        device_id,
+                        registration,
+                        offset_bytes,
+                        size_bytes,
+                    )?
                 }
             };
             let metadata = layer_tensor.metadata.clone();
@@ -220,15 +356,32 @@ impl CudaTensorRegistry {
             metadatas.push(metadata);
         }
 
+        let guard = if let Some(registration) = registration {
+            let guard = registration
+                .acquire(instance_id, device_id)
+                .map_err(PyRuntimeError::new_err)?;
+            context.native_registration = Some(Arc::clone(&registration));
+            self.native_instances
+                .insert(instance_id.to_string(), registration);
+            Some(guard)
+        } else {
+            None
+        };
         self.contexts.insert(context_key.to_string(), context);
-        Ok(metadatas)
+        Ok((metadatas, guard))
     }
 
-    fn drop_context(&mut self, context_key: &str) -> usize {
-        self.release_contexts(vec![context_key.to_string()])
+    fn drop_context(&mut self, context_key: &str) -> RemovedContexts {
+        let removed = self.release_contexts(vec![context_key.to_string()]);
+        for registration in &removed.registrations {
+            self.native_instances.remove(&registration.instance_id);
+            self.closing_native_instances
+                .insert(registration.instance_id.clone());
+        }
+        removed
     }
 
-    fn drop_instance(&mut self, instance_id: &str) -> usize {
+    fn drop_instance(&mut self, instance_id: &str) -> RemovedContexts {
         let prefix = format!("{instance_id}:");
         let keys: Vec<String> = self
             .contexts
@@ -236,13 +389,42 @@ impl CudaTensorRegistry {
             .filter(|key| key.starts_with(&prefix))
             .cloned()
             .collect();
-        self.release_contexts(keys)
+        let mut removed = self.release_contexts(keys);
+        if let Some(registration) = self.native_instances.remove(instance_id)
+            && !removed
+                .registrations
+                .iter()
+                .any(|existing| Arc::ptr_eq(existing, &registration))
+        {
+            removed.registrations.push(registration);
+        }
+        if !removed.registrations.is_empty() {
+            self.closing_native_instances
+                .insert(instance_id.to_string());
+        }
+        removed
     }
 
     /// Clear all contexts and return the total number of tensors removed.
-    fn clear_and_count(&mut self) -> usize {
+    fn clear(&mut self) -> RemovedContexts {
         let keys: Vec<String> = self.contexts.keys().cloned().collect();
-        self.release_contexts(keys)
+        let mut removed = self.release_contexts(keys);
+        for (_, registration) in self.native_instances.drain() {
+            if !removed
+                .registrations
+                .iter()
+                .any(|existing| Arc::ptr_eq(existing, &registration))
+            {
+                removed.registrations.push(registration);
+            }
+        }
+        self.closing_native_instances.extend(
+            removed
+                .registrations
+                .iter()
+                .map(|registration| registration.instance_id.clone()),
+        );
+        removed
     }
 
     /// Remove `keys` from the registry, returning the number of CUDA IPC tensors
@@ -254,19 +436,12 @@ impl CudaTensorRegistry {
     /// removed contexts actually hold live tensors. Dropping empty contexts is
     /// pure Rust, so an idle/empty registry never forces a CUDA device sync —
     /// which would block forever on a wedged GPU.
-    fn release_contexts(&mut self, keys: Vec<String>) -> usize {
+    fn release_contexts(&mut self, keys: Vec<String>) -> RemovedContexts {
         let tensor_count: usize = keys
             .iter()
             .filter_map(|key| self.contexts.get(key))
             .map(|ctx| ctx.tensors.len())
             .sum();
-
-        if tensor_count == 0 {
-            for key in &keys {
-                self.contexts.remove(key);
-            }
-            return 0;
-        }
 
         let needs_python = keys
             .iter()
@@ -277,6 +452,11 @@ impl CudaTensorRegistry {
             .iter()
             .filter_map(|key| self.contexts.remove(key))
             .collect();
+        let registrations = removed
+            .iter()
+            .filter_map(|context| context.native_registration.as_ref())
+            .cloned()
+            .collect::<Vec<_>>();
 
         if needs_python {
             Python::attach(|py| {
@@ -288,9 +468,33 @@ impl CudaTensorRegistry {
                 let cuda = torch.getattr("cuda").expect("torch.cuda");
                 let _ = cuda.call_method0("empty_cache");
             });
+        } else {
+            drop(removed);
         }
 
-        tensor_count
+        RemovedContexts::new(tensor_count, registrations)
+    }
+
+    fn acquire_registration(
+        &self,
+        instance_id: &str,
+        device_id: i32,
+    ) -> Result<Option<RegistrationGuard>, String> {
+        if let Some(registration) = self.native_instances.get(instance_id) {
+            return registration.acquire(instance_id, device_id).map(Some);
+        }
+        if self.closing_native_instances.contains(instance_id) {
+            return Err(format!("native instance {instance_id} is closing"));
+        }
+        Ok(None)
+    }
+
+    fn finish_cleanup(&mut self, cleanup: RegistryCleanup) {
+        for registration in &cleanup._registrations {
+            self.closing_native_instances
+                .remove(&registration.instance_id);
+        }
+        drop(cleanup);
     }
 
     fn materialize_python_tensor(device_id: i32, wrapper_bytes: &[u8]) -> PyResult<LayerTensor> {
@@ -328,10 +532,11 @@ impl CudaTensorRegistry {
 
     fn materialize_native_tensor(
         device_id: i32,
-        mapping: &Arc<VmmMapping>,
+        registration: &Arc<VmmRegistration>,
         offset_bytes: u64,
         size_bytes: u64,
     ) -> PyResult<LayerTensor> {
+        let mapping = registration.mapping.cuda();
         let offset = usize::try_from(offset_bytes)
             .map_err(|_| PyValueError::new_err("native view offset does not fit usize"))?;
         let size = usize::try_from(size_bytes)
@@ -349,7 +554,7 @@ impl CudaTensorRegistry {
             .checked_add(offset_bytes)
             .ok_or_else(|| PyValueError::new_err("native view pointer overflows u64"))?;
         Ok(LayerTensor {
-            owner: TensorOwner::Vmm(Arc::clone(mapping)),
+            owner: TensorOwner::Vmm(Arc::clone(registration)),
             metadata: TensorMetadata {
                 data_ptr,
                 size_bytes: size,
@@ -359,26 +564,39 @@ impl CudaTensorRegistry {
     }
 }
 
+type RegisterLayersResult = Result<(Vec<TensorMetadata>, Option<RegistrationGuard>), String>;
+type RegistrationPermit = OwnedRwLockReadGuard<()>;
+
 enum RegistryCommand {
     RegisterLayers {
         context_key: String,
+        instance_id: String,
         device_id: i32,
         layers: Vec<(String, TensorRegistration)>,
         /// `Some((fd, alloc_size))` for native VMM; `None` for Python.
         native_fd: Option<(std::os::fd::OwnedFd, usize)>,
         // Stringified on the actor thread (holds GIL).
-        reply: oneshot::Sender<Result<Vec<TensorMetadata>, String>>,
+        reply: oneshot::Sender<RegisterLayersResult>,
     },
     DropInstance {
         instance_id: String,
-        reply: oneshot::Sender<usize>,
+        reply: oneshot::Sender<RemovedContexts>,
     },
     DropContext {
         context_key: String,
-        reply: oneshot::Sender<usize>,
+        reply: oneshot::Sender<RemovedContexts>,
     },
     Clear {
-        reply: oneshot::Sender<usize>,
+        reply: oneshot::Sender<RemovedContexts>,
+    },
+    AcquireRegistration {
+        instance_id: String,
+        device_id: i32,
+        reply: oneshot::Sender<Result<Option<RegistrationGuard>, String>>,
+    },
+    FinishCleanup {
+        cleanup: RegistryCleanup,
+        reply: oneshot::Sender<()>,
     },
 }
 
@@ -396,6 +614,7 @@ enum RegistryCommand {
 #[derive(Clone)]
 pub struct RegistryHandle {
     tx: mpsc::Sender<RegistryCommand>,
+    registration_barrier: Arc<RwLock<()>>,
 }
 
 impl RegistryHandle {
@@ -409,51 +628,130 @@ impl RegistryHandle {
             .name("cuda-registry".to_string())
             .spawn(move || registry_actor(registry, rx))
             .expect("spawn cuda-registry thread");
-        Self { tx }
+        Self {
+            tx,
+            registration_barrier: Arc::new(RwLock::new(())),
+        }
     }
 
     /// Register layers under `context_key`. `native_fd`: VMM fd + size, or `None` for Python.
     pub(crate) async fn register_layers(
         &self,
         context_key: String,
+        instance_id: String,
         device_id: i32,
         layers: Vec<(String, TensorRegistration)>,
         native_fd: Option<(std::os::fd::OwnedFd, usize)>,
-    ) -> Result<Vec<TensorMetadata>, String> {
+    ) -> Result<
+        (
+            Vec<TensorMetadata>,
+            Option<RegistrationGuard>,
+            RegistrationPermit,
+        ),
+        String,
+    > {
+        let permit = Arc::clone(&self.registration_barrier).read_owned().await;
         let (reply, rx) = oneshot::channel();
         self.dispatch(RegistryCommand::RegisterLayers {
             context_key,
+            instance_id,
             device_id,
             layers,
             native_fd,
             reply,
         })
         .await;
-        rx.await.expect("cuda-registry thread dropped reply")
+        rx.await
+            .expect("cuda-registry thread dropped reply")
+            .map(|(metadatas, registration)| (metadatas, registration, permit))
     }
 
-    /// Drop all CUDA tensors belonging to `instance_id`; returns the count
-    /// released.
-    pub async fn drop_instance(&self, instance_id: String) -> usize {
+    /// Drain all CUDA tensors belonging to `instance_id`.
+    ///
+    /// The returned cleanup guard owns native mappings until the caller removes
+    /// the corresponding engine instance and drops the guard.
+    pub(crate) async fn drop_instance(&self, instance_id: String) -> RegistryCleanup {
+        let barrier = Arc::clone(&self.registration_barrier).write_owned().await;
         let (reply, rx) = oneshot::channel();
         self.dispatch(RegistryCommand::DropInstance { instance_id, reply })
             .await;
-        rx.await.expect("cuda-registry thread dropped reply")
+        self.finish_removal(
+            rx.await.expect("cuda-registry thread dropped reply"),
+            Some(barrier),
+        )
+        .await
     }
 
-    /// Drop exactly one context; returns the number of CUDA tensors released.
-    pub async fn drop_context(&self, context_key: String) -> usize {
+    /// Drain exactly one context, retaining native mappings in the returned guard.
+    pub(crate) async fn drop_context(&self, context_key: String) -> RegistryCleanup {
         let (reply, rx) = oneshot::channel();
         self.dispatch(RegistryCommand::DropContext { context_key, reply })
             .await;
+        self.finish_removal(rx.await.expect("cuda-registry thread dropped reply"), None)
+            .await
+    }
+
+    /// Drain every registered tensor, retaining native mappings in the returned guard.
+    pub(crate) async fn clear(&self) -> RegistryCleanup {
+        let barrier = Arc::clone(&self.registration_barrier).write_owned().await;
+        let (reply, rx) = oneshot::channel();
+        self.dispatch(RegistryCommand::Clear { reply }).await;
+        self.finish_removal(
+            rx.await.expect("cuda-registry thread dropped reply"),
+            Some(barrier),
+        )
+        .await
+    }
+
+    /// Release a drained cleanup on the dedicated registry thread.
+    ///
+    /// Call this only after the engine has discarded the instance's raw CUDA
+    /// addresses. Once dispatched, completion is independent of caller
+    /// cancellation; the reply confirms that CUDA teardown has finished.
+    pub(crate) async fn finish_cleanup(&self, cleanup: RegistryCleanup) {
+        let (reply, rx) = oneshot::channel();
+        self.dispatch(RegistryCommand::FinishCleanup { cleanup, reply })
+            .await;
+        rx.await
+            .expect("cuda-registry thread dropped cleanup reply");
+    }
+
+    pub(crate) async fn acquire_registration(
+        &self,
+        instance_id: String,
+        device_id: i32,
+    ) -> Result<Option<RegistrationGuard>, String> {
+        let (reply, rx) = oneshot::channel();
+        self.dispatch(RegistryCommand::AcquireRegistration {
+            instance_id,
+            device_id,
+            reply,
+        })
+        .await;
         rx.await.expect("cuda-registry thread dropped reply")
     }
 
-    /// Drop every registered tensor; returns the count released.
-    pub async fn clear(&self) -> usize {
-        let (reply, rx) = oneshot::channel();
-        self.dispatch(RegistryCommand::Clear { reply }).await;
-        rx.await.expect("cuda-registry thread dropped reply")
+    async fn finish_removal(
+        &self,
+        removed: RemovedContexts,
+        registration_barrier: Option<OwnedRwLockWriteGuard<()>>,
+    ) -> RegistryCleanup {
+        let RemovedContexts {
+            tensor_count,
+            mut registrations,
+        } = removed;
+        registrations.sort_by(|left, right| left.instance_id.cmp(&right.instance_id));
+        registrations.dedup_by(|left, right| Arc::ptr_eq(left, right));
+        let mut drained = Vec::with_capacity(registrations.len());
+        for registration in &registrations {
+            drained.push(registration.drain().await);
+        }
+        RegistryCleanup {
+            tensor_count,
+            _drained: drained,
+            _registrations: registrations,
+            _registration_barrier: registration_barrier,
+        }
     }
 
     async fn dispatch(&self, cmd: RegistryCommand) {
@@ -471,6 +769,7 @@ fn registry_actor(mut registry: CudaTensorRegistry, mut rx: mpsc::Receiver<Regis
         match cmd {
             RegistryCommand::RegisterLayers {
                 context_key,
+                instance_id,
                 device_id,
                 layers,
                 native_fd,
@@ -479,7 +778,7 @@ fn registry_actor(mut registry: CudaTensorRegistry, mut rx: mpsc::Receiver<Regis
                 use std::os::fd::AsRawFd;
                 let native = native_fd.as_ref().map(|(fd, size)| (fd.as_raw_fd(), *size));
                 let result = registry
-                    .register_layers(&context_key, device_id, layers, native)
+                    .register_layers(&context_key, &instance_id, device_id, layers, native)
                     .map_err(|err| Python::attach(|py| err.value(py).to_string()));
                 let _ = reply.send(result);
             }
@@ -490,52 +789,22 @@ fn registry_actor(mut registry: CudaTensorRegistry, mut rx: mpsc::Receiver<Regis
                 let _ = reply.send(registry.drop_context(&context_key));
             }
             RegistryCommand::Clear { reply } => {
-                let _ = reply.send(registry.clear_and_count());
+                let _ = reply.send(registry.clear());
+            }
+            RegistryCommand::AcquireRegistration {
+                instance_id,
+                device_id,
+                reply,
+            } => {
+                let _ = reply.send(registry.acquire_registration(&instance_id, device_id));
+            }
+            RegistryCommand::FinishCleanup { cleanup, reply } => {
+                registry.finish_cleanup(cleanup);
+                let _ = reply.send(());
             }
         }
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn drop_context_removes_only_that_context() {
-        let mut registry = CudaTensorRegistry::empty();
-        registry
-            .contexts
-            .insert("instance-a:tp0:pp0:dev0".to_string(), ContextState::new(0));
-        registry
-            .contexts
-            .insert("instance-a:tp0:pp1:dev1".to_string(), ContextState::new(1));
-
-        assert_eq!(registry.drop_context("instance-a:tp0:pp0:dev0"), 0);
-
-        assert!(!registry.contexts.contains_key("instance-a:tp0:pp0:dev0"));
-        assert!(registry.contexts.contains_key("instance-a:tp0:pp1:dev1"));
-    }
-
-    #[test]
-    fn register_layers_rejects_existing_context_before_materializing() {
-        let mut registry = CudaTensorRegistry::empty();
-        registry
-            .contexts
-            .insert("instance-a:tp0:pp0:dev0".to_string(), ContextState::new(7));
-
-        let err = registry
-            .register_layers("instance-a:tp0:pp0:dev0", 0, Vec::new(), None)
-            .expect_err("existing context must be rejected");
-
-        let message = Python::attach(|py| err.value(py).to_string());
-        assert!(message.contains("already registered"));
-        assert_eq!(
-            registry
-                .contexts
-                .get("instance-a:tp0:pp0:dev0")
-                .expect("existing context remains")
-                .device_id,
-            7
-        );
-    }
-}
+mod tests;

--- a/pegaflow-server/src/registry/cleanup.rs
+++ b/pegaflow-server/src/registry/cleanup.rs
@@ -1,0 +1,35 @@
+use super::VmmRegistration;
+use std::sync::Arc;
+use tokio::sync::OwnedRwLockWriteGuard;
+
+pub(super) struct RemovedContexts {
+    pub(super) tensor_count: usize,
+    pub(super) registrations: Vec<Arc<VmmRegistration>>,
+}
+
+impl RemovedContexts {
+    pub(super) fn new(tensor_count: usize, registrations: Vec<Arc<VmmRegistration>>) -> Self {
+        Self {
+            tensor_count,
+            registrations,
+        }
+    }
+}
+
+/// Owns native mappings after their tensor views leave the registry.
+///
+/// The service removes the corresponding engine addresses before returning
+/// this value to the registry actor for final CUDA teardown.
+#[must_use = "finish through RegistryHandle after engine registration is removed"]
+pub(crate) struct RegistryCleanup {
+    pub(super) tensor_count: usize,
+    pub(super) _drained: Vec<OwnedRwLockWriteGuard<()>>,
+    pub(super) _registrations: Vec<Arc<VmmRegistration>>,
+    pub(super) _registration_barrier: Option<OwnedRwLockWriteGuard<()>>,
+}
+
+impl RegistryCleanup {
+    pub(crate) fn tensor_count(&self) -> usize {
+        self.tensor_count
+    }
+}

--- a/pegaflow-server/src/registry/tests.rs
+++ b/pegaflow-server/src/registry/tests.rs
@@ -1,0 +1,155 @@
+use super::*;
+
+#[test]
+fn python_instances_keep_legacy_multi_context_semantics() {
+    let mut registry = CudaTensorRegistry::empty();
+
+    for context_key in ["instance-a:tp0:pp0:dev0", "instance-a:tp1:pp0:dev1"] {
+        registry
+            .register_layers(context_key, "instance-a", 0, Vec::new(), None)
+            .expect("Python instance may register multiple contexts");
+    }
+
+    assert_eq!(registry.contexts.len(), 2);
+}
+
+#[test]
+fn native_registration_does_not_mix_with_python_contexts() {
+    let mut registry = CudaTensorRegistry::empty();
+    registry
+        .register_layers("instance-a:tp0:pp0:dev0", "instance-a", 0, Vec::new(), None)
+        .expect("register Python context");
+
+    let err = match registry.register_layers(
+        "instance-a:tp1:pp0:dev0",
+        "instance-a",
+        0,
+        Vec::new(),
+        Some((-1, 1)),
+    ) {
+        Err(err) => err,
+        Ok(_) => panic!("native registration must fail before importing the invalid fd"),
+    };
+    let message = Python::attach(|py| err.value(py).to_string());
+    assert!(message.contains("already has Python contexts"));
+}
+
+#[tokio::test]
+async fn registry_cleanup_blocks_new_work_and_drains_in_flight_work() {
+    let mut state = CudaTensorRegistry::empty();
+    let registration = Arc::new(VmmRegistration::stub("native-a", 0));
+    let mut context = ContextState::new(0);
+    context.native_registration = Some(Arc::clone(&registration));
+    state
+        .contexts
+        .insert("native-a:tp0:pp0:dev0".to_string(), context);
+    state
+        .native_instances
+        .insert("native-a".to_string(), registration);
+    let registry = RegistryHandle::spawn(state);
+    let operation = registry
+        .acquire_registration("native-a".to_string(), 0)
+        .await
+        .expect("acquire native operation")
+        .expect("native registration");
+
+    let cleanup = tokio::spawn({
+        let registry = registry.clone();
+        async move { registry.drop_instance("native-a".to_string()).await }
+    });
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            match registry
+                .acquire_registration("native-a".to_string(), 0)
+                .await
+            {
+                Err(message) if message.contains("closing") => break,
+                Ok(Some(guard)) => drop(guard),
+                Ok(None) => panic!("native registration disappeared but context remained"),
+                Err(message) => panic!("unexpected native close error: {message}"),
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("cleanup must remove the registration");
+    assert!(
+        !cleanup.is_finished(),
+        "in-flight operation must block cleanup"
+    );
+
+    drop(operation);
+    let cleanup = tokio::time::timeout(std::time::Duration::from_secs(1), cleanup)
+        .await
+        .expect("cleanup must drain after operation")
+        .expect("cleanup task");
+    registry.finish_cleanup(cleanup).await;
+}
+
+#[tokio::test]
+async fn clear_waits_for_registration_to_finish() {
+    let registry = RegistryHandle::spawn(CudaTensorRegistry::empty());
+    let (_, _, registration_permit) = registry
+        .register_layers(
+            "instance-a:tp0:pp0:dev0".to_string(),
+            "instance-a".to_string(),
+            0,
+            Vec::new(),
+            None,
+        )
+        .await
+        .expect("register context");
+    let clear = tokio::spawn({
+        let registry = registry.clone();
+        async move { registry.clear().await }
+    });
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while Arc::clone(&registry.registration_barrier)
+            .try_read_owned()
+            .is_ok()
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("clear must queue for the registration barrier");
+    let next_registration = tokio::spawn({
+        let registry = registry.clone();
+        async move {
+            registry
+                .register_layers(
+                    "instance-b:tp0:pp0:dev0".to_string(),
+                    "instance-b".to_string(),
+                    0,
+                    Vec::new(),
+                    None,
+                )
+                .await
+        }
+    });
+    assert!(
+        !clear.is_finished(),
+        "clear must not cross an in-progress registration"
+    );
+    assert!(
+        !next_registration.is_finished(),
+        "new registration must queue behind clear"
+    );
+
+    drop(registration_permit);
+    let cleanup = tokio::time::timeout(std::time::Duration::from_secs(1), clear)
+        .await
+        .expect("clear must continue after registration")
+        .expect("clear task");
+    assert!(
+        !next_registration.is_finished(),
+        "clear must keep the barrier through engine cleanup"
+    );
+    registry.finish_cleanup(cleanup).await;
+    tokio::time::timeout(std::time::Duration::from_secs(1), next_registration)
+        .await
+        .expect("next registration must continue after cleanup")
+        .expect("registration task")
+        .expect("register next context");
+}

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -1,5 +1,6 @@
 use pegaflow_core::{trace_in_span, trace_root};
 
+use crate::fd_channel::RegistrationKey;
 use crate::metric::record_rpc_result;
 use crate::proto::engine::engine_server::Engine;
 use crate::proto::engine::{
@@ -7,21 +8,22 @@ use crate::proto::engine::{
     QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, QueryLoading, QueryReady,
     QueryRequest, QueryResponse, RdmaHandshakeRequest, RdmaHandshakeResponse,
     RegisterContextRequest, RegisterContextResponse, ReleaseRequest, ReleaseResponse,
-    ReleaseTransferLockRequest, ReleaseTransferLockResponse, ResponseStatus, SaveRequest,
-    SaveResponse, SessionEvent, SessionRequest, ShutdownRequest, ShutdownResponse,
-    TransferBlockInfo, TransferMode as ProtoTransferMode, TransferSlotInfo, UnregisterRequest,
-    UnregisterResponse, query_response,
+    ReleaseTransferLockRequest, ReleaseTransferLockResponse, SaveRequest, SaveResponse,
+    SessionEvent, SessionRequest, ShutdownRequest, ShutdownResponse, TransferBlockInfo,
+    TransferMode as ProtoTransferMode, TransferSlotInfo, UnregisterRequest, UnregisterResponse,
+    query_response,
 };
 use crate::registry::{RegistryHandle, TensorRegistration};
 use crate::session::SessionRegistry;
 use log::{debug, info, warn};
-use pegaflow_core::{EngineError, LayerSave, PegaEngine, PrefetchStatus, QueryLeaseId};
+use pegaflow_core::{LayerSave, PegaEngine, PrefetchStatus, QueryLeaseId};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{Notify, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, async_trait};
 
+mod helpers;
 mod validation;
 
 #[derive(Clone)]
@@ -49,131 +51,6 @@ impl GrpcEngineService {
             hll_tracker,
             session_registry: SessionRegistry::new(),
             fd_channel,
-        }
-    }
-
-    /// Drop CUDA IPC tensors and engine-side instance state for `instance_id`.
-    /// Idempotent — safe to call after the instance is already gone.
-    async fn cleanup_instance(
-        engine: &PegaEngine,
-        registry: &RegistryHandle,
-        instance_id: &str,
-        reason: &'static str,
-    ) {
-        let removed = registry.drop_instance(instance_id.to_string()).await;
-        if removed > 0 {
-            info!(
-                "Session cleanup ({}): dropped {} CUDA tensors for instance {}",
-                reason, removed, instance_id
-            );
-        }
-        if let Err(err) = engine.unregister_instance(instance_id) {
-            // `InstanceMissing` is normal if the instance was never registered
-            // (vllm died before any register_context_batch). Log at debug.
-            debug!(
-                "Session cleanup ({}): engine.unregister_instance({}) returned {}",
-                reason, instance_id, err
-            );
-        }
-    }
-
-    fn context_key(instance_id: &str, tp_rank: u32, pp_rank: u32, device_id: i32) -> String {
-        format!("{instance_id}:tp{tp_rank}:pp{pp_rank}:dev{device_id}")
-    }
-
-    fn ok_status() -> ResponseStatus {
-        ResponseStatus {
-            ok: true,
-            message: String::new(),
-        }
-    }
-
-    fn map_engine_error(err: EngineError) -> Status {
-        match err {
-            EngineError::InvalidArgument(_) => Status::invalid_argument(err.to_string()),
-            EngineError::InstanceMissing(_) | EngineError::WorkerMissing(_, _) => {
-                Status::failed_precondition(err.to_string())
-            }
-            EngineError::TopologyMismatch(_) => Status::failed_precondition(err.to_string()),
-            EngineError::CudaInit(_) | EngineError::Storage(_) | EngineError::Poisoned(_) => {
-                Status::internal(err.to_string())
-            }
-        }
-    }
-
-    fn usize_from_u64(value: u64, field: &str) -> Result<usize, Status> {
-        usize::try_from(value).map_err(|_| {
-            Status::invalid_argument(format!("{field}={value} does not fit into usize"))
-        })
-    }
-
-    fn usize_from_u32(value: u32, field: &str) -> Result<usize, Status> {
-        usize::try_from(value).map_err(|_| {
-            Status::invalid_argument(format!("{field}={value} does not fit into usize"))
-        })
-    }
-
-    fn validate_device_id(device_id: i32) -> Result<(), Status> {
-        if device_id < 0 {
-            return Err(Status::invalid_argument(format!(
-                "device_id {device_id} must be >= 0"
-            )));
-        }
-        Ok(())
-    }
-
-    fn validate_save_layers(saves: &[crate::proto::engine::SaveLayer]) -> Result<(), Status> {
-        for layer in saves {
-            if layer.block_ids.len() != layer.block_hashes.len() {
-                return Err(Status::invalid_argument(format!(
-                    "block_ids length {} does not match block_hashes {} for layer {}",
-                    layer.block_ids.len(),
-                    layer.block_hashes.len(),
-                    layer.layer_name
-                )));
-            }
-        }
-        Ok(())
-    }
-
-    fn validate_query_prefetch_request(req: &QueryRequest) -> Result<(), Status> {
-        if req.req_id.is_empty() {
-            return Err(Status::invalid_argument("req_id must not be empty"));
-        }
-        Ok(())
-    }
-
-    fn build_register_context_response() -> RegisterContextResponse {
-        RegisterContextResponse {
-            status: Some(Self::ok_status()),
-        }
-    }
-
-    fn build_simple_response() -> ResponseStatus {
-        Self::ok_status()
-    }
-
-    fn build_transfer_slot_info(
-        raw_block: &pegaflow_core::RawBlock,
-        numa_node: pegaflow_common::NumaNode,
-    ) -> TransferSlotInfo {
-        let layer_block = pegaflow_core::LayerBlock::new(raw_block);
-        if let Some(v_ptr) = layer_block.v_ptr() {
-            TransferSlotInfo {
-                k_ptr: layer_block.k_ptr() as u64,
-                k_size: layer_block.k_size() as u64,
-                v_ptr: v_ptr as u64,
-                v_size: layer_block.v_size().unwrap_or(0) as u64,
-                numa_node: numa_node.0,
-            }
-        } else {
-            TransferSlotInfo {
-                k_ptr: layer_block.k_ptr() as u64,
-                k_size: layer_block.k_size() as u64,
-                v_ptr: 0,
-                v_size: 0,
-                numa_node: numa_node.0,
-            }
         }
     }
 }
@@ -298,7 +175,7 @@ impl Engine for GrpcEngineService {
                 }
                 let fd = channel
                     .take(
-                        crate::fd_channel::RegistrationKey {
+                        RegistrationKey {
                             instance_id: req.instance_id.clone(),
                             device_id: req.device_id,
                         },
@@ -307,8 +184,8 @@ impl Engine for GrpcEngineService {
                     .await
                     .ok_or_else(|| {
                         Status::failed_precondition(format!(
-                            "no allocation fd received on the side-channel for instance {} device {}",
-                            req.instance_id, req.device_id
+                            "no allocation fd received on the side-channel for instance {}",
+                            req.instance_id
                         ))
                     })?;
                 Some((fd, alloc_size))
@@ -316,49 +193,69 @@ impl Engine for GrpcEngineService {
                 None
             };
 
-            let metadatas = self
-                .registry
-                .register_layers(context_key.clone(), req.device_id, layers, native_fd)
-                .await
-                .map_err(|message| Status::internal(format!("register tensor failed: {message}")))?;
-            let mut data_ptrs = Vec::with_capacity(batch_len);
-            let mut size_bytes_list = Vec::with_capacity(batch_len);
-            for metadata in &metadatas {
-                data_ptrs.push(metadata.data_ptr);
-                size_bytes_list.push(metadata.size_bytes);
-            }
-
-            // Call engine batch registration
-            if let Err(err) = self.engine.register_context_layer_batch_strided(
-                &req.instance_id,
-                &req.namespace,
-                req.device_id,
-                tp_rank,
-                pp_rank,
-                tp_size,
-                world_size,
-                &req.layer_names,
-                &data_ptrs,
-                &size_bytes_list,
-                &num_blocks_list,
-                &bytes_per_block_list,
-                &kv_stride_bytes_list,
-                &segments_list,
-                native.then_some(block_stride_bytes.as_slice()),
-                transfer_mode,
-                req.page_first,
-            ) {
-                let status = Self::map_engine_error(err);
-                let removed = self.registry.drop_context(context_key.clone()).await;
-                if removed > 0 {
-                    warn!(
-                        "Rolled back {} CUDA tensor(s) for failed register_context_batch context {}",
-                        removed, context_key
-                    );
+            let registry = self.registry.clone();
+            let engine = Arc::clone(&self.engine);
+            // Finish registry + engine publication, or rollback both, even if
+            // tonic cancels the request after the actor accepted registration.
+            tokio::spawn(async move {
+                let (metadatas, registration_guard, registration_permit) = registry
+                    .register_layers(
+                        context_key.clone(),
+                        req.instance_id.clone(),
+                        req.device_id,
+                        layers,
+                        native_fd,
+                    )
+                    .await
+                    .map_err(|message| {
+                        Status::internal(format!("register tensor failed: {message}"))
+                    })?;
+                let mut data_ptrs = Vec::with_capacity(batch_len);
+                let mut size_bytes_list = Vec::with_capacity(batch_len);
+                for metadata in &metadatas {
+                    data_ptrs.push(metadata.data_ptr);
+                    size_bytes_list.push(metadata.size_bytes);
                 }
-                return Err(status);
-            }
 
+                if let Err(err) = engine.register_context_layer_batch_strided(
+                    &req.instance_id,
+                    &req.namespace,
+                    req.device_id,
+                    tp_rank,
+                    pp_rank,
+                    tp_size,
+                    world_size,
+                    &req.layer_names,
+                    &data_ptrs,
+                    &size_bytes_list,
+                    &num_blocks_list,
+                    &bytes_per_block_list,
+                    &kv_stride_bytes_list,
+                    &segments_list,
+                    native.then_some(block_stride_bytes.as_slice()),
+                    transfer_mode,
+                    req.page_first,
+                ) {
+                    let status = Self::map_engine_error(err);
+                    drop(registration_guard);
+                    let cleanup = registry.drop_context(context_key.clone()).await;
+                    if cleanup.tensor_count() > 0 {
+                        warn!(
+                            "Rolled back {} CUDA tensor(s) for failed register_context_batch context {}",
+                            cleanup.tensor_count(),
+                            context_key
+                        );
+                    }
+                    registry.finish_cleanup(cleanup).await;
+                    drop(registration_permit);
+                    return Err(status);
+                }
+
+                drop(registration_permit);
+                Ok::<(), Status>(())
+            })
+            .await
+            .map_err(|err| Status::internal(format!("registration task failed: {err}")))??;
             Ok(Response::new(Self::build_register_context_response()))
         }
         .await;
@@ -411,6 +308,11 @@ impl Engine for GrpcEngineService {
             Self::validate_save_layers(&saves)?;
             let tp_rank = Self::usize_from_u32(tp_rank, "tp_rank")?;
             let pp_rank = Self::usize_from_u32(pp_rank, "pp_rank")?;
+            let registration = self
+                .registry
+                .acquire_registration(instance_id.clone(), device_id)
+                .await
+                .map_err(Status::failed_precondition)?;
 
             let saves: Vec<LayerSave> = saves
                 .into_iter()
@@ -426,10 +328,16 @@ impl Engine for GrpcEngineService {
                 instance_id, tp_rank, pp_rank, device_id, layer_count, total_blocks, total_hashes
             );
 
-            self.engine
-                .batch_save_kv_blocks_from_ipc(&instance_id, tp_rank, pp_rank, device_id, saves)
-                .await
-                .map_err(Self::map_engine_error)?;
+            let engine = Arc::clone(&self.engine);
+            tokio::spawn(async move {
+                let _registration = registration;
+                engine
+                    .batch_save_kv_blocks_from_ipc(&instance_id, tp_rank, pp_rank, device_id, saves)
+                    .await
+                    .map_err(Self::map_engine_error)
+            })
+            .await
+            .map_err(|err| Status::internal(format!("save operation task failed: {err}")))??;
 
             Ok(Response::new(SaveResponse {
                 status: Some(Self::build_simple_response()),
@@ -484,6 +392,16 @@ impl Engine for GrpcEngineService {
             } = req;
             Self::validate_device_id(device_id)?;
             let tp_rank = Self::usize_from_u32(tp_rank, "tp_rank")?;
+            let registration = self
+                .registry
+                .acquire_registration(instance_id.clone(), device_id)
+                .await
+                .map_err(Status::failed_precondition)?;
+            if registration.is_some() && !wait_for_completion {
+                return Err(Status::invalid_argument(
+                    "native VMM loads require wait_for_completion",
+                ));
+            }
             debug!(
                 "RPC [load]: instance_id={} tp_rank={} device_id={} layers={} loads={} blocks={} load_state_shm_len={}",
                 instance_id,
@@ -494,7 +412,6 @@ impl Engine for GrpcEngineService {
                 block_count,
                 load_state_shm.len()
             );
-            let layer_refs: Vec<&str> = layer_names.iter().map(|s| s.as_str()).collect();
             let loads: Vec<(QueryLeaseId, Vec<usize>)> = loads
                 .into_iter()
                 .map(|load| {
@@ -511,19 +428,27 @@ impl Engine for GrpcEngineService {
                         "synchronous load must not include load_state_shm",
                     ));
                 }
-                self.engine
-                    .batch_load_kv_blocks_multi_layer_inproc(
-                        &instance_id,
-                        tp_rank,
-                        device_id,
-                        &layer_refs,
-                        &loads,
-                    )
-                    .map_err(Self::map_engine_error)?
-                    .await
-                    .map_err(|_| Status::internal("load worker dropped completion"))?
-                    .map_err(Self::map_engine_error)?;
+                let engine = Arc::clone(&self.engine);
+                tokio::spawn(async move {
+                    let _registration = registration;
+                    let layer_refs: Vec<&str> = layer_names.iter().map(String::as_str).collect();
+                    engine
+                        .batch_load_kv_blocks_multi_layer_inproc(
+                            &instance_id,
+                            tp_rank,
+                            device_id,
+                            &layer_refs,
+                            &loads,
+                        )
+                        .map_err(Self::map_engine_error)?
+                        .await
+                        .map_err(|_| Status::internal("load worker dropped completion"))?
+                        .map_err(Self::map_engine_error)
+                })
+                .await
+                .map_err(|err| Status::internal(format!("load operation task failed: {err}")))??;
             } else {
+                let layer_refs: Vec<&str> = layer_names.iter().map(String::as_str).collect();
                 self.engine
                     .batch_load_kv_blocks_multi_layer(
                         &instance_id,
@@ -719,17 +644,24 @@ impl Engine for GrpcEngineService {
         let result: Result<Response<UnregisterResponse>, Status> = async {
             let req = request.into_inner();
             debug!("RPC [unregister_context]: instance_id={}", req.instance_id);
-            let removed = self.registry.drop_instance(req.instance_id.clone()).await;
-            if removed > 0 {
-                info!(
-                    "Dropped {} CUDA tensors for instance {}",
-                    removed, req.instance_id
-                );
-            }
-
-            self.engine
-                .unregister_instance(&req.instance_id)
-                .map_err(Self::map_engine_error)?;
+            let engine = Arc::clone(&self.engine);
+            let registry = self.registry.clone();
+            let instance_id = req.instance_id.clone();
+            tokio::spawn(async move {
+                let cleanup = registry.drop_instance(instance_id.clone()).await;
+                if cleanup.tensor_count() > 0 {
+                    info!(
+                        "Dropped {} CUDA tensors for instance {}",
+                        cleanup.tensor_count(),
+                        instance_id
+                    );
+                }
+                let unregister = engine.unregister_instance(&instance_id);
+                registry.finish_cleanup(cleanup).await;
+                unregister.map_err(Self::map_engine_error)
+            })
+            .await
+            .map_err(|err| Status::internal(format!("unregister task failed: {err}")))??;
 
             Ok(Response::new(UnregisterResponse {
                 status: Some(Self::build_simple_response()),

--- a/pegaflow-server/src/service/helpers.rs
+++ b/pegaflow-server/src/service/helpers.rs
@@ -1,0 +1,144 @@
+use super::GrpcEngineService;
+use crate::proto::engine::{
+    QueryRequest, RegisterContextResponse, ResponseStatus, SaveLayer, TransferSlotInfo,
+};
+use crate::registry::RegistryHandle;
+use log::{debug, info};
+use pegaflow_core::{EngineError, PegaEngine};
+use tonic::Status;
+
+impl GrpcEngineService {
+    /// Drop CUDA IPC tensors and engine-side instance state for `instance_id`.
+    /// Idempotent — safe to call after the instance is already gone.
+    pub(super) async fn cleanup_instance(
+        engine: &PegaEngine,
+        registry: &RegistryHandle,
+        instance_id: &str,
+        reason: &'static str,
+    ) {
+        let cleanup = registry.drop_instance(instance_id.to_string()).await;
+        if cleanup.tensor_count() > 0 {
+            info!(
+                "Session cleanup ({}): dropped {} CUDA tensors for instance {}",
+                reason,
+                cleanup.tensor_count(),
+                instance_id
+            );
+        }
+        let unregister = engine.unregister_instance(instance_id);
+        registry.finish_cleanup(cleanup).await;
+        if let Err(err) = unregister {
+            // `InstanceMissing` is normal if the instance was never registered
+            // (vllm died before any register_context_batch). Log at debug.
+            debug!(
+                "Session cleanup ({}): engine.unregister_instance({}) returned {}",
+                reason, instance_id, err
+            );
+        }
+    }
+
+    pub(super) fn context_key(
+        instance_id: &str,
+        tp_rank: u32,
+        pp_rank: u32,
+        device_id: i32,
+    ) -> String {
+        format!("{instance_id}:tp{tp_rank}:pp{pp_rank}:dev{device_id}")
+    }
+
+    fn ok_status() -> ResponseStatus {
+        ResponseStatus {
+            ok: true,
+            message: String::new(),
+        }
+    }
+
+    pub(super) fn map_engine_error(err: EngineError) -> Status {
+        match err {
+            EngineError::InvalidArgument(_) => Status::invalid_argument(err.to_string()),
+            EngineError::InstanceMissing(_) | EngineError::WorkerMissing(_, _) => {
+                Status::failed_precondition(err.to_string())
+            }
+            EngineError::TopologyMismatch(_) => Status::failed_precondition(err.to_string()),
+            EngineError::CudaInit(_) | EngineError::Storage(_) | EngineError::Poisoned(_) => {
+                Status::internal(err.to_string())
+            }
+        }
+    }
+
+    pub(super) fn usize_from_u64(value: u64, field: &str) -> Result<usize, Status> {
+        usize::try_from(value).map_err(|_| {
+            Status::invalid_argument(format!("{field}={value} does not fit into usize"))
+        })
+    }
+
+    pub(super) fn usize_from_u32(value: u32, field: &str) -> Result<usize, Status> {
+        usize::try_from(value).map_err(|_| {
+            Status::invalid_argument(format!("{field}={value} does not fit into usize"))
+        })
+    }
+
+    pub(super) fn validate_device_id(device_id: i32) -> Result<(), Status> {
+        if device_id < 0 {
+            return Err(Status::invalid_argument(format!(
+                "device_id {device_id} must be >= 0"
+            )));
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_save_layers(saves: &[SaveLayer]) -> Result<(), Status> {
+        for layer in saves {
+            if layer.block_ids.len() != layer.block_hashes.len() {
+                return Err(Status::invalid_argument(format!(
+                    "block_ids length {} does not match block_hashes {} for layer {}",
+                    layer.block_ids.len(),
+                    layer.block_hashes.len(),
+                    layer.layer_name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_query_prefetch_request(req: &QueryRequest) -> Result<(), Status> {
+        if req.req_id.is_empty() {
+            return Err(Status::invalid_argument("req_id must not be empty"));
+        }
+        Ok(())
+    }
+
+    pub(super) fn build_register_context_response() -> RegisterContextResponse {
+        RegisterContextResponse {
+            status: Some(Self::ok_status()),
+        }
+    }
+
+    pub(super) fn build_simple_response() -> ResponseStatus {
+        Self::ok_status()
+    }
+
+    pub(super) fn build_transfer_slot_info(
+        raw_block: &pegaflow_core::RawBlock,
+        numa_node: pegaflow_common::NumaNode,
+    ) -> TransferSlotInfo {
+        let layer_block = pegaflow_core::LayerBlock::new(raw_block);
+        if let Some(v_ptr) = layer_block.v_ptr() {
+            TransferSlotInfo {
+                k_ptr: layer_block.k_ptr() as u64,
+                k_size: layer_block.k_size() as u64,
+                v_ptr: v_ptr as u64,
+                v_size: layer_block.v_size().unwrap_or(0) as u64,
+                numa_node: numa_node.0,
+            }
+        } else {
+            TransferSlotInfo {
+                k_ptr: layer_block.k_ptr() as u64,
+                k_size: layer_block.k_size() as u64,
+                v_ptr: 0,
+                v_size: 0,
+                numa_node: numa_node.0,
+            }
+        }
+    }
+}

--- a/pegaflow-server/src/service/tests.rs
+++ b/pegaflow-server/src/service/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::proto::engine::SaveLayer;
+use crate::proto::engine::{NativeKvTensor, SaveLayer};
 use tonic::Code;
 
 #[test]
@@ -82,6 +82,53 @@ fn validate_register_context_rejects_client_version_mismatch() {
     assert_eq!(err.code(), Code::FailedPrecondition);
     assert!(err.message().contains("PegaFlow version mismatch"));
     assert!(err.message().contains("client=0.0.0-test-mismatch"));
+}
+
+#[test]
+fn native_registration_requires_side_channel_safe_instance_id() {
+    let err = validation::register_context(&native_register_request("instance/with/slashes"))
+        .expect_err("native fd correlation must use a side-channel-safe instance id");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("instance_id"));
+}
+
+#[test]
+fn native_registration_rejects_multi_gpu_topology() {
+    let mut request = native_register_request("qwen3-dev0-018f8f75-b82e-7c10-a7d4-01abc2345678");
+    request.world_size = 2;
+    let err = validation::register_context(&request)
+        .expect_err("v1 native ownership supports one fused allocation on one GPU");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("world_size=1"));
+}
+
+fn native_register_request(instance_id: &str) -> RegisterContextRequest {
+    RegisterContextRequest {
+        instance_id: instance_id.to_string(),
+        namespace: "namespace".to_string(),
+        client_version: pegaflow_proto::VERSION.to_string(),
+        tp_rank: 0,
+        tp_size: 1,
+        world_size: 1,
+        device_id: 0,
+        layer_names: vec!["layer".to_string()],
+        wrapper_bytes: Vec::new(),
+        num_blocks: vec![1],
+        bytes_per_block: vec![16],
+        kv_stride_bytes: vec![0],
+        segments: vec![1],
+        pp_rank: 0,
+        transfer_mode: ProtoTransferMode::Direct as i32,
+        page_first: false,
+        native_kv_tensors: vec![NativeKvTensor {
+            offset_bytes: 0,
+            size_bytes: 16,
+            block_stride_bytes: 16,
+        }],
+        native_alloc_size: 16,
+    }
 }
 
 #[test]

--- a/pegaflow-server/src/service/validation.rs
+++ b/pegaflow-server/src/service/validation.rs
@@ -38,6 +38,16 @@ pub(super) fn register_context(req: &RegisterContextRequest) -> Result<(), Statu
             "exactly one tensor payload must match layer_names",
         ));
     }
+    if native && !crate::fd_channel::valid_instance_id(&req.instance_id) {
+        return Err(Status::invalid_argument(
+            "native registration requires a side-channel-safe instance_id",
+        ));
+    }
+    if native && (req.tp_size != 1 || req.world_size != 1) {
+        return Err(Status::invalid_argument(
+            "native VMM registration currently requires tp_size=1 and world_size=1",
+        ));
+    }
     for tensor in &req.native_kv_tensors {
         if tensor.size_bytes == 0
             || tensor.block_stride_bytes == 0

--- a/pegaflow-server/tests/http_cleanup_hang_repro.rs
+++ b/pegaflow-server/tests/http_cleanup_hang_repro.rs
@@ -107,7 +107,6 @@ fn wait_until_serving(addr: SocketAddr) {
 struct TestCluster {
     http_addr: SocketAddr,
     client: EngineClient<Channel>,
-    registry: RegistryHandle,
     shutdown: Arc<Notify>,
     rt: tokio::runtime::Runtime,
     // Kept alive so the engine's pinned pool stays valid for the whole test.
@@ -176,10 +175,9 @@ impl TestCluster {
     }
 
     fn wait_for_registry_drain(&self, timeout: Duration) {
-        let registry = self.registry.clone();
-        self.rt
-            .block_on(async move { tokio::time::timeout(timeout, registry.clear()).await })
-            .expect("registry actor did not drain after releasing the GIL wedge");
+        let response = http_request(self.http_addr, "POST", "/instances/cleanup", timeout)
+            .expect("HTTP cleanup did not finish after releasing the GIL wedge");
+        assert!(response.contains("200"), "cleanup failed: {response:?}");
     }
 
     fn shutdown(self) {
@@ -320,7 +318,6 @@ fn start_cluster(worker_threads: usize) -> TestCluster {
     TestCluster {
         http_addr,
         client,
-        registry,
         shutdown,
         rt,
         _ctx: ctx,

--- a/pegaflow-server/tests/native_vmm_rpc_e2e.rs
+++ b/pegaflow-server/tests/native_vmm_rpc_e2e.rs
@@ -15,14 +15,13 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cudarc::driver::CudaContext;
 use cudarc::driver::sys;
-use pegaflow_core::sync_state::{LOAD_STATE_ERROR, LOAD_STATE_SUCCESS};
-use pegaflow_core::{LoadState, PegaEngine, StorageConfig};
+use pegaflow_core::{PegaEngine, StorageConfig};
 use pegaflow_server::fd_channel::FdChannel;
 use pegaflow_server::proto::engine::engine_client::EngineClient;
 use pegaflow_server::proto::engine::engine_server::EngineServer;
 use pegaflow_server::proto::engine::{
     LeaseLoad, LoadRequest, NativeKvTensor, QueryRequest, RegisterContextRequest, SaveLayer,
-    SaveRequest, TransferMode, query_response,
+    SaveRequest, TransferMode, UnregisterRequest, query_response,
 };
 use pegaflow_server::{CudaTensorRegistry, GrpcEngineService, RegistryHandle};
 use tokio::sync::Notify;
@@ -139,21 +138,18 @@ async fn native_vmm_register_save_load_roundtrip() {
             h
         })
         .collect();
-    let save = client
-        .save(SaveRequest {
-            instance_id: INSTANCE_ID.to_string(),
-            tp_rank: 0,
-            device_id: 0,
-            pp_rank: 0,
-            saves: vec![SaveLayer {
-                layer_name: LAYER_NAME.to_string(),
-                block_ids: (0..BLOCK_COUNT as u32).collect(),
-                block_hashes: hashes.clone(),
-            }],
-        })
-        .await
-        .expect("save")
-        .into_inner();
+    let save_request = SaveRequest {
+        instance_id: INSTANCE_ID.to_string(),
+        tp_rank: 0,
+        device_id: 0,
+        pp_rank: 0,
+        saves: vec![SaveLayer {
+            layer_name: LAYER_NAME.to_string(),
+            block_ids: (0..BLOCK_COUNT as u32).collect(),
+            block_hashes: hashes.clone(),
+        }],
+    };
+    let save = client.save(save_request).await.expect("save").into_inner();
     assert!(
         save.status.as_ref().is_some_and(|s| s.ok),
         "{:?}",
@@ -183,19 +179,18 @@ async fn native_vmm_register_save_load_roundtrip() {
     client_alloc.zero();
     assert!(client_alloc.copy_to_host().iter().all(|&b| b == 0));
 
-    let load_state = LoadState::new().expect("LoadState");
     let load = client
         .load(LoadRequest {
             instance_id: INSTANCE_ID.to_string(),
             tp_rank: 0,
             device_id: 0,
-            load_state_shm: load_state.shm_name().to_string(),
+            load_state_shm: String::new(),
             layer_names: vec![LAYER_NAME.to_string()],
             loads: vec![LeaseLoad {
                 lease: ready.lease,
                 block_ids: (0..BLOCK_COUNT as u32).collect(),
             }],
-            wait_for_completion: false,
+            wait_for_completion: true,
         })
         .await
         .expect("load")
@@ -205,12 +200,23 @@ async fn native_vmm_register_save_load_roundtrip() {
         "{:?}",
         load.status
     );
-    wait_load(&load_state).await;
-
     assert_eq!(
         client_alloc.copy_to_host(),
         expected,
         "H2D restore must match pre-save GPU pattern"
+    );
+
+    let unregister = client
+        .unregister_context(UnregisterRequest {
+            instance_id: INSTANCE_ID.to_string(),
+        })
+        .await
+        .expect("unregister_context")
+        .into_inner();
+    assert!(
+        unregister.status.as_ref().is_some_and(|status| status.ok),
+        "{:?}",
+        unregister.status
     );
 
     server.abort();
@@ -431,19 +437,6 @@ async fn connect(endpoint: &str) -> EngineClient<tonic::transport::Channel> {
             }
             Err(e) => panic!("connect: {e}"),
         }
-    }
-}
-
-async fn wait_load(state: &LoadState) {
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        let s = state.get();
-        if s == LOAD_STATE_SUCCESS {
-            return;
-        }
-        assert_ne!(s, LOAD_STATE_ERROR, "load ERROR");
-        assert!(Instant::now() < deadline, "load timeout");
-        tokio::time::sleep(Duration::from_millis(10)).await;
     }
 }
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -359,6 +359,9 @@ class PegaServerProcess:
         self._binary_path = find_server_binary()
         self._log_path: Path | None = None
         self._log_file = None
+        self._fd_socket_path = Path(tempfile.gettempdir()) / (
+            f"pegaflow-fd-test-{port}-{uuid.uuid4().hex}.sock"
+        )
 
     def start(self) -> bool:
         """Start the server process. Returns True if successful."""
@@ -386,6 +389,8 @@ class PegaServerProcess:
             self.pool_size,
             "--devices",
             self.devices,
+            "--fd-socket-path",
+            str(self._fd_socket_path),
         ]
 
         # Route logs to a tempfile so the pipe buffer cannot fill up and
@@ -447,6 +452,9 @@ class PegaServerProcess:
         if self._log_path and self._log_path.exists():
             with contextlib.suppress(OSError):
                 self._log_path.unlink()
+        if self._fd_socket_path.exists():
+            with contextlib.suppress(OSError):
+                self._fd_socket_path.unlink()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary

This is stacked on #414 and defines the server-side ownership contract needed by the OpenInfer consumer in openinfer-project/openinfer#740.

- use the existing native `instance_id` as the fresh, non-reused process/registration-attempt identity on both the fd side channel and gRPC; no second registration ID or RPC schema change
- keep native VMM v1 intentionally small: one GPU, one fused allocation, and multiple layer views; reject unsupported topology and mixed Python/native contexts while preserving legacy Python multi-context behavior
- let one `Arc<VmmRegistration>` own the imported mapping and an operation gate; save/load tasks retain a guard until GPU work finishes, even if the RPC is cancelled
- atomically remove a native registration before close, reject new native work, drain accepted work, remove engine raw addresses, and release the mapping on the registry actor
- run registry-to-engine registration and cleanup as cancellation-independent tasks, with one barrier preventing registration from crossing instance/all-instance teardown
- keep the existing v1 `instance_id\0device_id` SCM_RIGHTS message, but bound connections and pending fds, expire unmatched entries on activity, reject malformed/multi-fd messages without descriptor leaks, and recover only a verified stale socket inode
- disable the fd side channel by default; native deployments must configure a path explicitly
- auto-detect native-only CUDA devices through the CUDA driver without importing PyTorch

## Scope

Native VMM v1 supports the current Qwen layout only: one GPU, one fused allocation, and multiple layer views. Multiple GPUs or allocations per native instance, including the GLM layout, remain out of scope and fail early.

A native client must generate a fresh `instance_id` for every process/registration attempt and must not reuse it. Native loads require `wait_for_completion=true`; an asynchronous native load cannot transfer the mapping lifetime into the existing detached worker contract safely.

The UDS path remains explicit configuration rather than gRPC discovery. The wire protocol and `pegaflow_proto::VERSION` stay on `native-vmm-v1`.

## Validation

- `cargo check --workspace --all-targets --no-default-features --features cuda-13,rdma`
- `cargo clippy --workspace --all-targets --no-default-features --features cuda-13,rdma -- -D warnings`
- `cargo test -p pegaflow-server --lib --no-default-features --features cuda-13,rdma` — 34 passed
- `cargo test --release -p pegaflow-server --test mock_vllm_rpc_e2e --no-default-features --features cuda-13,rdma` — 8 passed
- `cargo test -p pegaflow-server --test native_vmm_rpc_e2e --no-default-features --features cuda-13,rdma -- --nocapture` — 1 passed on a real GPU
- `cd python && uv run pytest` — 202 passed, 11 deselected
- native-only startup with no explicit `--devices` — CUDA driver auto-detected the GPU, initialized the torch-free path, served gRPC/HTTP, and shut down cleanly
- `prek run` — all hooks passed, including release tests

The Python integration suite was not run because the local test environment does not include PyTorch; the native Rust GPU E2E covers the VMM registration/save/load/unregister path.
