### PR TITLE
feat(metrics): improve local HLL accuracy

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -141,18 +141,25 @@ PegaFlow exposes the following metrics for monitoring KV cache operations:
 
 ### HLL Reuse Metrics
 - **pegaflow_hll_cardinality** (Gauge)
-  - Estimated distinct block hashes observed in a configured sliding window
+  - Estimated distinct `(namespace, block hash)` objects classified as misses in a configured sliding window
   - Labels: `window` (`15m`, `1h`, `1d` by default)
   - Use case: Derive approximate prefix reuse over longer windows without
     storing every block hash
 
 - **pegaflow_hll_total_requests** (Gauge)
-  - Total block hash observations in the same configured sliding window
+  - Total queried blocks in the same configured sliding window, including ready blocks and duplicates
   - Labels: `window` (`15m`, `1h`, `1d` by default)
-  - Use case: Denominator for HLL-based estimated hit-rate PromQL
+  - Use case: Denominator for HLL-based reference reuse rate
 
-PegaFlow does not export a separate HLL hit-rate gauge. Use PromQL so the
-ratio is computed from values in the same scrape:
+- **pegaflow_hll_estimated_hit_rate** (Gauge)
+  - Server-computed miss-based infinite-cache reuse reference from the same
+    HLL snapshot as the two gauges above
+  - Labels: `window`
+  - Value is clamped to `[0, 1]`
+
+The existing cardinality and total metrics are retained. Existing PromQL
+continues to work, but new dashboards should prefer the direct gauge because
+it applies the same cardinality clamp as the tracker:
 
 ```promql
 1 - (
@@ -161,6 +168,18 @@ ratio is computed from values in the same scrape:
   clamp_min(pegaflow_hll_total_requests{window="1h"}, 1)
 )
 ```
+
+```promql
+pegaflow_hll_estimated_hit_rate{window="1h"}
+```
+
+This is a metrics semantic update, not an `/metrics` protocol breaking change:
+metric names, types, existing labels, and the HTTP endpoint are unchanged;
+the new gauge is additive. The default HLL size changes from 16,384 registers
+(`bucket_bits=14`, about 0.8% standard error) to 65,536 registers
+(`bucket_bits=16`, about 0.4%). Three default windows use about 192 KiB of
+register storage; sliding slots make the live tracker a few MiB per server.
+The setting remains configurable with `--metric-hll-bucket-bits`.
 
 ### Save Metrics (GPU → CPU)
 - **pegaflow_save_bytes_total** (Counter)
@@ -245,15 +264,17 @@ tier counters.
   - Only used when `--metrics-otel-endpoint` is set
 
 - `--metric-hll-windows`: Comma-separated HLL sliding windows for estimated
-  prefix reuse (default: `15m,1h,24h`)
+  prefix reuse (default: `15m,1h,1d`)
   - Supported units: `s`, `m`, `h`, `d`
   - Each configured duration becomes a canonical `window` label. For example,
     the default config exports `window="15m"`, `window="1h"`, and `window="1d"`.
   - Empty entries such as `15m,,1h` and duplicate durations such as `1h,60m`
     are rejected at startup.
 
