### PR TITLE
chore(release): bump version to 0.23.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "colored",
  "libc",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "axum",
  "clap",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-pd-wire"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "prost",
  "tonic",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "log",
  "mea",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "axum",
  "clap",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.23.5"
+version = "0.23.6"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.23.5"
+version = "0.23.6"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -114,6 +114,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.23.5"
+version = "0.23.6"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## Summary

- bump workspace / Python package version from `0.23.5` to `0.23.6`
- keep Cargo workspace, Python package, and Commitizen versions aligned
- update workspace package versions in `Cargo.lock`

## Highlights since 0.23.5

- #419 — cache residence TTL histogram, dashboard, and docs
- #418 — fix(connector): hold blocks until all save tasks finish

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- version consistency for Cargo, Python, and Commitizen metadata (local equivalent of the CI check)

## Release

After approval and merge, create and push tag `v0.23.6` to trigger the
release workflow.