### PR TITLE
fix(transfer): chunk pega_batch_copy launches at 64MB

### DIFF
--- a/pegaflow-core/src/transfer/kernel.rs
+++ b/pegaflow-core/src/transfer/kernel.rs
@@ -47,6 +47,13 @@ extern "C" __global__ void pega_batch_copy(const unsigned long long* __restrict_
 
 const BLOCK_DIM: u32 = 256;
 const MAX_GRID: u32 = 65535;
+/// Upper bound on bytes moved per kernel launch. A single launch covering a
+/// whole multi-GB restore parks one CTA per fragment across every SM for
+/// hundreds of ms; CUDA never preempts running CTAs, so co-resident decode
+/// kernels starve for the full duration — and on an EP fleet one starved rank
+/// stalls every peer's dispatch. Chunked launches bound that monopoly window
+/// to ~10-20ms; queued kernels from other streams interleave between chunks.
+const CHUNK_BYTES: usize = 64 << 20;
 
 /// Single-launch transfer backend. Compiled once per worker; the descriptor
 /// scratch buffer is reused across calls.
@@ -75,8 +82,49 @@ impl KernelBackend {
     }
 
     /// Enqueue the batch. `host_is_src` selects the direction: H2D reads the
-    /// host address and writes the device address, D2H is reversed.
+    /// host address and writes the device address, D2H is reversed. Split into
+    /// `CHUNK_BYTES` launches; same-stream ordering makes the scratch reuse
+    /// across chunks safe (chunk k+1's descriptor upload queues behind chunk
+    /// k's kernel).
     fn submit(
+        &self,
+        copies: &[CopyDesc],
+        host_is_src: bool,
+        stream: &Arc<CudaStream>,
+    ) -> Result<(), String> {
+        let mut chunks = Vec::new();
+        let mut start = 0;
+        while start < copies.len() {
+            let mut end = start;
+            let mut bytes = 0usize;
+            while end < copies.len() && (end == start || bytes + copies[end].size <= CHUNK_BYTES) {
+                bytes += copies[end].size;
+                end += 1;
+            }
+            chunks.push((start, end));
+            start = end;
+        }
+        // Grow the scratch to the largest chunk BEFORE the first launch: a
+        // grow mid-loop would free the buffer the in-flight chunk still reads.
+        // (Between submit calls the worker has synchronized, so this free is
+        // safe.)
+        if let Some(max_descs) = chunks.iter().map(|(s, e)| (e - s) * 3).max() {
+            let mut guard = self.scratch.borrow_mut();
+            if guard.as_ref().is_none_or(|s| s.len() < max_descs) {
+                *guard = Some(
+                    stream
+                        .alloc_zeros::<u64>(max_descs)
+                        .map_err(|e| format!("scratch alloc failed: {e:?}"))?,
+                );
+            }
+        }
+        for (s, e) in chunks {
+            self.submit_chunk(&copies[s..e], host_is_src, stream)?;
+        }
+        Ok(())
+    }
+
+    fn submit_chunk(
         &self,
         copies: &[CopyDesc],
         host_is_src: bool,


### PR DESCRIPTION
## Problem

`KernelBackend::submit` issues one `pega_batch_copy` launch for a whole restore batch — one CTA per ~34KB fragment, grid up to 65535. A multi-GB restore parks CTAs across every SM for **470–550ms**, and CUDA never preempts running CTAs, so co-resident decode kernels starve for the full duration. On an EP fleet this is amplified: one starved rank stalls every peer inside the all-to-all dispatch, so a single restore turns into a fleet-wide latency spike.

Caught by dual-node nsys on a GLM5.2 2P+2D agent-trace replay (GB300, EP8 decode): during each stall window a single `pega_batch_copy` occupied the culprit GPU at ~100% while decode kernels totalled 0.1–0.4ms; culprit GPUs rotate with restore traffic.

## Fix

Split `submit` into 64MB chunks (one launch each, ~2000 CTAs). Each launch bounds the SM monopoly window to ~10–20ms; kernels queued on other streams interleave between chunks. Scratch capacity is ensured for the largest chunk **before** the first launch — growing mid-loop would free the descriptor buffer an in-flight chunk still reads.

## Validation (same workload/config A/B, GLM5.2 replay, kernel transfer mode)

| metric | before | after |
|---|---|---|
| ITL p99 | 706 ms | **156 ms** |
| TPOT p99 | 273 ms | 84 ms |
| output throughput | 713 tok/s | 873 tok/s (+22%) |
| copy-kernel p50 / p99 | one 470–550ms launch per restore | 0.34 ms / 23 ms |
| fleet-wide stall events | continuous (~18/min) | cold-start bursts only |

Residual 300–825ms outliers in the profile are chunks stretched by SM *sharing* with decode — decode keeps running through them, which is the intended trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)