### PR TITLE
Fix final HMA cache saves after request completion

### DIFF
--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -361,17 +361,20 @@ class PegaConnectorMetadata(KVConnectorMetadata):
         self,
         load_intents: dict[str, LoadIntent] | None = None,
         save_intents: dict[str, SaveIntent] | None = None,
+        ready_save_intents: dict[str, SaveIntent] | None = None,
         preempted_req_ids: set[str] | None = None,
     ):
         super().__init__()
         # Maps request_id -> intent
         self.load_intents: dict[str, LoadIntent] = load_intents or {}
         self.save_intents: dict[str, SaveIntent] = save_intents or {}
+        self.ready_save_intents: dict[str, SaveIntent] = ready_save_intents or {}
         self.preempted_req_ids: set[str] = preempted_req_ids or set()
 
     def __repr__(self) -> str:
         return (
-            f"PegaConnectorMetadata(loads={len(self.load_intents)}, saves={len(self.save_intents)})"
+            f"PegaConnectorMetadata(loads={len(self.load_intents)}, "
+            f"saves={len(self.save_intents)}, ready_saves={len(self.ready_save_intents)})"
         )
 
 

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -179,6 +179,7 @@ class SchedulerConnector:
         self._requests: dict[str, Request] = {}
 
         # Completion tracking
+        self._deferred_save_intents: dict[str, SaveIntent] = {}
         self._pending_saves: set[str] = set()
         self._held_requests: set[str] = set()
 
@@ -442,6 +443,8 @@ class SchedulerConnector:
 
     def build_connector_meta(self, scheduler_output: "SchedulerOutput") -> PegaConnectorMetadata:
         # Collect all save intents that became available this scheduler step.
+        ready_save_intents = self._deferred_save_intents
+        self._deferred_save_intents = {}
         potential_saves: dict[str, SaveIntent] = {}
 
         load_intents = self._pending_load_intents
@@ -545,6 +548,7 @@ class SchedulerConnector:
         return PegaConnectorMetadata(
             load_intents=load_intents,
             save_intents=save_intents,
+            ready_save_intents=ready_save_intents,
             preempted_req_ids=scheduler_output.preempted_req_ids or None,
         )
 
@@ -743,6 +747,54 @@ class SchedulerConnector:
                 block_ids.append(block.block_id)
         return tuple(tuple(block_ids) for block_ids in block_ids_by_group)
 
+    def _consume_finished_hma_save(
+        self,
+        req_id: str,
+        block_ids: tuple[list[int], ...],
+        written: int,
+    ) -> SaveIntent | None:
+        block_hashes = self._block_hashes.get(req_id)
+        if block_hashes is None:
+            return None
+
+        start_block_idx = self._next_stored_block_idx.get(
+            req_id, self._block_index_offsets.get(req_id, 0)
+        )
+        saveable_block_idx = min(len(block_hashes), written // self._ctx.virtual_block_size)
+        if saveable_block_idx <= start_block_idx:
+            return None
+
+        groups = self._copy_block_ids_by_group(block_ids)
+        available = tuple(len(group) for group in groups)
+        required = tuple(
+            saveable_block_idx + 1
+            if group_index in self._cache_groups.recurrent_group_indices
+            else saveable_block_idx
+            for group_index in range(self._cache_groups.group_count)
+        )
+        if any(length < minimum for length, minimum in zip(available, required, strict=True)):
+            raise RuntimeError(
+                f"req {req_id} final HMA block table is shorter than its hash prefix: "
+                f"saveable={saveable_block_idx} available_by_group={available} "
+                f"required_by_group={required}"
+            )
+
+        num_new_blocks = saveable_block_idx - start_block_idx
+        save_block_ids_by_group = []
+        for group_index, group in enumerate(groups):
+            if group_index in self._cache_groups.recurrent_group_indices:
+                save_block_ids_by_group.append(
+                    (0,) * (num_new_blocks - 1) + (group[saveable_block_idx],)
+                )
+            else:
+                save_block_ids_by_group.append(group[start_block_idx:saveable_block_idx])
+
+        self._next_stored_block_idx[req_id] = saveable_block_idx
+        return SaveIntent(
+            block_ids_by_group=tuple(save_block_ids_by_group),
+            block_hashes=block_hashes[start_block_idx:saveable_block_idx],
+        )
+
     def _copy_block_ids_by_group(self, block_ids) -> tuple[tuple[int, ...], ...]:
         groups = tuple(tuple(group) for group in block_ids)
         if len(groups) != self._cache_groups.group_count:
@@ -782,7 +834,7 @@ class SchedulerConnector:
             logger.debug("[PegaKVConnector] Request %s save completed", req_id)
 
             # Clean up if request already finished
-            if req_id in self._held_requests:
+            if req_id in self._held_requests and req_id not in self._deferred_save_intents:
                 self._cleanup_request(req_id)
                 self._held_requests.discard(req_id)
 
@@ -792,6 +844,17 @@ class SchedulerConnector:
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict | None]:
         req_id = request.request_id
