### PR TITLE
fix(connector): hold blocks until all save tasks finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,8 @@ jobs:
           persist-credentials: false
       - name: Run ruff check
         uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.14.14"
 
   python-unit-tests:
     name: python unit tests

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -177,7 +177,7 @@ class WorkerConnector:
         )
         self._save_thread.start()
 
-        self._req_pending_saves: set[str] = set()
+        self._req_pending_save_tasks: dict[str, int] = {}
         self._completed_saves: set[str] = set()
         self._save_completion_lock = threading.Lock()
         self._save_completion_events: dict[str, threading.Event] = {}
@@ -374,7 +374,9 @@ class WorkerConnector:
 
         with self._save_completion_lock:
             # 1. Add newly finished requests (if they have pending saves) to tracking
-            self._finished_requests.update(finished_req_ids & self._req_pending_saves)
+            self._finished_requests.update(
+                finished_req_ids.intersection(self._req_pending_save_tasks)
+            )
             # 2. Identify requests whose saves have completed
             done_saves = self._completed_saves & self._finished_requests
             done_saves.update(self._completed_saves & finished_req_ids)
@@ -653,9 +655,11 @@ class WorkerConnector:
 
         with self._save_completion_lock:
             for req_id in request_ids:
-                if req_id not in self._req_pending_saves:
-                    self._req_pending_saves.add(req_id)
+                pending_tasks = self._req_pending_save_tasks.get(req_id, 0)
+                if pending_tasks == 0:
+                    self._completed_saves.discard(req_id)
                     self._save_completion_events[req_id] = threading.Event()
+                self._req_pending_save_tasks[req_id] = pending_tasks + 1
 
         self._save_queue.put(SaveTask(metadata=metadata, request_ids=request_ids))
 
@@ -784,13 +788,19 @@ class WorkerConnector:
 
         with self._save_completion_lock:
             for req_id in request_ids:
-                if req_id in self._req_pending_saves:
-                    self._req_pending_saves.discard(req_id)
-                    self._completed_saves.add(req_id)
-                    completed_reqs.append(req_id)
-                    event = self._save_completion_events.pop(req_id, None)
-                    if event:
-                        event.set()
+                pending_tasks = self._req_pending_save_tasks.get(req_id)
+                if pending_tasks is None:
+                    continue
+                if pending_tasks > 1:
+                    self._req_pending_save_tasks[req_id] = pending_tasks - 1
+                    continue
+
+                del self._req_pending_save_tasks[req_id]
+                self._completed_saves.add(req_id)
+                completed_reqs.append(req_id)
+                event = self._save_completion_events.pop(req_id, None)
+                if event:
+                    event.set()
 
         self._handle_save_completion(completed_reqs)
 
@@ -893,7 +903,7 @@ class WorkerConnector:
         with self._stats_lock:
             # Add current queue depth as gauge
             with self._save_completion_lock:
-                self._stats.data["pending_save_requests"] = len(self._req_pending_saves)
+                self._stats.data["pending_save_requests"] = len(self._req_pending_save_tasks)
 
             if self._stats.is_empty():
                 return None

