### PR TITLE
fix(connector): discard drifted TP prefetch results

### DIFF
--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -237,9 +237,16 @@ class SchedulerConnector:
             self._release_pending_query_probe(req_id)
             probe = None
 
-        # No reusable Ready result.  Ask backend.
+        # A Loading task is keyed by req_id server-side. If the current query
+        # drifted, finish polling with the original identity so the TP layer can
+        # validate the stale Ready before we release it below.
+        backend_query_hashes = query_hashes
+        if probe is not None and not probe.matches(computed_blocks, query_hashes, tail_tokens):
+            backend_query_hashes = probe.query_hashes
+
+        # No reusable Ready result. Ask backend.
         lookup_start = time.perf_counter()
-        ready = self._count_available_block_prefix(query_hashes, req_id)
+        ready = self._count_available_block_prefix(backend_query_hashes, req_id)
         lookup_us = (time.perf_counter() - lookup_start) * 1e6
 
         # Backend is still loading.  Keep the original snapshot.

--- a/python/tests/test_tp_shards.py
+++ b/python/tests/test_tp_shards.py
@@ -238,6 +238,52 @@ def test_scheduler_releases_ready_shards_when_another_shard_is_loading():
     first.release.assert_called_once_with(b"first")
 
 
+def test_scheduler_discards_drifted_prefetch_before_querying_new_hashes():
+    first = MagicMock()
+    second = MagicMock()
+    first.query_prefetch.side_effect = [
+        QueryLoading(),
+        QueryReady(4, b"first-old"),
+        QueryLoading(),
+    ]
+    second.query_prefetch.return_value = QueryReady(4, b"second-old")
+    scheduler = SchedulerConnector(_context(), engine_clients=(first, second))
+    request = SimpleNamespace(
+        request_id="request",
+        block_hashes=[b"h0", b"h1", b"h2", b"h3"],
+        num_tokens=64,
+    )
+
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (None, False)
+    assert scheduler.get_num_new_matched_tokens(request, 32) == (None, False)
+    assert scheduler.get_num_new_matched_tokens(request, 32) == (None, False)
+
+    original_hashes = request.block_hashes
+    current_hashes = request.block_hashes[2:]
+    assert first.query_prefetch.call_args_list == [
+        call(
+            "instance",
+            original_hashes,
+            req_id="request",
+            wait_for_full_prefix=False,
+        ),
+        call(
+            "instance",
+            original_hashes,
+            req_id="request",
+            wait_for_full_prefix=False,
+        ),
+        call(
+            "instance",
+            current_hashes,
+            req_id="request",
+            wait_for_full_prefix=False,
+        ),
+    ]
+    first.release.assert_called_once_with(b"first-old")
+    second.release.assert_called_once_with(b"second-old")
+
+
 @pytest.mark.parametrize(
     "invalid_ready",
     [


### PR DESCRIPTION
## Summary

- keep polling an in-flight prefetch with its original query identity when local prefix hits change
- let TP shard validation check the stale result against the query that created it
- release stale per-shard leases before issuing the updated query

## Root cause

The scheduler already snapshots `computed_blocks` and query hashes when `query_prefetch` returns Loading. After TP shard support was added, each shard validated a later Ready result against the current, shorter query before the scheduler could compare it with the saved snapshot. A valid stale result therefore raised `hits > queried blocks` instead of being discarded.

## Tests

- `cd python && uv run --extra test pytest -q` (257 passed, 13 deselected)
- `cd python && uv run --extra test pytest -q tests/test_tp_shards.py tests/test_combine_hashes.py` (66 passed)
- commit hooks, including `cargo test --release`, ruff, format, typos, and Commitizen