+
+        if self._cache_groups.has_recurrent_state and req_id in self._block_hashes:
+            self._block_hashes[req_id] = tuple(request.block_hashes)
+            final_save = self._consume_finished_hma_save(
+                req_id,
+                block_ids,
+                request.num_computed_tokens,
+            )
+            if final_save is not None:
+                self._deferred_save_intents[req_id] = final_save
+                self._pending_saves.add(req_id)
 
         # Check if there are pending saves for this request
         if req_id in self._pending_saves:
@@ -816,6 +879,7 @@ class SchedulerConnector:
         self._allocated_blocks.pop(req_id, None)
         self._scheduled_tokens.pop(req_id, None)
         self._next_stored_block_idx.pop(req_id, None)
+        self._deferred_save_intents.pop(req_id, None)
         self._pending_saves.discard(req_id)
         self._tail_saved.discard(req_id)
 

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -17,6 +17,7 @@ from pegaflow.connector.common import (
     ConnectorContext,
     PegaConnectorMetadata,
     PegaKVConnectorStats,
+    SaveIntent,
     logger,
     parse_env_int,
 )
@@ -547,6 +548,11 @@ class WorkerConnector:
     ) -> None:
         self._current_metadata = metadata
 
+        if metadata.ready_save_intents:
+            if not self._cache_groups.has_recurrent_state:
+                raise RuntimeError("ready save intents are only valid for HMA")
+            self._process_save_batch([self._make_save_task(metadata.ready_save_intents)])
+
         if not metadata.load_intents:
             return
 
@@ -721,7 +727,17 @@ class WorkerConnector:
         if metadata is None or not metadata.save_intents:
             return
 
-        request_ids = list(metadata.save_intents.keys())
+        task = self._make_save_task(metadata.save_intents)
+        if self._cache_groups.has_recurrent_state:
+            # Align-mode recurrent states can reuse their only live block on
+            # the next scheduler step. Finish D2H before returning so the
+            # saved boundary state cannot be overwritten underneath the copy.
+            self._process_save_batch([task])
+        else:
+            self._save_queue.put(task)
+
+    def _make_save_task(self, save_intents: dict[str, SaveIntent]) -> SaveTask:
+        request_ids = list(save_intents)
 
         with self._save_completion_lock:
             for req_id in request_ids:
@@ -731,14 +747,10 @@ class WorkerConnector:
                     self._save_completion_events[req_id] = threading.Event()
                 self._req_pending_save_tasks[req_id] = pending_tasks + 1
 
-        task = SaveTask(metadata=metadata, request_ids=request_ids)
-        if self._cache_groups.has_recurrent_state:
-            # Align-mode recurrent states can reuse their only live block on
-            # the next scheduler step. Finish D2H before returning so the
-            # saved boundary state cannot be overwritten underneath the copy.
-            self._process_save_batch([task])
-        else:
-            self._save_queue.put(task)
+        return SaveTask(
+            metadata=PegaConnectorMetadata(save_intents=save_intents),
+            request_ids=request_ids,
+        )
 
     def _save_worker(self) -> None:
         logger.debug("[PegaKVConnector] Save worker thread started")

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -104,6 +104,52 @@ def test_recurrent_save_waits_until_vllm_commits_all_groups():
     assert scheduler._next_stored_block_idx["r1"] == 0
 
 
+def test_recurrent_final_step_uses_finished_block_table():
+    scheduler = _make_recurrent_scheduler()
+    scheduler._get_local_cached_blocks = lambda _block_hash, _group_ids: None
+
+    assert scheduler._consume_full_block_saves("r1", written=32, computed_before_step=0) is None
+    request = SimpleNamespace(
+        request_id="r1",
+        num_computed_tokens=32,
+        block_hashes=[_hash(0), _hash(1)],
+    )
+
+    delay_free, params = scheduler.request_finished(
+        request,
+        ([11, 12, 13], [0, 0, 22, 30, 31, 32]),
+    )
+
+    assert delay_free is True
+    assert params is None
+
+    scheduler.update_connector_output(SimpleNamespace(finished_sending={"r1"}))
+    assert "r1" in scheduler._block_hashes
+
+    metadata = scheduler.build_connector_meta(
+        SimpleNamespace(
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=[],
+                resumed_req_ids=set(),
+                new_block_ids=[],
+                num_computed_tokens=[],
+            ),
+            num_scheduled_tokens={},
+            preempted_req_ids=set(),
+        )
+    )
+    assert metadata.ready_save_intents["r1"] == SaveIntent(
+        block_ids_by_group=((11, 12), (0, 22)),
+        block_hashes=(_hash(0), _hash(1)),
+    )
+    assert metadata.save_intents == {}
+
+    scheduler.update_connector_output(SimpleNamespace(finished_sending={"r1"}))
+    assert "r1" not in scheduler._block_hashes
+    assert "r1" not in scheduler._held_requests
+
+
 def test_recurrent_save_does_not_predict_current_step_state():
     scheduler = _make_recurrent_scheduler()
 