--- a/python/tests/test_connector_save_lifecycle.py
+++ b/python/tests/test_connector_save_lifecycle.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from pegaflow.connector.common import (  # noqa: E402
+    ConnectorContext,
+    PegaConnectorMetadata,
+    SaveIntent,
+)
+from pegaflow.connector.worker import WorkerConnector  # noqa: E402
+
+
+def make_worker() -> WorkerConnector:
+    context = ConnectorContext(
+        instance_id="test",
+        namespace="test",
+        block_size=16,
+        tp_size=1,
+        world_size=1,
+        tp_rank=0,
+        device_id=0,
+        engine_client=MagicMock(),
+        state_manager=MagicMock(),
+    )
+    with patch("pegaflow.connector.worker.threading.Thread.start"):
+        return WorkerConnector(
+            context,
+            vllm_config=SimpleNamespace(additional_config={}),
+        )
+
+
+def enqueue_save(
+    worker: WorkerConnector,
+    block_id: int = 1,
+    block_hash: bytes = b"hash",
+) -> threading.Event:
+    worker._current_metadata = PegaConnectorMetadata(
+        save_intents={
+            "request": SaveIntent(
+                block_ids=(block_id,),
+                block_hashes=(block_hash,),
+            )
+        }
+    )
+    worker.wait_for_save()
+    return worker._save_completion_events["request"]
+
+
+def complete_next_save(worker: WorkerConnector) -> None:
+    task = worker._save_queue.get_nowait()
+    worker._complete_save_requests(task.request_ids)
+
+
+def process_next_save(worker: WorkerConnector) -> None:
+    task = worker._save_queue.get_nowait()
+    with patch("torch.cuda.synchronize"):
+        worker._process_save_batch([task])
+
+
+def test_blocks_are_not_reused_until_every_save_task_completes():
+    worker = make_worker()
+    worker._registered_layers = ["layer"]
+    gpu_blocks = {1: b"first request block", 2: b"second request block"}
+    stored_blocks: dict[bytes, bytes] = {}
+
+    def save(_instance, _tp_rank, _pp_rank, _device_id, saves):
+        for _layer, block_ids, block_hashes in saves:
+            for block_id, block_hash in zip(block_ids, block_hashes, strict=True):
+                stored_blocks[block_hash] = gpu_blocks[block_id]
+        return True, ""
+
+    worker._ctx.engine_client.save.side_effect = save
+    enqueue_save(worker, 1, b"first hash")
+    enqueue_save(worker, 2, b"second hash")
+    process_next_save(worker)
+
+    finished_sending, _ = worker.get_finished({"request"})
+    if finished_sending:
+        gpu_blocks[2] = b"reused by another request"
+
+    process_next_save(worker)
+
+    assert stored_blocks[b"second hash"] == b"second request block"
+
+
+def test_later_save_reopens_completed_request():
+    worker = make_worker()
+    first_completion = enqueue_save(worker)
+    complete_next_save(worker)
+
+    assert first_completion.is_set()
+
+    second_completion = enqueue_save(worker)
+
+    assert not second_completion.is_set()
+    finished_sending, _ = worker.get_finished({"request"})
+    assert finished_sending is None
+
+    complete_next_save(worker)
+
+    assert second_completion.is_set()
+    finished_sending, _ = worker.get_finished({"request"})
+    assert finished_sending == {"request"}

--- a/python/tests/test_connector_save_lifecycle.py
+++ b/python/tests/test_connector_save_lifecycle.py
@@ -107,3 +107,41 @@ def test_later_save_reopens_completed_request():
     assert second_completion.is_set()
     finished_sending, _ = worker.get_finished({"request"})
     assert finished_sending == {"request"}
+
+
+def test_preemption_waits_for_every_save_task():
+    worker = make_worker()
+    completion = enqueue_save(worker)
+    enqueue_save(worker)
+    wait_started = threading.Event()
+    preemption_returned = threading.Event()
+    original_wait = completion.wait
+
+    def wait_for_completion(timeout: float | None = None) -> bool:
+        wait_started.set()
+        return original_wait(timeout)
+
+    def handle_preemption() -> None:
+        worker.handle_preemptions({"request"})
+        preemption_returned.set()
+
+    completed_tasks = 0
+    with patch.object(completion, "wait", side_effect=wait_for_completion):
+        preemption_thread = threading.Thread(target=handle_preemption)
+        preemption_thread.start()
+        try:
+            assert wait_started.wait(timeout=1)
+
+            complete_next_save(worker)
+            completed_tasks += 1
+            assert not preemption_returned.wait(timeout=0.1)
+
+            complete_next_save(worker)
+            completed_tasks += 1
+            assert preemption_returned.wait(timeout=1)
+        finally:
+            for _ in range(2 - completed_tasks):
+                complete_next_save(worker)
+            preemption_thread.join(timeout=1)
+
+    assert not preemption_thread.is_alive()


### PR DESCRIPTION
## Summary

- track pending save tasks per request instead of treating pending work as a boolean
- report `finished_sending` only after every queued task for the request completes
- clear stale completion state when a later save task is enqueued

## Failure mechanism

A request can enqueue multiple `SaveTask` instances across scheduler steps. The old set-based state marked the whole request complete after the first task. vLLM could then release and reuse GPU blocks while a later task still referenced their block IDs, allowing bytes from another request to be stored under the original block hash.

The regression test models that reuse directly. Against the old implementation, the value stored under `second hash` is `reused by another request`; with this change it remains `second request block`.

## Validation

- regression tests against old implementation: 2 failed as expected
- regression tests with this change: 2 passed
- source-only default Python gate: 204 passed, 11 deselected
- pre-commit hooks: passed, including release Cargo tests and Python lint/format checks
- H200 x8 GLM-5.2 FP8 clean round-trip: 606 external blocks hit, 38,784 cached prompt tokens, no replacement characters or repeated-exclamation corruption
- pre-fix synthetic GPU stress did not reproduce the production gibberish; this PR remains draft until the post-fix model-specific E2E is complete

## Scope

This proves and fixes a KV save lifecycle corruption path. It does not yet claim that this was the only cause of the observed production gibberish.