### PR TITLE
fix(core): allow SSD weak refs during pressure eviction

### DIFF
--- a/pegaflow-core/src/cache.rs
+++ b/pegaflow-core/src/cache.rs
@@ -72,14 +72,14 @@ impl TinyLfuCache<BlockKey, ArcSealedBlock> {
         self.lru.contains_key(key)
     }
 
-    /// Returns true only when the cache owns the block exclusively.
+    /// Returns true when the cache is the only strong owner of the block.
     ///
-    /// `Arc::get_mut` rejects both other strong references and weak references,
-    /// so no holder outside the cache can keep or reacquire the allocation.
-    pub(crate) fn is_exclusively_owned(&mut self, key: &BlockKey) -> bool {
+    /// Weak references from fire-and-forget backing-store work do not pin the
+    /// resident block: they may fail to upgrade after pressure eviction.
+    pub(crate) fn is_cache_owned_only(&self, key: &BlockKey) -> bool {
         self.lru
-            .peek_mut(key)
-            .is_some_and(|block| Arc::get_mut(block).is_some())
+            .peek(key)
+            .is_some_and(|block| Arc::strong_count(block) == 1)
     }
 
     /// Insert with TinyLFU admission. If the candidate is colder than the

--- a/pegaflow-core/src/storage/read_cache.rs
+++ b/pegaflow-core/src/storage/read_cache.rs
@@ -378,9 +378,9 @@ fn remove_lru_batch_from_class(
         else {
             break;
         };
-        if inner.cache.is_exclusively_owned(&key) {
+        if inner.cache.is_cache_owned_only(&key) {
             let block = remove_lru(inner, class)
-                .expect("exclusive LRU candidate must remain resident while locked");
+                .expect("cache-owned LRU candidate must remain resident while locked");
             removed.push(block);
         } else {
             class_lru(inner, class).get(&key);
@@ -497,18 +497,32 @@ mod tests {
     }
 
     #[test]
-    fn pressure_reclaim_waits_for_weak_references() {
+    fn pressure_reclaim_ignores_weak_references() {
         let cache = make_cache();
         let key = BlockKey::new("ns".into(), vec![1]);
         let block = make_block();
         let weak = Arc::downgrade(&block);
         cache.batch_insert(vec![(key.clone(), block)]);
 
+        assert_eq!(cache.remove_lru_batch(1)[0].0, key);
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn pressure_reclaim_waits_for_external_strong_reference() {
+        let cache = make_cache();
+        let key = BlockKey::new("ns".into(), vec![1]);
+        let block = make_block();
+        let external = Arc::clone(&block);
+        let weak = Arc::downgrade(&block);
+        cache.batch_insert(vec![(key.clone(), block)]);
+
         assert!(cache.remove_lru_batch(1).is_empty());
         assert_class(&cache, &key, ResidentClass::Retained);
 
-        drop(weak);
+        drop(external);
         assert_eq!(cache.remove_lru_batch(1)[0].0, key);
+        assert!(weak.upgrade().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Treat only additional strong `Arc<SealedBlock>` owners as pressure-eviction pins.
- Allow SSD write-queue `Weak<SealedBlock>` references to yield to memory pressure, preserving the existing fire-and-forget SSD contract.
- Add regression coverage for weak-only eviction and strong-reference retention.

## Validation

Ran on RTX 4090 / Linux with CUDA 13 and RDMA enabled:

- `cargo fmt --all -- --check`
- `cargo test --no-default-features --features cuda-13,rdma -p pegaflow-core storage::read_cache::tests -- --nocapture` (22 passed)
- `cargo clippy --workspace --all-targets --no-default-features --features cuda-13,rdma -- -D warnings`
- `cargo test --no-default-features --features cuda-13,rdma -p pegaflow-core --test eviction -- --nocapture --test-threads=1` (3 passed)

The existing `ssd_cache` integration suite was also attempted on the 4090 host, but its fixed 32 KiB test pool is split across the host's NUMA-local pools and exhausts before the first save; all 11 failures are `pinned pool exhausted`, before SSD assertions run.