--- a/python/tests/test_connector_save_lifecycle.py
+++ b/python/tests/test_connector_save_lifecycle.py
@@ -109,6 +109,50 @@ def test_later_save_reopens_completed_request():
     assert finished_sending == {"request"}
 
 
+def test_committed_save_runs_on_a_no_forward_step():
+    worker = make_worker()
+    worker._cache_groups = SimpleNamespace(has_recurrent_state=True)
+    worker._registered_layers = ["layer"]
+    worker._ctx.engine_client.save.return_value = (True, "")
+    metadata = PegaConnectorMetadata(
+        ready_save_intents={
+            "request": SaveIntent(
+                block_ids_by_group=((1,),),
+                block_hashes=(b"hash",),
+            )
+        }
+    )
+
+    with patch("torch.cuda.synchronize"):
+        worker.start_load_kv(metadata, None)
+
+    worker._ctx.engine_client.save.assert_called_once()
+    finished_sending, _ = worker.get_finished({"request"})
+    assert finished_sending == {"request"}
+
+
+def test_current_step_save_waits_for_forward_completion():
+    worker = make_worker()
+    worker._cache_groups = SimpleNamespace(has_recurrent_state=True)
+    worker._registered_layers = ["layer"]
+    worker._ctx.engine_client.save.return_value = (True, "")
+    metadata = PegaConnectorMetadata(
+        save_intents={
+            "request": SaveIntent(
+                block_ids_by_group=((1,),),
+                block_hashes=(b"hash",),
+            )
+        }
+    )
+
+    worker.start_load_kv(metadata, None)
+    worker._ctx.engine_client.save.assert_not_called()
+
+    with patch("torch.cuda.synchronize"):
+        worker.wait_for_save()
+    worker._ctx.engine_client.save.assert_called_once()
+
+
 def test_preemption_waits_for_every_save_task():
     worker = make_worker()
     completion = enqueue_save(worker)


### PR DESCRIPTION
## Summary

- defer final HMA saves until vLLM exposes the completed all-group block table
- execute committed final saves during the connector-only step after the request finishes
- keep request blocks alive until both current-step and deferred saves complete
- map the final recurrent-state slot to the final valid hash while preserving earlier null slots

## Root cause

HMA save planning intentionally avoids predicting recurrent state before forward. For a prefill that finishes in one model step, the request was cleaned up before another scheduling step could observe the committed all-group mapping. The finish callback also contains null recurrent slots followed by the final state and speculative slots, so slicing every cache group like dense attention saved only attention layers.

The result was a successful prefill with no reusable external cache entry.

## Performance Work

Measured on 2 nodes / 8 GPUs with TP8 and MultiConnector (NIXL producer + PegaFlow cache):

| Case | Before | After |
|---|---:|---:|
| Repeated 1,665-token traffic | 0 external hit blocks; 0 successful saves | 1 external hit block; 1,536 hit tokens |
| Cold 1,700-token request | no reusable entry | 8/8 rank saves; 98 layers per rank |
| Warm identical request | `cached_tokens=0` | `cached_tokens=1536`; 8/8 rank loads |
| Request latency | 0.395 s cold | 0.338 s warm |

These timings are request-level observations under shared traffic, not a throughput benchmark. The correctness signal is the cold-save/warm-load transition.

## Validation

- `uv run --directory python --extra test pytest` — 259 passed
- `uv run --directory python --isolated --no-project --with pytest --with numpy --with "requests>=2.26.0" pytest` — 259 passed
- `prek run` — passed, including release Cargo tests and Python checks
- manual HMA cold/warm test on 2 nodes / 8 GPUs with MultiConnector and NIXL — passed

## Scope

A single large prefill chunk may expose only its final recurrent-state snapshot. This change saves only states vLLM actually provides and does not fabricate intermediate HMA snapshots.