### PR TITLE
feat(metrics): add cache residence TTL dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,8 @@ jobs:
           persist-credentials: false
       - name: Run ruff check
         uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.14.14"
 
   python-unit-tests:
     name: python unit tests

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -102,6 +102,27 @@ PegaFlow exposes the following metrics for monitoring KV cache operations:
   - Current sealed block bytes resident in cache (sum of footprints)
   - Use case: Attribute pinned pool usage to cache residency
 
+- **pegaflow_cache_residence_duration_seconds** (Histogram)
+  - RAM resident block lifetime from its first successful cache insertion to
+    removal, measured in seconds
+  - Labels: `reason` (`pressure` or `cleanup`)
+  - `pressure`: allocator pressure removed the block through LRU reclaim
+  - `cleanup`: the memory-cache cleanup endpoint removed the block
+  - Buckets: `1s`, `5s`, `10s`, `30s`, `1m`, `2m`, `5m`, `10m`, `30m`,
+    `1h`, `2h`, `6h`, `12h`, `24h`, and `+Inf`
+  - Use case: Track typical and tail cache residence time and visualize the
+    eviction-age distribution
+  - Scope: each RAM residence is a separate lifetime. A block reinserted after
+    eviction starts a new lifetime; cache hits, duplicate inserts, and
+    replacement-class changes do not reset the original insertion time.
+  - The lifetime ends when the block leaves the resident cache, even if an
+    outstanding `Arc` keeps its pinned memory allocated. Correlate
+    `pegaflow_cache_block_evictions_still_referenced_total` and
+    `pegaflow_cache_eviction_reclaimed_bytes_total` to diagnose delayed memory
+    reclamation.
+  - SSD ring-cache overwrite and blocks still resident at server shutdown are
+    not observed.
+
 - **pegaflow_pinned_for_load_entries** (Gauge)
   - Current number of pinned_for_load entries (instance_id, block_key)
   - Use case: Diagnose load-path pins keeping evicted blocks alive
@@ -435,6 +456,33 @@ rate(pegaflow_save_bytes_total[1m]) / 1e6
 
 # Pool memory utilization
 pegaflow_pool_used_bytes / pegaflow_pool_capacity_bytes
+
+# RAM cache residence-time quantiles for pressure evictions
+histogram_quantile(
+  0.50,
+  sum by (le) (
+    rate(pegaflow_cache_residence_duration_seconds_bucket{reason="pressure"}[5m])
+  )
+)
+
+histogram_quantile(
+  0.95,
+  sum by (le) (
+    rate(pegaflow_cache_residence_duration_seconds_bucket{reason="pressure"}[5m])
+  )
+)
+
+histogram_quantile(
+  0.99,
+  sum by (le) (
+    rate(pegaflow_cache_residence_duration_seconds_bucket{reason="pressure"}[5m])
+  )
+)
+
+# RAM cache residence-time buckets for a Grafana heatmap
+sum by (le) (
+  rate(pegaflow_cache_residence_duration_seconds_bucket{reason="pressure"}[5m])
+)
 
 # HLL estimated hit rate for the 1h window
 1 - (

--- a/examples/metric-prometheus/grafana/dashboards/pegaflow.json
+++ b/examples/metric-prometheus/grafana/dashboards/pegaflow.json
@@ -879,12 +879,127 @@
       ],
       "title": "Background GC Rates",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 89 },
