### PR TITLE
fix(core): keep leased blocks indexed under pressure

### DIFF
--- a/pegaflow-core/src/cache.rs
+++ b/pegaflow-core/src/cache.rs
@@ -72,6 +72,16 @@ impl TinyLfuCache<BlockKey, ArcSealedBlock> {
         self.lru.contains_key(key)
     }
 
+    /// Returns true only when the cache owns the block exclusively.
+    ///
+    /// `Arc::get_mut` rejects both other strong references and weak references,
+    /// so no holder outside the cache can keep or reacquire the allocation.
+    pub(crate) fn is_exclusively_owned(&mut self, key: &BlockKey) -> bool {
+        self.lru
+            .peek_mut(key)
+            .is_some_and(|block| Arc::get_mut(block).is_some())
+    }
+
     /// Insert with TinyLFU admission. If the candidate is colder than the
     /// current LRU victim it is dropped.
     pub(crate) fn insert(&mut self, key: BlockKey, value: ArcSealedBlock) -> CacheInsertOutcome {

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -515,20 +515,10 @@ impl StorageEngine {
             }
 
             let mut batch_bytes = 0u64;
-            let mut still_referenced = 0u64;
             for (_key, block) in &evicted {
                 let b = block.memory_footprint();
                 batch_bytes = batch_bytes.saturating_add(b);
-                if Arc::strong_count(block) > 1 {
-                    still_referenced += 1;
-                }
                 core_metrics().cache_resident_bytes.add(-(b as i64), &[]);
-            }
-
-            if still_referenced > 0 {
-                core_metrics()
-                    .cache_block_evictions_still_referenced
-                    .add(still_referenced, &[]);
             }
 
             freed_bytes = freed_bytes.saturating_add(batch_bytes);

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -160,13 +160,19 @@ impl ReadCache {
         let removed = {
             let mut inner = self.inner.lock();
             let mut removed = Vec::with_capacity(batch_size);
-            while removed.len() < batch_size {
-                let next = remove_lru(&mut inner, ResidentClass::Reclaimable)
-                    .or_else(|| remove_lru(&mut inner, ResidentClass::Retained));
-                let Some(block) = next else {
-                    break;
-                };
-                removed.push(block);
+            remove_lru_batch_from_class(
+                &mut inner,
+                ResidentClass::Reclaimable,
+                batch_size,
+                &mut removed,
+            );
+            if removed.len() < batch_size {
+                remove_lru_batch_from_class(
+                    &mut inner,
+                    ResidentClass::Retained,
+                    batch_size,
+                    &mut removed,
+                );
             }
             removed
         };
@@ -353,6 +359,35 @@ fn remove_lru(inner: &mut ReadCacheInner, class: ResidentClass) -> Option<Remove
     None
 }
 
+fn remove_lru_batch_from_class(
+    inner: &mut ReadCacheInner,
+    class: ResidentClass,
+    batch_size: usize,
+    removed: &mut Vec<RemovedResident>,
+) {
+    let candidates = class_lru(inner, class).len();
+    for _ in 0..candidates {
+        if removed.len() == batch_size {
+            break;
+        }
+
+        let Some(key) = class_lru(inner, class)
+            .iter()
+            .next()
+            .map(|(key, _)| key.clone())
+        else {
+            break;
+        };
+        if inner.cache.is_exclusively_owned(&key) {
+            let block = remove_lru(inner, class)
+                .expect("exclusive LRU candidate must remain resident while locked");
+            removed.push(block);
+        } else {
+            class_lru(inner, class).get(&key);
+        }
+    }
+}
+
 fn record_residence_durations(
     removed: Vec<RemovedResident>,
     attributes: &[opentelemetry::KeyValue],
@@ -459,6 +494,21 @@ mod tests {
             evicted.into_iter().map(|(key, _)| key).collect::<Vec<_>>(),
             vec![reclaimable, retained]
         );
+    }
+
+    #[test]
+    fn pressure_reclaim_waits_for_weak_references() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        let block = make_block();
+        let weak = Arc::downgrade(&block);
+        cache.batch_insert(vec![(key.clone(), block)]);
+
+        assert!(cache.remove_lru_batch(1).is_empty());
+        assert_class(&cache, &key, ResidentClass::Retained);
+
+        drop(weak);
+        assert_eq!(cache.remove_lru_batch(1)[0].0, key);
     }
 
     #[test]

--- a/pegaflow-core/tests/eviction.rs
+++ b/pegaflow-core/tests/eviction.rs
@@ -11,7 +11,7 @@ use pegaflow_core::StorageConfig;
 
 const BLOCK_SIZE: usize = 4096;
 const NUM_BLOCKS: usize = 4;
-/// Pool fits one batch with headroom for metadata, but not two.
+/// Pool fits two batches, so a third batch must reclaim one of them.
 const POOL_SIZE: usize = NUM_BLOCKS * BLOCK_SIZE * 2;
 
 fn eviction_storage_config() -> StorageConfig {
@@ -61,11 +61,20 @@ async fn leased_blocks_survive_eviction_pressure() {
     env.save_and_wait(&hashes).await;
     let lease = env.assert_all_hit_lease(&hashes).await;
 
-    // Second batch creates eviction pressure while the first is leased.
-    let pressure = make_block_hashes(NUM_BLOCKS, 20);
-    env.save_layer(0, &pressure).await;
+    // Fill the remaining pool, then force a third batch to reclaim it while
+    // the first batch remains leased.
+    let reclaimed = make_block_hashes(NUM_BLOCKS, 20);
+    env.save_layer_and_flush(0, &reclaimed).await;
+    let pressure = make_block_hashes(NUM_BLOCKS, 21);
+    env.save_layer_and_flush(0, &pressure).await;
+    assert_eq!(env.count_hits_then_release(&reclaimed).await, 0);
 
-    // First batch is still leased — load must succeed.
+    // The lease pins both the allocation and its cache index, so an exact
+    // follow-up query must still see the same prefix after pressure.
+    let second_lease = env.assert_all_hit_lease(&hashes).await;
+    env.release(&second_lease);
+
+    // The original lease must still load the pinned data.
     env.data().zero_gpu();
     env.load_to_gpu(lease, hashes.len()).await;
     env.data().assert_gpu_matches_expected();


### PR DESCRIPTION
## Summary

- reclaim only cache entries exclusively owned by the resident cache
- keep leased, queried, loading, and weakly referenced blocks indexed during memory pressure
- preserve reclaimable-before-retained ordering with a bounded LRU scan
- strengthen the GPU eviction integration test to prove an unleased batch is reclaimed while a leased batch remains queryable and loadable

## Testing

- `cargo test --no-default-features --features cuda-13,rdma -p pegaflow-core storage::read_cache::tests -- --nocapture`
- `cargo test --no-default-features --features cuda-13,rdma -p pegaflow-core --test eviction -- --nocapture`
- `cargo clippy --workspace --all-targets --no-default-features --features cuda-13,rdma -- -D warnings`
- `prek run` (includes release-mode Rust test suite)