### PR TITLE
feat(connector): support vLLM hybrid KV cache models

### DIFF
--- a/pegaflow-core/benches/cpu_path.rs
+++ b/pegaflow-core/benches/cpu_path.rs
@@ -209,8 +209,11 @@ impl BenchFixture {
                 0,
                 DEVICE_ID,
                 load_state.shm_name(),
-                &[LAYER_NAME],
-                &[(lease, self.block_ids.clone())],
+                &[vec![LAYER_NAME]],
+                &[(
+                    lease,
+                    vec![self.block_ids.iter().copied().map(Some).collect()],
+                )],
             )
             .expect("submit load");
         wait_for_load(&load_state).await;

--- a/pegaflow-core/benches/transfer_h2d.rs
+++ b/pegaflow-core/benches/transfer_h2d.rs
@@ -291,6 +291,8 @@ fn copy_desc(device: u64, host: &MappedHost, device_offset: usize, host_offset: 
         host: unsafe { host.host.add(host_offset) },
         host_device: host.device + host_offset as u64,
         size: SEG,
+        device_allocation: 0,
+        host_allocation: 0,
     }
 }
 

--- a/pegaflow-core/src/block.rs
+++ b/pegaflow-core/src/block.rs
@@ -75,6 +75,10 @@ impl Segment {
             _allocation: allocation,
         }
     }
+
+    fn allocation_id(&self) -> usize {
+        Arc::as_ptr(&self._allocation) as usize
+    }
 }
 
 // Safety: Segment holds NonNull<u8> pointing to pinned memory whose lifetime
