### PR TITLE
feat(connector): support host-local shards for cross-host TP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "colored",
  "libc",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "axum",
  "clap",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-pd-wire"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "prost",
  "tonic",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "log",
  "mea",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "axum",
  "clap",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.23.6"
+version = "0.23.7"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/README.md
+++ b/python/README.md
@@ -109,6 +109,40 @@ vllm serve Qwen/Qwen3-0.6B \
 
 Valid values are `read_write` and `save_only`.
 
+#### TP Shards Across Hosts
+
+CUDA IPC is host-local. When one tensor-parallel replica spans multiple hosts,
+run one PegaFlow server on each host and configure the connector with every
+server endpoint in global TP-rank order:
+
+```json
+{
+  "kv_connector": "PegaKVConnector",
+  "kv_role": "kv_both",
+  "kv_connector_module_path": "pegaflow.connector",
+  "kv_connector_extra_config": {
+    "pegaflow.tp_shard_endpoints": [
+      "http://host-a:50055",
+      "http://host-b:50055"
+    ]
+  }
+}
+```
+
+For TP8 and two endpoints, global ranks 0-3 register with the first server and
+ranks 4-7 register with the second. Each server sees a local TP4 topology and
+must manage the four GPUs on its own host. Every vLLM process must receive the
+same ordered endpoint list.
+
+The scheduler queries every shard and only reuses the prefix available from all
+of them. Each worker loads with the lease issued by its local server. The
+connector gives every shard a distinct namespace, so deployments with a
+different host split cannot reuse an incompatible cache layout.
+
+TP sharding currently requires equal contiguous shards and TP-only parallelism.
+Pipeline, decode-context, and prefill-context parallelism are rejected when
+more than one endpoint is configured.
+
 #### P/D Partial Tail Blocks
 
 vLLM normally exposes hashes only for complete KV blocks. In a P/D deployment,

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -22,6 +22,7 @@ from pegaflow.connector.common import (
     PegaConnectorMode,
     PegaKVConnectorStats,
     PegaPromMetrics,
+    TpShardTopology,
     derive_namespace,
     detect_mla,
     logger,
@@ -64,7 +65,7 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             )
 
         cross_layer_blocks = os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
-        namespace = derive_namespace(
+        base_namespace = derive_namespace(
             vllm_config,
             effective_tp_size,
             dcp_world_size,
@@ -114,7 +115,26 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
                 "pegaflow.wait_for_full_prefix", False
             )
         )
-        self._engine_endpoint = f"{server_host}:{server_port}"
+        default_endpoint = f"{server_host}:{server_port}"
+        tp_shards = TpShardTopology.from_config(
+            default_endpoint=default_endpoint,
+            configured_endpoints=vllm_config.kv_transfer_config.get_from_extra_config(
+                "pegaflow.tp_shard_endpoints", None
+            ),
+            global_tp_size=tp_size,
+            global_world_size=world_size,
+        )
+        if tp_shards.shard_count > 1 and (
+            world_size != tp_size or dcp_world_size != 1 or pcp_world_size != 1
+        ):
+            raise ValueError(
+                "pegaflow.tp_shard_endpoints currently supports TP-only parallelism; "
+                f"got tp_size={tp_size}, world_size={world_size}, "
+                f"dcp_world_size={dcp_world_size}, pcp_world_size={pcp_world_size}"
+            )
+        shard_index = tp_shards.shard_index(tp_rank) if tp_rank is not None else 0
+        namespace = tp_shards.namespace(base_namespace, shard_index)
+        self._engine_endpoint = tp_shards.endpoints[shard_index]
         engine_client = EngineRpcClient(self._engine_endpoint)
         logger.debug("[PegaKVConnector] Connected to engine server at %s", self._engine_endpoint)
 
@@ -140,6 +160,7 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             pp_size=pp_size,
             mode=mode,
             wait_for_full_prefix=wait_for_full_prefix,
+            tp_shards=tp_shards,
         )
 
         # MLA attention backends expose no num-layers stride dimension, so vLLM
@@ -164,8 +185,13 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             pd_tail_load = bool(
                 vllm_config.kv_transfer_config.get_from_extra_config("pegaflow.pd_tail_load", False)
             )