-- `--metric-hll-bucket-bits`: HLL bucket index bits (default: `14`)
-  - Higher values use more memory and lower estimation error.
+- `--metric-hll-bucket-bits`: HLL bucket index bits (default: `16`)
+  - `2^16 = 65,536` registers per window and about 0.4% standard error.
+  - Higher values use more memory and lower estimation error; `18` remains
+    the supported maximum.
 
 **Example: Prometheus Metrics**
 ```bash
@@ -484,7 +505,10 @@ sum by (le) (
   rate(pegaflow_cache_residence_duration_seconds_bucket{reason="pressure"}[5m])
 )
 
-# HLL estimated hit rate for the 1h window
+# HLL estimated hit rate for the 1h window (preferred)
+pegaflow_hll_estimated_hit_rate{window="1h"}
+
+# Backward-compatible derivation from the retained gauges
 1 - (
   pegaflow_hll_cardinality{window="1h"}
   /

--- a/pegaflow-common/src/hll.rs
+++ b/pegaflow-common/src/hll.rs
@@ -22,6 +22,7 @@ pub const MAX_BUCKET_BITS: u8 = 18;
 /// Input hashes are expected to have good uniformity (e.g. SHA-256).
 /// The full hash is used: top `bucket_bits` bits select the register,
 /// remaining bits are scanned for leading zeros.
+#[derive(Debug)]
 pub struct HyperLogLog {
     registers: Vec<u8>,
     bucket_bits: u8,
@@ -34,8 +35,8 @@ impl HyperLogLog {
     /// Create a new HyperLogLog with the given bucket bits.
     ///
     /// `bucket_bits` determines the number of buckets (2^bucket_bits) and estimation
-    /// accuracy (~1.04 / sqrt(2^bucket_bits)).  14 gives 16384 buckets
-    /// and ~0.8% standard error.
+    /// accuracy (~1.04 / sqrt(2^bucket_bits)). 16 gives 65536 buckets
+    /// and ~0.4% standard error.
     pub fn new(bucket_bits: u8) -> Self {
         assert!(
             (MIN_BUCKET_BITS..=MAX_BUCKET_BITS).contains(&bucket_bits),
@@ -205,7 +206,7 @@ fn alpha_m(m: usize) -> f64 {
 /// Metric snapshot returned by [`HllTracker::metric`].
 #[derive(Debug, Clone)]
 pub struct HllMetric {
-    /// Estimated number of distinct block hashes in the window.
+    /// Estimated number of distinct miss block identities in the window.
     pub cardinality: f64,
     /// Total block requests (including duplicates) in the window.
     pub total_requests: u64,
@@ -225,7 +226,7 @@ struct WindowSlot {
 ///
 /// Divides time into fixed-duration slots and maintains a ring of HLLs.
 /// The merged cardinality across all active slots approximates the number
-/// of distinct blocks requested in the window. From this we derive:
+/// of distinct miss blocks recorded in the window. From this we derive:
 ///
 /// ```text
 /// hit_rate = (total_requests - cardinality) / total_requests
