### PR TITLE
ci(release): publish CUDA 13 ARM64 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   build:
+    if: github.event_name == 'push'
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -73,7 +75,65 @@ jobs:
         id: generate_tag
         run: |
           PYTAG=$(echo "py${{ matrix.python-version }}" | tr -d '.')
-          echo "artifact_tag=${PYTAG}-${{ matrix.cuda-variant }}" >> $GITHUB_OUTPUT
+          echo "artifact_tag=${PYTAG}-${{ matrix.cuda-variant }}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pegaflow-wheel-${{ steps.generate_tag.outputs.artifact_tag }}
+          path: dist/*.whl
+
+  build-arm-cu13:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install CUDA 13 toolkit and build dependencies
+        run: |
+          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          sudo apt-get update
+          sudo apt-get install -y \
+            cuda-cudart-dev-13-0 \
+            cuda-nvcc-13-0 \
+            cuda-nvrtc-dev-13-0 \
+            libibverbs-dev \
+            pkg-config \
+            protobuf-compiler
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.0
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Patch package name for cu13
+        run: |
+          sed -i 's/^name = "pegaflow-llm"$/name = "pegaflow-llm-cu13"/' python/pyproject.toml
+          sed -i 's/"pegaflow-llm\[/"pegaflow-llm-cu13\[/g' python/pyproject.toml
+
+      - name: Build wheel
+        run: |
+          ./scripts/build-wheel.sh --release --no-default-features --features cuda-13,rdma
+          mkdir -p dist
+          cp target/wheels/*.whl dist/
+        env:
+          CUDA_PATH: /usr/local/cuda-13.0
+
+      - name: Generate artifact tag
+        id: generate_tag
+        run: |
+          PYTAG=$(echo "py${{ matrix.python-version }}" | tr -d '.')
+          echo "artifact_tag=${PYTAG}-arm64-cu13" >> "$GITHUB_OUTPUT"
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
@@ -82,7 +142,8 @@ jobs:
           path: dist/*.whl
 
   publish-release:
-    needs: build
+    if: github.event_name == 'push'
+    needs: [build, build-arm-cu13]
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "colored",
  "libc",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "axum",
  "clap",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-pd-wire"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "prost",
  "tonic",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "log",
  "mea",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "axum",
  "clap",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.23.7"
+version = "0.23.8"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.23.7"
+version = "0.23.8"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -114,6 +114,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.23.7"
+version = "0.23.8"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## Summary

- build CUDA 13 wheels for aarch64 on GitHub-hosted Ubuntu ARM runners
- cover CPython 3.10 through 3.14 and publish the ARM wheels with the existing CUDA 13 package
- allow a manual ARM-only build preflight without publishing a GitHub Release or PyPI package
- bump the workspace and Python package version to 0.23.8

## Release behavior

- `workflow_dispatch`: builds only the five aarch64 CUDA 13 wheels and uploads workflow artifacts
- `v*` tag: builds the existing x86_64 CUDA 12/13 wheels plus aarch64 CUDA 13 wheels, then publishes all artifacts

## Validation

- `actionlint .github/workflows/release.yml`
- `prek run` with the CUDA 13 toolchain: passed
- native aarch64 wheel build: pending the post-merge manual workflow preflight