+            query_clients = tuple(
+                engine_client if index == shard_index else EngineRpcClient(endpoint)
+                for index, endpoint in enumerate(tp_shards.endpoints)
+            )
             self._scheduler = SchedulerConnector(
                 self._ctx,
+                engine_clients=query_clients,
                 pd_tail_save=pd_tail_save,
                 pd_tail_load=pd_tail_load,
                 vllm_config=vllm_config,
@@ -175,7 +201,13 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             # stream per vllm replica is enough — if any tp worker crashes,
             # the scheduler dies too, closing this stream and triggering
             # server-side cleanup of the instance's CUDA IPC mappings.
-            engine_client.start_session_watcher(instance_id, namespace, tp_size, world_size)
+            for index, client in enumerate(query_clients):
+                client.start_session_watcher(
+                    instance_id,
+                    tp_shards.namespace(base_namespace, index),
+                    self._ctx.effective_tp_size,
+                    self._ctx.effective_world_size,
+                )
         else:
             self._worker = WorkerConnector(
                 self._ctx,
@@ -187,7 +219,7 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s "
             "tp_rank=%s tp_size=%d pp_rank=%d pp_size=%d world_size=%d namespace=%s "
             "is_mla=%s collapse_mla_tp=%s transfer_backend=%s dcp_world_size=%d "
-            "pcp_world_size=%d dcp_rank=%d "
+            "pcp_world_size=%d dcp_rank=%d tp_shard=%d/%d "
             "mode=%s wait_for_full_prefix=%s",
             role.name,
             instance_id,
@@ -204,6 +236,8 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             dcp_world_size,
             pcp_world_size,
             dcp_rank,
+            shard_index,
+            tp_shards.shard_count,
             mode.value,
             wait_for_full_prefix,
         )

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -41,6 +41,83 @@ class PegaConnectorMode(str, Enum):
 
 
 @dataclass(frozen=True)
+class TpShardTopology:
+    """Equal contiguous TP shards served by node-local PegaFlow instances."""
+
+    endpoints: tuple[str, ...]
+    global_tp_size: int
+    global_world_size: int
+
+    @classmethod
+    def from_config(
+        cls,
+        default_endpoint: str,
+        configured_endpoints: object,
+        global_tp_size: int,
+        global_world_size: int,
+    ) -> "TpShardTopology":
+        if configured_endpoints is None:
+            endpoints = (default_endpoint,)
+        elif not isinstance(configured_endpoints, (list, tuple)):
+            raise ValueError("pegaflow.tp_shard_endpoints must be a list of endpoints")
+        else:
+            endpoints = tuple(configured_endpoints)
+
+        if not endpoints or any(
+            not isinstance(endpoint, str) or not endpoint for endpoint in endpoints
+        ):
+            raise ValueError("pegaflow.tp_shard_endpoints must contain non-empty strings")
+        if len(set(endpoints)) != len(endpoints):
+            raise ValueError("pegaflow.tp_shard_endpoints must not contain duplicates")
+        if global_tp_size <= 0 or global_tp_size % len(endpoints) != 0:
+            raise ValueError(
+                f"tensor_parallel_size={global_tp_size} must be divisible by "
+                f"the {len(endpoints)} PegaFlow TP shards"
+            )
+        if global_world_size <= 0 or global_world_size % len(endpoints) != 0:
+            raise ValueError(
+                f"world_size={global_world_size} must be divisible by "
+                f"the {len(endpoints)} PegaFlow TP shards"
+            )
+        return cls(
+            endpoints=endpoints,
+            global_tp_size=global_tp_size,
+            global_world_size=global_world_size,
+        )
+
+    @property
+    def shard_count(self) -> int:
+        return len(self.endpoints)
+
+    @property
+    def local_tp_size(self) -> int:
+        return self.global_tp_size // self.shard_count
+
+    @property
+    def local_world_size(self) -> int:
+        return self.global_world_size // self.shard_count
+
+    def shard_index(self, tp_rank: int) -> int:
+        if tp_rank < 0 or tp_rank >= self.global_tp_size:
+            raise ValueError(
+                f"tp_rank={tp_rank} is outside tensor_parallel_size={self.global_tp_size}"
+            )
+        return tp_rank // self.local_tp_size
+
+    def local_tp_rank(self, tp_rank: int) -> int:
+        return tp_rank % self.local_tp_size
+
+    def namespace(self, base_namespace: str, shard_index: int) -> str:
+        if self.shard_count == 1:
+            return base_namespace
+        if shard_index < 0 or shard_index >= self.shard_count:
+            raise ValueError(
+                f"TP shard index {shard_index} is outside shard_count={self.shard_count}"
+            )
+        return f"{base_namespace}:tp-shard-{shard_index}-of-{self.shard_count}"
+
+
+@dataclass(frozen=True)
 class ConnectorContext:
     """Shared configuration for scheduler/worker connectors."""
 
@@ -63,6 +140,7 @@ class ConnectorContext:
     pp_size: int = 1
     mode: PegaConnectorMode = PegaConnectorMode.READ_WRITE
     wait_for_full_prefix: bool = False
+    tp_shards: TpShardTopology | None = None
 
     @property
     def read_enabled(self) -> bool:
@@ -89,7 +167,10 @@ class ConnectorContext:
         """
         if self.is_mla and self.collapse_mla_tp:
             return self.dcp_rank
-        return self.tp_rank or 0
+        tp_rank = self.tp_rank or 0
+        if self.tp_shards is not None:
+            return self.tp_shards.local_tp_rank(tp_rank)
+        return tp_rank
 
     @property
     def effective_tp_size(self) -> int:
@@ -102,7 +183,38 @@ class ConnectorContext:
         """
         if self.is_mla and self.collapse_mla_tp:
             return max(1, self.dcp_world_size)
+        if self.tp_shards is not None:
+            return self.tp_shards.local_tp_size
         return self.tp_size
+
+    @property
+    def effective_world_size(self) -> int:
+        if self.tp_shards is not None:
+            return self.tp_shards.local_world_size
+        return self.world_size
+
+    @property
+    def local_physical_tp_rank(self) -> int:
+        tp_rank = self.tp_rank or 0
+        if self.tp_shards is not None:
+            return self.tp_shards.local_tp_rank(tp_rank)
+        return tp_rank
+
+    @property
+    def local_physical_tp_size(self) -> int:
+        if self.tp_shards is not None:
+            return self.tp_shards.local_tp_size
+        return self.tp_size
+
+    @property
+    def tp_shard_index(self) -> int:
+        if self.tp_shards is None or self.tp_rank is None:
+            return 0
+        return self.tp_shards.shard_index(self.tp_rank)
+
+    @property
+    def tp_shard_count(self) -> int:
+        return self.tp_shards.shard_count if self.tp_shards is not None else 1
 
 
 @dataclass(frozen=True)
@@ -110,7 +222,7 @@ class LoadIntent:
     """Intent for a KV load operation."""
 
     block_ids_by_group: tuple[tuple[int | None, ...], ...]
-    lease: bytes
+    leases: tuple[bytes, ...]
     num_tokens: int
 
 
@@ -392,6 +504,7 @@ __all__ = [
     "PegaKVConnectorStats",
     "PegaPromMetrics",
     "SaveIntent",
+    "TpShardTopology",
     "derive_namespace",
     "detect_mla",
     "logger",

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -18,7 +18,8 @@ from pegaflow.connector.common import (
     logger,
 )
 from pegaflow.connector.connector_metrics import PrefetchTracker
-from pegaflow.pegaflow import QueryLoading, QueryReady
+from pegaflow.connector.tp_shards import ShardedQueryReady, TpShardQueryClient
+from pegaflow.pegaflow import EngineRpcClient
 
 if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -51,7 +52,7 @@ class _QueryProbe:
 
     # ``None`` means the backend is still loading.
     hit_blocks: int | None = None
-    lease: bytes = b""
+    leases: tuple[bytes, ...] = ()
 
     @property
     def is_ready(self) -> bool:
@@ -69,7 +70,7 @@ class _QueryProbe:
             and self.tail_tokens == tail_tokens
         )
 
-    def mark_ready(self, ready: QueryReady) -> None:
+    def mark_ready(self, ready: ShardedQueryReady) -> None:
         hit_blocks = ready.num_hit_blocks
         if hit_blocks > len(self.query_hashes):
             raise RuntimeError(
@@ -77,7 +78,7 @@ class _QueryProbe:
                 f"{len(self.query_hashes)} hashes"
             )
         self.hit_blocks = hit_blocks
-        self.lease = ready.lease
+        self.leases = ready.leases
 
     def require_hit_blocks(self) -> int:
         if self.hit_blocks is None:
@@ -91,12 +92,21 @@ class SchedulerConnector:
     def __init__(
         self,
         context: ConnectorContext,
+        engine_clients: tuple[EngineRpcClient, ...] | None = None,
         pd_tail_save: bool = False,
         pd_tail_load: bool = False,
         vllm_config=None,
         kv_cache_config=None,
     ):
         self._ctx = context
+        engine_clients = tuple(engine_clients or (context.engine_client,))
+        expected_shards = context.tp_shards.shard_count if context.tp_shards is not None else 1
+        if len(engine_clients) != expected_shards:
+            raise ValueError(
+                f"scheduler has {len(engine_clients)} PegaFlow clients for "
+                f"{expected_shards} TP shards"
+            )
+        self._tp_shard_client = TpShardQueryClient(engine_clients)
         self._cache_groups = CacheGroupLayout.from_config(kv_cache_config)
         if self._cache_groups.has_recurrent_state and (pd_tail_save or pd_tail_load):
             raise ValueError("P/D tail-block caching is not supported with HMA")
@@ -255,8 +265,7 @@ class SchedulerConnector:
                 computed_blocks,
                 len(query_hashes),
             )