@@ -249,7 +250,7 @@ impl HllTracker {
     ///
     /// - `slot_duration`: how long each time slot lasts (e.g. 1 hour)
     /// - `window_duration`: total sliding window (e.g. 24 hours)
-    /// - `bucket_bits`: HLL bucket index bits (4..=18, default 14)
+    /// - `bucket_bits`: HLL bucket index bits (4..=18, default 16)
     pub fn new(slot_duration: Duration, window_duration: Duration, bucket_bits: u8) -> Self {
         Self {
             slots: VecDeque::new(),
@@ -268,6 +269,19 @@ impl HllTracker {
     /// time drift. For example with 1h slots: if the first slot starts at 0:00
     /// and the next request arrives at 1:30, the new slot starts at 1:00 (not 1:30).
     pub fn record(&mut self, hash: &[u8]) {
+        self.record_hashes_with_total(std::slice::from_ref(&hash), 1);
+    }
+
+    /// Record a batch of distinct identities while accounting for a possibly
+    /// larger observation count. The identities are inserted into HLL, while
+    /// `total_requests` is used as the denominator. This is used by the
+    /// miss-only reference: only cache misses enter HLL, but every queried
+    /// block still contributes to the total observation count.
+    pub fn record_hashes_with_total<T: AsRef<[u8]>>(&mut self, hashes: &[T], total_requests: u64) {
+        if total_requests == 0 {
+            return;
+        }
+
         let now = Instant::now();
 
         let need_new_slot = match self.slots.back() {
@@ -295,15 +309,15 @@ impl HllTracker {
         }
 
         let slot = self.slots.back_mut().unwrap();
-        slot.hll.insert(hash);
-        slot.request_count += 1;
+        for hash in hashes {
+            slot.hll.insert(hash.as_ref());
+        }
+        slot.request_count += total_requests;
     }
 
     /// Record a batch of block hashes from a gRPC request.
     pub fn record_hashes(&mut self, hashes: &[Vec<u8>]) {
-        for hash in hashes {
-            self.record(hash);
-        }
+        self.record_hashes_with_total(hashes, hashes.len() as u64);
     }
 
     /// Compute and return the current metric snapshot.
@@ -417,6 +431,25 @@ impl MultiWindowHllTracker {
         }
     }
 
+    /// Record all queried blocks in the denominator but insert only the
+    /// identities that were misses into HLL. Repeated misses remain deduped by
+    /// HLL, preserving the infinite-cache reuse reference without discarding
+    /// historical observations.
+    pub fn record_namespaced_misses(
+        &mut self,
+        namespace: &str,
+        total_requests: u64,
+        miss_hashes: &[Vec<u8>],
+    ) {
+        let namespaced_hashes: Vec<[u8; 8]> = miss_hashes
+            .iter()
+            .map(|hash| namespaced_hash(namespace, hash))
+            .collect();
+        for (_, tracker) in &mut self.windows {
+            tracker.record_hashes_with_total(&namespaced_hashes, total_requests);
+        }
+    }
+
     /// Snapshot every window. Returned in insertion order.
     pub fn metrics(&mut self) -> Vec<(String, HllMetric)> {
         self.windows
@@ -424,6 +457,38 @@ impl MultiWindowHllTracker {
             .map(|(label, tracker)| (label.clone(), tracker.metric()))
             .collect()
     }
+}
+
+/// Stable identity hash for `(namespace, block_hash)`.
+///
+/// Cluster aggregation unions raw HLL registers across nodes, so every node
+/// must map the same object to the exact same bits regardless of platform,
+/// architecture, or build. FNV-1a with a splitmix64 finalizer is fully
+/// specified byte-by-byte; do not replace it with a hasher that does not
+/// guarantee cross-platform stability (e.g. ahash, SipHash with random keys).
+fn namespaced_hash(namespace: &str, block_hash: &[u8]) -> [u8; 8] {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut h = FNV_OFFSET;
+    // Length prefix keeps (namespace, hash) boundaries unambiguous.
+    for &byte in (namespace.len() as u64)
+        .to_le_bytes()
+        .iter()
+        .chain(namespace.as_bytes())
+        .chain(block_hash)
+    {
+        h = (h ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
+    }
+    splitmix64(h).to_be_bytes()
+}
+
+/// splitmix64 finalizer: strengthens FNV-1a's avalanche so the top bits used
+/// for HLL bucket selection are uniformly distributed.
+fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^ (x >> 31)
 }
 
 fn derive_slot_duration(window: Duration) -> Duration {
@@ -766,7 +831,7 @@ mod tests {
             vec![
                 ("15m".into(), Duration::from_secs(15 * 60)),
                 ("1h".into(), Duration::from_secs(3600)),
-                ("24h".into(), Duration::from_secs(86400)),
+                ("1d".into(), Duration::from_secs(86400)),
             ],
             14,
         );
@@ -781,7 +846,7 @@ mod tests {
         assert_eq!(metrics.len(), 3);
         assert_eq!(metrics[0].0, "15m");
         assert_eq!(metrics[1].0, "1h");
-        assert_eq!(metrics[2].0, "24h");
+        assert_eq!(metrics[2].0, "1d");
         for (label, m) in metrics {
             assert_eq!(m.total_requests, 2000, "{label}: total");
             assert!(
@@ -790,6 +855,44 @@ mod tests {
                 m.cardinality
             );
         }
+    }
+
+    #[test]
+    fn namespaced_misses_keep_all_observations_in_denominator() {
+        let mut tracker =
+            MultiWindowHllTracker::new(vec![("15m".into(), Duration::from_secs(15 * 60))], 14);
+        let miss = vec![sha256_like(1).to_vec(), sha256_like(2).to_vec()];
+        tracker.record_namespaced_misses("model", 5, &miss);
+
+        let metric = tracker.metrics().remove(0).1;
+        assert_eq!(metric.total_requests, 5);
+        assert!(metric.cardinality > 1.0 && metric.cardinality < 3.5);
+        assert!(metric.estimated_hit_rate > 0.3);
+    }
+
+    #[test]
+    fn namespaced_misses_allow_all_hit_observation_without_hll_insert() {
+        let mut tracker =
+            MultiWindowHllTracker::new(vec![("15m".into(), Duration::from_secs(15 * 60))], 14);
+        tracker.record_namespaced_misses("model", 4, &[]);
+
+        let metric = tracker.metrics().remove(0).1;
+        assert_eq!(metric.total_requests, 4);
+        assert_eq!(metric.cardinality, 0.0);
+        assert_eq!(metric.estimated_hit_rate, 1.0);
+    }
+
+    #[test]
+    fn namespaced_misses_separate_equal_raw_hashes() {
+        let mut tracker =
+            MultiWindowHllTracker::new(vec![("15m".into(), Duration::from_secs(15 * 60))], 16);
+        let raw_hash = vec![42; 32];
+        tracker.record_namespaced_misses("model-a", 1, std::slice::from_ref(&raw_hash));
+        tracker.record_namespaced_misses("model-b", 1, std::slice::from_ref(&raw_hash));
+
+        let metric = tracker.metrics().remove(0).1;
+        assert_eq!(metric.total_requests, 2);
+        assert!((1.5..2.5).contains(&metric.cardinality));
     }
 
     #[test]
@@ -848,12 +951,5 @@ mod tests {
         let m3 = splitmix64(m2);
         hash[24..32].copy_from_slice(&m3.to_le_bytes());
         hash
-    }
-
-    fn splitmix64(mut x: u64) -> u64 {
-        x = x.wrapping_add(0x9e3779b97f4a7c15);
-        x = (x ^ (x >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
-        x = (x ^ (x >> 27)).wrapping_mul(0x94d049bb133111eb);
-        x ^ (x >> 31)
     }
 }

--- a/pegaflow-common/src/hll.rs
+++ b/pegaflow-common/src/hll.rs
@@ -269,7 +269,8 @@ impl HllTracker {
     /// time drift. For example with 1h slots: if the first slot starts at 0:00
     /// and the next request arrives at 1:30, the new slot starts at 1:00 (not 1:30).
     pub fn record(&mut self, hash: &[u8]) {
-        self.record_hashes_with_total(std::slice::from_ref(&hash), 1);
+        let hashes = [hash];
+        self.record_hashes_with_total(&hashes, 1);
     }
 
     /// Record a batch of distinct identities while accounting for a possibly
@@ -441,6 +442,11 @@ impl MultiWindowHllTracker {
         total_requests: u64,
         miss_hashes: &[Vec<u8>],
     ) {
+        if total_requests == 0 {
+            return;
+        }
+        debug_assert!(miss_hashes.len() as u64 <= total_requests);
+
         let namespaced_hashes: Vec<[u8; 8]> = miss_hashes
             .iter()
             .map(|hash| namespaced_hash(namespace, hash))

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -483,6 +483,11 @@ impl PegaEngine {
             .collect()
     }
 
+    /// Return the namespace associated with a registered instance.
+    pub fn instance_namespace(&self, instance_id: &str) -> Result<String, EngineError> {
+        Ok(self.get_instance(instance_id)?.namespace().to_string())
+    }
+
     /// Count prefix hit blocks with SSD prefetch support.
     ///
     /// Argument contract:

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -174,11 +174,11 @@ pub struct Cli {
     /// HLL sliding-window list for hit-rate estimation. Comma-separated humantime
     /// durations; each becomes a canonical `window` label in metrics (e.g. `15m,1h,1d`).
     /// Slot duration is derived as `clamp(window/24, 1min, 1h)`.
-    #[arg(long, default_value = "15m,1h,24h", value_parser = parse_hll_windows_arg)]
+    #[arg(long, default_value = "15m,1h,1d", value_parser = parse_hll_windows_arg)]
     pub metric_hll_windows: String,
 
-    /// HLL bucket index bits 4–18 (default: 14 → 16384 buckets, ~0.8% error)
-    #[arg(long, default_value_t = 14, value_parser = parse_hll_bucket_bits)]
+    /// HLL bucket index bits 4–18 (default: 16 → 65536 buckets, ~0.4% error)
+    #[arg(long, default_value_t = 16, value_parser = parse_hll_bucket_bits)]
     pub metric_hll_bucket_bits: u8,
 
     /// Transfer lock timeout in seconds. Blocks held for cross-node RDMA transfer are
@@ -211,7 +211,7 @@ fn parse_hll_windows_arg(s: &str) -> Result<String, String> {
     Ok(s.to_string())
 }
 
-/// Parse a comma-separated list of humantime windows (e.g. `15m,1h,24h`).
+/// Parse a comma-separated list of humantime windows (e.g. `15m,1h,1d`).
 /// Each entry becomes `(label, duration)` where label is canonicalized from
 /// the parsed duration.
 fn parse_hll_windows(s: &str) -> Result<Vec<(String, Duration)>, String> {
@@ -732,6 +732,7 @@ mod tests {
             parse_hll_windows(&cli.metric_hll_windows).unwrap(),
             expected_hll_windows()
         );
+        assert_eq!(cli.metric_hll_bucket_bits, 16);
     }
 
     #[test]

--- a/pegaflow-server/src/metric.rs
+++ b/pegaflow-server/src/metric.rs
@@ -8,6 +8,7 @@ use tonic::Status;
 struct HllGaugeHandles {
     _cardinality: ObservableGauge<f64>,
     _total_requests: ObservableGauge<u64>,
+    _estimated_hit_rate: ObservableGauge<f64>,
 }
 
 static HLL_GAUGES: OnceLock<HllGaugeHandles> = OnceLock::new();
@@ -15,18 +16,20 @@ static HLL_GAUGES: OnceLock<HllGaugeHandles> = OnceLock::new();
 /// Register HLL observable gauges backed by the multi-window tracker.
 ///
 /// Emits one time series per configured window, labeled with `window=<label>`.
-/// Hit rate is intentionally not exported — derive it in Prometheus via
-/// `1 - pegaflow_hll_cardinality / pegaflow_hll_total_requests`.
+/// The cardinality and total gauges remain available for compatibility. The
+/// direct hit-rate gauge is calculated from the same tracker snapshot and is
+/// clamped to the valid probability range.
 pub fn register_hll_gauges(tracker: &Arc<Mutex<MultiWindowHllTracker>>) {
     let t_card = Arc::clone(tracker);
     let t_total = Arc::clone(tracker);
+    let t_hit_rate = Arc::clone(tracker);
 
     HLL_GAUGES.get_or_init(|| {
         let meter = global::meter("pegaflow-core");
 
         let cardinality = meter
             .f64_observable_gauge("pegaflow_hll_cardinality")
-            .with_description("Estimated distinct blocks seen in the sliding window")
+            .with_description("Estimated distinct cache-miss blocks seen in the sliding window")
             .with_callback(move |observer| {
                 if let Ok(mut t) = t_card.lock() {
                     for (label, m) in t.metrics() {
@@ -38,7 +41,7 @@ pub fn register_hll_gauges(tracker: &Arc<Mutex<MultiWindowHllTracker>>) {
 
         let total_requests = meter
             .u64_observable_gauge("pegaflow_hll_total_requests")
-            .with_description("Total block requests in the sliding window")
+            .with_description("Total queried blocks in the sliding window")
             .with_callback(move |observer| {
                 if let Ok(mut t) = t_total.lock() {
                     for (label, m) in t.metrics() {
@@ -48,9 +51,22 @@ pub fn register_hll_gauges(tracker: &Arc<Mutex<MultiWindowHllTracker>>) {
             })
             .build();
 
+        let estimated_hit_rate = meter
+            .f64_observable_gauge("pegaflow_hll_estimated_hit_rate")
+            .with_description("Estimated infinite-cache reuse rate from HLL cache misses")
+            .with_callback(move |observer| {
+                if let Ok(mut t) = t_hit_rate.lock() {
+                    for (label, m) in t.metrics() {
+                        observer.observe(m.estimated_hit_rate, &[KeyValue::new("window", label)]);
+                    }
+                }
+            })
+            .build();
+
         HllGaugeHandles {
             _cardinality: cardinality,
             _total_requests: total_requests,
+            _estimated_hit_rate: estimated_hit_rate,
         }
     });
 }

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -650,7 +650,17 @@ impl Engine for GrpcEngineService {
                     PrefetchStatus::Ready { blocks, missing } => {
                         let hit = blocks.len();
                         if let Ok(mut t) = self.hll_tracker.lock() {
-                            t.record_hashes(&req.block_hashes);
+                            let miss_count = missing.min(req.block_hashes.len());
+                            let miss_start = req.block_hashes.len() - miss_count;
+                            debug_assert_eq!(hit + miss_count, req.block_hashes.len());
+                            if let Ok(namespace) = self.engine.instance_namespace(&req.instance_id)
+                            {
+                                t.record_namespaced_misses(
+                                    &namespace,
+                                    req.block_hashes.len() as u64,
+                                    &req.block_hashes[miss_start..],
+                                );
+                            }
                         }
                         let lease = if hit == 0 {
                             Vec::new()

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -652,14 +652,14 @@ impl Engine for GrpcEngineService {
                         let miss_count = missing.min(req.block_hashes.len());
                         let miss_start = req.block_hashes.len() - miss_count;
                         debug_assert_eq!(hit + miss_count, req.block_hashes.len());
-                        if let Ok(namespace) = self.engine.instance_namespace(&req.instance_id) {
-                            if let Ok(mut t) = self.hll_tracker.lock() {
-                                t.record_namespaced_misses(
-                                    &namespace,
-                                    req.block_hashes.len() as u64,
-                                    &req.block_hashes[miss_start..],
-                                );
-                            }
+                        if let Ok(namespace) = self.engine.instance_namespace(&req.instance_id)
+                            && let Ok(mut t) = self.hll_tracker.lock()
+                        {
+                            t.record_namespaced_misses(
+                                &namespace,
+                                req.block_hashes.len() as u64,
+                                &req.block_hashes[miss_start..],
+                            );
                         }
                         let lease = if hit == 0 {
                             Vec::new()

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -649,12 +649,11 @@ impl Engine for GrpcEngineService {
                 match status {
                     PrefetchStatus::Ready { blocks, missing } => {
                         let hit = blocks.len();
-                        if let Ok(mut t) = self.hll_tracker.lock() {
-                            let miss_count = missing.min(req.block_hashes.len());
-                            let miss_start = req.block_hashes.len() - miss_count;
-                            debug_assert_eq!(hit + miss_count, req.block_hashes.len());
-                            if let Ok(namespace) = self.engine.instance_namespace(&req.instance_id)
-                            {
+                        let miss_count = missing.min(req.block_hashes.len());
+                        let miss_start = req.block_hashes.len() - miss_count;
+                        debug_assert_eq!(hit + miss_count, req.block_hashes.len());
+                        if let Ok(namespace) = self.engine.instance_namespace(&req.instance_id) {
+                            if let Ok(mut t) = self.hll_tracker.lock() {
                                 t.record_namespaced_misses(
                                     &namespace,
                                     req.block_hashes.len() as u64,


### PR DESCRIPTION
## Summary

- Increase the default local HLL size from `bucket_bits=14` (16,384 registers) to `16` (65,536 registers), reducing the theoretical standard error from about 0.8% to about 0.4%.
- Record only the final miss suffix in HLL cardinality while keeping all queried blocks in `pegaflow_hll_total_requests`.
- Add `pegaflow_hll_estimated_hit_rate`, calculated and clamped in the tracker, while retaining the existing cardinality and total metrics and labels.
- Use stable `(namespace, block hash)` identities so local measurements do not collide across namespaces.
- Update the metrics documentation and default windows to `15m,1h,1d`.

## Compatibility

This is not an `/metrics` protocol breaking change: the HTTP endpoint, existing metric names, types, and labels remain available. The new gauge is additive. The existing PromQL remains valid, but the HLL cardinality semantics are now explicitly miss-only and the default precision is higher.

MetaServer HLL aggregation, heartbeat, protobuf, and MetaServer metrics are intentionally excluded and will be handled by a follow-up PR.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p pegaflow-common` (34 passed)
- `git diff --check`

Server compilation could not complete on the macOS development host because the workspace's Linux-only `io-uring`/CUDA dependencies require Linux headers/toolchains; Linux CI remains the authoritative server build check.