+      "id": 109,
+      "title": "Cache Residence TTL",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": null },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 90 },
+      "id": 27,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(pegaflow_cache_residence_duration_seconds_bucket{reason=~\"$reason\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(pegaflow_cache_residence_duration_seconds_bucket{reason=~\"$reason\"}[$__rate_interval])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(pegaflow_cache_residence_duration_seconds_bucket{reason=~\"$reason\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Residence TTL Quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": null },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "scaleDistribution": { "type": "linear" }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 90 },
+      "id": 28,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "filterValues": { "le": 1e-9 },
+        "legend": { "show": true },
+        "rowsFrame": { "layout": "auto" },
+        "tooltip": { "show": true, "yHistogram": false },
+        "yAxis": {
+          "axisLabel": "Residence duration",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (le) (rate(pegaflow_cache_residence_duration_seconds_bucket{reason=~\"$reason\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Residence TTL Distribution",
+      "type": "heatmap"
     }
   ],
   "schemaVersion": 39,
   "tags": ["pegaflow"],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "pressure", "value": "pressure" },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Removal reason",
+        "multi": false,
+        "name": "reason",
+        "options": [
+          { "selected": false, "text": "All", "value": "$__all" },
+          { "selected": true, "text": "pressure", "value": "pressure" },
+          { "selected": false, "text": "cleanup", "value": "cleanup" }
+        ],
+        "query": "pressure,cleanup",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
   },
   "time": {
     "from": "now-15m",

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -59,7 +59,7 @@ pub(crate) struct CoreMetrics {
     pub cache_block_evictions_by_class: Counter<u64>,
     pub cache_block_evictions_still_referenced: Counter<u64>,
     pub cache_eviction_reclaimed_bytes: Counter<u64>,
-    pub cache_residence_duration_seconds: Histogram<f64>,
+    pub cache_residence_duration: Histogram<f64>,
 
     // GPU <-> CPU transfer
     pub save_bytes: Counter<u64>,
@@ -312,7 +312,7 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
                 .with_unit("bytes")
                 .with_description("Estimated bytes actually reclaimed in pinned allocator after cache eviction")
                 .build(),
-            cache_residence_duration_seconds: meter
+            cache_residence_duration: meter
                 .f64_histogram("pegaflow_cache_residence_duration")
                 .with_unit("s")
                 .with_description(

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -26,6 +26,10 @@ pub(crate) static CACHE_CLASS_RECLAIMABLE: LazyLock<[KeyValue; 1]> =
     LazyLock::new(|| [KeyValue::new("class", "reclaimable")]);
 pub(crate) static CACHE_CLASS_RETAINED: LazyLock<[KeyValue; 1]> =
     LazyLock::new(|| [KeyValue::new("class", "retained")]);
+pub(crate) static CACHE_RESIDENCE_REASON_PRESSURE: LazyLock<[KeyValue; 1]> =
+    LazyLock::new(|| [KeyValue::new("reason", "pressure")]);
+pub(crate) static CACHE_RESIDENCE_REASON_CLEANUP: LazyLock<[KeyValue; 1]> =
+    LazyLock::new(|| [KeyValue::new("reason", "cleanup")]);
 
 pub(crate) struct CoreMetrics {
     // Pinned pool (allocator-level)
@@ -55,6 +59,7 @@ pub(crate) struct CoreMetrics {
     pub cache_block_evictions_by_class: Counter<u64>,
     pub cache_block_evictions_still_referenced: Counter<u64>,
     pub cache_eviction_reclaimed_bytes: Counter<u64>,
+    pub cache_residence_duration_seconds: Histogram<f64>,
 
     // GPU <-> CPU transfer
     pub save_bytes: Counter<u64>,
@@ -154,6 +159,13 @@ fn duration_seconds_boundaries() -> Vec<f64> {
         15.0,  // 15s
         30.0,  // 30s
         60.0,  // 60s
+    ]
+}
+
+fn cache_residence_duration_seconds_boundaries() -> Vec<f64> {
+    vec![
+        1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1_800.0, 3_600.0, 7_200.0, 21_600.0,
+        43_200.0, 86_400.0,
     ]
 }
 
@@ -299,6 +311,14 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
                 .u64_counter("pegaflow_cache_eviction_reclaimed_bytes")
                 .with_unit("bytes")
                 .with_description("Estimated bytes actually reclaimed in pinned allocator after cache eviction")
+                .build(),
+            cache_residence_duration_seconds: meter
+                .f64_histogram("pegaflow_cache_residence_duration")
+                .with_unit("s")
+                .with_description(
+                    "RAM cache block residence duration from first insertion to removal",
+                )
+                .with_boundaries(cache_residence_duration_seconds_boundaries())
                 .build(),
 
             // Transfer
@@ -462,4 +482,32 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
                 .build(),
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_residence_duration_boundaries_cover_one_second_to_one_day() {
+        assert_eq!(
+            cache_residence_duration_seconds_boundaries(),
+            vec![
+                1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1_800.0, 3_600.0, 7_200.0,
+                21_600.0, 43_200.0, 86_400.0,
+            ]
+        );
+    }
+
+    #[test]
+    fn cache_residence_reason_attributes_are_fixed_and_low_cardinality() {
+        assert_eq!(
+            &*CACHE_RESIDENCE_REASON_PRESSURE,
+            &[KeyValue::new("reason", "pressure")]
+        );
+        assert_eq!(
+            &*CACHE_RESIDENCE_REASON_CLEANUP,
+            &[KeyValue::new("reason", "cleanup")]
+        );
+    }
 }

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -1,11 +1,14 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use hashlink::LruCache;
 use parking_lot::Mutex;
 
 use crate::block::{BlockKey, SealedBlock};
 use crate::cache::{CacheInsertOutcome, TinyLfuCache};
-use crate::metrics::{CACHE_CLASS_RECLAIMABLE, CACHE_CLASS_RETAINED, core_metrics};
+use crate::metrics::{
+    CACHE_CLASS_RECLAIMABLE, CACHE_CLASS_RETAINED, CACHE_RESIDENCE_REASON_CLEANUP,
+    CACHE_RESIDENCE_REASON_PRESSURE, core_metrics,
+};
 
 pub(crate) struct ReadCache {
     inner: Mutex<ReadCacheInner>,
@@ -13,8 +16,19 @@ pub(crate) struct ReadCache {
 
 struct ReadCacheInner {
     cache: TinyLfuCache<BlockKey, Arc<SealedBlock>>,
-    reclaimable: LruCache<BlockKey, ()>,
-    retained: LruCache<BlockKey, ()>,
+    reclaimable: LruCache<BlockKey, ResidentMetadata>,
+    retained: LruCache<BlockKey, ResidentMetadata>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct ResidentMetadata {
+    inserted_at: Instant,
+}
+
+struct RemovedResident {
+    key: BlockKey,
+    block: Arc<SealedBlock>,
+    inserted_at: Option<Instant>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -126,39 +140,61 @@ impl ReadCache {
     }
 
     pub(super) fn remove_lru_batch(&self, batch_size: usize) -> Vec<(BlockKey, Arc<SealedBlock>)> {
-        let mut inner = self.inner.lock();
-        let mut evicted = Vec::with_capacity(batch_size);
-        while evicted.len() < batch_size {
-            let next = remove_lru(&mut inner, ResidentClass::Reclaimable)
-                .or_else(|| remove_lru(&mut inner, ResidentClass::Retained));
-            let Some(block) = next else {
-                break;
-            };
-            evicted.push(block);
-        }
-        evicted
+        let removed = {
+            let mut inner = self.inner.lock();
+            let mut removed = Vec::with_capacity(batch_size);
+            while removed.len() < batch_size {
+                let next = remove_lru(&mut inner, ResidentClass::Reclaimable)
+                    .or_else(|| remove_lru(&mut inner, ResidentClass::Retained));
+                let Some(block) = next else {
+                    break;
+                };
+                removed.push(block);
+            }
+            removed
+        };
+        record_residence_durations(removed, &*CACHE_RESIDENCE_REASON_PRESSURE)
     }
 
     pub(super) fn remove_all(&self) -> Vec<(BlockKey, Arc<SealedBlock>)> {
-        let mut inner = self.inner.lock();
-        let reclaimable_blocks = inner.reclaimable.len() as i64;
-        let retained_blocks = inner.retained.len() as i64;
-        inner.reclaimable.clear();
-        inner.retained.clear();
-        let removed = inner.cache.remove_all();
-        debug_assert_eq!(
-            removed.len() as i64,
-            reclaimable_blocks + retained_blocks,
-            "resident cache and replacement classes diverged"
-        );
-        let metrics = core_metrics();
-        metrics
-            .cache_resident_blocks
-            .add(-reclaimable_blocks, &*CACHE_CLASS_RECLAIMABLE);
-        metrics
-            .cache_resident_blocks
-            .add(-retained_blocks, &*CACHE_CLASS_RETAINED);
-        removed
+        let removed = {
+            let mut inner = self.inner.lock();
+            let reclaimable_blocks = inner.reclaimable.len() as i64;
+            let retained_blocks = inner.retained.len() as i64;
+            let mut metadata = HashMap::with_capacity(
+                inner.reclaimable.len().saturating_add(inner.retained.len()),
+            );
+            metadata.extend(inner.reclaimable.drain());
+            metadata.extend(inner.retained.drain());
+            let removed = inner
+                .cache
+                .remove_all()
+                .into_iter()
+                .map(|(key, block)| RemovedResident {
+                    inserted_at: metadata.remove(&key).map(|entry| entry.inserted_at),
+                    key,
+                    block,
+                })
+                .collect::<Vec<_>>();
+            debug_assert_eq!(
+                removed.len() as i64,
+                reclaimable_blocks + retained_blocks,
+                "resident cache and replacement classes diverged"
+            );
+            debug_assert!(
+                metadata.is_empty() && removed.iter().all(|entry| entry.inserted_at.is_some()),
+                "resident cache and replacement metadata diverged"
+            );
+            let metrics = core_metrics();
+            metrics
+                .cache_resident_blocks
+                .add(-reclaimable_blocks, &*CACHE_CLASS_RECLAIMABLE);
+            metrics
+                .cache_resident_blocks
+                .add(-retained_blocks, &*CACHE_CLASS_RETAINED);
+            removed
+        };
+        record_residence_durations(removed, &*CACHE_RESIDENCE_REASON_CLEANUP)
     }
 
     pub(crate) fn mark_reclaimable_hashes(&self, namespace: &str, hashes: &[Vec<u8>]) {
@@ -216,7 +252,12 @@ fn insert_block(
     let outcome = inner.cache.insert(key.clone(), block);
     match outcome {
         CacheInsertOutcome::InsertedNew => {
-            class_lru(inner, class).insert(key, ());
+            class_lru(inner, class).insert(
+                key,
+                ResidentMetadata {
+                    inserted_at: Instant::now(),
+                },
+            );
             let m = core_metrics();
             m.cache_block_insertions.add(1, &[]);
             m.cache_resident_bytes.add(footprint_bytes as i64, &[]);
@@ -230,7 +271,10 @@ fn insert_block(
     outcome
 }
 
-fn class_lru(inner: &mut ReadCacheInner, class: ResidentClass) -> &mut LruCache<BlockKey, ()> {
+fn class_lru(
+    inner: &mut ReadCacheInner,
+    class: ResidentClass,
+) -> &mut LruCache<BlockKey, ResidentMetadata> {
     match class {
         ResidentClass::Reclaimable => &mut inner.reclaimable,
         ResidentClass::Retained => &mut inner.retained,
@@ -249,8 +293,8 @@ fn mark_reclaimable(inner: &mut ReadCacheInner, key: &BlockKey) -> bool {
     if !inner.cache.contains_key(key) {
         return false;
     }
-    if inner.retained.remove(key).is_some() {
-        inner.reclaimable.insert(key.clone(), ());
+    if let Some(metadata) = inner.retained.remove(key) {
+        inner.reclaimable.insert(key.clone(), metadata);
         true
     } else {
         debug_assert!(
@@ -261,11 +305,8 @@ fn mark_reclaimable(inner: &mut ReadCacheInner, key: &BlockKey) -> bool {
     }
 }
 
-fn remove_lru(
-    inner: &mut ReadCacheInner,
-    class: ResidentClass,
-) -> Option<(BlockKey, Arc<SealedBlock>)> {
-    while let Some((key, ())) = class_lru(inner, class).remove_lru() {
+fn remove_lru(inner: &mut ReadCacheInner, class: ResidentClass) -> Option<RemovedResident> {
+    while let Some((key, metadata)) = class_lru(inner, class).remove_lru() {
         let block = inner.cache.remove(&key);
         debug_assert!(
             block.is_some(),
@@ -279,13 +320,45 @@ fn remove_lru(
         metrics
             .cache_block_evictions_by_class
             .add(1, class.attributes());
-        return Some((key, block));
+        return Some(RemovedResident {
+            key,
+            block,
+            inserted_at: Some(metadata.inserted_at),
+        });
     }
     None
 }
 
+fn record_residence_durations(
+    removed: Vec<RemovedResident>,
+    attributes: &[opentelemetry::KeyValue],
+) -> Vec<(BlockKey, Arc<SealedBlock>)> {
+    let removed_at = Instant::now();
+    let metrics = core_metrics();
+    removed
+        .into_iter()
+        .map(|entry| {
+            if let Some(inserted_at) = entry.inserted_at {
+                metrics.cache_residence_duration_seconds.record(
+                    residence_duration_seconds(inserted_at, removed_at),
+                    attributes,
+                );
+            }
+            (entry.key, entry.block)
+        })
+        .collect()
+}
+
+fn residence_duration_seconds(inserted_at: Instant, removed_at: Instant) -> f64 {
+    removed_at
+        .saturating_duration_since(inserted_at)
+        .as_secs_f64()
+}
+
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     fn make_cache() -> ReadCache {
@@ -307,6 +380,30 @@ mod tests {
             inner.retained.contains_key(key),
             expected == ResidentClass::Retained
         );
+    }
+
+    fn resident_metadata(cache: &ReadCache, key: &BlockKey) -> Option<ResidentMetadata> {
+        let inner = cache.inner.lock();
+        inner
+            .reclaimable
+            .peek(key)
+            .or_else(|| inner.retained.peek(key))
+            .copied()
+    }
+
+    fn backdate_resident(cache: &ReadCache, key: &BlockKey, age: Duration) -> Instant {
+        let inserted_at = Instant::now() - age;
+        let mut inner = cache.inner.lock();
+        let metadata = if let Some(metadata) = inner.reclaimable.peek_mut(key) {
+            metadata
+        } else {
+            inner
+                .retained
+                .peek_mut(key)
+                .expect("test resident must have replacement metadata")
+        };
+        metadata.inserted_at = inserted_at;
+        inserted_at
     }
 
     #[test]
@@ -352,9 +449,14 @@ mod tests {
             (hit.clone(), make_block()),
             (oldest.clone(), make_block()),
         ]);
+        let inserted_at = backdate_resident(&cache, &hit, Duration::from_secs(60));
         let (count, _) = cache.get_prefix_blocks(std::slice::from_ref(&hit));
 
         assert_eq!(count, 1);
+        assert_eq!(
+            resident_metadata(&cache, &hit).unwrap().inserted_at,
+            inserted_at
+        );
         assert_eq!(cache.remove_lru_batch(1)[0].0, oldest);
         assert_class(&cache, &hit, ResidentClass::Reclaimable);
     }
@@ -369,8 +471,13 @@ mod tests {
             (hit.clone(), make_block()),
             (oldest.clone(), make_block()),
         ]);
+        let inserted_at = backdate_resident(&cache, &hit, Duration::from_secs(60));
         assert_eq!(cache.get_blocks(std::slice::from_ref(&hit)).len(), 1);
 
+        assert_eq!(
+            resident_metadata(&cache, &hit).unwrap().inserted_at,
+            inserted_at
+        );
         assert_eq!(cache.remove_lru_batch(1)[0].0, oldest);
         assert_class(&cache, &hit, ResidentClass::Retained);
     }
@@ -396,6 +503,62 @@ mod tests {
         assert_eq!(cache.remove_lru_batch(1)[0].0, remote_first);
         assert_eq!(cache.remove_lru_batch(1)[0].0, local_other);
         assert_class(&cache, &local_first, ResidentClass::Retained);
+    }
+
+    #[test]
+    fn already_existing_insert_preserves_residence_start() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        cache.batch_insert(vec![(key.clone(), make_block())]);
+        let inserted_at = backdate_resident(&cache, &key, Duration::from_secs(60));
+
+        cache.batch_insert_resident_keys(vec![(key.clone(), make_block())]);
+
+        assert_eq!(
+            resident_metadata(&cache, &key).unwrap().inserted_at,
+            inserted_at
+        );
+        assert_class(&cache, &key, ResidentClass::Retained);
+    }
+
+    #[test]
+    fn class_migration_preserves_residence_start() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        cache.batch_insert(vec![(key.clone(), make_block())]);
+        let inserted_at = backdate_resident(&cache, &key, Duration::from_secs(60));
+
+        cache.mark_reclaimable_hashes("ns", std::slice::from_ref(&key.hash));
+
+        assert_eq!(
+            resident_metadata(&cache, &key).unwrap().inserted_at,
+            inserted_at
+        );
+        assert_class(&cache, &key, ResidentClass::Reclaimable);
+    }
+
+    #[test]
+    fn reinsert_after_eviction_starts_new_residence_episode() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        cache.batch_insert(vec![(key.clone(), make_block())]);
+        let first_inserted_at = backdate_resident(&cache, &key, Duration::from_secs(60));
+
+        cache.remove_lru_batch(1);
+        cache.batch_insert(vec![(key.clone(), make_block())]);
+
+        let second_inserted_at = resident_metadata(&cache, &key).unwrap().inserted_at;
+        assert!(second_inserted_at > first_inserted_at);
+    }
+
+    #[test]
+    fn residence_duration_is_non_negative_and_finite() {
+        let removed_at = Instant::now();
+        let inserted_at = removed_at - Duration::from_secs(60);
+
+        assert_eq!(residence_duration_seconds(inserted_at, removed_at), 60.0);
+        assert_eq!(residence_duration_seconds(removed_at, inserted_at), 0.0);
+        assert!(residence_duration_seconds(inserted_at, removed_at).is_finite());
     }
 
     #[test]

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -28,7 +28,8 @@ struct ResidentMetadata {
 struct RemovedResident {
     key: BlockKey,
     block: Arc<SealedBlock>,
-    inserted_at: Option<Instant>,
+    /// Insertion time taken from the block's replacement-class metadata.
+    inserted_at: Instant,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -170,10 +171,17 @@ impl ReadCache {
                 .cache
                 .remove_all()
                 .into_iter()
-                .map(|(key, block)| RemovedResident {
-                    inserted_at: metadata.remove(&key).map(|entry| entry.inserted_at),
-                    key,
-                    block,
+                .map(|(key, block)| {
+                    let inserted_at = metadata.remove(&key).map(|entry| entry.inserted_at);
+                    debug_assert!(
+                        inserted_at.is_some(),
+                        "resident block is missing its replacement metadata"
+                    );
+                    RemovedResident {
+                        inserted_at: inserted_at.unwrap_or_else(Instant::now),
+                        key,
+                        block,
+                    }
                 })
                 .collect::<Vec<_>>();
             debug_assert_eq!(
@@ -182,8 +190,8 @@ impl ReadCache {
                 "resident cache and replacement classes diverged"
             );
             debug_assert!(
-                metadata.is_empty() && removed.iter().all(|entry| entry.inserted_at.is_some()),
-                "resident cache and replacement metadata diverged"
+                metadata.is_empty(),
+                "replacement metadata outlives its resident block"
             );
             let metrics = core_metrics();
             metrics
@@ -323,7 +331,7 @@ fn remove_lru(inner: &mut ReadCacheInner, class: ResidentClass) -> Option<Remove
         return Some(RemovedResident {
             key,
             block,
-            inserted_at: Some(metadata.inserted_at),
+            inserted_at: metadata.inserted_at,
         });
     }
     None
@@ -338,12 +346,10 @@ fn record_residence_durations(
     removed
         .into_iter()
         .map(|entry| {
-            if let Some(inserted_at) = entry.inserted_at {
-                metrics.cache_residence_duration_seconds.record(
-                    residence_duration_seconds(inserted_at, removed_at),
-                    attributes,
-                );
-            }
+            metrics.cache_residence_duration.record(
+                residence_duration_seconds(entry.inserted_at, removed_at),
+                attributes,
+            );
             (entry.key, entry.block)
         })
         .collect()


### PR DESCRIPTION
## Summary

- record RAM cache residence duration from first insertion to removal as the `pegaflow_cache_residence_duration_seconds` histogram
- distinguish pressure eviction from cleanup removal with a fixed low-cardinality `reason` label and 1-second to 24-hour buckets
- add Grafana p50/p95/p99 and heatmap panels, a removal-reason selector, and metrics documentation

## Validation

### Rust and dashboard checks

- remote H200: `cargo fmt` check passed
- remote H200: `pegaflow-core` clippy passed with CUDA 13, RDMA, and warnings denied
- remote H200: library tests passed (144 passed, 1 ignored)
- remote H200: `engine_basic` GPU roundtrip tests passed (9 passed)
- remote H200: explicit CUDA kernel/direct test passed (1 passed)
- remote H200: remaining non-SSD integration tests passed (12 passed)
- local: dashboard JSON parsing, panel ID uniqueness, grid overlap, selector/PromQL consistency, and `git diff --check` passed
- CI: all checks passed, including Rust fmt/clippy, CUDA 12/13 cargo checks, Python unit tests, Ruff, and CUDA 12/13 wheel builds

### RTX 4090 vLLM 2P2D integration test

Environment:

| Item | Configuration |
| --- | --- |
| GPU host | 8 x RTX 4090 (`192.168.172.117`) |
| PegaFlow | 4 instances (2 prefill + 2 decode), 100 GB pool per instance |
| vLLM | 2P2D service with proxy and four engines |
| Model | `/data/models/DeepSeek-V2-Lite-Chat` |
| Transfer | NIXL with CPU buffer |
| Observability | Prometheus continuously scraped all four PegaFlow targets; Grafana imported the Direct Prometheus dashboard |

Multiturn workload:

- 256 conversations, 32 concurrent clients, 8 turns per conversation
- approximately 8,192 input tokens per turn and 128 output tokens
- 1,024 requests over 899.105 seconds
- 1.139 requests/second with zero request failures

Observed after the run:

| Metric | Value |
| --- | ---: |
| TTL / eviction observations | 438,784 |
| Residence duration sum | 169,195,707.67 s |
| Resident cache bytes | 91,574,157,312 |
| Reclaimed bytes | 1,788,841,558,016 |

The Grafana view below uses `reason=pressure` and the exact active-data window, `2026-07-31 20:27:30` to `20:43:00 CST`. The initial p95/p99 values near two hours are expected: blocks left resident by the earlier warmup/load were evicted when this sustained run applied pressure. The steady-state quantiles then fall to the seconds/minutes range.

![PegaFlow cache residence TTL Grafana dashboard after the RTX 4090 multiturn run](https://gist.githubusercontent.com/GentleCold/9b5b553414efdbd225fc69e4e9df6d25/raw/bd656d9bc7f381fdd1da25efa50e39438ec31eda/grafana-ttl-bottom-final.png)

## Known validation limit

The full `pegaflow-core` run has 11 existing `ssd_cache` failures on the H200 host. Its 8 GPU-local NUMA nodes split the fixed 32 KiB test pool into 4 KiB per node, below the 16 KiB test batch; serial execution reproduces the same topology-specific failure. The TTL implementation does not touch the SSD cache path.