-            if ready.lease:
-                self._ctx.engine_client.release(ready.lease)
+            self._release_leases(ready.leases, req_id)
             self._pending_query_probes.pop(req_id, None)
             return (None, False)
 
@@ -400,7 +409,7 @@ class SchedulerConnector:
             pending_probe = self._pending_query_probes.get(req_id)
             load_intent = LoadIntent(
                 block_ids_by_group=load_block_ids_by_group,
-                lease=pending_probe.lease if pending_probe is not None else b"",
+                leases=pending_probe.leases if pending_probe is not None else (),
                 num_tokens=num_external_tokens,
             )
             if pending_probe is not None:
@@ -415,7 +424,7 @@ class SchedulerConnector:
                         f"req {req_id} leased block mismatch: "
                         f"leased={leased_blocks} load={num_load_blocks}"
                     )
-            if not load_intent.lease:
+            if not load_intent.leases or any(not lease for lease in load_intent.leases):
                 raise RuntimeError(f"req {req_id} missing query lease for external load")
             self._pending_load_intents[req_id] = load_intent
             self._pending_query_probes.pop(req_id, None)
@@ -812,22 +821,21 @@ class SchedulerConnector:
 
     def _count_available_block_prefix(
         self, block_hashes: Iterable[bytes], req_id: str
-    ) -> QueryReady | None:
+    ) -> ShardedQueryReady | None:
         """Query available blocks with prefetch support.
 
         Returns:
-            QueryReady: Ready block count and lease
+            ShardedQueryReady: Common ready block count and one lease per TP shard
             None: Blocks are being prefetched from DFS, retry later
         """
         block_hash_list = list(block_hashes)
-        result = self._ctx.engine_client.query_prefetch(
+        ready = self._tp_shard_client.query(
             self._ctx.instance_id,
             block_hash_list,
-            req_id=req_id,
-            wait_for_full_prefix=self._ctx.wait_for_full_prefix,
+            req_id,
+            self._ctx.wait_for_full_prefix,
         )
-
-        if isinstance(result, QueryLoading):
+        if ready is None:
             if req_id not in self._prefetch_start_times:
                 self._prefetch_start_times[req_id] = time.perf_counter()
                 self._prefetch_tracker.on_prefetch_start()
@@ -838,26 +846,22 @@ class SchedulerConnector:
                 )
             return None
 
-        if not isinstance(result, QueryReady):
-            raise TypeError(f"query_prefetch returned unexpected outcome {type(result)!r}")
-
-        hit_blocks = result.num_hit_blocks
         if req_id in self._prefetch_start_times:
             prefetch_duration_ms = (
                 time.perf_counter() - self._prefetch_start_times.pop(req_id)
             ) * 1000
-            self._prefetch_tracker.on_prefetch_complete(prefetch_duration_ms, hit_blocks)
+            self._prefetch_tracker.on_prefetch_complete(prefetch_duration_ms, ready.num_hit_blocks)
 
             logger.debug(
                 "[PegaKVConnector] Prefetch completed: req=%s hit_blocks=%d "
                 "prefetch_duration_ms=%.2f pending_prefetches=%d",
                 req_id,
-                hit_blocks,
+                ready.num_hit_blocks,
                 prefetch_duration_ms,
                 self._prefetch_tracker.pending_prefetches,
             )
 
-        return result
+        return ready
 
     def _cancel_prefetch_tracking(self, req_id: str) -> None:
         """Drop in-flight prefetch metrics when polling stops before QueryReady."""
@@ -903,18 +907,13 @@ class SchedulerConnector:
         return self._release_query_probe(req_id, probe)
 
     def _release_query_probe(self, req_id: str, probe: _QueryProbe) -> bool:
-        if not probe.lease:
+        if not probe.leases or not any(probe.leases):
             self._cancel_prefetch_tracking(req_id)
             return True  # nothing leased server-side (still loading, or zero-hit Ready)
-        try:
-            self._ctx.engine_client.release(probe.lease)
-        except Exception:
-            logger.exception(
-                "[PegaKVConnector] pending query lease release exception: req=%s",
-                req_id,
-            )
-            return False
-        return True
+        return self._release_leases(probe.leases, req_id)
+
+    def _release_leases(self, leases: tuple[bytes, ...], req_id: str) -> bool:
+        return self._tp_shard_client.release(leases, req_id)
 
 
 __all__ = ["SchedulerConnector"]

