### PR TITLE
fix(release): start ARM64 wheels on 64 KiB Grace systems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,8 @@ jobs:
           cp target/wheels/*.whl dist/
         env:
           CUDA_PATH: /usr/local/cuda-13.0
+          # Grace systems commonly use 64 KiB kernel pages, while the runner uses 4 KiB.
+          JEMALLOC_SYS_WITH_LG_PAGE: "16"
 
       - name: Generate artifact tag
         id: generate_tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "colored",
  "libc",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "axum",
  "clap",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-pd-wire"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "prost",
  "tonic",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "log",
  "mea",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "axum",
  "clap",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.23.8"
+version = "0.23.9"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/pegaflow-common/src/numa.rs
+++ b/pegaflow-common/src/numa.rs
@@ -279,15 +279,22 @@ fn get_device_numa_node(device_id: u32) -> NumaNode {
         }
     };
 
-    if let Ok(stdout) = std::str::from_utf8(&output.stdout)
-        && let Some(line) = stdout.lines().next()
-        && let Some(numa_str) = line.split(':').nth(1)
-        && let Ok(node) = numa_str.trim().parse::<u32>()
-    {
-        return NumaNode(node);
+    if let Ok(stdout) = std::str::from_utf8(&output.stdout) {
+        return parse_closest_cpu_numa_node(stdout);
     }
 
     NumaNode::UNKNOWN
+}
+
+fn parse_closest_cpu_numa_node(output: &str) -> NumaNode {
+    output
+        .lines()
+        .next()
+        .and_then(|line| line.split(':').nth(1))
+        .and_then(|numa_ids| numa_ids.split(',').next())
+        .and_then(|numa_id| numa_id.trim().parse::<u32>().ok())
+        .map(NumaNode)
+        .unwrap_or(NumaNode::UNKNOWN)
 }
 
 /// Get NUMA affinity for all available GPUs.
@@ -580,6 +587,18 @@ mod tests {
         assert_eq!(
             topology.gpu_numa_nodes(),
             vec![NumaNode(0), NumaNode(3), NumaNode(5)]
+        );
+    }
+
+    #[test]
+    fn closest_cpu_numa_node_uses_first_reported_id() {
+        assert_eq!(
+            parse_closest_cpu_numa_node("NUMA ID of closest CPU: 3\n"),
+            NumaNode(3)
+        );
+        assert_eq!(
+            parse_closest_cpu_numa_node("NUMA IDs of closest CPU: 1,18-33\n"),
+            NumaNode(1)
         );
     }
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.23.8"
+version = "0.23.9"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -114,6 +114,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.23.8"
+version = "0.23.9"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"


### PR DESCRIPTION
## Summary

- build ARM64 CUDA 13 wheels with a 64 KiB jemalloc page size
- parse NVIDIA's multi-ID closest-CPU NUMA output and keep allocation on the first GPU-local CPU node
- bump the package version to `0.23.9`
- keep the allocator setting scoped to the ARM64 release jobs

## Motivation

The published ARM64 CUDA 13 wheel exits before CLI parsing on a 64 KiB-page Grace/GB300 host:

```text
<jemalloc>: Unsupported system page size
memory allocation of 4 bytes failed
```

The host reports `getconf PAGESIZE=65536`, while `tikv-jemalloc-sys` otherwise derives its allocator page size from the 4 KiB GitHub runner at build time. `JEMALLOC_SYS_WITH_LG_PAGE=16` makes the wheel compatible with the target 64 KiB kernel-page environment.

On a 4×GB300 ARM64 host, recent NVIDIA tooling reports values such as `NUMA IDs of closest CPU: 0,2-17`. The existing single-integer parser treated every GPU mapping as unknown, then fell back to all 34 reported NUMA nodes, including CPU-less nodes. Selecting the first comma-delimited CPU node preserves the intended GPU-local allocation: GPUs 0/1 use node 0 and GPUs 2/3 use node 1.

## Validation

- `cargo test -p pegaflow-common` (42 passed)
- `prek run --files pegaflow-common/src/numa.rs .github/workflows/release.yml`
- CI checks passed, including Rust fmt/clippy, CUDA 12/13 cargo checks, Python tests, and wheel builds
- manually dispatched ARM64 CUDA 13 release workflow built wheels for Python 3.10-3.14: [run 31494259292](https://github.com/novitalabs/pegaflow/actions/runs/31494259292)
- installed the Python 3.12 artifact in a clean `uv` environment with `torch==2.13.0+cu130` on an ARM64, 64 KiB-page, 4×GB300 host
- `pegaflow-server --help` passed, confirming the allocator initializes on the 64 KiB host
- with the installed NVIDIA CUDA library directories on `LD_LIBRARY_PATH`, the server started without `--disable-numa-affinity`, selected exactly two GPU-local NUMA nodes, and served both `/health` and `/metrics`