@@ -166,6 +170,13 @@ impl RawBlock {
     /// Get mapped host/device pointer pair by index.
     pub(crate) fn segment_mapped_ptr(&self, index: usize) -> Option<MappedPinnedPtr> {
         self.segments.as_slice().get(index).map(|s| s.ptr)
+    }
+
+    pub(crate) fn segment_allocation_id(&self, index: usize) -> Option<usize> {
+        self.segments
+            .as_slice()
+            .get(index)
+            .map(Segment::allocation_id)
     }
 
     /// Get segment size by index.

--- a/pegaflow-core/src/gpu_worker.rs
+++ b/pegaflow-core/src/gpu_worker.rs
@@ -354,7 +354,7 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
     let mut copies: Vec<CopyDesc> = Vec::new();
     let mut total_bytes = 0usize;
 
-    for layer in layers {
+    for (layer_index, layer) in layers.iter().enumerate() {
         let layer_name = &layer.layer_name;
 
         for block in &layer.blocks {
@@ -383,12 +383,18 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
                         host: k_ptr.host().as_ptr(),
                         host_device: k_ptr.device().as_ptr() as u64,
                         size: k.bytes,
+                        device_allocation: layer_index,
+                        host_allocation: raw.segment_allocation_id(0).unwrap(),
                     });
                     copies.push(CopyDesc {
                         device: v.addr,
                         host: v_ptr.host().as_ptr(),
                         host_device: v_ptr.device().as_ptr() as u64,
                         size: v.bytes,
+                        device_allocation: layer_index,
+                        host_allocation: raw
+                            .segment_allocation_id(1)
+                            .unwrap_or_else(|| raw.segment_allocation_id(0).unwrap()),
                     });
                     total_bytes += k.bytes + v.bytes;
                 }
@@ -404,6 +410,8 @@ fn build_copy_descs(layers: &[LayerTransferData]) -> Result<(Vec<CopyDesc>, usiz
                         host: ptr.host().as_ptr(),
                         host_device: ptr.device().as_ptr() as u64,
                         size: c.bytes,
+                        device_allocation: layer_index,
+                        host_allocation: block.block.raw().segment_allocation_id(0).unwrap(),
                     });
                     total_bytes += c.bytes;
                 }

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -554,8 +554,8 @@ impl PegaEngine {
         tp_rank: usize,
         device_id: i32,
         load_state_shm: &str,
-        layer_names: &[&str],
-        loads: &[(QueryLeaseId, Vec<usize>)],
+        layer_groups: &[Vec<&str>],
+        loads: &[(QueryLeaseId, Vec<Vec<Option<usize>>>)],
     ) -> Result<(), EngineError> {
         let load_state = LoadState::attach(load_state_shm)?;
 
@@ -563,7 +563,7 @@ impl PegaEngine {
             instance_id,
             tp_rank,
             device_id,
-            layer_names,
+            layer_groups,
             loads,
             LoadCompletion::Shm(load_state_shm.to_string()),
         );
@@ -590,15 +590,15 @@ impl PegaEngine {
         instance_id: &str,
         tp_rank: usize,
         device_id: i32,
-        layer_names: &[&str],
-        loads: &[(QueryLeaseId, Vec<usize>)],
+        layer_groups: &[Vec<&str>],
+        loads: &[(QueryLeaseId, Vec<Vec<Option<usize>>>)],
     ) -> Result<oneshot::Receiver<Result<(), EngineError>>, EngineError> {
         let (reply, rx) = oneshot::channel();
         self.batch_load_kv_blocks_multi_layer_inner(
             instance_id,
             tp_rank,
             device_id,
-            layer_names,
+            layer_groups,
             loads,
             LoadCompletion::Channel(reply),
         )?;
@@ -614,8 +614,8 @@ impl PegaEngine {
         instance_id: &str,
         tp_rank: usize,
         device_id: i32,
-        layer_names: &[&str],
-        loads: &[(QueryLeaseId, Vec<usize>)],
+        layer_groups: &[Vec<&str>],
+        loads: &[(QueryLeaseId, Vec<Vec<Option<usize>>>)],
         completion: LoadCompletion,
     ) -> Result<(), EngineError> {
         let instance = self.get_instance(instance_id)?;
@@ -624,21 +624,57 @@ impl PegaEngine {
             .get_gpu(device_id)
             .ok_or_else(|| EngineError::WorkerMissing(instance_id.to_string(), device_id))?;
 
+        if layer_groups.is_empty() {
+            return Err(EngineError::InvalidArgument(
+                "load requires at least one layer group".to_string(),
+            ));
+        }
+        let layer_count: usize = layer_groups.iter().map(Vec::len).sum();
+        let unique_layer_count = layer_groups
+            .iter()
+            .flatten()
+            .copied()
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        if unique_layer_count != layer_count {
+            return Err(EngineError::InvalidArgument(
+                "load layer names must be unique across groups".to_string(),
+            ));
+        }
+
         // Consume query leases reserved for this load.
         trace_scope!("load.cache_lookup", _s);
-        let mut block_ids = Vec::new();
+        let mut block_targets_by_group = vec![Vec::new(); layer_groups.len()];
         let mut block_cache = Vec::new();
-        for (lease, lease_block_ids) in loads {
+        for (lease, lease_block_ids_by_group) in loads {
             let blocks = self
                 .query_leases
                 .consume(instance_id, lease)
                 .map_err(EngineError::Storage)?;
-            if blocks.len() != lease_block_ids.len() {
+            if lease_block_ids_by_group.len() != layer_groups.len() {
                 return Err(EngineError::InvalidArgument(format!(
-                    "query lease block count {} does not match destination block count {}",
-                    blocks.len(),
-                    lease_block_ids.len()
+                    "load group count {} does not match layer group count {}",
+                    lease_block_ids_by_group.len(),
+                    layer_groups.len()
                 )));
+            }
+            let block_cache_start = block_cache.len();
+            for (group_index, lease_block_targets) in lease_block_ids_by_group.iter().enumerate() {
+                if blocks.len() != lease_block_targets.len() {
+                    return Err(EngineError::InvalidArgument(format!(
+                        "query lease block count {} does not match destination block count {} for group {}",
+                        blocks.len(),
+                        lease_block_targets.len(),
+                        group_index
+                    )));
+                }
+                block_targets_by_group[group_index].extend(
+                    lease_block_targets.iter().enumerate().filter_map(
+                        |(source_index, destination)| {
+                            destination.map(|block_id| (block_id, block_cache_start + source_index))
+                        },
+                    ),
+                );
             }
             // A stored block must carry exactly this instance's slot layout.
             // A mismatch means the namespace is shared by instances with
@@ -655,55 +691,58 @@ impl PegaEngine {
                     )));
                 }
             }
-            block_ids.extend_from_slice(lease_block_ids);
             block_cache.extend(blocks);
         }
         trace_drop!(_s);
 
         // Build load tasks for each layer
         trace_scope!("load.build_tasks");
-        let mut layers = Vec::with_capacity(layer_names.len());
+        let mut layers = Vec::with_capacity(layer_count);
 
-        for layer_name in layer_names {
-            let layer_id = topology.layer_id(layer_name)?;
+        for (group_index, layer_names) in layer_groups.iter().enumerate() {
+            let group_block_targets = &block_targets_by_group[group_index];
+            for layer_name in layer_names {
+                let layer_id = topology.layer_id(layer_name)?;
 
-            let layout = gpu.get_layout(layer_name).ok_or_else(|| {
-                EngineError::InvalidArgument(format!(
-                    "layer {layer_name} not registered on device {device_id}"
-                ))
-            })?;
+                let layout = gpu.get_layout(layer_name).ok_or_else(|| {
+                    EngineError::InvalidArgument(format!(
+                        "layer {layer_name} not registered on device {device_id}"
+                    ))
+                })?;
 
-            let slot_id = topology.slot_index(layer_id, tp_rank)?;
-            // Page-first: every layer reads from the one page slot (tp_rank) at
-            // its sealed byte offset. Layer-first: offset 0 (the whole slot
-            // RawBlock is the layer).
-            let host_offset = topology
-                .page_placement(layer_id)
-                .map_or(0, |(offset, _)| offset);
+                let slot_id = topology.slot_index(layer_id, tp_rank)?;
+                // Page-first: every layer reads from the one page slot (tp_rank) at
+                // its sealed byte offset. Layer-first: offset 0 (the whole slot
+                // RawBlock is the layer).
+                let host_offset = topology
+                    .page_placement(layer_id)
+                    .map_or(0, |(offset, _)| offset);
 
-            let mut blocks = Vec::with_capacity(block_ids.len());
-            for (block_idx, block_entry) in block_ids.iter().copied().zip(block_cache.iter()) {
-                if block_entry.get_slot(slot_id).is_none() {
-                    return Err(EngineError::InvalidArgument(format!(
-                        "stored block is missing slot {slot_id} for layer {layer_name}"
-                    )));
+                let mut blocks = Vec::with_capacity(group_block_targets.len());
+                for &(block_idx, source_index) in group_block_targets {
+                    let block_entry = &block_cache[source_index];
+                    if block_entry.get_slot(slot_id).is_none() {
+                        return Err(EngineError::InvalidArgument(format!(
+                            "stored block is missing slot {slot_id} for layer {layer_name}"
+                        )));
+                    }
+                    blocks.push(TransferBlock {
+                        block_idx,
+                        block: HostBlock::Cached {
+                            sealed: Arc::clone(block_entry),
+                            slot_id,
+                            offset: host_offset,
+                        },
+                    });
                 }
-                blocks.push(TransferBlock {
-                    block_idx,
-                    block: HostBlock::Cached {
-                        sealed: Arc::clone(block_entry),
-                        slot_id,
-                        offset: host_offset,
-                    },
-                });
-            }
 
-            if !blocks.is_empty() {
-                layers.push(LayerTransferData {
-                    layer_name: (*layer_name).to_string(),
-                    layout,
-                    blocks,
-                });
+                if !blocks.is_empty() {
+                    layers.push(LayerTransferData {
+                        layer_name: (*layer_name).to_string(),
+                        layout,
+                        blocks,
+                    });
+                }
             }
         }
 

--- a/pegaflow-core/src/transfer/kernel.rs
+++ b/pegaflow-core/src/transfer/kernel.rs
@@ -194,6 +194,8 @@ mod tests {
                 host: unsafe { host_base.host.add(k * seg) },
                 host_device: host_base.device + (k * seg) as u64,
                 size: seg,
+                device_allocation: 0,
+                host_allocation: 0,
             })
             .collect()
     }

--- a/pegaflow-core/src/transfer/memcpy.rs
+++ b/pegaflow-core/src/transfer/memcpy.rs
@@ -31,11 +31,13 @@ fn merge(copies: &[CopyDesc]) -> Vec<Merged> {
         let mut j = i + 1;
         while j < copies.len() {
             let next = copies[j];
+            let same_allocations = start.device_allocation == next.device_allocation
+                && start.host_allocation == next.host_allocation;
             let device_contiguous = start.device + size as u64 == next.device;
             // SAFETY: pointer arithmetic used only for an address-equality check;
             // the result is never dereferenced.
             let host_contiguous = unsafe { start.host.add(size) } == next.host;
-            if device_contiguous && host_contiguous {
+            if same_allocations && device_contiguous && host_contiguous {
                 size += next.size;
                 j += 1;
             } else {

--- a/pegaflow-core/src/transfer/memcpy.rs
+++ b/pegaflow-core/src/transfer/memcpy.rs
@@ -100,3 +100,40 @@ impl TransferBackend for MemcpyBackend {
         "direct"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn copy(
+        device: u64,
+        host: *mut u8,
+        device_allocation: usize,
+        host_allocation: usize,
+    ) -> CopyDesc {
+        CopyDesc {
+            device,
+            host,
+            host_device: 0,
+            size: 4,
+            device_allocation,
+            host_allocation,
+        }
+    }
+
+    #[test]
+    fn merge_requires_contiguous_ranges_from_the_same_allocations() {
+        let mut host = [0_u8; 8];
+        let first_host = host.as_mut_ptr();
+        // SAFETY: `host` contains eight bytes, so this points to its second half.
+        let second_host = unsafe { first_host.add(4) };
+
+        let merged = merge(&[copy(100, first_host, 1, 2), copy(104, second_host, 1, 2)]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].size, 8);
+
+        for second in [copy(104, second_host, 3, 2), copy(104, second_host, 1, 4)] {
+            assert_eq!(merge(&[copy(100, first_host, 1, 2), second]).len(), 2);
+        }
+    }
+}

--- a/pegaflow-core/src/transfer/mod.rs
+++ b/pegaflow-core/src/transfer/mod.rs
@@ -39,6 +39,8 @@ pub struct CopyDesc {
     pub host: *mut u8,
     pub host_device: u64,
     pub size: usize,
+    pub device_allocation: usize,
+    pub host_allocation: usize,
 }
 
 // SAFETY: `host` points into pinned memory owned by the caller, who guarantees

--- a/pegaflow-core/tests/common/harness.rs
+++ b/pegaflow-core/tests/common/harness.rs
@@ -94,6 +94,10 @@ impl TestGpuData {
         assert_eq!(self.gpu.copy_to_host(), self.expected, "GPU data mismatch");
     }
 
+    pub fn assert_gpu_matches(&self, expected: &[u8]) {
+        assert_eq!(self.gpu.copy_to_host(), expected, "GPU data mismatch");
+    }
+
     pub fn ptr(&self) -> u64 {
         self.gpu.as_u64()
     }
@@ -426,8 +430,9 @@ impl TestEnv {
 
     /// Load blocks from cache to GPU (lease must be held).
     pub async fn load_to_gpu(&self, lease: QueryLeaseId, block_count: usize) {
-        let block_ids: Vec<usize> = (0..block_count).collect();
+        let block_ids: Vec<Option<usize>> = (0..block_count).map(Some).collect();
         let layer_names: Vec<&str> = self.layers.iter().map(|l| l.name.as_str()).collect();
+        let layer_groups = vec![layer_names];
         let load_state = LoadState::new().expect("create LoadState");
         let shm_name = load_state.shm_name().to_string();
         self.engine
@@ -436,8 +441,8 @@ impl TestEnv {
                 0,
                 0,
                 &shm_name,
-                &layer_names,
-                &[(lease, block_ids)],
+                &layer_groups,
+                &[(lease, vec![block_ids])],
             )
             .expect("submit load");
         wait_for_load(&load_state, LOAD_WAIT_TIMEOUT).await;
@@ -445,8 +450,9 @@ impl TestEnv {
 
     /// Submit load and assert it fails synchronously with `expected_msg`.
     pub fn expect_load_error(&self, lease: QueryLeaseId, block_count: usize, expected_msg: &str) {
-        let block_ids: Vec<usize> = (0..block_count).collect();
+        let block_ids: Vec<Option<usize>> = (0..block_count).map(Some).collect();
         let layer_names: Vec<&str> = self.layers.iter().map(|l| l.name.as_str()).collect();
+        let layer_groups = vec![layer_names];
         let load_state = LoadState::new().expect("create LoadState");
         let shm_name = load_state.shm_name().to_string();
         let err = self
@@ -456,8 +462,8 @@ impl TestEnv {
                 0,
                 0,
                 &shm_name,
-                &layer_names,
-                &[(lease, block_ids)],
+                &layer_groups,
+                &[(lease, vec![block_ids])],
             )
             .expect_err("load should fail");
         assert!(

--- a/pegaflow-core/tests/engine_basic.rs
+++ b/pegaflow-core/tests/engine_basic.rs
@@ -57,6 +57,72 @@ async fn page_first_multi_layer_roundtrip() {
     }
 }
 
+/// HMA cache groups use different physical block tables for the same logical
+/// request. Each layer group must therefore load into its own destination IDs.
+#[tokio::test]
+async fn hybrid_groups_load_to_distinct_block_ids() {
+    let mut env = TestEnvBuilder::new("test-hybrid-groups", "test-ns")
+        .layer("full_attention", 4, 1024)
+        .layer("gdn", 4, 1024)
+        .build();
+    env.layers[1].data.overwrite(0x40);
+
+    let hashes = make_block_hashes(2, 0xAC);
+    let saves = vec![
+        LayerSave {
+            layer_name: env.layers[0].name.clone(),
+            block_ids: vec![0, 1],
+            block_hashes: hashes.clone(),
+        },
+        LayerSave {
+            layer_name: env.layers[1].name.clone(),
+            block_ids: vec![2, 3],
+            block_hashes: hashes.clone(),
+        },
+    ];
+    env.engine
+        .batch_save_kv_blocks_from_ipc(&env.instance_id, 0, 0, 0, saves)
+        .await
+        .expect("save hybrid groups");
+    env.engine.flush_saves().await;
+
+    for layer in &env.layers {
+        layer.data.zero_gpu();
+    }
+    let lease = env.assert_all_hit_lease(&hashes).await;
+    let layer_groups = vec![vec!["full_attention"], vec![], vec!["gdn"]];
+    let completion = env
+        .engine
+        .batch_load_kv_blocks_multi_layer_inproc(
+            &env.instance_id,
+            0,
+            0,
+            &layer_groups,
+            &[(
+                lease,
+                vec![
+                    vec![Some(2), Some(3)],
+                    vec![None, None],
+                    vec![None, Some(0)],
+                ],
+            )],
+        )
+        .expect("load hybrid groups");
+    completion
+        .await
+        .expect("load worker must reply")
+        .expect("load hybrid groups");
+
+    let mut full_expected = vec![0; 4 * 1024];
+    full_expected[2 * 1024..3 * 1024].fill(1);
+    full_expected[3 * 1024..4 * 1024].fill(2);
+    env.layers[0].data.assert_gpu_matches(&full_expected);
+
+    let mut gdn_expected = vec![0; 4 * 1024];
+    gdn_expected[0..1024].fill(4 + 0x40);
+    env.layers[1].data.assert_gpu_matches(&gdn_expected);
+}
+
 /// Page-first seals a block's single slot on the first save, so one save must
 /// carry EVERY layer of the page. A save covering only some layers (e.g. a
 /// pipeline stage holding a subset) would seal a page whose other offsets are

--- a/pegaflow-core/tests/prefetch_lease.rs
+++ b/pegaflow-core/tests/prefetch_lease.rs
@@ -51,8 +51,9 @@ async fn query_then_load_consumes_reservation_budget() {
     env.load_to_gpu(lease, hashes.len()).await;
     env.data().assert_gpu_matches_expected();
 
-    let block_ids: Vec<usize> = (0..hashes.len()).collect();
+    let block_ids: Vec<Option<usize>> = (0..hashes.len()).map(Some).collect();
     let layer_names: Vec<&str> = env.layers.iter().map(|l| l.name.as_str()).collect();
+    let layer_groups = vec![layer_names];
     let load_state = LoadState::new().expect("create LoadState");
     let err = env
         .engine
@@ -61,8 +62,8 @@ async fn query_then_load_consumes_reservation_budget() {
             0,
             0,
             load_state.shm_name(),
-            &layer_names,
-            &[(lease, block_ids)],
+            &layer_groups,
+            &[(lease, vec![block_ids])],
         )
         .expect_err("third load should fail");
     assert!(

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -75,13 +75,27 @@ message LoadRequest {
   uint32 tp_rank = 2;
   int32 device_id = 3;
   string load_state_shm = 4;
-  repeated string layer_names = 5;
+  repeated LoadGroup groups = 5;
   repeated LeaseLoad loads = 6;
+}
+
+message LoadGroup {
+  repeated string layer_names = 1;
+}
+
+message LoadBlockIds {
+  repeated LoadBlockTarget targets = 1;
+}
+
+message LoadBlockTarget {
+  // Absent for cache groups that have no physical destination for this
+  // logical block (for example historical recurrent-state blocks in HMA).
+  optional uint32 block_id = 1;
 }
 
 message LeaseLoad {
   bytes lease = 1;
-  repeated uint32 block_ids = 2;
+  repeated LoadBlockIds block_ids_by_group = 2;
 }
 
 message LoadResponse {

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -90,7 +90,9 @@ message LoadBlockIds {
 message LoadBlockTarget {
   // Absent for cache groups that have no physical destination for this
   // logical block (for example historical recurrent-state blocks in HMA).
-  optional uint32 block_id = 1;
+  oneof target {
+    uint32 block_id = 1;
+  }
 }
 
 message LeaseLoad {

--- a/pegaflow-server/examples/p2p_bench.rs
+++ b/pegaflow-server/examples/p2p_bench.rs
@@ -711,8 +711,8 @@ async fn verify_set(
                 tp_rank,
                 rb.device as i32,
                 load_state.shm_name(),
-                &layer_name_refs,
-                &[(lease, block_ids.clone())],
+                std::slice::from_ref(&layer_name_refs),
+                &[(lease, vec![block_ids.iter().copied().map(Some).collect()])],
             )
             .expect("batch_load");
         let deadline = Instant::now() + Duration::from_secs(30);

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -9,7 +9,7 @@ use crate::proto::engine::{
     ReleaseRequest, ReleaseResponse, ReleaseTransferLockRequest, ReleaseTransferLockResponse,
     ResponseStatus, SaveRequest, SaveResponse, SessionEvent, SessionRequest, ShutdownRequest,
     ShutdownResponse, TransferBlockInfo, TransferMode as ProtoTransferMode, TransferSlotInfo,
-    UnregisterRequest, UnregisterResponse, query_response,
+    UnregisterRequest, UnregisterResponse, load_block_target, query_response,
 };
 use crate::registry::RegistryHandle;
 use crate::session::SessionRegistry;
@@ -485,7 +485,11 @@ impl Engine for GrpcEngineService {
                             block_ids
                                 .targets
                                 .into_iter()
-                                .map(|target| target.block_id.map(|id| id as usize))
+                                .map(|target| {
+                                    target
+                                        .target
+                                        .map(|load_block_target::Target::BlockId(id)| id as usize)
+                                })
                                 .collect()
                         })
                         .collect();

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -430,9 +430,14 @@ impl Engine for GrpcEngineService {
         let start = Instant::now();
 
         let req = request.into_inner();
-        let layer_count = req.layer_names.len();
+        let layer_count: usize = req.groups.iter().map(|group| group.layer_names.len()).sum();
         let load_count = req.loads.len();
-        let block_count: usize = req.loads.iter().map(|load| load.block_ids.len()).sum();
+        let block_count: usize = req
+            .loads
+            .iter()
+            .flat_map(|load| &load.block_ids_by_group)
+            .map(|block_ids| block_ids.targets.len())
+            .sum();
 
         trace_root!("rpc.load", root, || {
             [
@@ -447,7 +452,7 @@ impl Engine for GrpcEngineService {
                 instance_id,
                 tp_rank,
                 device_id,
-                layer_names,
+                groups,
                 loads,
                 load_state_shm,
                 ..
@@ -464,14 +469,27 @@ impl Engine for GrpcEngineService {
                 block_count,
                 load_state_shm.len()
             );
-            let layer_refs: Vec<&str> = layer_names.iter().map(|s| s.as_str()).collect();
-            let loads: Vec<(QueryLeaseId, Vec<usize>)> = loads
+            let layer_groups: Vec<Vec<&str>> = groups
+                .iter()
+                .map(|group| group.layer_names.iter().map(String::as_str).collect())
+                .collect();
+            let loads: Vec<(QueryLeaseId, Vec<Vec<Option<usize>>>)> = loads
                 .into_iter()
                 .map(|load| {
                     let lease =
                         QueryLeaseId::from_bytes(&load.lease).map_err(Status::invalid_argument)?;
-                    let block_ids = load.block_ids.into_iter().map(|id| id as usize).collect();
-                    Ok::<_, Status>((lease, block_ids))
+                    let block_ids_by_group = load
+                        .block_ids_by_group
+                        .into_iter()
+                        .map(|block_ids| {
+                            block_ids
+                                .targets
+                                .into_iter()
+                                .map(|target| target.block_id.map(|id| id as usize))
+                                .collect()
+                        })
+                        .collect();
+                    Ok::<_, Status>((lease, block_ids_by_group))
                 })
                 .collect::<Result<_, _>>()?;
 
@@ -481,7 +499,7 @@ impl Engine for GrpcEngineService {
                     tp_rank,
                     device_id,
                     &load_state_shm,
-                    &layer_refs,
+                    &layer_groups,
                     &loads,
                 )
                 .map_err(Self::map_engine_error)?;

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -12,7 +12,7 @@ use pegaflow_server::proto::engine::engine_server::EngineServer;
 use pegaflow_server::proto::engine::{
     LeaseLoad, LoadBlockIds, LoadBlockTarget, LoadGroup, LoadRequest, LoadResponse, QueryRequest,
     QueryResponse, ReleaseRequest, ReleaseResponse, SaveLayer, SaveRequest, SaveResponse,
-    SessionEvent, SessionRequest,
+    SessionEvent, SessionRequest, load_block_target,
 };
 use pegaflow_server::{CudaTensorRegistry, GrpcEngineService, RegistryHandle};
 use tokio::sync::Notify;
@@ -382,7 +382,7 @@ impl MockVllmRpcHarness {
                 block_ids_by_group: vec![LoadBlockIds {
                     targets: (0..block_count as u32)
                         .map(|block_id| LoadBlockTarget {
-                            block_id: Some(block_id),
+                            target: Some(load_block_target::Target::BlockId(block_id)),
                         })
                         .collect(),
                 }],

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -10,8 +10,9 @@ use pegaflow_core::{LoadState, PegaEngine, PrefetchStatus, StorageConfig, Transf
 use pegaflow_server::proto::engine::engine_client::EngineClient;
 use pegaflow_server::proto::engine::engine_server::EngineServer;
 use pegaflow_server::proto::engine::{
-    LeaseLoad, LoadRequest, LoadResponse, QueryRequest, QueryResponse, ReleaseRequest,
-    ReleaseResponse, SaveLayer, SaveRequest, SaveResponse, SessionEvent, SessionRequest,
+    LeaseLoad, LoadBlockIds, LoadBlockTarget, LoadGroup, LoadRequest, LoadResponse, QueryRequest,
+    QueryResponse, ReleaseRequest, ReleaseResponse, SaveLayer, SaveRequest, SaveResponse,
+    SessionEvent, SessionRequest,
 };
 use pegaflow_server::{CudaTensorRegistry, GrpcEngineService, RegistryHandle};
 use tokio::sync::Notify;
@@ -373,10 +374,18 @@ impl MockVllmRpcHarness {
             tp_rank: worker.tp_rank,
             device_id: worker.device_id,
             load_state_shm: state.shm_name().to_string(),
-            layer_names: vec![LAYER_NAME.to_string()],
+            groups: vec![LoadGroup {
+                layer_names: vec![LAYER_NAME.to_string()],
+            }],
             loads: vec![LeaseLoad {
                 lease,
-                block_ids: (0..block_count as u32).collect(),
+                block_ids_by_group: vec![LoadBlockIds {
+                    targets: (0..block_count as u32)
+                        .map(|block_id| LoadBlockTarget {
+                            block_id: Some(block_id),
+                        })
+                        .collect(),
+                }],
             }],
         };
         match self.worker.load(request.clone()).await {

--- a/pegaflow-server/tests/mock_vllm_rpc_e2e.rs
+++ b/pegaflow-server/tests/mock_vllm_rpc_e2e.rs
@@ -9,13 +9,17 @@ use common::{
     BLOCK_COUNT, INSTANCE_ID, LAYER_NAME, MockVllmRpcHarness, SECOND_INSTANCE_ID,
     cuda_device_count, make_block_hashes,
 };
-use pegaflow_server::proto::engine::{LoadBlockIds, QueryReady, query_response};
+use pegaflow_server::proto::engine::{LoadBlockIds, QueryReady, load_block_target, query_response};
 
 fn load_targets(block_ids: &LoadBlockIds) -> Vec<Option<u32>> {
     block_ids
         .targets
         .iter()
-        .map(|target| target.block_id)
+        .map(|target| {
+            target
+                .target
+                .map(|load_block_target::Target::BlockId(block_id)| block_id)
+        })
         .collect()
 }
 

--- a/pegaflow-server/tests/mock_vllm_rpc_e2e.rs
+++ b/pegaflow-server/tests/mock_vllm_rpc_e2e.rs
@@ -9,7 +9,15 @@ use common::{
     BLOCK_COUNT, INSTANCE_ID, LAYER_NAME, MockVllmRpcHarness, SECOND_INSTANCE_ID,
     cuda_device_count, make_block_hashes,
 };
-use pegaflow_server::proto::engine::{QueryReady, query_response};
+use pegaflow_server::proto::engine::{LoadBlockIds, QueryReady, query_response};
+
+fn load_targets(block_ids: &LoadBlockIds) -> Vec<Option<u32>> {
+    block_ids
+        .targets
+        .iter()
+        .map(|target| target.block_id)
+        .collect()
+}
 
 #[tokio::test]
 async fn mock_vllm_save_query_load_roundtrip_over_rpc() {
@@ -50,8 +58,14 @@ async fn mock_vllm_save_query_load_roundtrip_over_rpc() {
     assert_eq!(load.request.tp_rank, 0);
     assert_eq!(load.request.device_id, 0);
     assert!(!load.request.load_state_shm.is_empty());
-    assert_eq!(load.request.layer_names, vec![LAYER_NAME.to_string()]);
-    assert_eq!(load.request.loads[0].block_ids, vec![0, 1, 2, 3]);
+    assert_eq!(
+        load.request.groups[0].layer_names,
+        vec![LAYER_NAME.to_string()]
+    );
+    assert_eq!(
+        load_targets(&load.request.loads[0].block_ids_by_group[0]),
+        vec![Some(0), Some(1), Some(2), Some(3)]
+    );
     assert_response_ok(load.response.status.as_ref(), "load");
 
     harness.wait_for_load(&load.state).await;
@@ -173,7 +187,10 @@ async fn mock_vllm_prefix_partial_query_returns_prefix_lease() {
 
     harness.gpus[0].zero();
     let load = harness.submit_load(ready.lease, 2).await;
-    assert_eq!(load.request.loads[0].block_ids, vec![0, 1]);
+    assert_eq!(
+        load_targets(&load.request.loads[0].block_ids_by_group[0]),
+        vec![Some(0), Some(1)]
+    );
     assert_response_ok(load.response.status.as_ref(), "prefix load");
     harness.wait_for_load(&load.state).await;
     harness.gpus[0].assert_prefix_loaded_and_suffix_zero(2);
@@ -202,7 +219,10 @@ async fn mock_vllm_load_rejects_lease_block_count_mismatch() {
         Ok(_) => panic!("load block count mismatch should fail"),
         Err(err) => err,
     };
-    assert_eq!(mismatch.request.loads[0].block_ids, vec![0, 1, 2, 3]);
+    assert_eq!(
+        load_targets(&mismatch.request.loads[0].block_ids_by_group[0]),
+        vec![Some(0), Some(1), Some(2), Some(3)]
+    );
     assert_eq!(mismatch.status.code(), tonic::Code::InvalidArgument);
     assert!(
         mismatch
@@ -343,7 +363,10 @@ async fn mock_vllm_naive_tp2_load_roundtrip_over_rpc() {
         .await;
     assert_eq!(load_tp0.request.tp_rank, 0);
     assert_eq!(load_tp0.request.device_id, 0);
-    assert_eq!(load_tp0.request.loads[0].block_ids, vec![0, 1, 2, 3]);
+    assert_eq!(
+        load_targets(&load_tp0.request.loads[0].block_ids_by_group[0]),
+        vec![Some(0), Some(1), Some(2), Some(3)]
+    );
     assert_response_ok(load_tp0.response.status.as_ref(), "load tp0");
 
     let load_tp1 = harness
@@ -351,7 +374,10 @@ async fn mock_vllm_naive_tp2_load_roundtrip_over_rpc() {
         .await;
     assert_eq!(load_tp1.request.tp_rank, 1);
     assert_eq!(load_tp1.request.device_id, 1);
-    assert_eq!(load_tp1.request.loads[0].block_ids, vec![0, 1, 2, 3]);
+    assert_eq!(
+        load_targets(&load_tp1.request.loads[0].block_ids_by_group[0]),
+        vec![Some(0), Some(1), Some(2), Some(3)]
+    );
     assert_response_ok(load_tp1.response.status.as_ref(), "load tp1");
 
     harness.wait_for_load(&load_tp0.state).await;

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -513,8 +513,8 @@ async fn p2p_rdma_remote_fetch_roundtrip() {
             0,
             DEVICE_ID,
             &shm_name,
-            &[LAYER],
-            &[(lease, block_ids.clone())],
+            &[vec![LAYER]],
+            &[(lease, vec![block_ids.iter().copied().map(Some).collect()])],
         )
         .expect("batch_load on engine B");
 

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -12,6 +12,7 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.distributed.parallel_state import get_pp_group, get_tensor_model_parallel_rank
 
@@ -33,7 +34,7 @@ from pegaflow.connector.worker import WorkerConnector
 from pegaflow.pegaflow import EngineRpcClient
 
 
-class PegaKVConnector(KVConnectorBase_V1):
+class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
     """v1 KV connector for PegaFlow with separated scheduler/worker logic."""
 
     def __init__(self, vllm_config, role: KVConnectorRole, kv_cache_config=None):
@@ -143,7 +144,8 @@ class PegaKVConnector(KVConnectorBase_V1):
         # is silently ignored upstream and falls back to per-layer — surface
         # that instead of pretending the request was honored.
         env_cross_layer = os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
-        self._prefer_cross_layer = env_cross_layer and not is_mla
+        cache_groups = tuple(getattr(kv_cache_config, "kv_cache_groups", ()) or ())
+        self._prefer_cross_layer = env_cross_layer and not is_mla and len(cache_groups) <= 1
         if is_mla and env_cross_layer:
             logger.warning(
                 "[PegaKVConnector] PEGAFLOW_CROSS_LAYER_BLOCKS=1 is ignored for MLA "
@@ -165,6 +167,7 @@ class PegaKVConnector(KVConnectorBase_V1):
                 pd_tail_save=pd_tail_save,
                 pd_tail_load=pd_tail_load,
                 vllm_config=vllm_config,
+                kv_cache_config=kv_cache_config,
             )
             # Open the liveness stream from the scheduler process only. One
             # stream per vllm replica is enough — if any tp worker crashes,
@@ -265,10 +268,23 @@ class PegaKVConnector(KVConnectorBase_V1):
         if self._scheduler:
             self._scheduler.update_connector_output(connector_output)
 
+    def bind_gpu_block_pool(self, gpu_block_pool) -> None:
+        if self._scheduler:
+            self._scheduler.bind_gpu_block_pool(gpu_block_pool)
+
     def request_finished(
         self,
         request,
         block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        if self._scheduler:
+            return self._scheduler.request_finished(request, (block_ids,))
+        return (False, None)
+
+    def request_finished_all_groups(
+        self,
+        request,
+        block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
         if self._scheduler:
             return self._scheduler.request_finished(request, block_ids)
@@ -366,17 +382,22 @@ class PegaKVConnector(KVConnectorBase_V1):
             self._state_manager.shutdown()
 
 
-class NoopKVConnector(KVConnectorBase_V1):
+class NoopKVConnector(KVConnectorBase_V1, SupportsHMA):
     """Connector-path baseline for tests."""
 
     def __init__(self, vllm_config, role: KVConnectorRole, kv_cache_config=None):
         super().__init__(vllm_config, role, kv_cache_config)
         self._is_mla = detect_mla(vllm_config)
+        self._cache_group_count = len(tuple(getattr(kv_cache_config, "kv_cache_groups", ()) or ()))
 
     @property
     def prefer_cross_layer_blocks(self) -> bool:
         # MLA cannot use cross-layer KV (no num-layers stride); be honest.
-        return not self._is_mla and os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
+        return (
+            not self._is_mla
+            and self._cache_group_count <= 1
+            and os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
+        )
 
     def start_load_kv(self, forward_context, **kwargs: Any) -> None:
         return
@@ -404,6 +425,13 @@ class NoopKVConnector(KVConnectorBase_V1):
 
     def build_connector_meta(self, scheduler_output) -> PegaConnectorMetadata:
         return PegaConnectorMetadata()
+
+    def request_finished_all_groups(
+        self,
+        request,
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        return (False, None)
 
 
 def _resolve_device_id() -> int:

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -44,13 +44,15 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
         tp_size = vllm_config.parallel_config.tensor_parallel_size
         world_size = vllm_config.parallel_config.world_size
         is_mla = detect_mla(vllm_config)
+        cache_groups = tuple(getattr(kv_cache_config, "kv_cache_groups", ()) or ())
+        collapse_mla_tp = is_mla and len(cache_groups) <= 1
         dcp_world_size = (
             getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1) or 1
         )
         pcp_world_size = (
             getattr(vllm_config.parallel_config, "prefill_context_parallel_size", 1) or 1
         )
-        effective_tp_size = max(1, dcp_world_size) if is_mla else tp_size
+        effective_tp_size = max(1, dcp_world_size) if collapse_mla_tp else tp_size
 
         if dcp_world_size > 1 and not is_mla:
             logger.warning(
@@ -129,6 +131,7 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             engine_client=engine_client,
             state_manager=self._state_manager,
             is_mla=is_mla,
+            collapse_mla_tp=collapse_mla_tp,
             transfer_backend=transfer_backend,
             dcp_world_size=dcp_world_size,
             pcp_world_size=pcp_world_size,
@@ -144,7 +147,6 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
         # is silently ignored upstream and falls back to per-layer — surface
         # that instead of pretending the request was honored.
         env_cross_layer = os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
-        cache_groups = tuple(getattr(kv_cache_config, "kv_cache_groups", ()) or ())
         self._prefer_cross_layer = env_cross_layer and not is_mla and len(cache_groups) <= 1
         if is_mla and env_cross_layer:
             logger.warning(
@@ -184,7 +186,8 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
         logger.debug(
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
             "tp_rank=%s tp_size=%d pp_rank=%d pp_size=%d world_size=%d namespace=%s "
-            "is_mla=%s transfer_backend=%s dcp_world_size=%d pcp_world_size=%d dcp_rank=%d "
+            "is_mla=%s collapse_mla_tp=%s transfer_backend=%s dcp_world_size=%d "
+            "pcp_world_size=%d dcp_rank=%d "
             "mode=%s wait_for_full_prefix=%s",
             role.name,
             instance_id,
@@ -196,6 +199,7 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             world_size,
             namespace,
             is_mla,
+            collapse_mla_tp,
             transfer_backend,
             dcp_world_size,
             pcp_world_size,

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -106,7 +106,7 @@ class ConnectorContext:
 class LoadIntent:
     """Intent for a KV load operation."""
 
-    block_ids: tuple[int, ...]
+    block_ids_by_group: tuple[tuple[int, ...], ...]
     lease: bytes
     num_tokens: int
 
@@ -115,8 +115,64 @@ class LoadIntent:
 class SaveIntent:
     """Intent for a KV save operation."""
 
-    block_ids: tuple[int, ...]
+    block_ids_by_group: tuple[tuple[int, ...], ...]
     block_hashes: tuple[bytes, ...]
+
+
+@dataclass(frozen=True)
+class CacheGroupLayout:
+    """Stable vLLM cache-group order shared by scheduler and worker."""
+
+    layer_names: tuple[tuple[str, ...], ...]
+    hash_group_index: int
+    has_recurrent_state: bool
+
+    @classmethod
+    def from_config(cls, kv_cache_config) -> "CacheGroupLayout":
+        groups = tuple(getattr(kv_cache_config, "kv_cache_groups", ()) or ())
+        if not groups:
+            return cls(layer_names=((),), hash_group_index=0, has_recurrent_state=False)
+
+        from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+        block_sizes = {group.kv_cache_spec.block_size for group in groups}
+        if len(groups) > 1 and len(block_sizes) != 1:
+            raise RuntimeError(
+                "PegaFlow HMA requires cache groups with identical logical block sizes"
+            )
+
+        hash_group_index = next(
+            (
+                index
+                for index, group in enumerate(groups)
+                if isinstance(group.kv_cache_spec, FullAttentionSpec)
+            ),
+            None,
+        )
+        if hash_group_index is None and len(groups) > 1:
+            raise RuntimeError(
+                "PegaFlow requires a dense FullAttention cache group for block hashes"
+            )
+        hash_group_index = hash_group_index or 0
+
+        return cls(
+            layer_names=tuple(tuple(group.layer_names) for group in groups),
+            hash_group_index=hash_group_index,
+            has_recurrent_state=any(isinstance(group.kv_cache_spec, MambaSpec) for group in groups),
+        )
+
+    @property
+    def group_count(self) -> int:
+        return len(self.layer_names)
+
+    def layer_to_group(self) -> dict[str, int]:
+        result: dict[str, int] = {}
+        for group_index, names in enumerate(self.layer_names):
+            for name in names:
+                if name in result:
+                    raise RuntimeError(f"KV cache layer belongs to multiple groups: {name}")
+                result[name] = group_index
+        return result
 
 
 class PegaConnectorMetadata(KVConnectorMetadata):

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -54,6 +54,7 @@ class ConnectorContext:
     engine_client: EngineRpcClient
     state_manager: "ServiceStateManager"
     is_mla: bool = False
+    collapse_mla_tp: bool = True
     transfer_backend: str = "direct"
     dcp_world_size: int = 1
     pcp_world_size: int = 1
@@ -83,9 +84,10 @@ class ConnectorContext:
 
         - MLA without DCP: 0 (data identical across TP ranks).
         - MLA with DCP: dcp_rank (each DCP rank stores different interleaved tokens).
+        - Hybrid MLA: tp_rank (non-MLA cache groups differ across TP ranks).
         - Non-MLA: tp_rank (each TP rank has different KV heads, already unique).
         """
-        if self.is_mla:
+        if self.is_mla and self.collapse_mla_tp:
             return self.dcp_rank
         return self.tp_rank or 0
 
@@ -95,9 +97,10 @@ class ConnectorContext:
 
         - MLA without DCP: 1.
         - MLA with DCP: dcp_world_size.
+        - Hybrid MLA: tp_size.
         - Non-MLA: tp_size (unique per TP rank regardless of DCP).
         """
-        if self.is_mla:
+        if self.is_mla and self.collapse_mla_tp:
             return max(1, self.dcp_world_size)
         return self.tp_size
 
@@ -106,7 +109,7 @@ class ConnectorContext:
 class LoadIntent:
     """Intent for a KV load operation."""
 
-    block_ids_by_group: tuple[tuple[int, ...], ...]
+    block_ids_by_group: tuple[tuple[int | None, ...], ...]
     lease: bytes
     num_tokens: int
 
@@ -126,14 +129,33 @@ class CacheGroupLayout:
     layer_names: tuple[tuple[str, ...], ...]
     hash_group_index: int
     has_recurrent_state: bool
+    recurrent_group_indices: frozenset[int]
+    recurrent_layer_names: frozenset[str]
 
     @classmethod
     def from_config(cls, kv_cache_config) -> "CacheGroupLayout":
         groups = tuple(getattr(kv_cache_config, "kv_cache_groups", ()) or ())
         if not groups:
-            return cls(layer_names=((),), hash_group_index=0, has_recurrent_state=False)
+            return cls(
+                layer_names=((),),
+                hash_group_index=0,
+                has_recurrent_state=False,
+                recurrent_group_indices=frozenset(),
+                recurrent_layer_names=frozenset(),
+            )
 
         from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+        if len(groups) > 1 and any(
+            not isinstance(group.kv_cache_spec, (FullAttentionSpec, MambaSpec)) for group in groups
+        ):
+            raise RuntimeError("PegaFlow HMA supports only FullAttention and Mamba cache groups")
+        if len(groups) > 1 and any(
+            isinstance(group.kv_cache_spec, MambaSpec)
+            and group.kv_cache_spec.mamba_cache_mode != "align"
+            for group in groups
+        ):
+            raise RuntimeError("PegaFlow HMA requires mamba_cache_mode='align'")
 
         block_sizes = {group.kv_cache_spec.block_size for group in groups}
         if len(groups) > 1 and len(block_sizes) != 1:
@@ -159,6 +181,17 @@ class CacheGroupLayout:
             layer_names=tuple(tuple(group.layer_names) for group in groups),
             hash_group_index=hash_group_index,
             has_recurrent_state=any(isinstance(group.kv_cache_spec, MambaSpec) for group in groups),
+            recurrent_group_indices=frozenset(
+                index
+                for index, group in enumerate(groups)
+                if isinstance(group.kv_cache_spec, MambaSpec)
+            ),
+            recurrent_layer_names=frozenset(
+                layer_name
+                for group in groups
+                if isinstance(group.kv_cache_spec, MambaSpec)
+                for layer_name in group.layer_names
+            ),
         )
 
     @property

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -144,18 +144,41 @@ class CacheGroupLayout:
                 recurrent_layer_names=frozenset(),
             )
 
-        from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+        from vllm.v1.kv_cache_interface import (
+            FullAttentionSpec,
+            MambaSpec,
+            MLAAttentionSpec,
+        )
 
-        if len(groups) > 1 and any(
-            not isinstance(group.kv_cache_spec, (FullAttentionSpec, MambaSpec)) for group in groups
-        ):
-            raise RuntimeError("PegaFlow HMA supports only FullAttention and Mamba cache groups")
-        if len(groups) > 1 and any(
-            isinstance(group.kv_cache_spec, MambaSpec)
-            and group.kv_cache_spec.mamba_cache_mode != "align"
-            for group in groups
-        ):
-            raise RuntimeError("PegaFlow HMA requires mamba_cache_mode='align'")
+        specs = tuple(group.kv_cache_spec for group in groups)
+        if len(specs) == 1:
+            if type(specs[0]) not in (FullAttentionSpec, MLAAttentionSpec):
+                raise RuntimeError(
+                    "PegaFlow supports a single cache group only for FullAttention or MLA"
+                )
+        else:
+            if any(
+                type(spec) is not FullAttentionSpec and not isinstance(spec, MambaSpec)
+                for spec in specs
+            ):
+                raise RuntimeError(
+                    "PegaFlow HMA supports only FullAttention and Mamba cache groups"
+                )
+
+            has_full_attention = any(type(spec) is FullAttentionSpec for spec in specs)
+            has_mamba = any(isinstance(spec, MambaSpec) for spec in specs)
+            if not has_full_attention:
+                raise RuntimeError(
+                    "PegaFlow requires a dense FullAttention cache group for block hashes"
+                )
+            if not has_mamba:
+                raise RuntimeError(
+                    "PegaFlow HMA requires both FullAttention and Mamba cache groups"
+                )
+            if any(
+                isinstance(spec, MambaSpec) and spec.mamba_cache_mode != "align" for spec in specs
+            ):
+                raise RuntimeError("PegaFlow HMA requires mamba_cache_mode='align'")
 
         block_sizes = {group.kv_cache_spec.block_size for group in groups}
         if len(groups) > 1 and len(block_sizes) != 1:
@@ -171,11 +194,10 @@ class CacheGroupLayout:
             ),
             None,
         )
-        if hash_group_index is None and len(groups) > 1:
+        if hash_group_index is None:
             raise RuntimeError(
                 "PegaFlow requires a dense FullAttention cache group for block hashes"
             )
-        hash_group_index = hash_group_index or 0
 
         return cls(
             layer_names=tuple(tuple(group.layer_names) for group in groups),
@@ -305,6 +327,8 @@ def derive_namespace(
     - `mla_layer_split_kv_cache`: MLA layer-split registration shards each
       block's slots across ranks, a different per-block layout than the
       default full-slot registration.
+    - `is_hma_enabled`: vLLM's hybrid cache manager changes whether hybrid
+      cache layouts can share one logical block namespace.
     """
     model_config = vllm_config.model_config
     cache_config = vllm_config.cache_config
@@ -319,6 +343,7 @@ def derive_namespace(
         "head_size": model_config.get_head_size(),
         "num_hidden_layers": model_config.get_total_num_hidden_layers(),
         "cache_dtype": str(cache_config.cache_dtype),
+        "is_hma_enabled": not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager,
         "dcp_world_size": dcp_world_size,
         "pcp_world_size": pcp_world_size,
         "cross_layer_blocks": cross_layer_blocks,

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -100,7 +100,7 @@ class SchedulerConnector:
         self._cache_groups = CacheGroupLayout.from_config(kv_cache_config)
         if self._cache_groups.has_recurrent_state and (pd_tail_save or pd_tail_load):
             raise ValueError("P/D tail-block caching is not supported with HMA")
-        self._unsafe_recurrent_saves: set[str] = set()
+        self._get_local_cached_blocks = None
 
         # P/D tail-block extension (`pegaflow.pd_tail_save`): vLLM only hashes
         # full blocks, so a prompt's partial tail block never enters the tier
@@ -173,6 +173,7 @@ class SchedulerConnector:
         self._held_requests: set[str] = set()
 
     def bind_gpu_block_pool(self, gpu_block_pool) -> None:
+        self._get_local_cached_blocks = gpu_block_pool.get_cached_block
         if self._cache_groups.group_count <= 1:
             return
 
@@ -386,21 +387,19 @@ class SchedulerConnector:
             start_block_idx = num_computed_blocks
             vbs = self._ctx.virtual_block_size
             num_load_blocks = (num_external_tokens + vbs - 1) // vbs
-            expected_load_blocks = {
-                len(block_ids) - num_computed_blocks for block_ids in block_ids_by_group
-            }
-            if expected_load_blocks != {num_load_blocks}:
-                self._release_pending_query_probe(req_id)
-                raise RuntimeError(
-                    f"req {req_id} load block mismatch: external={num_load_blocks} "
-                    f"expected_by_group={sorted(expected_load_blocks)}"
+            try:
+                load_block_ids_by_group = self._load_block_ids_by_group(
+                    block_ids_by_group,
+                    start_block_idx,
+                    num_load_blocks,
                 )
+            except RuntimeError:
+                self._release_pending_query_probe(req_id)
+                raise
 
             pending_probe = self._pending_query_probes.get(req_id)
             load_intent = LoadIntent(
-                block_ids_by_group=tuple(
-                    block_ids[start_block_idx:] for block_ids in block_ids_by_group
-                ),
+                block_ids_by_group=load_block_ids_by_group,
                 lease=pending_probe.lease if pending_probe is not None else b"",
                 num_tokens=num_external_tokens,
             )
@@ -469,7 +468,11 @@ class SchedulerConnector:
             # is reset on preemption — no connector-side bookkeeping can be
             # trusted across a preempt/resume cycle).
             written = req.num_computed_tokens + num_tokens
-            if save_intent := self._consume_save_intent(req_id, written):
+            if save_intent := self._consume_save_intent(
+                req_id,
+                written,
+                req.num_computed_tokens,
+            ):
                 potential_saves[req_id] = save_intent
 
         # Process cached (running) requests
@@ -512,7 +515,11 @@ class SchedulerConnector:
                 )
 
             written = cached_reqs.num_computed_tokens[idx] + num_tokens
-            if save_intent := self._consume_save_intent(req_id, written):
+            if save_intent := self._consume_save_intent(
+                req_id,
+                written,
+                cached_reqs.num_computed_tokens[idx],
+            ):
                 potential_saves[req_id] = save_intent
 
         save_intents = potential_saves
@@ -532,13 +539,18 @@ class SchedulerConnector:
             preempted_req_ids=scheduler_output.preempted_req_ids or None,
         )
 
-    def _consume_save_intent(self, req_id: str, written: int) -> SaveIntent | None:
+    def _consume_save_intent(
+        self,
+        req_id: str,
+        written: int,
+        computed_before_step: int = 0,
+    ) -> SaveIntent | None:
         """Calculate and return SaveIntent for new blocks that need saving.
 
         `written` = positions with valid KV once this step's schedule runs
         (scheduler-authoritative num_computed_tokens + this step's tokens).
         """
-        regular = self._consume_full_block_saves(req_id, written)
+        regular = self._consume_full_block_saves(req_id, written, computed_before_step)
         tail = self._consume_tail_save(req_id, written)
         if tail is None:
             return regular
@@ -639,7 +651,12 @@ class SchedulerConnector:
             return query_hashes, 0
         return query_hashes + (tail[0],), tail[1]
 
-    def _consume_full_block_saves(self, req_id: str, written: int) -> SaveIntent | None:
+    def _consume_full_block_saves(
+        self,
+        req_id: str,
+        written: int,
+        computed_before_step: int | None = None,
+    ) -> SaveIntent | None:
         # block_hashes are at virtual_block_size granularity, 1-to-1 with block_ids.
         block_hashes = self._block_hashes.get(req_id)
         if block_hashes is None:
@@ -654,36 +671,33 @@ class SchedulerConnector:
         # In external-hit cases, the prefix-loaded block IDs are still present at
         # the front, so save intents must slice by global block index rather than
         # rebasing to a local-only view.
-        local_saveable = min(
-            min((len(group) for group in allocated), default=0),
-            scheduled // self._ctx.virtual_block_size,
-        )
-        saveable_block_idx = min(len(block_hashes), base_block_idx + local_saveable)
+        if self._cache_groups.has_recurrent_state:
+            if computed_before_step is None:
+                computed_before_step = written
+            saveable_block_idx = min(
+                len(block_hashes),
+                computed_before_step // self._ctx.virtual_block_size,
+            )
+        else:
+            local_saveable = min(
+                min((len(group) for group in allocated), default=0),
+                scheduled // self._ctx.virtual_block_size,
+            )
+            saveable_block_idx = min(len(block_hashes), base_block_idx + local_saveable)
         new_blocks = saveable_block_idx - start_block_idx
         if new_blocks <= 0:
             return None
 
-        if self._cache_groups.has_recurrent_state:
-            if req_id in self._unsafe_recurrent_saves:
-                return None
-            state_boundary = saveable_block_idx * self._ctx.virtual_block_size
-            if new_blocks != 1 or written != state_boundary:
-                self._unsafe_recurrent_saves.add(req_id)
-                logger.warning(
-                    "[PegaKVConnector] req=%s recurrent save disabled: "
-                    "new_blocks=%d written=%d boundary=%d",
-                    req_id,
-                    new_blocks,
-                    written,
-                    state_boundary,
-                )
-                return None
-
         hash_start = start_block_idx
         save_hashes = block_hashes[hash_start : hash_start + new_blocks]
-        save_block_ids_by_group = tuple(
-            tuple(group[hash_start : hash_start + new_blocks]) for group in allocated
-        )
+        if self._cache_groups.has_recurrent_state:
+            save_block_ids_by_group = self._local_cached_block_ids(save_hashes)
+            if save_block_ids_by_group is None:
+                return None
+        else:
+            save_block_ids_by_group = tuple(
+                tuple(group[hash_start : hash_start + new_blocks]) for group in allocated
+            )
         self._next_stored_block_idx[req_id] = saveable_block_idx
 
         logger.debug(
@@ -703,6 +717,23 @@ class SchedulerConnector:
             block_hashes=save_hashes,
         )
 
+    def _local_cached_block_ids(
+        self,
+        block_hashes: tuple[bytes, ...],
+    ) -> tuple[tuple[int, ...], ...] | None:
+        if self._get_local_cached_blocks is None:
+            raise RuntimeError("HMA block pool was not bound before building save metadata")
+
+        group_ids = list(range(self._cache_groups.group_count))
+        block_ids_by_group = [[] for _ in group_ids]
+        for block_hash in block_hashes:
+            cached_blocks = self._get_local_cached_blocks(block_hash, group_ids)
+            if cached_blocks is None:
+                return None
+            for block_ids, block in zip(block_ids_by_group, cached_blocks, strict=True):
+                block_ids.append(block.block_id)
+        return tuple(tuple(block_ids) for block_ids in block_ids_by_group)
+
     def _copy_block_ids_by_group(self, block_ids) -> tuple[tuple[int, ...], ...]:
         groups = tuple(tuple(group) for group in block_ids)
         if len(groups) != self._cache_groups.group_count:
@@ -710,14 +741,31 @@ class SchedulerConnector:
                 "KV cache group count mismatch: "
                 f"expected={self._cache_groups.group_count} actual={len(groups)}"
             )
-        lengths = {len(group) for group in groups}
-        if len(lengths) > 1:
-            raise RuntimeError(
-                f"PegaFlow HMA requires aligned block counts across groups: {sorted(lengths)}"
-            )
         if any(block_id < 0 for group in groups for block_id in group):
             raise RuntimeError("KV cache block IDs must be non-negative")
         return groups
+
+    def _load_block_ids_by_group(
+        self,
+        block_ids_by_group: tuple[tuple[int, ...], ...],
+        start_block_idx: int,
+        num_load_blocks: int,
+    ) -> tuple[tuple[int | None, ...], ...]:
+        end_block_idx = start_block_idx + num_load_blocks
+        available = [len(group) for group in block_ids_by_group]
+        if any(length < end_block_idx for length in available):
+            raise RuntimeError(
+                f"load block mismatch: start={start_block_idx} count={num_load_blocks} "
+                f"available_by_group={available}"
+            )
+
+        result: list[tuple[int | None, ...]] = []
+        for group_index, block_ids in enumerate(block_ids_by_group):
+            destinations = block_ids[start_block_idx:end_block_idx]
+            if group_index in self._cache_groups.recurrent_group_indices and destinations:
+                destinations = (None,) * (len(destinations) - 1) + (destinations[-1],)
+            result.append(destinations)
+        return tuple(result)
 
     def update_connector_output(self, connector_output: "KVConnectorOutput") -> None:
         for req_id in connector_output.finished_sending or []:
@@ -759,7 +807,6 @@ class SchedulerConnector:
         self._allocated_blocks.pop(req_id, None)
         self._scheduled_tokens.pop(req_id, None)
         self._next_stored_block_idx.pop(req_id, None)
-        self._unsafe_recurrent_saves.discard(req_id)
         self._pending_saves.discard(req_id)
         self._tail_saved.discard(req_id)
 

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -2,12 +2,14 @@
 Scheduler-side connector logic.
 """
 
+import os
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from pegaflow.connector.common import (
+    CacheGroupLayout,
     ConnectorContext,
     LoadIntent,
     PegaConnectorMetadata,
@@ -92,8 +94,13 @@ class SchedulerConnector:
         pd_tail_save: bool = False,
         pd_tail_load: bool = False,
         vllm_config=None,
+        kv_cache_config=None,
     ):
         self._ctx = context
+        self._cache_groups = CacheGroupLayout.from_config(kv_cache_config)
+        if self._cache_groups.has_recurrent_state and (pd_tail_save or pd_tail_load):
+            raise ValueError("P/D tail-block caching is not supported with HMA")
+        self._unsafe_recurrent_saves: set[str] = set()
 
         # P/D tail-block extension (`pegaflow.pd_tail_save`): vLLM only hashes
         # full blocks, so a prompt's partial tail block never enters the tier
@@ -102,15 +109,16 @@ class SchedulerConnector:
         # saves the partial tail block under a key derived with vLLM's OWN
         # hash function over (last_full_hash, tail_prompt_token_ids, None) —
         # well-defined, and independently derivable by the decode peer.
-        # Only xxhash_cbor is validated cross-engine; everything else is
-        # rejected (the pickle-based algos aren't even derivable elsewhere).
+        # vLLM derives NONE_HASH from PYTHONHASHSEED when it is set. A fixed
+        # seed makes the configured hash function reproducible across the
+        # scheduler processes participating in the transfer.
         self._tail_save_enabled = pd_tail_save
         self._tail_load_enabled = pd_tail_load
         self._tail_hash_fn = None
         if pd_tail_save or pd_tail_load:
             assert vllm_config is not None
             algo = vllm_config.cache_config.prefix_caching_hash_algo
-            if algo != "xxhash_cbor":
+            if os.environ.get("PYTHONHASHSEED") is None:
                 enabled_options = ", ".join(
                     option
                     for enabled, option in (
@@ -120,10 +128,8 @@ class SchedulerConnector:
                     if enabled
                 )
                 raise ValueError(
-                    "P/D tail-block caching requires prefix_caching_hash_algo "
-                    f"'xxhash_cbor' (cross-engine derivable, validated); got {algo!r} — "
-                    f"enabled options: {enabled_options}; "
-                    f"run vLLM with --prefix-caching-hash-algo xxhash_cbor"
+                    "P/D tail-block caching requires a fixed PYTHONHASHSEED "
+                    f"across vLLM processes; enabled options: {enabled_options}"
                 )
             from vllm.utils.hashing import get_hash_fn_by_name
             from vllm.v1.core import kv_cache_utils
@@ -154,7 +160,7 @@ class SchedulerConnector:
         self._block_hashes: dict[str, tuple[bytes, ...]] = {}
         self._external_matched_blocks: dict[str, int] = {}
         self._block_index_offsets: dict[str, int] = {}
-        self._allocated_blocks: dict[str, list[int]] = {}
+        self._allocated_blocks: dict[str, list[list[int]]] = {}
         self._scheduled_tokens: dict[str, int] = {}
         self._next_stored_block_idx: dict[str, int] = {}
 
@@ -165,6 +171,18 @@ class SchedulerConnector:
         # Completion tracking
         self._pending_saves: set[str] = set()
         self._held_requests: set[str] = set()
+
+    def bind_gpu_block_pool(self, gpu_block_pool) -> None:
+        if self._cache_groups.group_count <= 1:
+            return
+
+        # vLLM can cache an async-loaded dense group and expose it to a sibling
+        # before the sparse group has a usable state. PegaFlow is the sole HMA
+        # prefix index until vLLM exposes an atomic all-group cache hook.
+        def no_local_hma_prefix_hit(*_args, **_kwargs) -> None:
+            return None
+
+        gpu_block_pool.get_cached_block = no_local_hma_prefix_hit
 
     def get_num_new_matched_tokens(
         self,
@@ -349,29 +367,40 @@ class SchedulerConnector:
             # prefix. Track that global block index explicitly.
             base_block_idx = self._external_matched_blocks.get(req_id, 0)
             self._block_index_offsets[req_id] = base_block_idx
-            self._allocated_blocks[req_id] = []
+            self._allocated_blocks[req_id] = [[] for _ in range(self._cache_groups.group_count)]
             self._scheduled_tokens[req_id] = 0
             self._next_stored_block_idx[req_id] = base_block_idx
 
         if num_external_tokens > 0:
-            block_ids = list(blocks.get_block_ids()[0]) if blocks else []
+            block_ids_by_group = (
+                self._copy_block_ids_by_group(blocks.get_block_ids())
+                if blocks
+                else tuple(() for _ in range(self._cache_groups.group_count))
+            )
+            hash_group_index = self._cache_groups.hash_group_index
             num_computed_blocks = (
-                sum(block.block_hash is not None for block in blocks.blocks[0]) if blocks else 0
+                sum(block.block_hash is not None for block in blocks.blocks[hash_group_index])
+                if blocks
+                else 0
             )
             start_block_idx = num_computed_blocks
             vbs = self._ctx.virtual_block_size
             num_load_blocks = (num_external_tokens + vbs - 1) // vbs
-            expected_load_blocks = len(block_ids) - num_computed_blocks
-            if num_load_blocks != expected_load_blocks:
+            expected_load_blocks = {
+                len(block_ids) - num_computed_blocks for block_ids in block_ids_by_group
+            }
+            if expected_load_blocks != {num_load_blocks}:
                 self._release_pending_query_probe(req_id)
                 raise RuntimeError(
                     f"req {req_id} load block mismatch: external={num_load_blocks} "
-                    f"expected={expected_load_blocks}"
+                    f"expected_by_group={sorted(expected_load_blocks)}"
                 )
 
             pending_probe = self._pending_query_probes.get(req_id)
             load_intent = LoadIntent(
-                block_ids=tuple(block_ids[start_block_idx:]),
+                block_ids_by_group=tuple(
+                    block_ids[start_block_idx:] for block_ids in block_ids_by_group
+                ),
                 lease=pending_probe.lease if pending_probe is not None else b"",
                 num_tokens=num_external_tokens,
             )
@@ -395,9 +424,9 @@ class SchedulerConnector:
                 "[PegaKVConnector] req=%s alloc: total_blocks=%d computed_blocks=%d "
                 "load_blocks=%d start_block_idx=%d load_tokens=%d pending_loads=%d",
                 req_id,
-                len(block_ids),
+                len(block_ids_by_group[hash_group_index]),
                 num_computed_blocks,
-                len(load_intent.block_ids),
+                len(load_intent.block_ids_by_group[hash_group_index]),
                 start_block_idx,
                 load_intent.num_tokens,
                 len(self._pending_load_intents),
@@ -423,7 +452,9 @@ class SchedulerConnector:
             # Populate block IDs from scheduler_output — single source of
             # truth for the save path (consistent with offloading connector).
             if req.block_ids:
-                self._allocated_blocks[req_id] = list(req.block_ids[0])
+                self._allocated_blocks[req_id] = [
+                    list(group) for group in self._copy_block_ids_by_group(req.block_ids)
+                ]
 
             if self._ctx.read_enabled:
                 self._scheduled_tokens[req_id] += num_tokens
@@ -458,9 +489,18 @@ class SchedulerConnector:
             # Append newly allocated blocks
             new_block_ids = cached_reqs.new_block_ids[idx]
             if req_id in cached_reqs.resumed_req_ids:
-                self._allocated_blocks[req_id] = list(new_block_ids[0]) if new_block_ids else []
+                self._allocated_blocks[req_id] = (
+                    [list(group) for group in self._copy_block_ids_by_group(new_block_ids)]
+                    if new_block_ids
+                    else [[] for _ in range(self._cache_groups.group_count)]
+                )
             elif new_block_ids:
-                self._allocated_blocks[req_id].extend(new_block_ids[0])
+                for allocated, new_group in zip(
+                    self._allocated_blocks[req_id],
+                    self._copy_block_ids_by_group(new_block_ids),
+                    strict=True,
+                ):
+                    allocated.extend(new_group)
 
             if self._ctx.read_enabled:
                 self._scheduled_tokens[req_id] += num_tokens
@@ -498,14 +538,21 @@ class SchedulerConnector:
         `written` = positions with valid KV once this step's schedule runs
         (scheduler-authoritative num_computed_tokens + this step's tokens).
         """
-        regular = self._consume_full_block_saves(req_id)
+        regular = self._consume_full_block_saves(req_id, written)
         tail = self._consume_tail_save(req_id, written)
         if tail is None:
             return regular
         if regular is None:
             return tail
         return SaveIntent(
-            block_ids=regular.block_ids + tail.block_ids,
+            block_ids_by_group=tuple(
+                regular_ids + tail_ids
+                for regular_ids, tail_ids in zip(
+                    regular.block_ids_by_group,
+                    tail.block_ids_by_group,
+                    strict=True,
+                )
+            ),
             block_hashes=regular.block_hashes + tail.block_hashes,
         )
 
@@ -534,17 +581,24 @@ class SchedulerConnector:
         tail_idx = prompt_len // vbs
         allocated = self._allocated_blocks.get(req_id, [])
         block_hashes = self._block_hashes.get(req_id) or ()
-        if tail_idx >= len(allocated) or tail_idx > len(block_hashes):
+        if (
+            not allocated
+            or any(tail_idx >= len(group) for group in allocated)
+            or tail_idx > len(block_hashes)
+        ):
             return None  # tail block not allocated / full-block hashes lagging
         self._tail_saved.add(req_id)
         logger.info(
             "[PegaKVConnector] req=%s pd_tail_save: block_id=%d tail_tokens=%d key=%s",
             req_id,
-            allocated[tail_idx],
+            allocated[self._cache_groups.hash_group_index][tail_idx],
             tail_len,
             tail_key.hex(),
         )
-        return SaveIntent(block_ids=(allocated[tail_idx],), block_hashes=(tail_key,))
+        return SaveIntent(
+            block_ids_by_group=tuple((group[tail_idx],) for group in allocated),
+            block_hashes=(tail_key,),
+        )
 
     def _derive_tail_block(self, request: "Request") -> tuple[bytes, int] | None:
         if self._tail_hash_fn is None:
@@ -585,7 +639,7 @@ class SchedulerConnector:
             return query_hashes, 0
         return query_hashes + (tail[0],), tail[1]
 
-    def _consume_full_block_saves(self, req_id: str) -> SaveIntent | None:
+    def _consume_full_block_saves(self, req_id: str, written: int) -> SaveIntent | None:
         # block_hashes are at virtual_block_size granularity, 1-to-1 with block_ids.
         block_hashes = self._block_hashes.get(req_id)
         if block_hashes is None:
@@ -601,7 +655,7 @@ class SchedulerConnector:
         # the front, so save intents must slice by global block index rather than
         # rebasing to a local-only view.
         local_saveable = min(
-            len(allocated),
+            min((len(group) for group in allocated), default=0),
             scheduled // self._ctx.virtual_block_size,
         )
         saveable_block_idx = min(len(block_hashes), base_block_idx + local_saveable)
@@ -609,10 +663,28 @@ class SchedulerConnector:
         if new_blocks <= 0:
             return None
 
-        self._next_stored_block_idx[req_id] = saveable_block_idx
+        if self._cache_groups.has_recurrent_state:
+            if req_id in self._unsafe_recurrent_saves:
+                return None
+            state_boundary = saveable_block_idx * self._ctx.virtual_block_size
+            if new_blocks != 1 or written != state_boundary:
+                self._unsafe_recurrent_saves.add(req_id)
+                logger.warning(
+                    "[PegaKVConnector] req=%s recurrent save disabled: "
+                    "new_blocks=%d written=%d boundary=%d",
+                    req_id,
+                    new_blocks,
+                    written,
+                    state_boundary,
+                )
+                return None
+
         hash_start = start_block_idx
         save_hashes = block_hashes[hash_start : hash_start + new_blocks]
-        save_block_ids = allocated[hash_start : hash_start + new_blocks]
+        save_block_ids_by_group = tuple(
+            tuple(group[hash_start : hash_start + new_blocks]) for group in allocated
+        )
+        self._next_stored_block_idx[req_id] = saveable_block_idx
 
         logger.debug(
             "[PegaKVConnector] req=%s save_intent: start=%d hash_start=%d "
@@ -627,9 +699,25 @@ class SchedulerConnector:
         )
 
         return SaveIntent(
-            block_ids=tuple(save_block_ids),
+            block_ids_by_group=save_block_ids_by_group,
             block_hashes=save_hashes,
         )
+
+    def _copy_block_ids_by_group(self, block_ids) -> tuple[tuple[int, ...], ...]:
+        groups = tuple(tuple(group) for group in block_ids)
+        if len(groups) != self._cache_groups.group_count:
+            raise RuntimeError(
+                "KV cache group count mismatch: "
+                f"expected={self._cache_groups.group_count} actual={len(groups)}"
+            )
+        lengths = {len(group) for group in groups}
+        if len(lengths) > 1:
+            raise RuntimeError(
+                f"PegaFlow HMA requires aligned block counts across groups: {sorted(lengths)}"
+            )
+        if any(block_id < 0 for group in groups for block_id in group):
+            raise RuntimeError("KV cache block IDs must be non-negative")
+        return groups
 
     def update_connector_output(self, connector_output: "KVConnectorOutput") -> None:
         for req_id in connector_output.finished_sending or []:
@@ -644,7 +732,7 @@ class SchedulerConnector:
     def request_finished(
         self,
         request: "Request",
-        block_ids: list[int],  # noqa: ARG002 - required by vLLM interface
+        block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict | None]:
         req_id = request.request_id
 
@@ -671,6 +759,7 @@ class SchedulerConnector:
         self._allocated_blocks.pop(req_id, None)
         self._scheduled_tokens.pop(req_id, None)
         self._next_stored_block_idx.pop(req_id, None)
+        self._unsafe_recurrent_saves.discard(req_id)
         self._pending_saves.discard(req_id)
         self._tail_saved.discard(req_id)
 

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -66,6 +66,7 @@ def _infer_kv_cache_registration(
     logical_block_size: int,
     *,
     is_mla: bool = False,
+    is_recurrent_state: bool = False,
 ) -> _KVCacheRegistrationInfo:
     """Infer the PegaFlow registration from a vLLM KV cache tensor.
 
@@ -83,8 +84,8 @@ def _infer_kv_cache_registration(
     if logical_block_size <= 0:
         raise ValueError(f"logical block size must be > 0, got {logical_block_size}")
 
-    if not is_mla:
-        if len(shape) >= 2 and shape[0] == 2:
+    if is_recurrent_state or not is_mla:
+        if not is_recurrent_state and len(shape) >= 2 and shape[0] == 2:
             layout = "KV-first"
             num_blocks = shape[1]
             bytes_per_block = stride[1] * element_size
@@ -295,7 +296,6 @@ class WorkerConnector:
         if not kv_caches:
             raise RuntimeError("No KV cache layers were selected for registration")
 
-        self._registered_layers = list(kv_caches.keys())
         self._page_first = self._use_page_first()
         first_tensor = _registration_tensor(next(iter(kv_caches.values())))
         self._torch_device = first_tensor.device
@@ -320,6 +320,10 @@ class WorkerConnector:
         split_logical_blocks = 0
 
         for layer_name, kv_cache in kv_caches.items():
+            is_recurrent_state = (
+                layer_name in self._cache_groups.recurrent_layer_names
+                or isinstance(kv_cache, (tuple, list))
+            )
             registration_tensor = _registration_tensor(kv_cache)
             assert registration_tensor.storage_offset() == 0, (
                 f"KV cache for {layer_name} must have zero storage offset"
@@ -332,6 +336,7 @@ class WorkerConnector:
                 registration_tensor,
                 self._ctx.block_size,
                 is_mla=self._ctx.is_mla,
+                is_recurrent_state=is_recurrent_state,
             )
             layout = registration.layout
 
@@ -377,6 +382,8 @@ class WorkerConnector:
             if "PegaFlow version mismatch" in message:
                 raise RuntimeError(f"Register context failed: {message}")
             raise RuntimeError(f"Register context batch failed for layers {layer_names}: {message}")
+
+        self._registered_layers = layer_names
 
         if split_layer_count:
             logger.info(
@@ -551,12 +558,9 @@ class WorkerConnector:
         request_ids: list[str] = []
 
         for req_id, load_intent in metadata.load_intents.items():
-            block_ids_by_group = [
-                [None if block_id == 0 else block_id for block_id in group]
-                for group in load_intent.block_ids_by_group
-            ]
-            for block_ids in load_intent.block_ids_by_group:
-                all_block_ids.extend(block_id for block_id in block_ids if block_id != 0)
+            block_ids_by_group = [list(group) for group in load_intent.block_ids_by_group]
+            for block_ids in block_ids_by_group:
+                all_block_ids.extend(block_id for block_id in block_ids if block_id is not None)
             loads.append((load_intent.lease, block_ids_by_group))
             request_ids.append(req_id)
 
@@ -903,26 +907,17 @@ class WorkerConnector:
     def _use_page_first(self) -> bool:
         """Whether this instance stores blocks page-first.
 
-        Page-first packs each block's layers into contiguous host pages — one
-        slot per *shard* (the set of layers one worker holds) instead of one
-        slot per layer — cutting per-block metadata by ~num_layers / num_shards.
-        Two MLA shapes qualify:
-
-        * full-replica (every rank holds all layers): one shard, so a block's
-          whole page is a single slot and ranks block-stripe the writes.
-        * layer-split (each rank holds a disjoint subset): one shard per rank,
-          and each rank writes its own sub-page as a slot.
-
-        Pipeline parallelism is excluded: with pp_size > 1 each stage holds only
-        some layers, but the engine seals one topology spanning the union of all
-        stages, so the layers a single worker holds are not one of the sealed
-        shards. The first save would seal a partial page and the other stages'
-        same-hash saves dedup instead of repairing it. Page-first requires that
-        one worker can write each shard's entire page. DCP is excluded because a
-        DCP rank stores a different token slice of every layer, not a layer
-        partition.
+        Page-first requires one worker to write every layer in its page shard.
+        PP workers hold only part of a sealed shard, DCP workers hold different
+        token slices, and HMA groups can save different block sets, so none can
+        safely use one common block set across every layer in a page.
         """
-        return self._ctx.is_mla and self._ctx.dcp_world_size == 1 and self._ctx.pp_size == 1
+        return (
+            self._ctx.is_mla
+            and self._cache_groups.group_count == 1
+            and self._ctx.dcp_world_size == 1
+            and self._ctx.pp_size == 1
+        )
 
     def _block_shard(
         self,

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import torch
 
 from pegaflow.connector.common import (
+    CacheGroupLayout,
     ConnectorContext,
     PegaConnectorMetadata,
     PegaKVConnectorStats,
@@ -148,6 +149,31 @@ def _infer_kv_cache_registration(
     )
 
 
+def _registration_tensor(kv_cache) -> torch.Tensor:
+    if not isinstance(kv_cache, (tuple, list)):
+        return kv_cache
+
+    states = tuple(kv_cache)
+    if not states or not all(isinstance(state, torch.Tensor) for state in states):
+        raise TypeError("KV cache must be a tensor or a non-empty sequence of state tensors")
+
+    first = states[0]
+    if first.storage_offset() != 0:
+        raise RuntimeError("the first recurrent-state tensor must start at storage offset zero")
+    storage_ptr = first.untyped_storage().data_ptr()
+    num_blocks = first.shape[0]
+    page_bytes = first.stride(0) * first.element_size()
+    for state in states:
+        if state.untyped_storage().data_ptr() != storage_ptr:
+            raise RuntimeError("recurrent-state tensors must share one CUDA allocation")
+        if state.shape[0] != num_blocks:
+            raise RuntimeError("recurrent-state tensors must have the same block count")
+        if state.stride(0) * state.element_size() != page_bytes:
+            raise RuntimeError("recurrent-state tensors must have one common page stride")
+
+    return first
+
+
 class WorkerConnector:
     """Holds worker-only state and behaviors."""
 
@@ -166,6 +192,8 @@ class WorkerConnector:
     ):
         self._ctx = context
         self._kv_cache_config = kv_cache_config
+        self._cache_groups = CacheGroupLayout.from_config(kv_cache_config)
+        self._layer_to_group = self._cache_groups.layer_to_group()
         additional_config = getattr(vllm_config, "additional_config", {}) or {}
         self._use_mla_layer_split_registration = context.is_mla and bool(
             additional_config.get("mla_layer_split_kv_cache", False)
@@ -228,7 +256,7 @@ class WorkerConnector:
 
         self._registered_layers.clear()
 
-    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+    def register_kv_caches(self, kv_caches: dict[str, Any]):
         """Register exactly the KV caches vLLM built on this device.
 
         The engine derives the instance-wide layer-id space once every worker
@@ -269,7 +297,15 @@ class WorkerConnector:
 
         self._registered_layers = list(kv_caches.keys())
         self._page_first = self._use_page_first()
-        self._torch_device = next(iter(kv_caches.values())).device
+        first_tensor = _registration_tensor(next(iter(kv_caches.values())))
+        self._torch_device = first_tensor.device
+
+        if self._cache_groups.group_count > 1:
+            unmapped_layers = [name for name in kv_caches if name not in self._layer_to_group]
+            if unmapped_layers:
+                raise RuntimeError(
+                    f"HMA registration contains layers outside cache groups: {unmapped_layers[:8]}"
+                )
 
         layout = "unknown"
 
@@ -284,15 +320,16 @@ class WorkerConnector:
         split_logical_blocks = 0
 
         for layer_name, kv_cache in kv_caches.items():
-            assert kv_cache.storage_offset() == 0, (
+            registration_tensor = _registration_tensor(kv_cache)
+            assert registration_tensor.storage_offset() == 0, (
                 f"KV cache for {layer_name} must have zero storage offset"
             )
 
-            wrapper = CudaIPCWrapper(kv_cache)
+            wrapper = CudaIPCWrapper(registration_tensor)
             wrapper_bytes = pickle.dumps(wrapper)
 
             registration = _infer_kv_cache_registration(
-                kv_cache,
+                registration_tensor,
                 self._ctx.block_size,
                 is_mla=self._ctx.is_mla,
             )
@@ -373,21 +410,19 @@ class WorkerConnector:
         finished_recving: set[str] | None = None
 
         with self._save_completion_lock:
-            # 1. Add newly finished requests (if they have pending saves) to tracking
             self._finished_requests.update(
                 finished_req_ids.intersection(self._req_pending_save_tasks)
             )
-            # 2. Identify requests whose saves have completed
             done_saves = self._completed_saves & self._finished_requests
             done_saves.update(self._completed_saves & finished_req_ids)
 
             if done_saves:
-                # 3. Clean up completed requests
                 self._completed_saves -= done_saves
                 self._finished_requests -= done_saves
                 finished_sending = done_saves
 
         timeout_triggered = False
+        hma_load_failure: str | None = None
         with self._load_completion_lock:
             completed_reqs: set[str] = set()
             completed_shms: list[str] = []
@@ -415,7 +450,11 @@ class WorkerConnector:
                             req_ids,
                             state,
                         )
-                        if meta is not None:
+                        if self._cache_groups.group_count > 1:
+                            hma_load_failure = (
+                                f"async load failed for requests {sorted(req_ids)}: state={state}"
+                            )
+                        elif meta is not None:
                             self._failed_load_block_ids.update(meta[2])
                     else:
                         logger.debug(
@@ -442,7 +481,12 @@ class WorkerConnector:
                         duration,
                         num_blocks,
                     )
-                    self._failed_load_block_ids.update(block_ids)
+                    if self._cache_groups.group_count > 1:
+                        hma_load_failure = (
+                            f"load timed out for requests {sorted(req_ids)} after {duration:.1f}s"
+                        )
+                    else:
+                        self._failed_load_block_ids.update(block_ids)
                     load_stats_to_record.append((duration, num_blocks, False))
                     completed_reqs.update(req_ids)
                     completed_shms.append(shm_name)
@@ -454,8 +498,6 @@ class WorkerConnector:
                 for req_id in shm_req_ids:
                     self._pending_loads.pop(req_id, None)
 
-            # Drain sync-failure reqs recorded by start_load_kv so they also
-            # reach vLLM as finished_recving in this pass.
             if self._failed_load_reqs:
                 completed_reqs.update(self._failed_load_reqs)
                 self._failed_load_reqs = set()
@@ -466,11 +508,17 @@ class WorkerConnector:
         if timeout_triggered:
             self._ctx.state_manager.mark_unavailable("load timeout")
 
-        # Record load stats outside the lock
         if load_stats_to_record:
             with self._stats_lock:
                 for duration, num_blocks, success in load_stats_to_record:
                     self._stats.record_load(duration, num_blocks, success)
+
+        if hma_load_failure is not None:
+            self._ctx.state_manager.mark_unavailable(hma_load_failure)
+            raise RuntimeError(
+                f"PegaFlow HMA load failed; vLLM 0.26 cannot recover failed "
+                f"loads for multiple cache groups: {hma_load_failure}"
+            )
 
         if finished_sending:
             logger.debug(
@@ -499,27 +547,34 @@ class WorkerConnector:
         load_start = time.perf_counter()
 
         all_block_ids: list[int] = []
-        loads: list[tuple[bytes, list[int]]] = []
+        loads: list[tuple[bytes, list[list[int | None]]]] = []
         request_ids: list[str] = []
 
         for req_id, load_intent in metadata.load_intents.items():
-            block_ids = list(load_intent.block_ids)
-            all_block_ids.extend(block_ids)
-            loads.append((load_intent.lease, block_ids))
+            block_ids_by_group = [
+                [None if block_id == 0 else block_id for block_id in group]
+                for group in load_intent.block_ids_by_group
+            ]
+            for block_ids in load_intent.block_ids_by_group:
+                all_block_ids.extend(block_id for block_id in block_ids if block_id != 0)
+            loads.append((load_intent.lease, block_ids_by_group))
             request_ids.append(req_id)
 
         if not all_block_ids:
             return
 
         if self._cross_layer_mode:
-            target_layers = [self._cross_layer_key]
+            layer_groups = [[self._cross_layer_key]]
         else:
             assert self._registered_layers, (
                 "KV caches must be registered before submitting load intents"
             )
-            target_layers = list(self._registered_layers)
+            layer_groups = [[] for _ in range(self._cache_groups.group_count)]
+            for layer_name in self._registered_layers:
+                group_index = self._layer_to_group.get(layer_name, 0)
+                layer_groups[group_index].append(layer_name)
 
-        if not target_layers:
+        if not any(layer_groups):
             return
 
         load_state = PyLoadState()
@@ -531,7 +586,7 @@ class WorkerConnector:
                 self._ctx.effective_tp_rank,
                 self._ctx.device_id,
                 shm_name,
-                target_layers,
+                layer_groups,
                 loads,
             )
         except Exception as e:
@@ -543,8 +598,13 @@ class WorkerConnector:
                 len(all_block_ids),
             )
             self._release_load_leases(loads)
-            self._record_load_failure(request_ids, all_block_ids, load_start)
             self._ctx.state_manager.mark_unavailable(f"load rpc exception: {e}")
+            if self._cache_groups.group_count > 1:
+                raise RuntimeError(
+                    "PegaFlow HMA load failed; vLLM 0.26 cannot recover failed "
+                    "loads for multiple cache groups"
+                ) from e
+            self._record_load_failure(request_ids, all_block_ids, load_start)
             return
 
         if not ok:
@@ -556,11 +616,16 @@ class WorkerConnector:
                 len(all_block_ids),
             )
             self._release_load_leases(loads)
-            self._record_load_failure(request_ids, all_block_ids, load_start)
             self._ctx.state_manager.mark_unavailable(f"load rpc failed: {message}")
+            if self._cache_groups.group_count > 1:
+                raise RuntimeError(
+                    "PegaFlow HMA load failed; vLLM 0.26 cannot recover failed "
+                    f"loads for multiple cache groups: {message}"
+                )
+            self._record_load_failure(request_ids, all_block_ids, load_start)
             return
 
-        num_layers = len(target_layers)
+        num_layers = sum(len(group) for group in layer_groups)
         num_blocks = len(all_block_ids)
 
         schedule_end = time.perf_counter()
@@ -570,10 +635,6 @@ class WorkerConnector:
             for req_id in request_ids:
                 self._pending_loads[req_id] = load_state
             self._pending_load_reqs[shm_name] = set(request_ids)
-            # Keep load_start as the shared baseline so timeout and stats duration
-            # are comparable to the sync-failure path (which also uses load_start).
-            # all_block_ids is not mutated after this point; keep the reference
-            # instead of an extra defensive copy.
             self._pending_load_meta[shm_name] = (
                 load_start,
                 num_blocks,
@@ -593,7 +654,7 @@ class WorkerConnector:
     def wait_for_layer_load(self, layer_name: str) -> None:
         pass
 
-    def _release_load_leases(self, loads: list[tuple[bytes, list[int]]]) -> None:
+    def _release_load_leases(self, loads: list[tuple[bytes, list[list[int | None]]]]) -> None:
         seen: set[bytes] = set()
         for lease, _block_ids in loads:
             if not lease or lease in seen:
@@ -661,7 +722,14 @@ class WorkerConnector:
                     self._save_completion_events[req_id] = threading.Event()
                 self._req_pending_save_tasks[req_id] = pending_tasks + 1
 
-        self._save_queue.put(SaveTask(metadata=metadata, request_ids=request_ids))
+        task = SaveTask(metadata=metadata, request_ids=request_ids)
+        if self._cache_groups.has_recurrent_state:
+            # Align-mode recurrent states can reuse their only live block on
+            # the next scheduler step. Finish D2H before returning so the
+            # saved boundary state cannot be overwritten underneath the copy.
+            self._process_save_batch([task])
+        else:
+            self._save_queue.put(task)
 
     def _save_worker(self) -> None:
         logger.debug("[PegaKVConnector] Save worker thread started")
@@ -699,37 +767,51 @@ class WorkerConnector:
             all_request_ids.extend(task.request_ids)
 
             for save_intent in task.metadata.save_intents.values():
-                if not save_intent.block_ids:
+                if not any(save_intent.block_ids_by_group):
                     continue
-
-                block_ids = save_intent.block_ids
-                block_hashes = save_intent.block_hashes
 
                 if self._cross_layer_mode:
                     target_layers = (self._cross_layer_key,)
                 elif self._page_first:
-                    # Page-first: a block's page holds a whole shard's layers, so
-                    # this rank writes all its registered layers (its shard).
                     assert self._registered_layers, (
                         "KV caches must be registered before submitting save intents"
                     )
                     target_layers = tuple(self._registered_layers)
-                    if not self._use_mla_layer_split_registration:
-                        # Full-replica (one shard): every rank holds all layers,
-                        # so spread the whole-page writes across ranks by block
-                        # stripe. Layer-split ranks are each the sole writer of
-                        # their shard and keep the full block set (no striping).
-                        block_ids, block_hashes = self._block_shard(save_intent)
                 else:
                     assert self._registered_layers, (
                         "KV caches must be registered before submitting save intents"
                     )
                     target_layers = tuple(self._registered_layers)
 
-                if not block_ids:
-                    continue
-
                 for layer_name in target_layers:
+                    group_index = self._layer_to_group.get(layer_name, 0)
+                    try:
+                        block_ids = save_intent.block_ids_by_group[group_index]
+                    except IndexError as exc:
+                        raise RuntimeError(
+                            f"save intent is missing cache group {group_index} for {layer_name}"
+                        ) from exc
+                    block_hashes = save_intent.block_hashes
+                    if len(block_ids) != len(block_hashes):
+                        raise RuntimeError(
+                            f"save block/hash count mismatch for {layer_name}: "
+                            f"blocks={len(block_ids)} hashes={len(block_hashes)}"
+                        )
+                    non_null = tuple(
+                        (block_id, block_hash)
+                        for block_id, block_hash in zip(block_ids, block_hashes, strict=True)
+                        if block_id != 0
+                    )
+                    block_ids = tuple(block_id for block_id, _ in non_null)
+                    block_hashes = tuple(block_hash for _, block_hash in non_null)
+                    if self._page_first and not self._use_mla_layer_split_registration:
+                        # Full-replica (one shard): every rank holds all layers,
+                        # so spread the whole-page writes across ranks by block
+                        # stripe. Layer-split ranks are each the sole writer of
+                        # their shard and keep the full block set (no striping).
+                        block_ids, block_hashes = self._block_shard(block_ids, block_hashes)
+                    if not block_ids:
+                        continue
                     if layer_name not in saves_by_layer:
                         saves_by_layer[layer_name] = ([], [])
 
@@ -776,7 +858,6 @@ class WorkerConnector:
 
             save_duration = time.perf_counter() - save_start
 
-            # Record stats
             with self._stats_lock:
                 self._stats.record_save(save_duration, total_blocks, success)
 
@@ -843,7 +924,11 @@ class WorkerConnector:
         """
         return self._ctx.is_mla and self._ctx.dcp_world_size == 1 and self._ctx.pp_size == 1
 
-    def _block_shard(self, save_intent) -> tuple[list[int], list[bytes]]:
+    def _block_shard(
+        self,
+        block_ids: Iterable[int],
+        block_hashes: Iterable[bytes],
+    ) -> tuple[list[int], list[bytes]]:
         """`(block_ids, hashes)` this rank saves under page-first: a block stripe.
 
         A page needs all layers, so page-first distributes save work by block
@@ -854,13 +939,11 @@ class WorkerConnector:
         """
         tp_size = self._ctx.tp_size
         if tp_size <= 1:
-            return list(save_intent.block_ids), list(save_intent.block_hashes)
+            return list(block_ids), list(block_hashes)
         tp_rank = self._ctx.tp_rank or 0
         ids: list[int] = []
         hashes: list[bytes] = []
-        for block_id, block_hash in zip(
-            save_intent.block_ids, save_intent.block_hashes, strict=True
-        ):
+        for block_id, block_hash in zip(block_ids, block_hashes, strict=True):
             if block_id % tp_size == tp_rank:
                 ids.append(block_id)
                 hashes.append(block_hash)
@@ -901,7 +984,6 @@ class WorkerConnector:
     def get_stats(self) -> PegaKVConnectorStats | None:
         """Get and reset worker stats for the current interval."""
         with self._stats_lock:
-            # Add current queue depth as gauge
             with self._save_completion_lock:
                 self._stats.data["pending_save_requests"] = len(self._req_pending_save_tasks)
 

--- a/python/pegaflow/pegaflow.pyi
+++ b/python/pegaflow/pegaflow.pyi
@@ -184,22 +184,22 @@ class EngineRpcClient:
         tp_rank: int,
         device_id: int,
         load_state_shm: str,
-        layer_names: list[str],
-        loads: list[tuple[bytes, list[int]]],
+        layer_groups: list[list[str]],
+        loads: list[tuple[bytes, list[list[int | None]]]],
     ) -> tuple[bool, str]:
         """Load KV blocks from the engine.
 
         Contract: device_id must be non-negative; each lease must be returned
-        by query_prefetch; each lease's block count must match its destination
-        block_ids count.
+        by query_prefetch; each lease's block count must match the destination
+        block_ids count in every cache group.
 
         Args:
             instance_id: Model instance ID.
             tp_rank: Tensor parallel rank.
             device_id: CUDA device ID.
             load_state_shm: Shared memory name from PyLoadState.shm_name().
-            layer_names: List of layer names to load.
-            loads: List of (lease, destination block IDs) pairs.
+            layer_groups: Cache-group ordered lists of layer names to load.
+            loads: List of (lease, destination block IDs by group) pairs.
 
         Returns:
             Tuple of (ok, message) indicating success/failure.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -4,7 +4,7 @@ use pegaflow_proto::proto::engine::{
     HealthRequest, LeaseLoad, LoadBlockIds, LoadBlockTarget, LoadGroup, LoadRequest, QueryRequest,
     RegisterContextRequest, ReleaseRequest, ResponseStatus, SaveLayer, SaveRequest, SessionEvent,
     SessionRequest, ShutdownRequest, TransferMode, UnregisterRequest, engine_client::EngineClient,
-    query_response,
+    load_block_target, query_response,
 };
 use pyo3::{
     create_exception,
@@ -417,7 +417,9 @@ impl EngineRpcClient {
                     .map(|targets| LoadBlockIds {
                         targets: targets
                             .into_iter()
-                            .map(|block_id| LoadBlockTarget { block_id })
+                            .map(|block_id| LoadBlockTarget {
+                                target: block_id.map(load_block_target::Target::BlockId),
+                            })
                             .collect(),
                     })
                     .collect(),

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,9 +1,10 @@
 use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_TIMEOUT};
 use pegaflow_core::LoadState;
 use pegaflow_proto::proto::engine::{
-    HealthRequest, LeaseLoad, LoadRequest, QueryRequest, RegisterContextRequest, ReleaseRequest,
-    ResponseStatus, SaveLayer, SaveRequest, SessionEvent, SessionRequest, ShutdownRequest,
-    TransferMode, UnregisterRequest, engine_client::EngineClient, query_response,
+    HealthRequest, LeaseLoad, LoadBlockIds, LoadBlockTarget, LoadGroup, LoadRequest, QueryRequest,
+    RegisterContextRequest, ReleaseRequest, ResponseStatus, SaveLayer, SaveRequest, SessionEvent,
+    SessionRequest, ShutdownRequest, TransferMode, UnregisterRequest, engine_client::EngineClient,
+    query_response,
 };
 use pyo3::{
     create_exception,
@@ -30,6 +31,7 @@ create_exception!(pegaflow, PegaFlowError, PyException);
 create_exception!(pegaflow, PegaflowInternal, PegaFlowError);
 
 static TOKIO_RUNTIME: OnceLock<Runtime> = OnceLock::new();
+type PyLeaseLoad = (Vec<u8>, Vec<Vec<Option<u32>>>);
 
 /// Get or create the global Tokio runtime (shared across all RPC calls)
 fn get_runtime() -> PyResult<&'static Runtime> {
@@ -388,8 +390,8 @@ impl EngineRpcClient {
     ///     tp_rank: Tensor parallel rank
     ///     device_id: CUDA device ID
     ///     load_state_shm: Shared memory name for load state sync
-    ///     layer_names: List of layer names to load
-    ///     loads: List of (lease, block_ids) pairs
+    ///     layer_groups: Cache-group ordered lists of layer names
+    ///     loads: List of (lease, block_ids_by_group) pairs
     ///
     /// Returns: (ok: bool, message: str)
     #[allow(
@@ -403,12 +405,27 @@ impl EngineRpcClient {
         tp_rank: u32,
         device_id: i32,
         load_state_shm: String,
-        layer_names: Vec<String>,
-        loads: Vec<(Vec<u8>, Vec<u32>)>,
+        layer_groups: Vec<Vec<String>>,
+        loads: Vec<PyLeaseLoad>,
     ) -> PyResult<(bool, String)> {
         let loads = loads
             .into_iter()
-            .map(|(lease, block_ids)| LeaseLoad { lease, block_ids })
+            .map(|(lease, block_ids_by_group)| LeaseLoad {
+                lease,
+                block_ids_by_group: block_ids_by_group
+                    .into_iter()
+                    .map(|targets| LoadBlockIds {
+                        targets: targets
+                            .into_iter()
+                            .map(|block_id| LoadBlockTarget { block_id })
+                            .collect(),
+                    })
+                    .collect(),
+            })
+            .collect();
+        let groups = layer_groups
+            .into_iter()
+            .map(|layer_names| LoadGroup { layer_names })
             .collect();
         self.call(py, "load", |mut c| async move {
             let resp = c
@@ -417,7 +434,7 @@ impl EngineRpcClient {
                     tp_rank,
                     device_id,
                     load_state_shm,
-                    layer_names,
+                    groups,
                     loads,
                 })
                 .await?;

--- a/python/tests/test_cache_group_layout.py
+++ b/python/tests/test_cache_group_layout.py
@@ -1,0 +1,145 @@
+"""Capability tests for vLLM cache-group layouts supported by PegaFlow."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from vllm.v1.kv_cache_interface import (  # noqa: E402
+    FullAttentionSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    SlidingWindowSpec,
+)
+
+from pegaflow.connector.common import CacheGroupLayout  # noqa: E402
+
+
+def _group(name, spec):
+    return SimpleNamespace(layer_names=(name,), kv_cache_spec=spec)
+
+
+def _config(*groups):
+    return SimpleNamespace(kv_cache_groups=groups)
+
+
+def _full_attention(block_size=16):
+    spec = FullAttentionSpec()
+    spec.block_size = block_size
+    return spec
+
+
+def _mamba(block_size=16, mode="align"):
+    spec = MambaSpec()
+    spec.block_size = block_size
+    spec.mamba_cache_mode = mode
+    return spec
+
+
+def test_accepts_full_attention_with_aligned_mamba():
+    config = _config(
+        _group("attention", _full_attention(block_size=528)),
+        _group("recurrent", _mamba(block_size=528)),
+    )
+
+    layout = CacheGroupLayout.from_config(config)
+
+    assert layout.layer_names == (("attention",), ("recurrent",))
+    assert layout.hash_group_index == 0
+    assert layout.has_recurrent_state
+    assert layout.recurrent_group_indices == frozenset({1})
+    assert layout.recurrent_layer_names == frozenset({"recurrent"})
+
+
+@pytest.mark.parametrize("spec_type", [FullAttentionSpec, MLAAttentionSpec])
+def test_accepts_single_attention_group(spec_type):
+    attention = spec_type()
+    attention.block_size = 16
+
+    layout = CacheGroupLayout.from_config(_config(_group("attention", attention)))
+
+    assert layout.hash_group_index == 0
+    assert not layout.has_recurrent_state
+
+
+@pytest.mark.parametrize("mode", ["align", "all"])
+def test_rejects_single_mamba_group(mode):
+    with pytest.raises(RuntimeError, match="single cache group"):
+        CacheGroupLayout.from_config(_config(_group("recurrent", _mamba(mode=mode))))
+
+
+def test_rejects_single_sliding_window_group():
+    sliding_window = SlidingWindowSpec()
+    sliding_window.block_size = 16
+
+    with pytest.raises(RuntimeError, match="single cache group"):
+        CacheGroupLayout.from_config(_config(_group("sliding_window", sliding_window)))
+
+
+def test_rejects_misaligned_logical_block_sizes():
+    config = _config(
+        _group("attention", _full_attention(block_size=16)),
+        _group("recurrent", _mamba(block_size=32)),
+    )
+
+    with pytest.raises(RuntimeError, match="identical logical block sizes"):
+        CacheGroupLayout.from_config(config)
+
+
+def test_rejects_multiple_full_attention_groups_without_mamba():
+    config = _config(
+        _group("first", _full_attention()),
+        _group("second", _full_attention()),
+    )
+
+    with pytest.raises(RuntimeError, match="both FullAttention and Mamba"):
+        CacheGroupLayout.from_config(config)
+
+
+def test_rejects_mamba_groups_without_full_attention():
+    config = _config(
+        _group("recurrent.0", _mamba(block_size=528)),
+        _group("recurrent.1", _mamba(block_size=528)),
+    )
+
+    with pytest.raises(RuntimeError, match="dense FullAttention"):
+        CacheGroupLayout.from_config(config)
+
+
+def test_rejects_full_attention_with_sliding_window():
+    sliding_window = SlidingWindowSpec()
+    sliding_window.block_size = 16
+    config = _config(
+        _group("attention", _full_attention()),
+        _group("sliding_window", sliding_window),
+    )
+
+    with pytest.raises(RuntimeError, match="only FullAttention and Mamba"):
+        CacheGroupLayout.from_config(config)
+
+
+def test_rejects_mla_with_mamba():
+    mla = MLAAttentionSpec()
+    mla.block_size = 16
+    config = _config(
+        _group("attention", mla),
+        _group("recurrent", _mamba()),
+    )
+
+    with pytest.raises(RuntimeError, match="only FullAttention and Mamba"):
+        CacheGroupLayout.from_config(config)
+
+
+def test_rejects_non_align_mamba_mode():
+    config = _config(
+        _group("attention", _full_attention()),
+        _group("recurrent", _mamba(mode="all")),
+    )
+
+    with pytest.raises(RuntimeError, match="mamba_cache_mode='align'"):
+        CacheGroupLayout.from_config(config)

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -12,10 +12,12 @@ from .unit_stubs import install_connector_unit_stubs
 
 install_connector_unit_stubs()
 
-from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec  # noqa: E402
+from vllm.v1.kv_cache_interface import (  # noqa: E402
+    FullAttentionSpec,
+    MambaSpec,
+)
 
 from pegaflow.connector.common import (  # noqa: E402
-    CacheGroupLayout,
     ConnectorContext,
     PegaConnectorMetadata,
     PegaConnectorMode,
@@ -76,91 +78,6 @@ def _make_recurrent_scheduler() -> SchedulerConnector:
     }
     scheduler._get_local_cached_blocks = lambda block_hash, _group_ids: blocks.get(block_hash)
     return scheduler
-
-
-def test_cache_group_layout_accepts_structurally_compatible_mixed_specs():
-    attention = FullAttentionSpec()
-    attention.block_size = 528
-    recurrent = MambaSpec()
-    recurrent.block_size = 528
-    recurrent.mamba_cache_mode = "align"
-    config = SimpleNamespace(
-        kv_cache_groups=(
-            SimpleNamespace(layer_names=("attention",), kv_cache_spec=attention),
-            SimpleNamespace(layer_names=("recurrent",), kv_cache_spec=recurrent),
-        )
-    )
-
-    layout = CacheGroupLayout.from_config(config)
-
-    assert layout.layer_names == (("attention",), ("recurrent",))
-    assert layout.hash_group_index == 0
-    assert layout.has_recurrent_state
-    assert layout.recurrent_group_indices == frozenset({1})
-    assert layout.recurrent_layer_names == frozenset({"recurrent"})
-
-
-def test_cache_group_layout_rejects_misaligned_logical_block_sizes():
-    first = FullAttentionSpec()
-    first.block_size = 16
-    second = FullAttentionSpec()
-    second.block_size = 32
-    config = SimpleNamespace(
-        kv_cache_groups=(
-            SimpleNamespace(layer_names=("first",), kv_cache_spec=first),
-            SimpleNamespace(layer_names=("second",), kv_cache_spec=second),
-        )
-    )
-
-    with pytest.raises(RuntimeError, match="identical logical block sizes"):
-        CacheGroupLayout.from_config(config)
-
-
-def test_cache_group_layout_rejects_missing_dense_hash_group():
-    recurrent = MambaSpec()
-    recurrent.block_size = 528
-    recurrent.mamba_cache_mode = "align"
-    config = SimpleNamespace(
-        kv_cache_groups=(
-            SimpleNamespace(layer_names=("recurrent.0",), kv_cache_spec=recurrent),
-            SimpleNamespace(layer_names=("recurrent.1",), kv_cache_spec=recurrent),
-        )
-    )
-
-    with pytest.raises(RuntimeError, match="dense FullAttention"):
-        CacheGroupLayout.from_config(config)
-
-
-def test_cache_group_layout_rejects_sparse_attention_group():
-    attention = FullAttentionSpec()
-    attention.block_size = 16
-    sparse_attention = SimpleNamespace(block_size=16)
-    config = SimpleNamespace(
-        kv_cache_groups=(
-            SimpleNamespace(layer_names=("attention",), kv_cache_spec=attention),
-            SimpleNamespace(layer_names=("sliding_window",), kv_cache_spec=sparse_attention),
-        )
-    )
-
-    with pytest.raises(RuntimeError, match="only FullAttention and Mamba"):
-        CacheGroupLayout.from_config(config)
-
-
-def test_cache_group_layout_rejects_non_align_mamba_mode():
-    attention = FullAttentionSpec()
-    attention.block_size = 16
-    recurrent = MambaSpec()
-    recurrent.block_size = 16
-    recurrent.mamba_cache_mode = "all"
-    config = SimpleNamespace(
-        kv_cache_groups=(
-            SimpleNamespace(layer_names=("attention",), kv_cache_spec=attention),
-            SimpleNamespace(layer_names=("recurrent",), kv_cache_spec=recurrent),
-        )
-    )
-
-    with pytest.raises(RuntimeError, match="mamba_cache_mode='align'"):
-        CacheGroupLayout.from_config(config)
 
 
 def test_recurrent_save_uses_committed_local_hma_mapping():

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -64,11 +64,17 @@ def _make_recurrent_scheduler() -> SchedulerConnector:
         group_count=2,
         hash_group_index=0,
         has_recurrent_state=True,
+        recurrent_group_indices=frozenset({1}),
     )
     scheduler._block_hashes["r1"] = (_hash(0), _hash(1))
     scheduler._allocated_blocks["r1"] = [[11, 12], [21, 22]]
     scheduler._block_index_offsets["r1"] = 0
     scheduler._next_stored_block_idx["r1"] = 0
+    blocks = {
+        _hash(0): [SimpleNamespace(block_id=11), SimpleNamespace(block_id=21)],
+        _hash(1): [SimpleNamespace(block_id=12), SimpleNamespace(block_id=22)],
+    }
+    scheduler._get_local_cached_blocks = lambda block_hash, _group_ids: blocks.get(block_hash)
     return scheduler
 
 
@@ -77,6 +83,7 @@ def test_cache_group_layout_accepts_structurally_compatible_mixed_specs():
     attention.block_size = 528
     recurrent = MambaSpec()
     recurrent.block_size = 528
+    recurrent.mamba_cache_mode = "align"
     config = SimpleNamespace(
         kv_cache_groups=(
             SimpleNamespace(layer_names=("attention",), kv_cache_spec=attention),
@@ -89,6 +96,8 @@ def test_cache_group_layout_accepts_structurally_compatible_mixed_specs():
     assert layout.layer_names == (("attention",), ("recurrent",))
     assert layout.hash_group_index == 0
     assert layout.has_recurrent_state
+    assert layout.recurrent_group_indices == frozenset({1})
+    assert layout.recurrent_layer_names == frozenset({"recurrent"})
 
 
 def test_cache_group_layout_rejects_misaligned_logical_block_sizes():
@@ -110,6 +119,7 @@ def test_cache_group_layout_rejects_misaligned_logical_block_sizes():
 def test_cache_group_layout_rejects_missing_dense_hash_group():
     recurrent = MambaSpec()
     recurrent.block_size = 528
+    recurrent.mamba_cache_mode = "align"
     config = SimpleNamespace(
         kv_cache_groups=(
             SimpleNamespace(layer_names=("recurrent.0",), kv_cache_spec=recurrent),
@@ -121,13 +131,43 @@ def test_cache_group_layout_rejects_missing_dense_hash_group():
         CacheGroupLayout.from_config(config)
 
 
-def test_recurrent_save_accepts_one_exact_state_boundary_per_step():
+def test_cache_group_layout_rejects_sparse_attention_group():
+    attention = FullAttentionSpec()
+    attention.block_size = 16
+    sparse_attention = SimpleNamespace(block_size=16)
+    config = SimpleNamespace(
+        kv_cache_groups=(
+            SimpleNamespace(layer_names=("attention",), kv_cache_spec=attention),
+            SimpleNamespace(layer_names=("sliding_window",), kv_cache_spec=sparse_attention),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="only FullAttention and Mamba"):
+        CacheGroupLayout.from_config(config)
+
+
+def test_cache_group_layout_rejects_non_align_mamba_mode():
+    attention = FullAttentionSpec()
+    attention.block_size = 16
+    recurrent = MambaSpec()
+    recurrent.block_size = 16
+    recurrent.mamba_cache_mode = "all"
+    config = SimpleNamespace(
+        kv_cache_groups=(
+            SimpleNamespace(layer_names=("attention",), kv_cache_spec=attention),
+            SimpleNamespace(layer_names=("recurrent",), kv_cache_spec=recurrent),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="mamba_cache_mode='align'"):
+        CacheGroupLayout.from_config(config)
+
+
+def test_recurrent_save_uses_committed_local_hma_mapping():
     scheduler = _make_recurrent_scheduler()
 
-    scheduler._scheduled_tokens["r1"] = 16
-    first = scheduler._consume_full_block_saves("r1", written=16)
-    scheduler._scheduled_tokens["r1"] = 32
-    second = scheduler._consume_full_block_saves("r1", written=32)
+    first = scheduler._consume_full_block_saves("r1", written=23, computed_before_step=16)
+    second = scheduler._consume_full_block_saves("r1", written=39, computed_before_step=32)
 
     assert first == SaveIntent(
         block_ids_by_group=((11,), (21,)),
@@ -139,21 +179,29 @@ def test_recurrent_save_accepts_one_exact_state_boundary_per_step():
     )
 
 
-def test_recurrent_save_disables_request_after_skipping_a_state_boundary():
+def test_recurrent_save_waits_until_vllm_commits_all_groups():
     scheduler = _make_recurrent_scheduler()
-    scheduler._scheduled_tokens["r1"] = 32
+    scheduler._get_local_cached_blocks = lambda _block_hash, _group_ids: None
 
-    assert scheduler._consume_full_block_saves("r1", written=32) is None
-    assert "r1" in scheduler._unsafe_recurrent_saves
+    assert scheduler._consume_full_block_saves("r1", written=23, computed_before_step=16) is None
+    assert scheduler._next_stored_block_idx["r1"] == 0
+
+
+def test_recurrent_save_does_not_predict_current_step_state():
+    scheduler = _make_recurrent_scheduler()
+
+    assert scheduler._consume_full_block_saves("r1", written=16, computed_before_step=0) is None
     assert scheduler._next_stored_block_idx["r1"] == 0
 
 
 def test_recurrent_save_preserves_vllm_null_block_for_worker_filtering():
     scheduler = _make_recurrent_scheduler()
-    scheduler._allocated_blocks["r1"][1][0] = 0
-    scheduler._scheduled_tokens["r1"] = 16
+    scheduler._get_local_cached_blocks = lambda _block_hash, _group_ids: [
+        SimpleNamespace(block_id=11),
+        SimpleNamespace(block_id=0),
+    ]
 
-    intent = scheduler._consume_full_block_saves("r1", written=16)
+    intent = scheduler._consume_full_block_saves("r1", written=23, computed_before_step=16)
 
     assert intent == SaveIntent(
         block_ids_by_group=((11,), (0,)),
@@ -169,17 +217,25 @@ def test_hma_binding_disables_local_prefix_lookup_before_scheduling():
     assert block_pool.get_cached_block(b"hash", [0, 1]) is None
 
 
-def test_non_recurrent_hma_accepts_sparse_sliding_window_targets():
-    scheduler = SchedulerConnector(_make_ctx())
-    scheduler._cache_groups = SimpleNamespace(
-        group_count=2,
-        hash_group_index=0,
-        has_recurrent_state=False,
+def test_hma_accepts_different_allocator_block_counts():
+    scheduler = _make_recurrent_scheduler()
+
+    assert scheduler._copy_block_ids_by_group([[11, 12], [21, 22, 23, 24, 25, 26, 27, 28]]) == (
+        (11, 12),
+        (21, 22, 23, 24, 25, 26, 27, 28),
     )
 
-    assert scheduler._copy_block_ids_by_group([[11, 12], [0, 21]]) == (
-        (11, 12),
-        (0, 21),
+
+def test_hma_loads_only_final_recurrent_state():
+    scheduler = _make_recurrent_scheduler()
+    groups = (
+        (11, 12, 13, 14),
+        (21, 22, 23, 24, 25, 26, 27, 28, 29, 30),
+    )
+
+    assert scheduler._load_block_ids_by_group(groups, 1, 2) == (
+        (12, 13),
+        (None, 23),
     )
 
 
@@ -237,6 +293,13 @@ def test_virtual_block_size_cases(case: str, kwargs: dict, expected: int):
             1,
             2,
             id="mla_with_dcp_uses_dcp",
+        ),
+        pytest.param(
+            "hybrid_mla_keeps_tp",
+            {"is_mla": True, "collapse_mla_tp": False, "tp_rank": 3, "tp_size": 4},
+            3,
+            4,
+            id="hybrid_mla_keeps_tp",
         ),
     ],
 )
@@ -312,6 +375,31 @@ def test_use_page_first_detection(case: str, kwargs: dict, additional_config: di
     )
     try:
         assert worker._use_page_first() is expected, case
+    finally:
+        worker.shutdown()
+
+
+def test_hma_disables_page_first_registration():
+    from pegaflow.connector.worker import WorkerConnector
+
+    attention = FullAttentionSpec()
+    attention.block_size = 16
+    recurrent = MambaSpec()
+    recurrent.block_size = 16
+    recurrent.mamba_cache_mode = "align"
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=(
+            SimpleNamespace(layer_names=("attention",), kv_cache_spec=attention),
+            SimpleNamespace(layer_names=("recurrent",), kv_cache_spec=recurrent),
+        )
+    )
+    worker = WorkerConnector(
+        _make_ctx(is_mla=True),
+        vllm_config=SimpleNamespace(additional_config={}),
+        kv_cache_config=kv_cache_config,
+    )
+    try:
+        assert not worker._use_page_first()
     finally:
         worker.shutdown()
 
@@ -795,7 +883,7 @@ class TestSchedulerQueryProbeReuse:
 
         assert sc.get_num_new_matched_tokens(req, num_computed_tokens=0) == (32, True)
 
-        with pytest.raises(RuntimeError, match="load block mismatch"):
+        with pytest.raises(RuntimeError, match="leased block mismatch"):
             sc.update_state_after_alloc(req, blocks, num_external_tokens=16)
 
         engine_client.release.assert_called_once_with(b"lease-1")

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -12,7 +12,10 @@ from .unit_stubs import install_connector_unit_stubs
 
 install_connector_unit_stubs()
 
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec  # noqa: E402
+
 from pegaflow.connector.common import (  # noqa: E402
+    CacheGroupLayout,
     ConnectorContext,
     PegaConnectorMetadata,
     PegaConnectorMode,
@@ -53,6 +56,131 @@ def _make_ctx(
     }
     defaults.update(kwargs)
     return ConnectorContext(**defaults)  # type: ignore[arg-type]
+
+
+def _make_recurrent_scheduler() -> SchedulerConnector:
+    scheduler = SchedulerConnector(_make_ctx())
+    scheduler._cache_groups = SimpleNamespace(
+        group_count=2,
+        hash_group_index=0,
+        has_recurrent_state=True,
+    )
+    scheduler._block_hashes["r1"] = (_hash(0), _hash(1))
+    scheduler._allocated_blocks["r1"] = [[11, 12], [21, 22]]
+    scheduler._block_index_offsets["r1"] = 0
+    scheduler._next_stored_block_idx["r1"] = 0
+    return scheduler
+
+
+def test_cache_group_layout_accepts_structurally_compatible_mixed_specs():
+    attention = FullAttentionSpec()
+    attention.block_size = 528
+    recurrent = MambaSpec()
+    recurrent.block_size = 528
+    config = SimpleNamespace(
+        kv_cache_groups=(
+            SimpleNamespace(layer_names=("attention",), kv_cache_spec=attention),
+            SimpleNamespace(layer_names=("recurrent",), kv_cache_spec=recurrent),
+        )
+    )
+
+    layout = CacheGroupLayout.from_config(config)
+
+    assert layout.layer_names == (("attention",), ("recurrent",))
+    assert layout.hash_group_index == 0
+    assert layout.has_recurrent_state
+
+
+def test_cache_group_layout_rejects_misaligned_logical_block_sizes():
+    first = FullAttentionSpec()
+    first.block_size = 16
+    second = FullAttentionSpec()
+    second.block_size = 32
+    config = SimpleNamespace(
+        kv_cache_groups=(
+            SimpleNamespace(layer_names=("first",), kv_cache_spec=first),
+            SimpleNamespace(layer_names=("second",), kv_cache_spec=second),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="identical logical block sizes"):
+        CacheGroupLayout.from_config(config)
+
+
+def test_cache_group_layout_rejects_missing_dense_hash_group():
+    recurrent = MambaSpec()
+    recurrent.block_size = 528
+    config = SimpleNamespace(
+        kv_cache_groups=(
+            SimpleNamespace(layer_names=("recurrent.0",), kv_cache_spec=recurrent),
+            SimpleNamespace(layer_names=("recurrent.1",), kv_cache_spec=recurrent),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="dense FullAttention"):
+        CacheGroupLayout.from_config(config)
+
+
+def test_recurrent_save_accepts_one_exact_state_boundary_per_step():
+    scheduler = _make_recurrent_scheduler()
+
+    scheduler._scheduled_tokens["r1"] = 16
+    first = scheduler._consume_full_block_saves("r1", written=16)
+    scheduler._scheduled_tokens["r1"] = 32
+    second = scheduler._consume_full_block_saves("r1", written=32)
+
+    assert first == SaveIntent(
+        block_ids_by_group=((11,), (21,)),
+        block_hashes=(_hash(0),),
+    )
+    assert second == SaveIntent(
+        block_ids_by_group=((12,), (22,)),
+        block_hashes=(_hash(1),),
+    )
+
+
+def test_recurrent_save_disables_request_after_skipping_a_state_boundary():
+    scheduler = _make_recurrent_scheduler()
+    scheduler._scheduled_tokens["r1"] = 32
+
+    assert scheduler._consume_full_block_saves("r1", written=32) is None
+    assert "r1" in scheduler._unsafe_recurrent_saves
+    assert scheduler._next_stored_block_idx["r1"] == 0
+
+
+def test_recurrent_save_preserves_vllm_null_block_for_worker_filtering():
+    scheduler = _make_recurrent_scheduler()
+    scheduler._allocated_blocks["r1"][1][0] = 0
+    scheduler._scheduled_tokens["r1"] = 16
+
+    intent = scheduler._consume_full_block_saves("r1", written=16)
+
+    assert intent == SaveIntent(
+        block_ids_by_group=((11,), (0,)),
+        block_hashes=(_hash(0),),
+    )
+
+
+def test_hma_binding_disables_local_prefix_lookup_before_scheduling():
+    scheduler = _make_recurrent_scheduler()
+    block_pool = SimpleNamespace(get_cached_block=lambda *_args: object())
+    scheduler.bind_gpu_block_pool(block_pool)
+
+    assert block_pool.get_cached_block(b"hash", [0, 1]) is None
+
+
+def test_non_recurrent_hma_accepts_sparse_sliding_window_targets():
+    scheduler = SchedulerConnector(_make_ctx())
+    scheduler._cache_groups = SimpleNamespace(
+        group_count=2,
+        hash_group_index=0,
+        has_recurrent_state=False,
+    )
+
+    assert scheduler._copy_block_ids_by_group([[11, 12], [0, 21]]) == (
+        (11, 12),
+        (0, 21),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -196,7 +324,7 @@ def test_page_first_block_shard_is_a_partition():
 
     block_ids = tuple(range(13))
     block_hashes = tuple(bytes([i]) for i in block_ids)
-    intent = SaveIntent(block_ids=block_ids, block_hashes=block_hashes)
+    intent = SaveIntent(block_ids_by_group=(block_ids,), block_hashes=block_hashes)
     tp_size = 4
 
     seen: list[int] = []
@@ -204,7 +332,7 @@ def test_page_first_block_shard_is_a_partition():
         ctx = _make_ctx(is_mla=True, tp_rank=tp_rank, tp_size=tp_size)
         worker = WorkerConnector(ctx, vllm_config=SimpleNamespace(additional_config={}))
         try:
-            ids, hashes = worker._block_shard(intent)
+            ids, hashes = worker._block_shard(intent.block_ids_by_group[0], intent.block_hashes)
         finally:
             worker.shutdown()
         # block_ids and block_hashes stay aligned after striping.
@@ -230,8 +358,8 @@ def test_page_first_saves_all_layers_for_this_ranks_block_stripe():
     meta = PegaConnectorMetadata(
         save_intents={
             "r1": SaveIntent(
-                block_ids=(0, 1, 2, 3),
-                block_hashes=(b"h0", b"h1", b"h2", b"h3"),
+                block_ids_by_group=((1, 2, 3, 4),),
+                block_hashes=(b"h1", b"h2", b"h3", b"h4"),
             )
         }
     )
@@ -250,6 +378,36 @@ def test_page_first_saves_all_layers_for_this_ranks_block_stripe():
     for _name, ids, hashes in saves_list:
         assert list(ids) == [1, 3]
         assert list(hashes) == [b"h1", b"h3"]
+
+
+def test_recurrent_save_omits_null_group_target():
+    from pegaflow.connector.worker import SaveTask, WorkerConnector
+
+    ctx = _make_ctx()
+    worker = WorkerConnector(ctx, vllm_config=SimpleNamespace(additional_config={}))
+    worker._cache_groups = SimpleNamespace(has_recurrent_state=True)
+    worker._registered_layers = ["attention", "recurrent"]
+    worker._layer_to_group = {"attention": 0, "recurrent": 1}
+    worker._torch_device = None
+    ctx.engine_client.save.return_value = (True, "")
+    metadata = PegaConnectorMetadata(
+        save_intents={
+            "r1": SaveIntent(
+                block_ids_by_group=((11,), (0,)),
+                block_hashes=(b"h0",),
+            )
+        }
+    )
+
+    try:
+        with patch("torch.cuda.synchronize"):
+            worker._process_save_batch([SaveTask(metadata=metadata, request_ids=["r1"])])
+    finally:
+        worker._registered_layers = []
+        worker.shutdown()
+
+    saves = ctx.engine_client.save.call_args.args[4]
+    assert saves == [("attention", [11], [b"h0"])]
 
 
 def test_page_first_layer_split_saves_own_layers_for_all_blocks():
@@ -272,8 +430,8 @@ def test_page_first_layer_split_saves_own_layers_for_all_blocks():
     meta = PegaConnectorMetadata(
         save_intents={
             "r1": SaveIntent(
-                block_ids=(0, 1, 2, 3),
-                block_hashes=(b"h0", b"h1", b"h2", b"h3"),
+                block_ids_by_group=((1, 2, 3, 4),),
+                block_hashes=(b"h1", b"h2", b"h3", b"h4"),
             )
         }
     )
@@ -290,8 +448,8 @@ def test_page_first_layer_split_saves_own_layers_for_all_blocks():
     assert {name for name, _ids, _hashes in saves_list} == {"b", "d"}
     # ...and every block (no striping), hashes kept aligned.
     for _name, ids, hashes in saves_list:
-        assert list(ids) == [0, 1, 2, 3]
-        assert list(hashes) == [b"h0", b"h1", b"h2", b"h3"]
+        assert list(ids) == [1, 2, 3, 4]
+        assert list(hashes) == [b"h1", b"h2", b"h3", b"h4"]
 
 
 # ---------------------------------------------------------------------------
@@ -334,12 +492,12 @@ class TestDecodeHashRefresh:
         blocks = _make_fake_blocks([10, 11, 12, 13])
 
         sc.update_state_after_alloc(req, blocks, num_external_tokens=0)
-        sc._allocated_blocks["r1"] = [10, 11, 12, 13]
+        sc._allocated_blocks["r1"] = [[10, 11, 12, 13]]
         sc._scheduled_tokens["r1"] = 128  # 4 * 32
 
         intent = sc._consume_save_intent("r1", 0)
         assert intent is not None
-        assert len(intent.block_ids) == 4
+        assert len(intent.block_ids_by_group[0]) == 4
         assert len(intent.block_hashes) == 4
 
     def test_decode_blocks_saved_after_refresh(self):
@@ -350,18 +508,18 @@ class TestDecodeHashRefresh:
         blocks = _make_fake_blocks([10, 11, 12, 13])
 
         sc.update_state_after_alloc(req, blocks, num_external_tokens=0)
-        sc._allocated_blocks["r1"] = [10, 11, 12, 13]
+        sc._allocated_blocks["r1"] = [[10, 11, 12, 13]]
         sc._scheduled_tokens["r1"] = 128  # 4 * 32
 
         # Save initial 4 blocks
         intent = sc._consume_save_intent("r1", 0)
         assert intent is not None
-        assert len(intent.block_ids) == 4
+        assert len(intent.block_ids_by_group[0]) == 4
 
         # Simulate decode: request grows by 2 blocks
         new_hashes = [_hash(i) for i in range(4, 6)]
         req.block_hashes.extend(new_hashes)  # live Request grows
-        sc._allocated_blocks["r1"].extend([14, 15])  # new block_ids
+        sc._allocated_blocks["r1"][0].extend([14, 15])  # new block_ids
         sc._scheduled_tokens["r1"] += 64  # 2 * 32 more tokens
 
         # Before refresh: _block_hashes is stale (4 entries) → no new saves
@@ -374,8 +532,8 @@ class TestDecodeHashRefresh:
         # Now the 2 decode blocks become saveable
         intent2 = sc._consume_save_intent("r1", 0)
         assert intent2 is not None
-        assert len(intent2.block_ids) == 2
-        assert intent2.block_ids == (14, 15)
+        assert len(intent2.block_ids_by_group[0]) == 2
+        assert intent2.block_ids_by_group == ((14, 15),)
         assert intent2.block_hashes == (new_hashes[0], new_hashes[1])
 
     def test_cleanup_removes_request_ref(self):
@@ -401,23 +559,13 @@ class TestDecodeHashRefresh:
         sc._block_index_offsets["r1"] = 6
         sc._next_stored_block_idx["r1"] = 6
         sc._scheduled_tokens["r1"] = 48  # 3 virtual blocks beyond the external hit
-        sc._allocated_blocks["r1"] = [
-            100,
-            101,
-            102,
-            103,
-            104,
-            105,
-            200,
-            201,
-            202,
-        ]
+        sc._allocated_blocks["r1"] = [[100, 101, 102, 103, 104, 105, 200, 201, 202]]
 
         intent = sc._consume_save_intent("r1", 0)
 
         assert intent is not None
         assert intent.block_hashes == block_hashes[6:9]
-        assert intent.block_ids == (200, 201, 202)
+        assert intent.block_ids_by_group == ((200, 201, 202),)
 
     def test_save_only_mode_counts_precomputed_prefix_as_saveable(self):
         """NIXL-loaded prefix should be saveable in Pega save-only mode."""
@@ -450,7 +598,7 @@ class TestDecodeHashRefresh:
         metadata = sc.build_connector_meta(scheduler_output)
 
         intent = metadata.save_intents["r1"]
-        assert intent.block_ids == (10, 11, 12)
+        assert intent.block_ids_by_group == ((10, 11, 12),)
         assert intent.block_hashes == tuple(block_hashes[:3])
 
     def test_save_only_mode_handles_full_prompt_hit_recompute_token(self):
@@ -481,7 +629,7 @@ class TestDecodeHashRefresh:
         metadata = sc.build_connector_meta(scheduler_output)
 
         intent = metadata.save_intents["r1"]
-        assert intent.block_ids == (10, 11, 12, 13)
+        assert intent.block_ids_by_group == ((10, 11, 12, 13),)
         assert intent.block_hashes == tuple(block_hashes)
 
     def test_read_write_mode_does_not_save_unowned_precomputed_prefix(self):
@@ -520,7 +668,7 @@ class TestDecodeHashRefresh:
         req = _make_fake_request("r1", list(block_hashes))
 
         sc.update_state_after_alloc(req, _make_fake_blocks([]), num_external_tokens=0)
-        sc._allocated_blocks["r1"] = [1, 2]
+        sc._allocated_blocks["r1"] = [[1, 2]]
         sc._next_stored_block_idx["r1"] = 2
         sc._scheduled_tokens["r1"] = 32
 
@@ -540,7 +688,7 @@ class TestDecodeHashRefresh:
 
         intent = metadata.save_intents["r1"]
         assert intent.block_hashes == tuple(block_hashes[2:3])
-        assert intent.block_ids == (12,)
+        assert intent.block_ids_by_group == ((12,),)
 
 
 class TestSchedulerQueryProbeReuse:

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -45,6 +45,7 @@ class FakeEngineClient:
         self.register_response: tuple[bool, str] = (True, "ok")
         self.register_exception: Exception | None = None
         self.register_calls: list[tuple] = []
+        self.unregister_calls: list[str] = []
         self.release_calls: list[bytes] = []
 
     def load(
@@ -83,6 +84,7 @@ class FakeEngineClient:
         return (True, "ok")
 
     def unregister_context(self, instance_id: str) -> tuple[bool, str]:
+        self.unregister_calls.append(instance_id)
         return (True, "ok")
 
     def release(self, lease: bytes) -> None:
@@ -222,13 +224,13 @@ def test_hma_load_rpc_failure_crashes_before_vllm_partial_recovery(failure_mode:
     worker.shutdown()
 
 
-def test_hma_load_sends_absent_target_for_historical_recurrent_state():
+def test_hma_load_distinguishes_block_zero_from_absent_recurrent_target():
     worker, client, _state_mgr = _make_worker()
     _configure_hma_worker(worker)
     metadata = PegaConnectorMetadata(
         load_intents={
             "hma-sparse": LoadIntent(
-                block_ids_by_group=((11, 12), (0, 21)),
+                block_ids_by_group=((0, 12), (None, 21)),
                 lease=b"lease-hma-sparse",
                 num_tokens=32,
             )
@@ -237,7 +239,7 @@ def test_hma_load_sends_absent_target_for_historical_recurrent_state():
 
     worker.start_load_kv(metadata, _stub_forward_context())
 
-    assert client.load_calls[0][5] == [11, 12, None, 21]
+    assert client.load_calls[0][5] == [0, 12, None, 21]
     worker.shutdown()
 
 
@@ -376,8 +378,10 @@ def test_register_version_mismatch_raises_startup_error(monkeypatch):
     assert "server=0.22.5" in str(exc_info.value)
     assert "for layer.0" not in str(exc_info.value)
     assert len(client.register_calls) == 1
+    assert client.unregister_calls == []
 
     worker.shutdown()
+    assert client.unregister_calls == []
 
 
 def test_register_non_version_failure_reports_batch_layers(monkeypatch):

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -23,6 +23,8 @@ from .unit_stubs import install_connector_unit_stubs
 
 install_connector_unit_stubs()
 
+from vllm.v1.kv_cache_interface import FullAttentionSpec  # noqa: E402
+
 from pegaflow.connector.common import (  # noqa: E402
     ConnectorContext,
     LoadIntent,
@@ -132,6 +134,12 @@ def _stub_forward_context() -> MagicMock:
     ctx = MagicMock()
     ctx.no_compile_layers = {}
     return ctx
+
+
+def _single_attention_cache_group(*layer_names: str) -> MagicMock:
+    spec = FullAttentionSpec()
+    spec.block_size = 16
+    return MagicMock(layer_names=layer_names, kv_cache_spec=spec)
 
 
 def _load_metadata(req_id: str, block_ids: tuple[int, ...]) -> PegaConnectorMetadata:
@@ -409,7 +417,9 @@ def test_register_non_version_failure_reports_batch_layers(monkeypatch):
 
 def test_register_kv_caches_ignores_shared_by_without_layer_split_opt_in(monkeypatch):
     kv_cache_config = MagicMock()
-    kv_cache_config.kv_cache_groups = [MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))]
+    kv_cache_config.kv_cache_groups = [
+        _single_attention_cache_group("layer.0", "layer.1", "layer.2")
+    ]
     kv_cache_config.kv_cache_tensors = [
         MagicMock(shared_by=("layer.1",)),
     ]
@@ -436,7 +446,9 @@ def test_register_kv_caches_ignores_shared_by_without_layer_split_opt_in(monkeyp
 
 def test_register_kv_caches_uses_layer_split_shared_by_plan(monkeypatch):
     kv_cache_config = MagicMock()
-    kv_cache_config.kv_cache_groups = [MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))]
+    kv_cache_config.kv_cache_groups = [
+        _single_attention_cache_group("layer.0", "layer.1", "layer.2")
+    ]
     kv_cache_config.kv_cache_tensors = [
         MagicMock(shared_by=("layer.1",)),
         MagicMock(shared_by=()),
@@ -467,7 +479,7 @@ def test_register_kv_caches_uses_layer_split_shared_by_plan(monkeypatch):
 
 def test_register_kv_caches_requires_shared_by_layers(monkeypatch):
     kv_cache_config = MagicMock()
-    kv_cache_config.kv_cache_groups = [MagicMock(layer_names=("layer.0", "layer.1"))]
+    kv_cache_config.kv_cache_groups = [_single_attention_cache_group("layer.0", "layer.1")]
     kv_cache_config.kv_cache_tensors = [MagicMock(shared_by=("layer.1",))]
     worker, _, _ = _make_worker(
         kv_cache_config=kv_cache_config,

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -53,17 +53,17 @@ class FakeEngineClient:
         tp_rank: int,
         device_id: int,
         load_state_shm: str,
-        layer_names,
+        layer_groups,
         loads,
     ) -> tuple[bool, str]:
-        block_ids = [block_id for _, ids in loads for block_id in ids]
+        block_ids = [block_id for _, groups in loads for ids in groups for block_id in ids]
         self.load_calls.append(
             (
                 instance_id,
                 tp_rank,
                 device_id,
                 load_state_shm,
-                list(layer_names),
+                [list(group) for group in layer_groups],
                 list(block_ids),
             )
         )
@@ -136,9 +136,28 @@ def _load_metadata(req_id: str, block_ids: tuple[int, ...]) -> PegaConnectorMeta
     return PegaConnectorMetadata(
         load_intents={
             req_id: LoadIntent(
-                block_ids=block_ids,
+                block_ids_by_group=(block_ids,),
                 lease=f"lease-{req_id}".encode(),
                 num_tokens=len(block_ids) * 16,
+            )
+        }
+    )
+
+
+def _configure_hma_worker(worker: WorkerConnector) -> None:
+    worker._cross_layer_mode = False
+    worker._cache_groups = MagicMock(group_count=2, has_recurrent_state=True)
+    worker._registered_layers = ["attention", "recurrent"]
+    worker._layer_to_group = {"attention": 0, "recurrent": 1}
+
+
+def _hma_load_metadata(req_id: str) -> PegaConnectorMetadata:
+    return PegaConnectorMetadata(
+        load_intents={
+            req_id: LoadIntent(
+                block_ids_by_group=((11,), (21,)),
+                lease=f"lease-{req_id}".encode(),
+                num_tokens=16,
             )
         }
     )
@@ -182,6 +201,61 @@ def test_load_rpc_failure_reports_failures_without_raise(
     assert worker._pending_load_reqs == {}
     assert worker._pending_load_meta == {}
 
+    worker.shutdown()
+
+
+@pytest.mark.parametrize("failure_mode", ["ok_false", "exception"])
+def test_hma_load_rpc_failure_crashes_before_vllm_partial_recovery(failure_mode: str):
+    worker, client, state_mgr = _make_worker()
+    _configure_hma_worker(worker)
+    if failure_mode == "ok_false":
+        client.fail_load_with_ok_false = True
+    else:
+        client.fail_load_with_exception = ConnectionError("server gone")
+
+    with pytest.raises(RuntimeError, match="cannot recover failed loads"):
+        worker.start_load_kv(_hma_load_metadata("hma-failure"), _stub_forward_context())
+
+    assert state_mgr.mark_unavailable.called
+    assert client.release_calls == [b"lease-hma-failure"]
+    assert worker._pending_loads == {}
+    worker.shutdown()
+
+
+def test_hma_load_sends_absent_target_for_historical_recurrent_state():
+    worker, client, _state_mgr = _make_worker()
+    _configure_hma_worker(worker)
+    metadata = PegaConnectorMetadata(
+        load_intents={
+            "hma-sparse": LoadIntent(
+                block_ids_by_group=((11, 12), (0, 21)),
+                lease=b"lease-hma-sparse",
+                num_tokens=32,
+            )
+        }
+    )
+
+    worker.start_load_kv(metadata, _stub_forward_context())
+
+    assert client.load_calls[0][5] == [11, 12, None, 21]
+    worker.shutdown()
+
+
+def test_hma_load_timeout_crashes_before_vllm_partial_recovery(monkeypatch):
+    worker, _client, state_mgr = _make_worker()
+    _configure_hma_worker(worker)
+    clock = {"now": 10_000.0}
+    monkeypatch.setattr("pegaflow.connector.worker.time.perf_counter", lambda: clock["now"])
+    worker.start_load_kv(_hma_load_metadata("hma-timeout"), _stub_forward_context())
+    clock["now"] += worker.LOAD_TIMEOUT_SECONDS + 1
+
+    with pytest.raises(RuntimeError, match="cannot recover failed loads"):
+        worker.get_finished(set())
+
+    assert state_mgr.mark_unavailable.called
+    assert worker._pending_loads == {}
+    assert worker._pending_load_reqs == {}
+    assert worker._pending_load_meta == {}
     worker.shutdown()
 
 
@@ -259,7 +333,7 @@ def test_load_uses_registered_layer_names_before_forward_context_names():
     worker.start_load_kv(_load_metadata("req_registered_layers", (1, 2)), forward_context)
 
     assert len(client.load_calls) == 1
-    assert client.load_calls[0][4] == ["registered.layer.0", "registered.layer.1"]
+    assert client.load_calls[0][4] == [["registered.layer.0", "registered.layer.1"]]
 
     worker.shutdown()
 
@@ -331,9 +405,7 @@ def test_register_non_version_failure_reports_batch_layers(monkeypatch):
 
 def test_register_kv_caches_ignores_shared_by_without_layer_split_opt_in(monkeypatch):
     kv_cache_config = MagicMock()
-    kv_cache_config.kv_cache_groups = [
-        MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))
-    ]
+    kv_cache_config.kv_cache_groups = [MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))]
     kv_cache_config.kv_cache_tensors = [
         MagicMock(shared_by=("layer.1",)),
     ]
@@ -360,9 +432,7 @@ def test_register_kv_caches_ignores_shared_by_without_layer_split_opt_in(monkeyp
 
 def test_register_kv_caches_uses_layer_split_shared_by_plan(monkeypatch):
     kv_cache_config = MagicMock()
-    kv_cache_config.kv_cache_groups = [
-        MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))
-    ]
+    kv_cache_config.kv_cache_groups = [MagicMock(layer_names=("layer.0", "layer.1", "layer.2"))]
     kv_cache_config.kv_cache_tensors = [
         MagicMock(shared_by=("layer.1",)),
         MagicMock(shared_by=()),

--- a/python/tests/test_connector_save_lifecycle.py
+++ b/python/tests/test_connector_save_lifecycle.py
@@ -43,7 +43,7 @@ def enqueue_save(
     worker._current_metadata = PegaConnectorMetadata(
         save_intents={
             "request": SaveIntent(
-                block_ids=(block_id,),
+                block_ids_by_group=((block_id,),),
                 block_hashes=(block_hash,),
             )
         }

--- a/python/tests/test_derive_namespace.py
+++ b/python/tests/test_derive_namespace.py
@@ -20,6 +20,7 @@ def _make_vllm_config(
     *,
     pp_size: int = 1,
     mla_layer_split: bool = False,
+    disable_hma: bool = False,
 ) -> SimpleNamespace:
     model_config = SimpleNamespace(
         model="/data/models/GLM-5.2-FP8",
@@ -31,6 +32,9 @@ def _make_vllm_config(
     return SimpleNamespace(
         model_config=model_config,
         cache_config=SimpleNamespace(cache_dtype="fp8"),
+        scheduler_config=SimpleNamespace(
+            disable_hybrid_kv_cache_manager=disable_hma,
+        ),
         parallel_config=SimpleNamespace(pipeline_parallel_size=pp_size),
         additional_config={"mla_layer_split_kv_cache": mla_layer_split},
     )
@@ -50,6 +54,10 @@ def test_mla_layer_split_isolates_namespace():
     # Layer-split registration shards each block's slots differently from the
     # default full-slot layout (the haitao GLM-5.2 99-vs-156 collision).
     assert _ns(mla_layer_split=False) != _ns(mla_layer_split=True)
+
+
+def test_hma_enablement_isolates_namespace():
+    assert _ns(disable_hma=False) != _ns(disable_hma=True)
 
 
 def test_namespace_is_stable_for_same_config():

--- a/python/tests/test_mla_replica_registration.py
+++ b/python/tests/test_mla_replica_registration.py
@@ -214,8 +214,8 @@ def test_mla_replica_devices_save_and_load(dual_device_server):
             workers[1].ctx.effective_tp_rank,
             workers[1].ctx.device_id,
             load_state.shm_name(),
-            layer_names,
-            [(lease, LOAD_DST_BLOCK_IDS)],
+            [layer_names],
+            [(lease, [LOAD_DST_BLOCK_IDS])],
         )
         assert ok, f"load into the second MLA replica device must succeed, got: {message}"
 

--- a/python/tests/test_pd_tail_save.py
+++ b/python/tests/test_pd_tail_save.py
@@ -76,7 +76,7 @@ def _make_connector(req, allocated: list[int]) -> SchedulerConnector:
     sc._hash_block_tokens = lambda fn, parent, tokens, extra: b"tail:%d" % len(tokens)
     sc._requests[req.request_id] = req
     sc._block_hashes[req.request_id] = tuple(req.block_hashes)
-    sc._allocated_blocks[req.request_id] = allocated
+    sc._allocated_blocks[req.request_id] = [allocated]
     sc._scheduled_tokens[req.request_id] = 0
     sc._block_index_offsets[req.request_id] = 0
     sc._next_stored_block_idx[req.request_id] = 0
@@ -103,7 +103,7 @@ class TestTailSaveTrigger:
         assert sc._consume_tail_save("r1", written=49) is None
         intent = sc._consume_tail_save("r1", written=50)
         assert intent is not None
-        assert intent.block_ids == (13,)
+        assert intent.block_ids_by_group == ((13,),)
         # Once saved, never again (content-addressed dedup upstream would
         # reject a correction, so a re-save is pure waste).
         assert sc._consume_tail_save("r1", written=51) is None
@@ -123,7 +123,7 @@ class TestTailSaveTrigger:
         sc = _make_connector(req, allocated=[10])
         intent = sc._consume_tail_save("r1", written=10)
         assert intent is not None
-        assert intent.block_ids == (10,)
+        assert intent.block_ids_by_group == ((10,),)
         assert intent.block_hashes == (b"tail:10",)
 
     def test_salted_or_lora_requests_never_tail_save(self):
@@ -178,7 +178,7 @@ class TestTailSaveThroughBuildConnectorMeta:
         )
         intent = meta.save_intents.get("r1")
         assert intent is not None
-        assert 13 in intent.block_ids
+        assert 13 in intent.block_ids_by_group[0]
 
     def test_preempt_resume_does_not_fire_early(self):
         # Chunked prefill: 32 of 50 scheduled, then preempted (all progress
@@ -192,7 +192,10 @@ class TestTailSaveThroughBuildConnectorMeta:
             sc,
             new=[{"id": "r1", "blocks": [10, 11, 12, 13], "computed": 0, "scheduled": 32}],
         )
-        assert meta.save_intents.get("r1") is None or 13 not in meta.save_intents["r1"].block_ids
+        assert (
+            meta.save_intents.get("r1") is None
+            or 13 not in meta.save_intents["r1"].block_ids_by_group[0]
+        )
 
         # Preempted; resume re-schedules from scratch.
         meta = self._step(
@@ -207,7 +210,10 @@ class TestTailSaveThroughBuildConnectorMeta:
                 }
             ],
         )
-        assert meta.save_intents.get("r1") is None or 13 not in meta.save_intents["r1"].block_ids
+        assert (
+            meta.save_intents.get("r1") is None
+            or 13 not in meta.save_intents["r1"].block_ids_by_group[0]
+        )
 
         meta = self._step(
             sc,
@@ -215,7 +221,7 @@ class TestTailSaveThroughBuildConnectorMeta:
         )
         intent = meta.save_intents.get("r1")
         assert intent is not None
-        assert 13 in intent.block_ids
+        assert 13 in intent.block_ids_by_group[0]
 
 
 class TestTailLoad:
@@ -243,7 +249,7 @@ class TestTailLoad:
         sc.update_state_after_alloc(req, blocks, num_external_tokens=49)
 
         intent = sc._pending_load_intents["r1"]
-        assert intent.block_ids == (10, 11, 12, 13)
+        assert intent.block_ids_by_group == ((10, 11, 12, 13),)
         assert intent.num_tokens == 49
         assert intent.lease == b"lease"
 
@@ -263,7 +269,7 @@ class TestTailLoad:
         sc.update_state_after_alloc(req, blocks, num_external_tokens=33)
 
         intent = sc._pending_load_intents["r1"]
-        assert intent.block_ids == (11, 12, 13)
+        assert intent.block_ids_by_group == ((11, 12, 13),)
         assert intent.num_tokens == 33
 
     def test_request_drift_is_reported_separately_from_lease_count(self):

--- a/python/tests/test_vllm_e2e_correctness.py
+++ b/python/tests/test_vllm_e2e_correctness.py
@@ -28,7 +28,9 @@ import pytest
 from .vllm_helpers import (
     PegaFlowServer,
     VLLMServer,
+    adapt_prompt_for_hybrid_cache,
     call_openai_api,
+    e2e_max_tokens,
     fetch_pegaflow_metrics,
     fetch_pegaflow_rpc_failures,
 )
@@ -163,6 +165,8 @@ EXECUTION_PLAN: list[tuple[str, str, str]] = [
     ("prefix_base", PREFIX_BASE, "cold"),
     ("rollback_long", ROLLBACK_LONG, "cold"),
     ("multi_r1", MULTI_ROUND[0], "cold"),
+    # Same-process warm hit proves vLLM's local HMA cache cannot mask PegaFlow.
+    ("short_same_process", SHORT_PROMPT, "warm-same-process"),
     # Round 2: warm hits — exact same prompts
     ("short_warm", SHORT_PROMPT, "warm"),
     ("long_warm", LONG_PROMPT, "warm"),
@@ -194,6 +198,7 @@ _LABEL_TO_BASELINE: dict[str, str] = {
     "prefix_base": "prefix_base",
     "rollback_long": "rollback_long",
     "multi_r1": "multi_r1",
+    "short_same_process": "short",
     "short_warm": "short",
     "long_warm": "long",
     "prefix_extend": "prefix_extend",
@@ -217,8 +222,8 @@ class TestE2ECorrectness:
       Phase 1 — run all unique prompts through baseline vLLM, collect golden outputs.
       Phase 2 — run execution plan through PegaFlow vLLM, collect outputs + metrics.
     The equality test walks every execution-plan label and reports the label
-    that failed, so one expensive fixture run does not pretend to be 11
-    independent tests.
+    that failed, so one expensive fixture run does not pretend each path is an
+    independent test.
     """
 
     @pytest.fixture(scope="class")
@@ -265,7 +270,12 @@ class TestE2ECorrectness:
             max_model_len=max_model_len,
         ):
             for key, prompt in ALL_PROMPTS.items():
-                result = call_openai_api(base_port, model, prompt)
+                result = call_openai_api(
+                    base_port,
+                    model,
+                    adapt_prompt_for_hybrid_cache(model, prompt),
+                    max_tokens=e2e_max_tokens(model),
+                )
                 outputs[key] = result["text"]
                 print(f"  [{key}] {len(result['text'])} chars")
 
@@ -288,6 +298,8 @@ class TestE2ECorrectness:
         print("[Phase 2] PegaFlow vLLM — executing cache plan")
         pega_port = base_port + 1
         outputs: dict[str, str] = {}
+        metrics_port = pegaflow_server.metrics_port
+        metrics_start = fetch_pegaflow_metrics(metrics_port)
 
         with VLLMServer(
             model,
@@ -300,11 +312,41 @@ class TestE2ECorrectness:
             max_model_len=max_model_len,
             transfer_backend=pegaflow_transfer_backend,
         ):
-            metrics_port = pegaflow_server.metrics_port
-            metrics_start = fetch_pegaflow_metrics(metrics_port)
-
             for label, prompt, expectation in EXECUTION_PLAN:
-                result = call_openai_api(pega_port, model, prompt)
+                if expectation not in {"cold", "warm-same-process"}:
+                    continue
+                result = call_openai_api(
+                    pega_port,
+                    model,
+                    adapt_prompt_for_hybrid_cache(model, prompt),
+                    max_tokens=e2e_max_tokens(model),
+                )
+                outputs[label] = result["text"]
+                print(f"  [{label}] ({expectation}) {len(result['text'])} chars")
+
+            metrics_same_process = fetch_pegaflow_metrics(metrics_port)
+
+        with VLLMServer(
+            model,
+            pega_port,
+            use_pegaflow=True,
+            pegaflow_port=pegaflow_server.grpc_port,
+            log_file=log_dir / "pegaflow-load.log",
+            tensor_parallel_size=tensor_parallel_size,
+            pipeline_parallel_size=pipeline_parallel_size,
+            max_model_len=max_model_len,
+            transfer_backend=pegaflow_transfer_backend,
+            server_label="PegaFlow load",
+        ):
+            for label, prompt, expectation in EXECUTION_PLAN:
+                if expectation in {"cold", "warm-same-process"}:
+                    continue
+                result = call_openai_api(
+                    pega_port,
+                    model,
+                    adapt_prompt_for_hybrid_cache(model, prompt),
+                    max_tokens=e2e_max_tokens(model),
+                )
                 outputs[label] = result["text"]
                 print(f"  [{label}] ({expectation}) {len(result['text'])} chars")
 
@@ -314,6 +356,7 @@ class TestE2ECorrectness:
         return {
             "outputs": outputs,
             "metrics_start": metrics_start,
+            "metrics_same_process": metrics_same_process,
             "metrics_end": metrics_end,
         }
 
@@ -354,6 +397,21 @@ class TestE2ECorrectness:
         print(
             f"\n[Metrics] saves={insertions:.0f} blocks ({save_bytes / 1e6:.1f}MB), "
             f"hits={hits:.0f} blocks ({load_bytes / 1e6:.1f}MB)"
+        )
+
+    def test_same_process_hma_load_uses_pegaflow(self, pegaflow_results):
+        """The warm request in the first vLLM process must load from PegaFlow."""
+        m_start = pegaflow_results["metrics_start"]
+        m_end = pegaflow_results["metrics_same_process"]
+        hit_delta = m_end.get("pegaflow_cache_block_hits_total", 0) - m_start.get(
+            "pegaflow_cache_block_hits_total", 0
+        )
+        load_delta = m_end.get("pegaflow_load_bytes_total", 0) - m_start.get(
+            "pegaflow_load_bytes_total", 0
+        )
+        assert hit_delta > 0 or load_delta > 0, (
+            "same-process warm HMA request bypassed PegaFlow: "
+            f"hit_delta={hit_delta}, load_delta={load_delta}"
         )
 
     def test_no_data_path_rpc_failures(self, pegaflow_results, pegaflow_server: PegaFlowServer):

--- a/python/tests/test_worker_kv_layout.py
+++ b/python/tests/test_worker_kv_layout.py
@@ -96,6 +96,26 @@ def test_mla_equal_physical_and_logical_block_size_is_unchanged():
     assert info.physical_blocks_per_logical_block == 1
 
 
+def test_recurrent_state_uses_one_page_per_logical_block():
+    info = _infer_kv_cache_registration(
+        FakeTensor(
+            shape=(2, 1, 4096),
+            stride=(4096, 4096, 1),
+            element_size=2,
+        ),
+        logical_block_size=1536,
+        is_mla=True,
+        is_recurrent_state=True,
+    )
+
+    assert info.layout == "blocks-first"
+    assert info.num_blocks == 2
+    assert info.bytes_per_block == 4096 * 2
+    assert info.kv_stride_bytes == 0
+    assert info.segments == 1
+    assert info.physical_blocks_per_logical_block == 1
+
+
 def test_non_mla_cross_layer_layout_uses_legacy_block_stride():
     info = _infer_kv_cache_registration(
         FakeTensor(

--- a/python/tests/unit_stubs.py
+++ b/python/tests/unit_stubs.py
@@ -158,6 +158,16 @@ def _install_vllm_stubs() -> None:
 
     models_utils.extract_layer_index = extract_layer_index
     _ensure_module("vllm.v1")
+    kv_cache_interface = _ensure_module("vllm.v1.kv_cache_interface")
+
+    class FullAttentionSpec:
+        pass
+
+    class MambaSpec:
+        pass
+
+    kv_cache_interface.FullAttentionSpec = FullAttentionSpec
+    kv_cache_interface.MambaSpec = MambaSpec
     _ensure_module("vllm.v1.metrics")
     _ensure_module("vllm.v1.metrics.utils").create_metric_per_engine = lambda *_args, **_kwargs: {}
 

--- a/python/tests/unit_stubs.py
+++ b/python/tests/unit_stubs.py
@@ -163,11 +163,19 @@ def _install_vllm_stubs() -> None:
     class FullAttentionSpec:
         pass
 
+    class MLAAttentionSpec(FullAttentionSpec):
+        pass
+
     class MambaSpec:
         pass
 
+    class SlidingWindowSpec:
+        pass
+
     kv_cache_interface.FullAttentionSpec = FullAttentionSpec
+    kv_cache_interface.MLAAttentionSpec = MLAAttentionSpec
     kv_cache_interface.MambaSpec = MambaSpec
+    kv_cache_interface.SlidingWindowSpec = SlidingWindowSpec
     _ensure_module("vllm.v1.metrics")
     _ensure_module("vllm.v1.metrics.utils").create_metric_per_engine = lambda *_args, **_kwargs: {}
 

--- a/python/tests/vllm_helpers.py
+++ b/python/tests/vllm_helpers.py
@@ -3,6 +3,7 @@
 Extracted from test_vllm_e2e_correctness.py to enable reuse across test modules.
 """
 
+import hashlib
 import json
 import os
 import re
@@ -16,6 +17,30 @@ from pathlib import Path
 import requests
 
 DEFAULT_VLLM_SEED = 42
+
+
+def _uses_linear_attention(model: str) -> bool:
+    config_path = Path(model) / "config.json"
+    if not config_path.is_file():
+        return False
+    try:
+        config = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    text_config = config.get("text_config", config)
+    return "linear_attention" in (text_config.get("layer_types") or ())
+
+
+def adapt_prompt_for_hybrid_cache(model: str, prompt: str) -> str:
+    if not _uses_linear_attention(model):
+        return prompt
+    family = hashlib.sha256(prompt[:80].encode()).hexdigest()[:8]
+    prefix = f"Hybrid cache boundary {family} contains deterministic background context. " * 80
+    return prefix + prompt
+
+
+def e2e_max_tokens(model: str) -> int:
+    return 8 if _uses_linear_attention(model) else 50
 
 
 def _detect_pegaflow_cargo_features() -> list[str]:
@@ -89,7 +114,10 @@ class VLLMServer:
 
         env = os.environ.copy()
         env["PYTHONHASHSEED"] = "0"
-        env["VLLM_BATCH_INVARIANT"] = "1"
+        if _uses_linear_attention(self.model):
+            env.pop("VLLM_BATCH_INVARIANT", None)
+        else:
+            env["VLLM_BATCH_INVARIANT"] = "1"
 
         if self.pegaflow_port is not None:
             env["PEGAFLOW_PORT"] = str(self.pegaflow_port)
@@ -108,7 +136,11 @@ class VLLMServer:
             "--port",
             str(self.port),
             "--trust-remote-code",
-            "--no-enable-prefix-caching",
+            (
+                "--enable-prefix-caching"
+                if _uses_linear_attention(self.model)
+                else "--no-enable-prefix-caching"
+            ),
             "--gpu-memory-utilization",
             str(self.gpu_memory_utilization),
             "--attention-backend",
@@ -127,6 +159,15 @@ class VLLMServer:
 
         if self.max_model_len is not None:
             cmd.extend(["--max-model-len", str(self.max_model_len)])
+        if _uses_linear_attention(self.model):
+            cmd.extend(
+                [
+                    "--max-num-seqs",
+                    "1",
+                    "--max-num-batched-tokens",
+                    "528",
+                ]
+            )
 
         if self.kv_transfer_config is not None:
             cmd.extend(["--kv-transfer-config", json.dumps(self.kv_transfer_config)])
@@ -140,10 +181,11 @@ class VLLMServer:
             # The server no longer selects a transfer backend; the connector
             # does. Force it here so --pegaflow-transfer-backend still exercises
             # the chosen path end-to-end, regardless of the model's MLA default.
+            extra_config: dict[str, object] = {}
             if self.use_pegaflow and self.transfer_backend is not None:
-                kv_config["kv_connector_extra_config"] = {
-                    "pegaflow.transfer_backend": self.transfer_backend,
-                }
+                extra_config["pegaflow.transfer_backend"] = self.transfer_backend
+            if extra_config:
+                kv_config["kv_connector_extra_config"] = extra_config
             cmd.extend(["--kv-transfer-config", json.dumps(kv_config)])
 
         cmd.extend(self.extra_args)
@@ -371,7 +413,7 @@ class PegaFlowServer:
         if libdir := sysconfig.get_config_var("LIBDIR"):
             env["LD_LIBRARY_PATH"] = f"{libdir}:{env.get('LD_LIBRARY_PATH', '')}"
         python_dir = str(Path(__file__).parent.parent)
-        site_packages = next((p for p in sys.path if "site-packages" in p), None)
+        site_packages = sysconfig.get_path("purelib")
         env["PYTHONPATH"] = f"{python_dir}" + (f":{site_packages}" if site_packages else "")
 
         feature_label = ",".join(self.cargo_features) or "default"


### PR DESCRIPTION
## Summary

- extend the load RPC with cache-grouped layers and explicit per-group destination presence
- support FullAttention + Mamba hybrid cache models in `align` mode across registration, save, query, and load
- preserve real TP rank identity for hybrid MLA while retaining pure-MLA TP deduplication
- source recurrent saves from committed vLLM cache mappings and load only the final recurrent state
- reject unsupported sparse-attention and non-align Mamba combinations at startup
- prevent direct DMA coalescing across distinct host or device allocations

## Breaking change

The load RPC now accepts grouped layers and per-group destination targets. Compatibility with older clients and servers is intentionally not preserved.

## Validation

- Python default gate: 224 passed, 12 deselected
- Python source-only gate: 224 passed, 12 deselected
- Cargo workspace tests with CUDA 13 and RDMA features
- full pre-commit gate: format, clippy, release tests, Ruff, and typos passed
- CPython 3.12 CUDA 13 + RDMA wheel built and installed successfully
- Qwen3.5-4B vLLM correctness E2E: 5 passed
- Kimi-K3 hybrid-cache wheel E2E on B300 × 8: 5/5 exact cold/warm outputs at 0/1536/3072/4608/6144 cached-token boundaries
- five-sample A/B at 4608 cached tokens: 1.1215s cold median, 0.4632s warm median, 2.42× median speedup, 5/5 exact outputs
- cross-process vLLM restart E2E: 4608 cached tokens, exact output, 1.0019s cold to 0.3487s warm
- toxic-reviewer final verdict: Ready for Review