--- a/python/pegaflow/connector/tp_shards.py
+++ b/python/pegaflow/connector/tp_shards.py
@@ -1,0 +1,119 @@
+"""Query and lease coordination for node-local TP shards."""
+
+from dataclasses import dataclass
+
+from pegaflow.connector.common import logger
+from pegaflow.pegaflow import EngineRpcClient, QueryLoading, QueryReady
+
+
+@dataclass(frozen=True, slots=True)
+class ShardedQueryReady:
+    num_hit_blocks: int
+    leases: tuple[bytes, ...]
+
+
+class TpShardQueryClient:
+    def __init__(self, clients: tuple[EngineRpcClient, ...]):
+        self._clients = clients
+
+    def query(
+        self,
+        instance_id: str,
+        block_hashes: list[bytes],
+        req_id: str,
+        wait_for_full_prefix: bool,
+    ) -> ShardedQueryReady | None:
+        results: list[QueryReady] = []
+        try:
+            for client in self._clients:
+                result = client.query_prefetch(
+                    instance_id,
+                    block_hashes,
+                    req_id=req_id,
+                    wait_for_full_prefix=wait_for_full_prefix,
+                )
+                if isinstance(result, QueryLoading):
+                    self.release(tuple(ready.lease for ready in results), req_id)
+                    return None
+                if not isinstance(result, QueryReady):
+                    raise TypeError(f"query_prefetch returned unexpected outcome {type(result)!r}")
+                results.append(result)
+                self._validate_ready(result, len(block_hashes), len(results) - 1)
+        except Exception:
+            self.release(tuple(ready.lease for ready in results), req_id)
+            raise
+
+        common_blocks = min(result.num_hit_blocks for result in results)
+        leases = [result.lease for result in results]
+        if common_blocks == 0:
+            self.release(tuple(leases), req_id)
+            return ShardedQueryReady(0, tuple(b"" for _ in results))
+
+        exact_hashes = block_hashes[:common_blocks]
+        try:
+            for index, (client, result) in enumerate(zip(self._clients, results, strict=True)):
+                if result.num_hit_blocks == common_blocks:
+                    continue
+                exact = client.query_prefetch(
+                    instance_id,
+                    exact_hashes,
+                    req_id=f"{req_id}:tp-common-{common_blocks}",
+                    wait_for_full_prefix=False,
+                )
+                if not isinstance(exact, QueryReady):
+                    raise RuntimeError(
+                        f"TP shard {index} could not lease the common {common_blocks}-block prefix"
+                    )
+                try:
+                    self._validate_ready(exact, common_blocks, index)
+                    if exact.num_hit_blocks != common_blocks:
+                        raise RuntimeError(
+                            f"TP shard {index} could not lease the common "
+                            f"{common_blocks}-block prefix"
+                        )
+                except Exception:
+                    self._release_one(client, exact.lease, req_id)
+                    raise
+                old_lease = leases[index]
+                leases[index] = exact.lease
+                self._release_one(client, old_lease, req_id)
+        except Exception:
+            self.release(tuple(leases), req_id)
+            raise
+
+        return ShardedQueryReady(common_blocks, tuple(leases))
+
+    def release(self, leases: tuple[bytes, ...], req_id: str) -> bool:
+        released = True
+        for client, lease in zip(self._clients, leases, strict=False):
+            released = self._release_one(client, lease, req_id) and released
+        return released
+
+    @staticmethod
+    def _validate_ready(result: QueryReady, queried_blocks: int, shard_index: int) -> None:
+        if result.num_hit_blocks > queried_blocks:
+            raise RuntimeError(
+                f"TP shard {shard_index} reported {result.num_hit_blocks} hits for "
+                f"a {queried_blocks}-block query"
+            )
+        if result.num_hit_blocks and not result.lease:
+            raise RuntimeError(
+                f"TP shard {shard_index} returned {result.num_hit_blocks} hits without a lease"
+            )
+
+    @staticmethod
+    def _release_one(client: EngineRpcClient, lease: bytes, req_id: str) -> bool:
+        if not lease:
+            return True
+        try:
+            client.release(lease)
+        except Exception:
+            logger.exception(
+                "[PegaKVConnector] query lease release exception: req=%s",
+                req_id,
+            )
+            return False
+        return True
+
+
+__all__ = ["ShardedQueryReady", "TpShardQueryClient"]

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -250,7 +250,7 @@ class WorkerConnector:
         if not self._registered_layers:
             return
 
-        if self._ctx.tp_rank == 0:
+        if self._ctx.local_physical_tp_rank == 0:
             ok, message = self._ctx.engine_client.unregister_context(self._ctx.instance_id)
             if not ok:
                 logger.warning("[PegaKVConnector] Unregister context failed: %s", message)
@@ -366,7 +366,7 @@ class WorkerConnector:
             self._ctx.effective_tp_rank,
             self._ctx.pp_rank,
             self._ctx.effective_tp_size,
-            self._ctx.world_size,
+            self._ctx.effective_world_size,
             self._ctx.device_id,
             layer_names,
             ipc_wrappers,
@@ -558,10 +558,15 @@ class WorkerConnector:
         request_ids: list[str] = []
 
         for req_id, load_intent in metadata.load_intents.items():
+            if len(load_intent.leases) != self._ctx.tp_shard_count:
+                raise RuntimeError(
+                    f"load intent has {len(load_intent.leases)} TP shard leases; "
+                    f"expected {self._ctx.tp_shard_count}"
+                )
             block_ids_by_group = [list(group) for group in load_intent.block_ids_by_group]
             for block_ids in block_ids_by_group:
                 all_block_ids.extend(block_id for block_id in block_ids if block_id is not None)
-            loads.append((load_intent.lease, block_ids_by_group))
+            loads.append((load_intent.leases[self._ctx.tp_shard_index], block_ids_by_group))
             request_ids.append(req_id)
 
         if not all_block_ids:
