### PR TITLE
fix(connector): accept full attention spec subclasses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "colored",
  "libc",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "axum",
  "clap",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-pd-wire"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "prost",
  "tonic",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "log",
  "mea",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "axum",
  "clap",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.23.9"
+version = "0.23.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -280,15 +280,12 @@ class CacheGroupLayout:
                     "or uniformly grouped MLA layers"
                 )
         else:
-            if any(
-                type(spec) is not FullAttentionSpec and not isinstance(spec, MambaSpec)
-                for spec in specs
-            ):
+            if any(not isinstance(spec, (FullAttentionSpec, MambaSpec)) for spec in specs):
                 raise RuntimeError(
                     "PegaFlow HMA supports only FullAttention and Mamba cache groups"
                 )
 
-            has_full_attention = any(type(spec) is FullAttentionSpec for spec in specs)
+            has_full_attention = any(isinstance(spec, FullAttentionSpec) for spec in specs)
             has_mamba = any(isinstance(spec, MambaSpec) for spec in specs)
             if not has_full_attention:
                 raise RuntimeError(
@@ -316,7 +313,7 @@ class CacheGroupLayout:
                 (
                     index
                     for index, group in enumerate(groups)
-                    if type(group.kv_cache_spec) is FullAttentionSpec
+                    if isinstance(group.kv_cache_spec, FullAttentionSpec)
                 ),
                 None,
             )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.23.9"
+version = "0.23.10"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -114,6 +114,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.23.9"
+version = "0.23.10"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"

--- a/python/tests/test_cache_group_layout.py
+++ b/python/tests/test_cache_group_layout.py
@@ -49,9 +49,16 @@ def _mla(block_size=16, head_size=128):
     return spec
 
 
-def test_accepts_full_attention_with_aligned_mamba():
+class SpecializedFullAttentionSpec(FullAttentionSpec):
+    pass
+
+
+@pytest.mark.parametrize("spec_type", [FullAttentionSpec, SpecializedFullAttentionSpec])
+def test_accepts_full_attention_with_aligned_mamba(spec_type):
+    attention = spec_type()
+    attention.block_size = 528
     config = _config(
-        _group("attention", _full_attention(block_size=528)),
+        _group("attention", attention),
         _group("recurrent", _mamba(block_size=528)),
     )
 
@@ -170,7 +177,7 @@ def test_rejects_full_attention_with_sliding_window():
         CacheGroupLayout.from_config(config)
 
 
-def test_rejects_mla_with_mamba():
+def test_accepts_mla_with_mamba():
     mla = MLAAttentionSpec()
     mla.block_size = 16
     config = _config(
@@ -178,8 +185,10 @@ def test_rejects_mla_with_mamba():
         _group("recurrent", _mamba()),
     )
 
-    with pytest.raises(RuntimeError, match="only FullAttention and Mamba"):
-        CacheGroupLayout.from_config(config)
+    layout = CacheGroupLayout.from_config(config)
+
+    assert layout.hash_group_index == 0
+    assert layout.has_recurrent_state
 
 
 def test_rejects_non_align_mamba_mode():


### PR DESCRIPTION
## Summary

- classify `FullAttentionSpec` subclasses as full-attention cache groups
- allow specialized full-attention specs used by the latest Kimi K3 vLLM release to initialize with aligned Mamba groups
- cover subclass and MLA inheritance behavior in cache-group layout tests
- bump the workspace and Python package version to `0.23.10` for release

## Testing

- `cd python && uv run --extra test pytest` (256 passed, 13 deselected)
- `cd python && uv run --isolated --no-project --with pytest --with numpy --with 'requests>=2.26.0' pytest` (256 passed, 13 deselected)
- pre-commit hooks, including `cargo test --release`, Ruff, and Commitizen checks
- `cargo metadata --locked --no-deps --format-version 1`
- Cargo workspace, Python package, and Commitizen versions verified at `0.23.10`

## Release

After merge, create and push tag `v0.23.10` to trigger the release workflow.

## Performance Work

Not a performance change; no benchmark was required.