### PR TITLE
fix(connector): support uniformly grouped MLA cache specs

### DIFF
--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -260,13 +260,24 @@ class CacheGroupLayout:
             FullAttentionSpec,
             MambaSpec,
             MLAAttentionSpec,
+            UniformTypeKVCacheSpecs,
         )
 
         specs = tuple(group.kv_cache_spec for group in groups)
         if len(specs) == 1:
-            if type(specs[0]) not in (FullAttentionSpec, MLAAttentionSpec):
+            spec = specs[0]
+            is_uniform_mla = (
+                type(spec) is UniformTypeKVCacheSpecs
+                and bool(spec.kv_cache_specs)
+                and all(
+                    type(layer_spec) is MLAAttentionSpec
+                    for layer_spec in spec.kv_cache_specs.values()
+                )
+            )
+            if type(spec) not in (FullAttentionSpec, MLAAttentionSpec) and not is_uniform_mla:
                 raise RuntimeError(
-                    "PegaFlow supports a single cache group only for FullAttention or MLA"
+                    "PegaFlow supports a single cache group only for FullAttention, MLA, "
+                    "or uniformly grouped MLA layers"
                 )
         else:
             if any(
@@ -298,13 +309,17 @@ class CacheGroupLayout:
                 "PegaFlow HMA requires cache groups with identical logical block sizes"
             )
 
-        hash_group_index = next(
-            (
-                index
-                for index, group in enumerate(groups)
-                if isinstance(group.kv_cache_spec, FullAttentionSpec)
-            ),
-            None,
+        hash_group_index = (
+            0
+            if len(groups) == 1
+            else next(
+                (
+                    index
+                    for index, group in enumerate(groups)
+                    if type(group.kv_cache_spec) is FullAttentionSpec
+                ),
+                None,
+            )
         )
         if hash_group_index is None:
             raise RuntimeError(

--- a/python/tests/test_cache_group_layout.py
+++ b/python/tests/test_cache_group_layout.py
@@ -15,6 +15,7 @@ from vllm.v1.kv_cache_interface import (  # noqa: E402
     MambaSpec,
     MLAAttentionSpec,
     SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
 )
 
 from pegaflow.connector.common import CacheGroupLayout  # noqa: E402
@@ -38,6 +39,13 @@ def _mamba(block_size=16, mode="align"):
     spec = MambaSpec()
     spec.block_size = block_size
     spec.mamba_cache_mode = mode
+    return spec
+
+
+def _mla(block_size=16, head_size=128):
+    spec = MLAAttentionSpec()
+    spec.block_size = block_size
+    spec.head_size = head_size
     return spec
 
 
@@ -65,6 +73,45 @@ def test_accepts_single_attention_group(spec_type):
 
     assert layout.hash_group_index == 0
     assert not layout.has_recurrent_state
+
+
+def test_accepts_single_uniform_mla_group():
+    group = SimpleNamespace(
+        layer_names=("model.layers.0.self_attn.attn", "model.layers.0.self_attn.indexer.k_cache"),
+        kv_cache_spec=UniformTypeKVCacheSpecs(
+            block_size=16,
+            kv_cache_specs={
+                "model.layers.0.self_attn.attn": _mla(head_size=576),
+                "model.layers.0.self_attn.indexer.k_cache": _mla(head_size=128),
+            },
+        ),
+    )
+
+    layout = CacheGroupLayout.from_config(_config(group))
+
+    assert layout.layer_names == (group.layer_names,)
+    assert layout.hash_group_index == 0
+    assert not layout.has_recurrent_state
+
+
+@pytest.mark.parametrize("other_spec_type", [FullAttentionSpec, SlidingWindowSpec])
+def test_rejects_uniform_group_with_non_mla_layer(other_spec_type):
+    other_spec = other_spec_type()
+    other_spec.block_size = 16
+    spec = UniformTypeKVCacheSpecs(
+        block_size=16,
+        kv_cache_specs={"attention": _mla(), "other": other_spec},
+    )
+
+    with pytest.raises(RuntimeError, match="single cache group"):
+        CacheGroupLayout.from_config(_config(_group("attention", spec)))
+
+
+def test_rejects_empty_uniform_mla_group():
+    spec = UniformTypeKVCacheSpecs(block_size=16, kv_cache_specs={})
+
+    with pytest.raises(RuntimeError, match="single cache group"):
+        CacheGroupLayout.from_config(_config(_group("attention", spec)))
 
 
 @pytest.mark.parametrize("mode", ["align", "all"])

--- a/python/tests/unit_stubs.py
+++ b/python/tests/unit_stubs.py
@@ -172,10 +172,16 @@ def _install_vllm_stubs() -> None:
     class SlidingWindowSpec:
         pass
 
+    class UniformTypeKVCacheSpecs:
+        def __init__(self, block_size, kv_cache_specs):
+            self.block_size = block_size
+            self.kv_cache_specs = kv_cache_specs
+
     kv_cache_interface.FullAttentionSpec = FullAttentionSpec
     kv_cache_interface.MLAAttentionSpec = MLAAttentionSpec
     kv_cache_interface.MambaSpec = MambaSpec
     kv_cache_interface.SlidingWindowSpec = SlidingWindowSpec
+    kv_cache_interface.UniformTypeKVCacheSpecs = UniformTypeKVCacheSpecs
     _ensure_module("vllm.v1.metrics")
     _ensure_module("vllm.v1.metrics.utils").create_metric_per_engine = lambda *_args, **_kwargs: {}
 


### PR DESCRIPTION
## Summary

- accept a single UniformTypeKVCacheSpecs group only when it is non-empty and every inner spec is exactly MLAAttentionSpec
- use the single logical group as the block-hash group while preserving all MLA and sparse-indexer layer names
- keep the existing multi-group FullAttention plus aligned Mamba capability boundary unchanged
- cover GLM-style MLA plus indexer layouts and rejection of mixed or empty wrappers

## Validation

- default Python gate: 255 passed, 13 deselected
- source-only Python gate: 255 passed, 13 deselected
- pre-commit hooks, including cargo test --release
- constructed the layout with real vLLM main MLAAttentionSpec and UniformTypeKVCacheSpecs objects using different main-attention and indexer head sizes