@@ -932,10 +937,10 @@ class WorkerConnector:
         disjoint and complete, so every block's page is written exactly once.
         With tp_size == 1 this is the whole set.
         """
-        tp_size = self._ctx.tp_size
+        tp_size = self._ctx.local_physical_tp_size
         if tp_size <= 1:
             return list(block_ids), list(block_hashes)
-        tp_rank = self._ctx.tp_rank or 0
+        tp_rank = self._ctx.local_physical_tp_rank
         ids: list[int] = []
         hashes: list[bytes] = []
         for block_id, block_hash in zip(block_ids, block_hashes, strict=True):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.23.6"
+version = "0.23.7"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -114,6 +114,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.23.6"
+version = "0.23.7"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -147,7 +147,7 @@ def _load_metadata(req_id: str, block_ids: tuple[int, ...]) -> PegaConnectorMeta
         load_intents={
             req_id: LoadIntent(
                 block_ids_by_group=(block_ids,),
-                lease=f"lease-{req_id}".encode(),
+                leases=(f"lease-{req_id}".encode(),),
                 num_tokens=len(block_ids) * 16,
             )
         }
@@ -166,7 +166,7 @@ def _hma_load_metadata(req_id: str) -> PegaConnectorMetadata:
         load_intents={
             req_id: LoadIntent(
                 block_ids_by_group=((11,), (21,)),
-                lease=f"lease-{req_id}".encode(),
+                leases=(f"lease-{req_id}".encode(),),
                 num_tokens=16,
             )
         }
@@ -239,7 +239,7 @@ def test_hma_load_distinguishes_block_zero_from_absent_recurrent_target():
         load_intents={
             "hma-sparse": LoadIntent(
                 block_ids_by_group=((0, 12), (None, 21)),
-                lease=b"lease-hma-sparse",
+                leases=(b"lease-hma-sparse",),
                 num_tokens=32,
             )
         }

--- a/python/tests/test_pd_tail_save.py
+++ b/python/tests/test_pd_tail_save.py
@@ -251,7 +251,7 @@ class TestTailLoad:
         intent = sc._pending_load_intents["r1"]
         assert intent.block_ids_by_group == ((10, 11, 12, 13),)
         assert intent.num_tokens == 49
-        assert intent.lease == b"lease"
+        assert intent.leases == (b"lease",)
 
     def test_tail_hit_starts_after_the_local_block_prefix(self):
         req = _make_request("r1", prompt_len=50, full_hashes=3)

--- a/python/tests/test_tp_shards.py
+++ b/python/tests/test_tp_shards.py
@@ -1,0 +1,307 @@
+"""Contracts for splitting one vLLM TP replica across PegaFlow servers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (  # noqa: E402
+    KVConnectorRole,
+)
+
+from pegaflow.connector import PegaKVConnector  # noqa: E402
+from pegaflow.connector.common import (  # noqa: E402
+    ConnectorContext,
+    LoadIntent,
+    PegaConnectorMetadata,
+    TpShardTopology,
+)
+from pegaflow.connector.scheduler import SchedulerConnector  # noqa: E402
+from pegaflow.connector.worker import WorkerConnector  # noqa: E402
+from pegaflow.pegaflow import QueryLoading, QueryReady  # noqa: E402
+
+
+def _topology() -> TpShardTopology:
+    return TpShardTopology.from_config(
+        default_endpoint="http://unused:50055",
+        configured_endpoints=["http://node-a:50055", "http://node-b:50055"],
+        global_tp_size=8,
+        global_world_size=8,
+    )
+
+
+def _context(**kwargs) -> ConnectorContext:
+    defaults = {
+        "instance_id": "instance",
+        "namespace": "namespace:tp-shard-0-of-2",
+        "block_size": 16,
+        "tp_size": 8,
+        "world_size": 8,
+        "tp_rank": 0,
+        "device_id": 0,
+        "engine_client": MagicMock(),
+        "state_manager": MagicMock(),
+        "tp_shards": _topology(),
+    }
+    defaults.update(kwargs)
+    return ConnectorContext(**defaults)  # type: ignore[arg-type]
+
+
+def _vllm_config(**parallel_overrides):
+    extra_config = {
+        "pegaflow.tp_shard_endpoints": [
+            "http://node-a:50055",
+            "http://node-b:50055",
+        ]
+    }
+    kv_transfer_config = SimpleNamespace(
+        engine_id="instance",
+        get_from_extra_config=lambda key, default: extra_config.get(key, default),
+    )
+    return SimpleNamespace(
+        model_config=SimpleNamespace(
+            model="model",
+            dtype="bfloat16",
+            hf_text_config=SimpleNamespace(kv_lora_rank=None),
+            get_total_num_kv_heads=lambda: 8,
+            get_head_size=lambda: 128,
+            get_total_num_hidden_layers=lambda: 32,
+        ),
+        cache_config=SimpleNamespace(cache_dtype="auto", block_size=16),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        parallel_config=SimpleNamespace(
+            **{
+                "tensor_parallel_size": 8,
+                "pipeline_parallel_size": 1,
+                "world_size": 8,
+                "decode_context_parallel_size": 1,
+                "prefill_context_parallel_size": 1,
+                **parallel_overrides,
+            }
+        ),
+        kv_transfer_config=kv_transfer_config,
+        additional_config={},
+    )
+
+
+def test_topology_maps_contiguous_global_tp_ranks_to_local_servers():
+    topology = _topology()
+
+    assert topology.local_tp_size == 4
+    assert topology.local_world_size == 4
+    assert topology.shard_index(3) == 0
+    assert topology.shard_index(4) == 1
+    assert topology.local_tp_rank(4) == 0
+    assert topology.local_tp_rank(7) == 3
+    assert topology.namespace("base", 1) == "base:tp-shard-1-of-2"
+
+
+@pytest.mark.parametrize(
+    ("endpoints", "tp_size", "world_size", "message"),
+    [
+        ([], 8, 8, "non-empty strings"),
+        (["http://a", "http://a"], 8, 8, "duplicates"),
+        (["http://a", "http://b", "http://c"], 8, 8, "tensor_parallel_size"),
+        (["http://a", "http://b"], 8, 9, "world_size"),
+    ],
+)
+def test_topology_rejects_ambiguous_shard_layouts(endpoints, tp_size, world_size, message):
+    with pytest.raises(ValueError, match=message):
+        TpShardTopology.from_config("http://unused", endpoints, tp_size, world_size)
+
+
+def test_context_exposes_node_local_server_topology_for_hma():
+    context = _context(tp_rank=5, is_mla=True, collapse_mla_tp=False)
+
+    assert context.tp_shard_index == 1
+    assert context.effective_tp_rank == 1
+    assert context.effective_tp_size == 4
+    assert context.effective_world_size == 4
+
+
+def test_worker_connector_routes_global_tp_rank_to_its_local_server(monkeypatch):
+    client = MagicMock()
+    monkeypatch.setattr("pegaflow.connector.get_tensor_model_parallel_rank", lambda: 5)
+    client_factory = MagicMock(return_value=client)
+    monkeypatch.setattr("pegaflow.connector.EngineRpcClient", client_factory)
+    monkeypatch.setattr("pegaflow.connector.ServiceStateManager", MagicMock())
+
+    connector = PegaKVConnector(_vllm_config(), KVConnectorRole.WORKER)
+    try:
+        assert connector._engine_endpoint == "http://node-b:50055"
+        assert connector._ctx.namespace.endswith(":tp-shard-1-of-2")
+        assert connector._ctx.effective_tp_rank == 1
+        assert connector._ctx.effective_tp_size == 4
+        assert connector._ctx.effective_world_size == 4
+    finally:
+        connector.shutdown()
+
+    client_factory.assert_called_once_with("http://node-b:50055")
+
+
+def test_scheduler_opens_a_local_topology_session_on_every_server(monkeypatch):
+    first = MagicMock()
+    second = MagicMock()
+    client_factory = MagicMock(side_effect=[first, second])
+    monkeypatch.setattr("pegaflow.connector.EngineRpcClient", client_factory)
+    monkeypatch.setattr("pegaflow.connector.ServiceStateManager", MagicMock())
+
+    connector = PegaKVConnector(_vllm_config(), KVConnectorRole.SCHEDULER)
+    try:
+        first.start_session_watcher.assert_called_once()
+        first_session = first.start_session_watcher.call_args.args
+        assert first_session[0] == "instance"
+        assert first_session[1].endswith(":tp-shard-0-of-2")
+        assert first_session[2:] == (4, 4)
+        second.start_session_watcher.assert_called_once()
+        second_session = second.start_session_watcher.call_args.args
+        assert second_session[0] == "instance"
+        assert second_session[1].endswith(":tp-shard-1-of-2")
+        assert second_session[2:] == (4, 4)
+    finally:
+        connector.shutdown()
+
+
+@pytest.mark.parametrize(
+    "parallel_overrides",
+    [
+        {"pipeline_parallel_size": 2, "world_size": 16},
+        {"decode_context_parallel_size": 2},
+        {"prefill_context_parallel_size": 2},
+    ],
+)
+def test_connector_rejects_non_tp_parallelism_across_server_shards(monkeypatch, parallel_overrides):
+    monkeypatch.setattr("pegaflow.connector.EngineRpcClient", MagicMock())
+
+    with pytest.raises(ValueError, match="TP-only parallelism"):
+        PegaKVConnector(_vllm_config(**parallel_overrides), KVConnectorRole.SCHEDULER)
+
+
+def test_pure_mla_collapses_storage_tp_but_stripes_saves_within_each_node():
+    context = _context(tp_rank=5, is_mla=True, collapse_mla_tp=True)
+
+    assert context.effective_tp_rank == 0
+    assert context.effective_tp_size == 1
+    assert context.effective_world_size == 4
+    assert context.local_physical_tp_rank == 1
+    assert context.local_physical_tp_size == 4
+
+
+def test_scheduler_uses_common_prefix_and_exact_per_shard_leases():
+    first = MagicMock()
+    second = MagicMock()
+    first.query_prefetch.side_effect = [
+        QueryReady(3, b"first-long"),
+        QueryReady(2, b"first-exact"),
+    ]
+    second.query_prefetch.return_value = QueryReady(2, b"second-exact")
+    scheduler = SchedulerConnector(_context(), engine_clients=(first, second))
+    hashes = [b"h0", b"h1", b"h2"]
+
+    ready = scheduler._count_available_block_prefix(hashes, "request")
+
+    assert ready is not None
+    assert ready.num_hit_blocks == 2
+    assert ready.leases == (b"first-exact", b"second-exact")
+    assert first.query_prefetch.call_args_list == [
+        call(
+            "instance",
+            hashes,
+            req_id="request",
+            wait_for_full_prefix=False,
+        ),
+        call(
+            "instance",
+            hashes[:2],
+            req_id="request:tp-common-2",
+            wait_for_full_prefix=False,
+        ),
+    ]
+    first.release.assert_called_once_with(b"first-long")
+    second.release.assert_not_called()
+
+
+def test_scheduler_releases_ready_shards_when_another_shard_is_loading():
+    first = MagicMock()
+    second = MagicMock()
+    first.query_prefetch.return_value = QueryReady(2, b"first")
+    second.query_prefetch.return_value = QueryLoading()
+    scheduler = SchedulerConnector(_context(), engine_clients=(first, second))
+
+    assert scheduler._count_available_block_prefix([b"h0", b"h1"], "request") is None
+    first.release.assert_called_once_with(b"first")
+
+
+@pytest.mark.parametrize(
+    "invalid_ready",
+    [
+        QueryReady(3, b"too-many"),
+        QueryReady(1, b""),
+    ],
+)
+def test_scheduler_rejects_invalid_shard_query_results_without_leaking_lease(invalid_ready):
+    first = MagicMock()
+    second = MagicMock()
+    first.query_prefetch.return_value = QueryReady(2, b"first")
+    second.query_prefetch.return_value = invalid_ready
+    scheduler = SchedulerConnector(_context(), engine_clients=(first, second))
+
+    with pytest.raises(RuntimeError, match="TP shard 1"):
+        scheduler._count_available_block_prefix([b"h0", b"h1"], "request")
+
+    first.release.assert_called_once_with(b"first")
+    if invalid_ready.lease:
+        second.release.assert_called_once_with(invalid_ready.lease)
+
+
+def test_worker_selects_the_lease_for_its_local_server():
+    engine_client = MagicMock()
+    engine_client.load.return_value = (True, "")
+    context = _context(
+        tp_rank=5,
+        device_id=1,
+        namespace="namespace:tp-shard-1-of-2",
+        engine_client=engine_client,
+    )
+    worker = WorkerConnector(context)
+    worker._registered_layers = ["layer"]
+    metadata = PegaConnectorMetadata(
+        load_intents={
+            "request": LoadIntent(
+                block_ids_by_group=((7,),),
+                leases=(b"node-a", b"node-b"),
+                num_tokens=16,
+            )
+        }
+    )
+
+    try:
+        worker.start_load_kv(metadata, SimpleNamespace(no_compile_layers={}))
+    finally:
+        worker._registered_layers = []
+        worker.shutdown()
+
+    loads = engine_client.load.call_args.args[5]
+    assert loads == [(b"node-b", [[7]])]
+
+
+def test_each_tp_shard_has_a_local_unregister_leader():
+    for tp_rank in range(8):
+        engine_client = MagicMock()
+        engine_client.unregister_context.return_value = (True, "")
+        worker = WorkerConnector(_context(tp_rank=tp_rank, engine_client=engine_client))
+        worker._registered_layers = ["layer"]
+
+        worker.unregister_context()
+        worker.shutdown()
+
+        if tp_rank in (0, 4):
+            engine_client.unregister_context.assert_called_once_with("instance")
+        else:
+            engine_client.unregister_context.assert_not_called()

--- a/python/tests/test_vllm_tp_shards_e2e.py
+++ b/python/tests/test_vllm_tp_shards_e2e.py
@@ -1,0 +1,176 @@
+"""E2E coverage for one TP replica split across two PegaFlow servers."""
+
+from __future__ import annotations
+
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
+from pathlib import Path
+
+import pytest
+
+from .vllm_helpers import (
+    PegaFlowServer,
+    VLLMServer,
+    call_openai_api,
+    fetch_pegaflow_metrics,
+    fetch_pegaflow_rpc_failures,
+)
+
+PROMPT = (
+    "Distributed inference splits one tensor-parallel model replica across GPUs. "
+    "Each rank owns a different slice of the attention state, while the scheduler "
+    "must treat a cached prefix as reusable only when every rank can load it. "
+) * 8
+REQUEST_COUNT = 96
+CONCURRENCY = 8
+POOL_SIZE = "2gb"
+PROMPTS = tuple(
+    PROMPT
+    + (
+        f" Workload variant {index} verifies an independent suffix while preserving "
+        "the shared distributed-inference prefix."
+    )
+    * 4
+    for index in range(REQUEST_COUNT)
+)
+
+
+def _test_devices(tensor_parallel_size: int) -> list[int]:
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible:
+        slots = [slot.strip() for slot in visible.split(",") if slot.strip()]
+        if not all(slot.isdigit() for slot in slots):
+            pytest.skip("TP-shard E2E requires numeric CUDA_VISIBLE_DEVICES entries")
+        devices = [int(slot) for slot in slots]
+    else:
+        torch = pytest.importorskip("torch")
+        devices = list(range(torch.cuda.device_count()))
+
+    if len(devices) < tensor_parallel_size:
+        pytest.skip(f"TP{tensor_parallel_size} requires {tensor_parallel_size} visible GPUs")
+    return devices[:tensor_parallel_size]
+
+
+def _activity_delta(before: dict[str, float], after: dict[str, float], *names: str) -> float:
+    return sum(after.get(name, 0) - before.get(name, 0) for name in names)
+
+
+def _run_traffic(port: int, model: str) -> tuple[list[str], float, float, float]:
+    def send(prompt: str) -> tuple[str, float]:
+        started = time.perf_counter()
+        result = call_openai_api(port, model, prompt, max_tokens=8)
+        return result["text"], time.perf_counter() - started
+
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=CONCURRENCY) as executor:
+        samples = list(executor.map(send, PROMPTS))
+    elapsed = time.perf_counter() - started
+    latencies = sorted(latency for _, latency in samples)
+    return (
+        [output for output, _ in samples],
+        elapsed,
+        latencies[len(latencies) // 2],
+        latencies[int(len(latencies) * 0.95) - 1],
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.gpu
+def test_vllm_tp_replica_uses_every_pegaflow_shard(
+    model: str,
+    base_port: int,
+    tensor_parallel_size: int,
+    pipeline_parallel_size: int,
+    max_model_len: int | None,
+    pegaflow_transfer_backend: str,
+    tmp_path: Path,
+):
+    if tensor_parallel_size < 2 or tensor_parallel_size % 2:
+        pytest.skip("TP-shard E2E requires an even tensor parallel size of at least two")
+    if pipeline_parallel_size != 1:
+        pytest.skip("TP-shard E2E covers TP-only parallelism")
+
+    server_binary = Path(__file__).parents[2] / "target/release/pegaflow-server"
+    if not server_binary.is_file():
+        pytest.skip("TP-shard E2E requires a release pegaflow-server build")
+
+    devices = _test_devices(tensor_parallel_size)
+    middle = tensor_parallel_size // 2
+    device_shards = (devices[:middle], devices[middle:])
+
+    with ExitStack() as stack:
+        servers = tuple(
+            stack.enter_context(
+                PegaFlowServer(
+                    log_file=tmp_path / f"pegaflow-shard-{index}.log",
+                    pool_size=POOL_SIZE,
+                    devices=",".join(map(str, shard)),
+                    server_binary=str(server_binary),
+                )
+            )
+            for index, shard in enumerate(device_shards)
+        )
+        endpoints = [f"http://127.0.0.1:{server.grpc_port}" for server in servers]
+        kv_config = {
+            "kv_connector": "PegaKVConnector",
+            "kv_role": "kv_both",
+            "kv_connector_module_path": "pegaflow.connector",
+            "kv_connector_extra_config": {
+                "pegaflow.tp_shard_endpoints": endpoints,
+                "pegaflow.transfer_backend": pegaflow_transfer_backend,
+            },
+        }
+        metrics_before = [fetch_pegaflow_metrics(server.metrics_port) for server in servers]
+
+        with VLLMServer(
+            model,
+            base_port,
+            kv_transfer_config=kv_config,
+            log_file=tmp_path / "vllm-cold.log",
+            tensor_parallel_size=tensor_parallel_size,
+            max_model_len=max_model_len,
+            server_label="PegaFlow TP-shard cold",
+        ):
+            cold_outputs, cold_seconds, cold_p50, cold_p95 = _run_traffic(base_port, model)
+        metrics_after_save = [fetch_pegaflow_metrics(server.metrics_port) for server in servers]
+
+        with VLLMServer(
+            model,
+            base_port,
+            kv_transfer_config=kv_config,
+            log_file=tmp_path / "vllm-warm.log",
+            tensor_parallel_size=tensor_parallel_size,
+            max_model_len=max_model_len,
+            server_label="PegaFlow TP-shard warm",
+        ):
+            warm_outputs, warm_seconds, warm_p50, warm_p95 = _run_traffic(base_port, model)
+        metrics_after_load = [fetch_pegaflow_metrics(server.metrics_port) for server in servers]
+
+        assert warm_outputs == cold_outputs
+        for index, server in enumerate(servers):
+            save_activity = _activity_delta(
+                metrics_before[index],
+                metrics_after_save[index],
+                "pegaflow_save_bytes_total",
+                "pegaflow_cache_block_insertions_total",
+            )
+            load_activity = _activity_delta(
+                metrics_after_save[index],
+                metrics_after_load[index],
+                "pegaflow_load_bytes_total",
+                "pegaflow_cache_block_hits_total",
+            )
+            assert save_activity > 0, f"PegaFlow shard {index} saved no KV blocks"
+            assert load_activity > 0, f"PegaFlow shard {index} loaded no KV blocks"
+            failures = fetch_pegaflow_rpc_failures(server.metrics_port)
+            assert not failures, f"PegaFlow shard {index} RPC failures: {failures}"
+
+        print(
+            f"TP-shard E2E traffic ({REQUEST_COUNT} requests, concurrency={CONCURRENCY}): "
+            f"cold={REQUEST_COUNT / cold_seconds:.2f} req/s "
+            f"p50={cold_p50:.3f}s p95={cold_p95:.3f}s; "
+            f"warm={REQUEST_COUNT / warm_seconds:.2f} req/s "
+            f"p50={warm_p50:.3f}s p95={warm_p95:.3f}s"
+        )

--- a/python/tests/vllm_helpers.py
+++ b/python/tests/vllm_helpers.py
@@ -349,12 +349,16 @@ class PegaFlowServer:
         log_level: str | None = None,
         cargo_features: list[str] | None = None,
         use_hugepages: bool = False,
+        devices: str | None = None,
+        server_binary: str | None = None,
     ):
         self.grpc_port = find_available_port()
         self.http_port = find_available_port()
         self.pool_size = pool_size
         self.log_level = log_level
         self.use_hugepages = use_hugepages
+        self.devices = devices
+        self.server_binary = server_binary
         self.cargo_features = (
             cargo_features if cargo_features is not None else _detect_pegaflow_cargo_features()
         )
@@ -369,19 +373,16 @@ class PegaFlowServer:
     def __enter__(self):
         project_root = Path(__file__).parent.parent.parent
 
-        cmd = [
-            "cargo",
-            "run",
-            "-r",
-        ]
-        if self.cargo_features:
-            cmd.append("--no-default-features")
-            cmd.extend(["--features", ",".join(self.cargo_features)])
+        if self.server_binary is None:
+            cmd = ["cargo", "run", "-r"]
+            if self.cargo_features:
+                cmd.append("--no-default-features")
+                cmd.extend(["--features", ",".join(self.cargo_features)])
+            cmd.extend(["--bin", "pegaflow-server", "--"])
+        else:
+            cmd = [self.server_binary]
         cmd.extend(
             [
-                "--bin",
-                "pegaflow-server",
-                "--",
                 "--addr",
                 f"127.0.0.1:{self.grpc_port}",
                 "--http-addr",
@@ -393,6 +394,8 @@ class PegaFlowServer:
         )
         if self.use_hugepages:
             cmd.append("--use-hugepages")
+        if self.devices is not None:
+            cmd.extend(["--devices", self.devices])
         if self.log_level is not None:
             cmd.extend(["--log-level", self.log_level])
 
@@ -411,16 +414,19 @@ class PegaFlowServer:
         env["PYO3_PYTHON"] = sys.executable
         env["PYTHONHOME"] = sys.base_prefix
         if libdir := sysconfig.get_config_var("LIBDIR"):
-            env["LD_LIBRARY_PATH"] = f"{libdir}:{env.get('LD_LIBRARY_PATH', '')}"
+            existing_library_path = env.get("LD_LIBRARY_PATH")
+            env["LD_LIBRARY_PATH"] = (
+                f"{existing_library_path}:{libdir}" if existing_library_path else libdir
+            )
         python_dir = str(Path(__file__).parent.parent)
         site_packages = sysconfig.get_path("purelib")
         env["PYTHONPATH"] = f"{python_dir}" + (f":{site_packages}" if site_packages else "")
 
-        feature_label = ",".join(self.cargo_features) or "default"
-        print(
-            f"\n[PegaFlow Server] cargo run -r features={feature_label} "
-            f"on gRPC={self.grpc_port}, HTTP={self.http_port}"
-        )
+        if self.server_binary is None:
+            launch_label = f"cargo run -r features={','.join(self.cargo_features) or 'default'}"
+        else:
+            launch_label = self.server_binary
+        print(f"\n[PegaFlow Server] {launch_label} on gRPC={self.grpc_port}, HTTP={self.http_port}")
 
         if self.log_file:
             print(f"[PegaFlow Server] Logging to: {self.log_file}")


### PR DESCRIPTION
## Summary

- add ordered `pegaflow.tp_shard_endpoints` configuration for one TP replica spanning multiple hosts
- remap global TP ranks to host-local server topology and isolate each shard namespace
- query every shard, use the common prefix, and carry one exact lease per shard to workers
- open one session watcher per shard and reject unsupported PP, DCP, PCP, uneven, or duplicate layouts
- add unit coverage plus a focused multi-server vLLM E2E gate

## Supported topology

Endpoints map equal contiguous global TP rank ranges. For TP8 with two endpoints, ranks 0-3 use shard 0 and ranks 4-7 use shard 1. Each server only opens CUDA IPC handles for GPUs on its own host.

## Validation

- `uv run ruff check .`
- default Python gate: 251 passed
- source-only Python gate: 251 passed
- targeted connector tests: 98 passed
- `cargo test --release`
- staged `prek run`
- toxic reviewer: READY
- vLLM E2E on 4 GPUs: TP4 split into two local TP2 servers, Qwen3-4B, kernel transfer backend, 96 cold plus 96 warm requests at concurrency 8; outputs matched, both shards recorded save/load activity, and all RPCs succeeded

Measured request traffic:

- cold: 33.81 req/s, p50 224 ms, p95 321 ms
- warm: 42.74 req/s, p50 187 ms, p95 203 ms

## Pressure note

A separate undersized pinned-pool experiment triggered eviction, but also exposed existing `pinned pool exhausted` save failures under forced pressure. This PR does not claim eviction-pressure robustness and keeps that allocator behavior out of scope.