### PR TITLE
feat(metaserver): aggregate HLL reports across nodes

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -157,6 +157,31 @@ PegaFlow exposes the following metrics for monitoring KV cache operations:
   - Labels: `window`
   - Value is clamped to `[0, 1]`
 
+The MetaServer exports the active-node register union. Do not sum per-server
+cardinality gauges: the same object observed on multiple nodes must count only
+once at cluster scope.
+
+- **pegaflow_metaserver_hll_cardinality** (Gauge)
+  - Estimated distinct cache objects in the active-node HLL register union
+  - Labels: `window`
+- **pegaflow_metaserver_hll_total_requests** (Gauge)
+  - Sum of observations in the latest reports from active node sessions
+  - Labels: `window`
+- **pegaflow_metaserver_hll_estimated_hit_rate** (Gauge)
+  - Miss-based infinite-cache reuse reference from the same aggregate snapshot
+  - Labels: `window`
+- **pegaflow_metaserver_hll_active_nodes** (Gauge)
+  - Active node sessions included in the union
+  - Labels: `window`
+- **pegaflow_metaserver_hll_snapshot_age** (Gauge, unit `s`)
+  - Age of the oldest active-node report in the aggregate
+  - Labels: `window`
+
+Missing or damaged HLL reports are best-effort observability failures: the
+MetaServer keeps the node live for metadata, excludes that report from the
+cluster union, and the server increments
+`pegaflow_metaserver_hll_report_failures` when it cannot build a report.
+
 The existing cardinality and total metrics are retained. Existing PromQL
 continues to work, but new dashboards should prefer the direct gauge because
 it applies the same cardinality clamp as the tracker:
@@ -438,6 +463,8 @@ Same as above: http://localhost:3000
 |--------------------|-------|----------|--------------------------------------|
 | PegaFlow Server    | 50055 | gRPC     | Engine service                       |
 | PegaFlow Server    | 9091  | HTTP     | Prometheus metrics endpoint          |
+| PegaFlow MetaServer | 50056 | gRPC     | Cross-node metadata and HLL reports  |
+| PegaFlow MetaServer | 9092  | HTTP     | Prometheus metrics endpoint          |
 | OTel Collector     | 4321  | gRPC     | OTLP gRPC receiver (deprecated)      |
 | OTel Collector     | 8889  | HTTP     | Prometheus exporter (deprecated)     |
 | Prometheus         | 9090  | HTTP     | Query API & Web UI                   |
@@ -507,6 +534,9 @@ sum by (le) (
 
 # HLL estimated hit rate for the 1h window (preferred)
 pegaflow_hll_estimated_hit_rate{window="1h"}
+
+# Cluster HLL estimated hit rate for the 1h window
+pegaflow_metaserver_hll_estimated_hit_rate{window="1h"}
 
 # Backward-compatible derivation from the retained gauges
 1 - (

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -181,8 +181,12 @@ Missing or damaged HLL reports are best-effort observability failures: the
 MetaServer keeps the node live for metadata, excludes that report from the
 cluster union, and the server increments
 `pegaflow_metaserver_hll_report_failures` when it cannot build a report.
-All active reports must use the same window label, duration, and `bucket_bits`;
-an incompatible report is excluded from the union while the node remains live.
+The MetaServer validates every report against its startup
+`--metric-hll-windows` and `--metric-hll-bucket-bits` configuration. Pega
+servers and the MetaServer must use the same values; an incompatible report is
+excluded from the union while the node remains live. Valid metadata
+insert/remove activity refreshes owner visibility but never refreshes HLL
+report age.
 
 The existing cardinality and total metrics are retained. Existing PromQL
 continues to work, but new dashboards should prefer the direct gauge because
@@ -302,6 +306,10 @@ tier counters.
   - `2^16 = 65,536` registers per window and about 0.4% standard error.
   - Higher values use more memory and lower estimation error; `18` remains
     the supported maximum.
+
+Use the same two HLL options on `pegaflow-server` and
+`pegaflow-metaserver`. The MetaServer rejects mismatched reports from the
+cluster union without failing node heartbeats.
 
 **Example: Prometheus Metrics**
 ```bash

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -181,6 +181,8 @@ Missing or damaged HLL reports are best-effort observability failures: the
 MetaServer keeps the node live for metadata, excludes that report from the
 cluster union, and the server increments
 `pegaflow_metaserver_hll_report_failures` when it cannot build a report.
+All active reports must use the same window label, duration, and `bucket_bits`;
+an incompatible report is excluded from the union while the node remains live.
 
 The existing cardinality and total metrics are retained. Existing PromQL
 continues to work, but new dashboards should prefer the direct gauge because

--- a/examples/metric-prometheus/prometheus.yml
+++ b/examples/metric-prometheus/prometheus.yml
@@ -6,3 +6,7 @@ scrape_configs:
   - job_name: 'pegaflow'
     static_configs:
       - targets: ['host.docker.internal:9091']
+
+  - job_name: 'pegaflow-metaserver'
+    static_configs:
+      - targets: ['host.docker.internal:9092']

--- a/examples/metric-prometheus/prometheus.yml
+++ b/examples/metric-prometheus/prometheus.yml
@@ -6,7 +6,3 @@ scrape_configs:
   - job_name: 'pegaflow'
     static_configs:
       - targets: ['host.docker.internal:9091']
-
-  - job_name: 'pegaflow-metaserver'
-    static_configs:
-      - targets: ['host.docker.internal:9092']

--- a/pegaflow-common/src/hll.rs
+++ b/pegaflow-common/src/hll.rs
@@ -12,6 +12,8 @@ use std::time::{Duration, Instant};
 /// Allowed range for `bucket_bits` (register index width).
 pub const MIN_BUCKET_BITS: u8 = 4;
 pub const MAX_BUCKET_BITS: u8 = 18;
+pub const MAX_HLL_REPORT_BYTES: usize = 1024 * 1024;
+pub const MAX_HLL_WINDOWS: usize = 32;
 
 // ============================================================================
 // HyperLogLog core
@@ -83,6 +85,35 @@ impl HyperLogLog {
                 *a = *b;
             }
         }
+    }
+
+    /// Build an HLL from a mergeable register snapshot.
+    pub fn from_registers(bucket_bits: u8, registers: Vec<u8>) -> Result<Self, String> {
+        if !(MIN_BUCKET_BITS..=MAX_BUCKET_BITS).contains(&bucket_bits) {
+            return Err(format!(
+                "HLL bucket_bits must be in {MIN_BUCKET_BITS}..={MAX_BUCKET_BITS}, got {bucket_bits}"
+            ));
+        }
+        let expected = 1usize << bucket_bits;
+        if registers.len() != expected {
+            return Err(format!(
+                "HLL registers length must be {expected} for bucket_bits={bucket_bits}, got {}",
+                registers.len()
+            ));
+        }
+        Ok(Self {
+            registers,
+            bucket_bits,
+            lz_mask: (1u32 << (32 - bucket_bits)) - 1,
+        })
+    }
+
+    pub fn registers(&self) -> &[u8] {
+        &self.registers
+    }
+
+    pub fn registers_mut(&mut self) -> &mut [u8] {
+        &mut self.registers
     }
 
     /// Reset all registers to zero.
@@ -216,6 +247,16 @@ pub struct HllMetric {
     pub window_slot_count: usize,
 }
 
+/// Mergeable snapshot for one configured sliding window.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HllWindowSnapshot {
+    pub window: String,
+    pub window_secs: u64,
+    pub bucket_bits: u8,
+    pub registers: Vec<u8>,
+    pub total_requests: u64,
+}
+
 struct WindowSlot {
     hll: HyperLogLog,
     start: Instant,
@@ -319,6 +360,25 @@ impl HllTracker {
     /// Record a batch of block hashes from a gRPC request.
     pub fn record_hashes(&mut self, hashes: &[Vec<u8>]) {
         self.record_hashes_with_total(hashes, hashes.len() as u64);
+    }
+
+    fn snapshot(&mut self, window: String) -> HllWindowSnapshot {
+        self.expire_old_slots(Instant::now());
+        self.ensure_merged();
+
+        let mut hll = HyperLogLog::new(self.bucket_bits);
+        hll.merge(&self.merged);
+        if let Some(back) = self.slots.back() {
+            hll.merge(&back.hll);
+        }
+
+        HllWindowSnapshot {
+            window,
+            window_secs: self.window_duration.as_secs(),
+            bucket_bits: self.bucket_bits,
+            registers: hll.registers,
+            total_requests: self.slots.iter().map(|slot| slot.request_count).sum(),
+        }
     }
 
     /// Compute and return the current metric snapshot.
@@ -463,6 +523,14 @@ impl MultiWindowHllTracker {
             .map(|(label, tracker)| (label.clone(), tracker.metric()))
             .collect()
     }
+
+    /// Snapshot every window in mergeable register form, including empty windows.
+    pub fn snapshots(&mut self) -> Vec<HllWindowSnapshot> {
+        self.windows
+            .iter_mut()
+            .map(|(label, tracker)| tracker.snapshot(label.clone()))
+            .collect()
+    }
 }
 
 /// Stable identity hash for `(namespace, block_hash)`.
@@ -586,6 +654,24 @@ mod tests {
             (800.0..1200.0).contains(&card_merged),
             "expected ~1000, got {card_merged}"
         );
+    }
+
+    #[test]
+    fn hll_register_snapshot_round_trip() {
+        let mut original = HyperLogLog::new(8);
+        for i in 0u32..100 {
+            original.insert(&sha256_like(i));
+        }
+
+        let restored = HyperLogLog::from_registers(8, original.registers().to_vec()).unwrap();
+        assert_eq!(restored.registers(), original.registers());
+        assert_eq!(restored.cardinality(), original.cardinality());
+    }
+
+    #[test]
+    fn hll_register_snapshot_rejects_wrong_length() {
+        let err = HyperLogLog::from_registers(8, vec![0; 255]).unwrap_err();
+        assert!(err.contains("registers length must be 256"));
     }
 
     #[test]
@@ -886,6 +972,18 @@ mod tests {
         assert_eq!(metric.total_requests, 4);
         assert_eq!(metric.cardinality, 0.0);
         assert_eq!(metric.estimated_hit_rate, 1.0);
+    }
+
+    #[test]
+    fn multi_window_snapshot_includes_empty_registers() {
+        let mut tracker =
+            MultiWindowHllTracker::new(vec![("15m".into(), Duration::from_secs(15 * 60))], 8);
+
+        let snapshots = tracker.snapshots();
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0].window, "15m");
+        assert_eq!(snapshots[0].total_requests, 0);
+        assert_eq!(snapshots[0].registers, vec![0; 256]);
     }
 
     #[test]

--- a/pegaflow-common/src/hll.rs
+++ b/pegaflow-common/src/hll.rs
@@ -87,27 +87,6 @@ impl HyperLogLog {
         }
     }
 
-    /// Build an HLL from a mergeable register snapshot.
-    pub fn from_registers(bucket_bits: u8, registers: Vec<u8>) -> Result<Self, String> {
-        if !(MIN_BUCKET_BITS..=MAX_BUCKET_BITS).contains(&bucket_bits) {
-            return Err(format!(
-                "HLL bucket_bits must be in {MIN_BUCKET_BITS}..={MAX_BUCKET_BITS}, got {bucket_bits}"
-            ));
-        }
-        let expected = 1usize << bucket_bits;
-        if registers.len() != expected {
-            return Err(format!(
-                "HLL registers length must be {expected} for bucket_bits={bucket_bits}, got {}",
-                registers.len()
-            ));
-        }
-        Ok(Self {
-            registers,
-            bucket_bits,
-            lz_mask: (1u32 << (32 - bucket_bits)) - 1,
-        })
-    }
-
     pub fn registers(&self) -> &[u8] {
         &self.registers
     }
@@ -654,24 +633,6 @@ mod tests {
             (800.0..1200.0).contains(&card_merged),
             "expected ~1000, got {card_merged}"
         );
-    }
-
-    #[test]
-    fn hll_register_snapshot_round_trip() {
-        let mut original = HyperLogLog::new(8);
-        for i in 0u32..100 {
-            original.insert(&sha256_like(i));
-        }
-
-        let restored = HyperLogLog::from_registers(8, original.registers().to_vec()).unwrap();
-        assert_eq!(restored.registers(), original.registers());
-        assert_eq!(restored.cardinality(), original.cardinality());
-    }
-
-    #[test]
-    fn hll_register_snapshot_rejects_wrong_length() {
-        let err = HyperLogLog::from_registers(8, vec![0; 255]).unwrap_err();
-        assert!(err.contains("registers length must be 256"));
     }
 
     #[test]

--- a/pegaflow-common/src/hll_config.rs
+++ b/pegaflow-common/src/hll_config.rs
@@ -1,0 +1,139 @@
+//! Shared HLL deployment configuration parsing.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use crate::hll::{MAX_BUCKET_BITS, MAX_HLL_WINDOWS, MIN_BUCKET_BITS};
+
+pub const DEFAULT_HLL_WINDOWS: &str = "15m,1h,1d";
+pub const DEFAULT_HLL_BUCKET_BITS: u8 = 16;
+
+pub fn parse_hll_bucket_bits(value: &str) -> Result<u8, String> {
+    let bucket_bits: u8 = value.parse().map_err(|error| format!("{error}"))?;
+    if !(MIN_BUCKET_BITS..=MAX_BUCKET_BITS).contains(&bucket_bits) {
+        return Err(format!(
+            "HLL bucket_bits must be in {MIN_BUCKET_BITS}..={MAX_BUCKET_BITS}, got {bucket_bits}"
+        ));
+    }
+    Ok(bucket_bits)
+}
+
+pub fn parse_hll_windows_arg(value: &str) -> Result<String, String> {
+    parse_hll_windows(value)?;
+    Ok(value.to_string())
+}
+
+/// Parse comma-separated `<number><unit>` windows and canonicalize their labels.
+pub fn parse_hll_windows(value: &str) -> Result<Vec<(String, Duration)>, String> {
+    let mut windows = Vec::new();
+    let mut seen = HashSet::new();
+    for (index, token) in value.split(',').map(str::trim).enumerate() {
+        if token.is_empty() {
+            return Err(format!(
+                "--metric-hll-windows contains an empty window at position {}",
+                index + 1
+            ));
+        }
+        let duration = parse_duration(token)?;
+        if duration < Duration::from_secs(60) {
+            return Err(format!("HLL window {token} must be at least 1 minute"));
+        }
+        if !seen.insert(duration) {
+            return Err(format!(
+                "duplicate HLL window duration: {token} ({})",
+                format_window_label(duration)
+            ));
+        }
+        windows.push((format_window_label(duration), duration));
+    }
+    if windows.is_empty() {
+        return Err("--metric-hll-windows must list at least one window".into());
+    }
+    if windows.len() > MAX_HLL_WINDOWS {
+        return Err(format!(
+            "--metric-hll-windows supports at most {MAX_HLL_WINDOWS} windows, got {}",
+            windows.len()
+        ));
+    }
+    Ok(windows)
+}
+
+fn parse_duration(value: &str) -> Result<Duration, String> {
+    let (number, unit) = value.split_at(
+        value
+            .find(|character: char| !character.is_ascii_digit())
+            .ok_or_else(|| format!("missing time unit in {value}"))?,
+    );
+    let number: u64 = number
+        .parse()
+        .map_err(|error| format!("invalid number in {value}: {error}"))?;
+    let seconds = match unit {
+        "s" => number,
+        "m" => number
+            .checked_mul(60)
+            .ok_or_else(|| format!("duration overflows seconds in {value}"))?,
+        "h" => number
+            .checked_mul(3_600)
+            .ok_or_else(|| format!("duration overflows seconds in {value}"))?,
+        "d" => number
+            .checked_mul(86_400)
+            .ok_or_else(|| format!("duration overflows seconds in {value}"))?,
+        _ => {
+            return Err(format!(
+                "unknown time unit {unit:?} in {value}; use s/m/h/d"
+            ));
+        }
+    };
+    Ok(Duration::from_secs(seconds))
+}
+
+fn format_window_label(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if seconds.is_multiple_of(86_400) {
+        format!("{}d", seconds / 86_400)
+    } else if seconds.is_multiple_of(3_600) {
+        format!("{}h", seconds / 3_600)
+    } else if seconds.is_multiple_of(60) {
+        format!("{}m", seconds / 60)
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_are_canonicalized() {
+        assert_eq!(
+            parse_hll_windows("15m,60m,24h").unwrap(),
+            vec![
+                ("15m".to_string(), Duration::from_secs(15 * 60)),
+                ("1h".to_string(), Duration::from_secs(60 * 60)),
+                ("1d".to_string(), Duration::from_secs(24 * 60 * 60)),
+            ]
+        );
+    }
+
+    #[test]
+    fn windows_reject_empty_and_duplicate_entries() {
+        assert!(
+            parse_hll_windows("15m,,1h")
+                .unwrap_err()
+                .contains("empty window")
+        );
+        assert!(
+            parse_hll_windows("1h,60m")
+                .unwrap_err()
+                .contains("duplicate HLL window duration")
+        );
+    }
+
+    #[test]
+    fn bucket_bits_use_hll_bounds() {
+        assert_eq!(parse_hll_bucket_bits("16").unwrap(), 16);
+        assert!(parse_hll_bucket_bits("3").is_err());
+        assert!(parse_hll_bucket_bits("19").is_err());
+    }
+}

--- a/pegaflow-common/src/lib.rs
+++ b/pegaflow-common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod block;
 pub mod grpc;
 pub mod hll;
+pub mod hll_config;
 pub mod logging;
 #[cfg(target_os = "linux")]
 pub mod numa;

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, Weak};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use log::{debug, error, info, warn};
 use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_TIMEOUT};
@@ -780,10 +779,7 @@ async fn send_heartbeat(
 }
 
 fn invalid_hll_report() -> HllSnapshotReport {
-    HllSnapshotReport {
-        snapshot_at_unix_ms: 0,
-        windows: Vec::new(),
-    }
+    HllSnapshotReport::default()
 }
 
 fn build_hll_report(
@@ -809,14 +805,7 @@ fn build_hll_report(
         ));
     }
 
-    let snapshot_at_unix_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|error| format!("system clock is before Unix epoch: {error}"))?
-        .as_millis()
-        .try_into()
-        .map_err(|_| "snapshot timestamp does not fit into uint64".to_string())?;
     Ok(HllSnapshotReport {
-        snapshot_at_unix_ms,
         windows: snapshots
             .into_iter()
             .map(|snapshot| HllWindowSnapshot {

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -1,11 +1,14 @@
 use std::collections::HashMap;
-use std::sync::Weak;
+use std::sync::{Arc, Mutex, Weak};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use log::{debug, error, info, warn};
 use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_TIMEOUT};
+use pegaflow_common::hll::{MAX_HLL_REPORT_BYTES, MAX_HLL_WINDOWS, MultiWindowHllTracker};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
 use pegaflow_proto::proto::engine::{
-    HeartbeatNodeRequest, InsertBlockHashesRequest, RemoveBlockHashesRequest, UnregisterNodeRequest,
+    HeartbeatNodeRequest, HllSnapshotReport, HllWindowSnapshot, InsertBlockHashesRequest,
+    RemoveBlockHashesRequest, UnregisterNodeRequest,
 };
 #[cfg(feature = "rdma")]
 use pegaflow_proto::proto::engine::{NodePrefixResult, QueryPrefixBlocksRequest};
@@ -153,7 +156,11 @@ impl MetaServerClient {
     /// Create a new client and spawn the background registration loop.
     ///
     /// Must be called from within a tokio runtime context.
-    pub(crate) fn new(config: MetaServerClientConfig, read_cache: Weak<ReadCache>) -> Self {
+    pub(crate) fn new(
+        config: MetaServerClientConfig,
+        read_cache: Weak<ReadCache>,
+        hll_tracker: Arc<Mutex<MultiWindowHllTracker>>,
+    ) -> Self {
         let endpoint = metaserver_endpoint(config.metaserver_addr.clone());
         let (command_tx, rx) = mpsc::channel(config.queue_depth);
 
@@ -163,6 +170,7 @@ impl MetaServerClient {
             endpoint.clone(),
             config.advertise_addr,
             read_cache,
+            hll_tracker,
         ));
 
         // Lazy-connect query client: connects on first RPC, not here
@@ -333,6 +341,7 @@ async fn registration_loop(
     endpoint: Endpoint,
     advertise_addr: String,
     read_cache: Weak<ReadCache>,
+    hll_tracker: Arc<Mutex<MultiWindowHllTracker>>,
 ) {
     let mut client: Option<MetaServerGrpcClient<Channel>> = None;
     let node_id = Uuid::new_v4().to_string();
@@ -354,6 +363,7 @@ async fn registration_loop(
                     &endpoint,
                     &advertise_addr,
                     &node_id,
+                    &hll_tracker,
                 ).await {
                     Ok(next_period) => {
                         heartbeat.period = next_period;
@@ -453,6 +463,7 @@ async fn registration_loop(
             &advertise_addr,
             &node_id,
             &mut heartbeat,
+            &hll_tracker,
         )
         .await
         .is_err()
@@ -659,6 +670,7 @@ async fn ensure_heartbeat_registered(
     advertise_addr: &str,
     node_id: &str,
     heartbeat: &mut HeartbeatState,
+    hll_tracker: &Arc<Mutex<MultiWindowHllTracker>>,
 ) -> Result<(), ()> {
     if heartbeat.node_registered && client.is_some() {
         return Ok(());
@@ -675,6 +687,7 @@ async fn ensure_heartbeat_registered(
         endpoint,
         advertise_addr,
         node_id,
+        hll_tracker,
     )
     .await
     {
@@ -697,6 +710,7 @@ async fn send_heartbeat(
     endpoint: &Endpoint,
     advertise_addr: &str,
     node_id: &str,
+    hll_tracker: &Arc<Mutex<MultiWindowHllTracker>>,
 ) -> Result<Duration, Duration> {
     if client.is_none() {
         match connect_metaserver_client(endpoint).await {
@@ -713,11 +727,21 @@ async fn send_heartbeat(
         }
     }
 
+    let hll_report = match build_hll_report(hll_tracker) {
+        Ok(report) => report,
+        Err(error) => {
+            warn!("Failed to build HLL heartbeat report: {error}");
+            core_metrics().metaserver_hll_report_failures.add(1, &[]);
+            invalid_hll_report()
+        }
+    };
+
     let c = client.as_mut().expect("client is connected");
     match c
         .heartbeat_node(HeartbeatNodeRequest {
             node: advertise_addr.to_string(),
             node_id: node_id.to_string(),
+            hll_report: Some(hll_report),
         })
         .await
     {
@@ -753,6 +777,57 @@ async fn send_heartbeat(
             Err(heartbeat.advance_backoff())
         }
     }
+}
+
+fn invalid_hll_report() -> HllSnapshotReport {
+    HllSnapshotReport {
+        snapshot_at_unix_ms: 0,
+        windows: Vec::new(),
+    }
+}
+
+fn build_hll_report(
+    tracker: &Arc<Mutex<MultiWindowHllTracker>>,
+) -> Result<HllSnapshotReport, String> {
+    let snapshots = tracker
+        .lock()
+        .map_err(|error| format!("HLL tracker lock poisoned: {error}"))?
+        .snapshots();
+    if snapshots.is_empty() || snapshots.len() > MAX_HLL_WINDOWS {
+        return Err(format!(
+            "HLL report window count must be in 1..={MAX_HLL_WINDOWS}, got {}",
+            snapshots.len()
+        ));
+    }
+    let payload_bytes: usize = snapshots
+        .iter()
+        .map(|snapshot| snapshot.registers.len())
+        .sum();
+    if payload_bytes > MAX_HLL_REPORT_BYTES {
+        return Err(format!(
+            "HLL register payload exceeds {MAX_HLL_REPORT_BYTES} bytes: {payload_bytes}"
+        ));
+    }
+
+    let snapshot_at_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| format!("system clock is before Unix epoch: {error}"))?
+        .as_millis()
+        .try_into()
+        .map_err(|_| "snapshot timestamp does not fit into uint64".to_string())?;
+    Ok(HllSnapshotReport {
+        snapshot_at_unix_ms,
+        windows: snapshots
+            .into_iter()
+            .map(|snapshot| HllWindowSnapshot {
+                window: snapshot.window,
+                window_secs: snapshot.window_secs,
+                bucket_bits: u32::from(snapshot.bucket_bits),
+                registers: snapshot.registers,
+                total_requests: snapshot.total_requests,
+            })
+            .collect(),
+    })
 }
 
 fn heartbeat_period_from_stale_after(stale_after_secs: u64) -> Duration {
@@ -865,8 +940,15 @@ mod tests {
     impl MetaServer for FakeMetaServer {
         async fn heartbeat_node(
             &self,
-            _request: Request<HeartbeatNodeRequest>,
+            request: Request<HeartbeatNodeRequest>,
         ) -> Result<Response<HeartbeatNodeResponse>, Status> {
+            let report = request
+                .into_inner()
+                .hll_report
+                .expect("client heartbeat must include an HLL report envelope");
+            assert_eq!(report.windows.len(), 1);
+            assert_eq!(report.windows[0].window, "1m");
+            assert_eq!(report.windows[0].registers.len(), 16);
             self.state.heartbeat_count.fetch_add(1, Ordering::SeqCst);
             self.state.heartbeat_notify.notify_waiters();
             Ok(Response::new(HeartbeatNodeResponse {
@@ -1017,12 +1099,20 @@ mod tests {
         }
     }
 
+    fn test_hll_tracker() -> Arc<Mutex<MultiWindowHllTracker>> {
+        Arc::new(Mutex::new(MultiWindowHllTracker::new(
+            vec![("1m".into(), Duration::from_secs(60))],
+            4,
+        )))
+    }
+
     #[tokio::test]
     async fn heartbeat_loop_sends_initial_heartbeat_and_unregisters_on_shutdown() {
         let (addr, service, shutdown_tx) = start_fake_metaserver().await;
         let client = MetaServerClient::new(
             MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
             Weak::new(),
+            test_hll_tracker(),
         );
 
         wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
@@ -1041,6 +1131,7 @@ mod tests {
         let client = MetaServerClient::new(
             MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
             Weak::new(),
+            test_hll_tracker(),
         );
 
         wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
@@ -1057,6 +1148,7 @@ mod tests {
         let client = MetaServerClient::new(
             MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
             Weak::new(),
+            test_hll_tracker(),
         );
 
         client.try_register_namespace("ns".to_string(), vec![vec![1], vec![2]]);
@@ -1094,6 +1186,7 @@ mod tests {
         let client = MetaServerClient::new(
             MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
             Arc::downgrade(&read_cache),
+            test_hll_tracker(),
         );
 
         client.try_register_namespace("ns".to_string(), hashes);
@@ -1117,6 +1210,7 @@ mod tests {
         let client = MetaServerClient::new(
             MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
             Weak::new(),
+            test_hll_tracker(),
         );
 
         client.try_register_namespace("ns".to_string(), vec![vec![1]]);
@@ -1149,6 +1243,7 @@ mod tests {
         let client = MetaServerClient::new(
             MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
             Weak::new(),
+            test_hll_tracker(),
         );
         wait_for_count(&service.heartbeat_notify, &service.heartbeat_count, 1).await;
 
@@ -1244,6 +1339,7 @@ mod tests {
             endpoint,
             "node-a:50055".to_string(),
             Weak::new(),
+            test_hll_tracker(),
         ));
 
         wait_for_count(&service.insert_notify, &service.insert_count, 2).await;

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -488,6 +488,24 @@ impl PegaEngine {
         Ok(self.get_instance(instance_id)?.namespace().to_string())
     }
 
+    /// Record the miss suffix for the shared local and MetaServer HLL tracker.
+    pub fn record_hll_misses(
+        &self,
+        namespace: &str,
+        total_observations: u64,
+        miss_hashes: &[Vec<u8>],
+    ) {
+        self.storage
+            .record_hll_misses(namespace, total_observations, miss_hashes);
+    }
+
+    /// Access the tracker shared by local metrics and MetaServer heartbeats.
+    pub fn hll_tracker(
+        &self,
+    ) -> &std::sync::Arc<std::sync::Mutex<pegaflow_common::hll::MultiWindowHllTracker>> {
+        self.storage.hll_tracker()
+    }
+
     /// Count prefix hit blocks with SSD prefetch support.
     ///
     /// Argument contract:

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -95,6 +95,7 @@ pub(crate) struct CoreMetrics {
     pub metaserver_removal_failures: Counter<u64>,
     pub metaserver_removal_queue_full: Counter<u64>,
     pub metaserver_heartbeat_failures: Counter<u64>,
+    pub metaserver_hll_report_failures: Counter<u64>,
     pub metaserver_session_resets: Counter<u64>,
     pub metaserver_unregister_failures: Counter<u64>,
 
@@ -441,6 +442,10 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
             metaserver_heartbeat_failures: meter
                 .u64_counter("pegaflow_metaserver_heartbeat_failures")
                 .with_description("MetaServer HeartbeatNode RPC failures")
+                .build(),
+            metaserver_hll_report_failures: meter
+                .u64_counter("pegaflow_metaserver_hll_report_failures")
+                .with_description("HLL reports skipped or replaced with an invalid best-effort report")
                 .build(),
             metaserver_session_resets: meter
                 .u64_counter("pegaflow_metaserver_session_resets")

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -8,7 +8,7 @@ use bytesize::ByteSize;
 use log::{debug, info, warn};
 use std::collections::HashSet;
 use std::num::NonZeroU64;
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
 use crate::backing::{AllocateFn, DEFAULT_MAX_PREFETCH_BLOCKS, SsdBackingStore, SsdCacheConfig};
@@ -20,6 +20,7 @@ use crate::internode::metaserver_client::MetaServerClientConfig;
 use crate::metrics::core_metrics;
 use crate::pinned_pool::{PinnedAllocation, PinnedAllocator};
 use pegaflow_common::NumaNode;
+use pegaflow_common::hll::MultiWindowHllTracker;
 
 use prefetch::PrefetchScheduler;
 #[cfg(feature = "rdma")]
@@ -69,6 +70,10 @@ pub struct StorageConfig {
     pub metaserver_queue_depth: usize,
     /// Number of shards for the pinned memory pool (reduces allocator lock contention).
     pub pool_shards: usize,
+    /// HLL window config: (label, duration) pairs.
+    pub hll_windows: Vec<(String, Duration)>,
+    /// HLL bucket bits (register array size = 2^bucket_bits).
+    pub hll_bucket_bits: u8,
 }
 
 impl Default for StorageConfig {
@@ -87,6 +92,12 @@ impl Default for StorageConfig {
             advertise_addr: None,
             metaserver_queue_depth: crate::internode::DEFAULT_METASERVER_QUEUE_DEPTH,
             pool_shards: 1,
+            hll_windows: vec![
+                ("15m".to_string(), Duration::from_secs(15 * 60)),
+                ("1h".to_string(), Duration::from_secs(60 * 60)),
+                ("1d".to_string(), Duration::from_secs(24 * 60 * 60)),
+            ],
+            hll_bucket_bits: 16,
         }
     }
 }
@@ -100,6 +111,7 @@ pub(crate) struct StorageEngine {
     #[cfg(feature = "rdma")]
     rdma_transport: Option<Arc<RdmaTransport>>,
     blockwise_alloc: bool,
+    hll_tracker: Arc<Mutex<MultiWindowHllTracker>>,
     metaserver_client: Option<Arc<MetaServerClient>>,
     transfer_lock: Arc<transfer_lock::TransferLockManager>,
 }
@@ -120,6 +132,10 @@ impl StorageEngine {
         let rdma_qps_per_peer = config.rdma_qps_per_peer;
         let blockwise_alloc = config.blockwise_alloc;
         let transfer_lock_timeout = config.transfer_lock_timeout;
+        let hll_tracker = Arc::new(Mutex::new(MultiWindowHllTracker::new(
+            config.hll_windows.clone(),
+            config.hll_bucket_bits,
+        )));
 
         if blockwise_alloc {
             info!("Blockwise allocation enabled for batch_save");
@@ -174,6 +190,7 @@ impl StorageEngine {
             Arc::new(MetaServerClient::new(
                 ms_config,
                 Arc::downgrade(&read_cache),
+                Arc::clone(&hll_tracker),
             ))
         });
 
@@ -249,6 +266,7 @@ impl StorageEngine {
                 #[cfg(feature = "rdma")]
                 rdma_transport,
                 blockwise_alloc,
+                hll_tracker,
                 metaserver_client,
                 transfer_lock,
             }
@@ -288,6 +306,26 @@ impl StorageEngine {
     /// Returns true if blockwise allocation is enabled.
     pub(crate) fn blockwise_alloc(&self) -> bool {
         self.blockwise_alloc
+    }
+
+    pub(crate) fn record_hll_misses(
+        &self,
+        namespace: &str,
+        total_observations: u64,
+        miss_hashes: &[Vec<u8>],
+    ) {
+        match self.hll_tracker.lock() {
+            Ok(mut tracker) => {
+                tracker.record_namespaced_misses(namespace, total_observations, miss_hashes);
+            }
+            Err(error) => {
+                warn!("HLL tracker lock poisoned; observations were not recorded: {error}");
+            }
+        }
+    }
+
+    pub(crate) fn hll_tracker(&self) -> &Arc<Mutex<MultiWindowHllTracker>> {
+        &self.hll_tracker
     }
 
     /// Allocate pinned memory, returning `None` if the pool is exhausted after eviction.

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -21,6 +21,9 @@ use crate::metrics::core_metrics;
 use crate::pinned_pool::{PinnedAllocation, PinnedAllocator};
 use pegaflow_common::NumaNode;
 use pegaflow_common::hll::MultiWindowHllTracker;
+use pegaflow_common::hll_config::{
+    DEFAULT_HLL_BUCKET_BITS, DEFAULT_HLL_WINDOWS, parse_hll_windows,
+};
 
 use prefetch::PrefetchScheduler;
 #[cfg(feature = "rdma")]
@@ -92,12 +95,9 @@ impl Default for StorageConfig {
             advertise_addr: None,
             metaserver_queue_depth: crate::internode::DEFAULT_METASERVER_QUEUE_DEPTH,
             pool_shards: 1,
-            hll_windows: vec![
-                ("15m".to_string(), Duration::from_secs(15 * 60)),
-                ("1h".to_string(), Duration::from_secs(60 * 60)),
-                ("1d".to_string(), Duration::from_secs(24 * 60 * 60)),
-            ],
-            hll_bucket_bits: 16,
+            hll_windows: parse_hll_windows(DEFAULT_HLL_WINDOWS)
+                .expect("default HLL window configuration must be valid"),
+            hll_bucket_bits: DEFAULT_HLL_BUCKET_BITS,
         }
     }
 }

--- a/pegaflow-metaserver/README.md
+++ b/pegaflow-metaserver/README.md
@@ -63,6 +63,9 @@ cargo run -p pegaflow-metaserver -- --log-level debug
 # Custom node lifecycle timings
 cargo run -p pegaflow-metaserver -- --node-stale-secs 30 --ttl-minutes 120 --sweep-interval-secs 600
 
+# Match a custom Pega server HLL configuration
+cargo run -p pegaflow-metaserver -- --metric-hll-windows 15m,1h,1d --metric-hll-bucket-bits 16
+
 # All options combined
 cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056 --node-stale-secs 30 --ttl-minutes 120 --sweep-interval-secs 600 --log-level info
 
@@ -77,6 +80,8 @@ cargo run -p pegaflow-metaserver -- --help
 - `--node-stale-secs <SECONDS>`: Hide nodes from query after this many seconds without heartbeat (default: `30`)
 - `--ttl-minutes <MINUTES>`: Purge ownership and node records after this many minutes (default: `120`)
 - `--sweep-interval-secs <SECONDS>`: Run the lifecycle sweep at this interval (default: `600`)
+- `--metric-hll-windows <WINDOWS>`: Expected HLL windows from every Pega server (default: `15m,1h,1d`)
+- `--metric-hll-bucket-bits <BITS>`: Expected HLL bucket bits from every Pega server (default: `16`)
 
 ### Storage Configuration
 
@@ -84,7 +89,8 @@ The MetaServer uses a DashMap-based in-memory store with the following character
 
 - **Multi-owner**: A block hash can be registered by multiple nodes simultaneously
 - **Node lifecycle**: Servers generate a `node_id`, announce it with `HeartbeatNode`, heartbeat periodically, and include the same `node_id` in insert/remove RPCs.
-- **Stale filtering**: Nodes stop appearing in query results after 30 seconds without heartbeat by default.
+- **Stale filtering**: Nodes stop appearing in query results after 30 seconds without heartbeat or valid metadata writes by default.
+- **HLL freshness**: Only heartbeat reports refresh cluster HLL data; metadata writes do not keep an old report in the union.
 - **TTL sweep**: A background task runs every `--sweep-interval-secs` and removes expired owners and nodes after `--ttl-minutes`.
 - **Conditional removal**: `RemoveBlockHashes` only removes the requesting node's ownership; other nodes' entries are untouched.
 - **Memory**: Scales with unique blocks across all nodes. No hard capacity cap — memory is naturally bounded by the total number of blocks in the cluster.
@@ -103,6 +109,7 @@ stale.
 message HeartbeatNodeRequest {
   string node = 1;
   string node_id = 2;
+  HllSnapshotReport hll_report = 3;
 }
 ```
 

--- a/pegaflow-metaserver/benches/unregister_node.rs
+++ b/pegaflow-metaserver/benches/unregister_node.rs
@@ -21,7 +21,6 @@ const TARGET_OWNED_KEYS: usize = 10_000;
 
 fn empty_hll_report() -> HllNodeReport {
     HllNodeReport {
-        snapshot_at_unix_ms: 1,
         windows: vec![HllWindowSnapshot {
             window: "15m".into(),
             window_secs: 900,

--- a/pegaflow-metaserver/benches/unregister_node.rs
+++ b/pegaflow-metaserver/benches/unregister_node.rs
@@ -12,7 +12,8 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use pegaflow_common::hll::HllWindowSnapshot;
-use pegaflow_metaserver::store::{BlockHashStore, HllNodeReport, StoreConfig};
+use pegaflow_metaserver::hll::{HllNodeReport, HllSchema};
+use pegaflow_metaserver::store::{BlockHashStore, StoreConfig};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -32,10 +33,14 @@ fn empty_hll_report() -> HllNodeReport {
 }
 
 fn populate_store() -> (BlockHashStore, String, Uuid) {
-    let store = BlockHashStore::with_config(StoreConfig {
-        node_stale_after: Duration::from_secs(30),
-        ttl: Duration::from_secs(7_200),
-    });
+    let schema = HllSchema::new(vec![("15m".into(), Duration::from_secs(900))], 4).unwrap();
+    let store = BlockHashStore::with_config_and_hll_schema(
+        StoreConfig {
+            node_stale_after: Duration::from_secs(30),
+            ttl: Duration::from_secs(7_200),
+        },
+        schema,
+    );
     let target_node = "target-node:50055".to_string();
     let other_node = "other-node:50055".to_string();
     let target_id = Uuid::new_v4();

--- a/pegaflow-metaserver/benches/unregister_node.rs
+++ b/pegaflow-metaserver/benches/unregister_node.rs
@@ -11,12 +11,26 @@
 //! leave owner cleanup to the lifecycle sweep.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use pegaflow_metaserver::store::{BlockHashStore, StoreConfig};
+use pegaflow_common::hll::HllWindowSnapshot;
+use pegaflow_metaserver::store::{BlockHashStore, HllNodeReport, StoreConfig};
 use std::time::Duration;
 use uuid::Uuid;
 
 const TOTAL_KEYS: usize = 1_000_000;
 const TARGET_OWNED_KEYS: usize = 10_000;
+
+fn empty_hll_report() -> HllNodeReport {
+    HllNodeReport {
+        snapshot_at_unix_ms: 1,
+        windows: vec![HllWindowSnapshot {
+            window: "15m".into(),
+            window_secs: 900,
+            bucket_bits: 4,
+            registers: vec![0; 16],
+            total_requests: 0,
+        }],
+    }
+}
 
 fn populate_store() -> (BlockHashStore, String, Uuid) {
     let store = BlockHashStore::with_config(StoreConfig {
@@ -27,8 +41,12 @@ fn populate_store() -> (BlockHashStore, String, Uuid) {
     let other_node = "other-node:50055".to_string();
     let target_id = Uuid::new_v4();
     let other_id = Uuid::new_v4();
-    store.heartbeat_node(&target_node, target_id).unwrap();
-    store.heartbeat_node(&other_node, other_id).unwrap();
+    store
+        .heartbeat_node(&target_node, target_id, empty_hll_report())
+        .unwrap();
+    store
+        .heartbeat_node(&other_node, other_id, empty_hll_report())
+        .unwrap();
 
     for chunk_start in (0..TOTAL_KEYS).step_by(1_000) {
         let chunk_end = (chunk_start + 1_000).min(TOTAL_KEYS);

--- a/pegaflow-metaserver/src/hll.rs
+++ b/pegaflow-metaserver/src/hll.rs
@@ -1,0 +1,503 @@
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use pegaflow_common::hll::{
+    HllWindowSnapshot, HyperLogLog, MAX_BUCKET_BITS, MAX_HLL_REPORT_BYTES, MAX_HLL_WINDOWS,
+    MIN_BUCKET_BITS,
+};
+use pegaflow_common::hll_config::{
+    DEFAULT_HLL_BUCKET_BITS, DEFAULT_HLL_WINDOWS, parse_hll_windows,
+};
+
+const AGGREGATE_CACHE_LIFETIME: Duration = Duration::from_millis(250);
+
+#[derive(Debug, Clone)]
+pub struct HllNodeReport {
+    pub windows: Vec<HllWindowSnapshot>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ClusterHllSnapshot {
+    pub windows: Vec<ClusterHllWindowSnapshot>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClusterHllWindowSnapshot {
+    pub window: String,
+    pub cardinality: f64,
+    pub total_requests: u64,
+    pub estimated_hit_rate: f64,
+    pub active_nodes: u64,
+    pub snapshot_age_seconds: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HllWindowSchema {
+    window: String,
+    window_secs: u64,
+    bucket_bits: u8,
+    register_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HllSchema {
+    windows: Vec<HllWindowSchema>,
+}
+
+impl HllSchema {
+    pub fn new(windows: Vec<(String, Duration)>, bucket_bits: u8) -> Result<Self, String> {
+        if windows.is_empty() || windows.len() > MAX_HLL_WINDOWS {
+            return Err(format!(
+                "HLL schema window count must be in 1..={MAX_HLL_WINDOWS}, got {}",
+                windows.len()
+            ));
+        }
+        if !(MIN_BUCKET_BITS..=MAX_BUCKET_BITS).contains(&bucket_bits) {
+            return Err(format!(
+                "HLL bucket_bits must be in {MIN_BUCKET_BITS}..={MAX_BUCKET_BITS}, got {bucket_bits}"
+            ));
+        }
+
+        let mut labels = HashSet::with_capacity(windows.len());
+        let mut durations = HashSet::with_capacity(windows.len());
+        for (window, duration) in &windows {
+            if window.is_empty() {
+                return Err("HLL window label must not be empty".into());
+            }
+            if *duration < Duration::from_secs(60) {
+                return Err(format!("HLL window {window} must be at least 1 minute"));
+            }
+            if !labels.insert(window) || !durations.insert(duration) {
+                return Err(format!(
+                    "duplicate HLL window label or duration: {window} ({}s)",
+                    duration.as_secs()
+                ));
+            }
+        }
+
+        let register_count = 1usize << bucket_bits;
+        let payload_bytes = register_count.saturating_mul(windows.len());
+        if payload_bytes > MAX_HLL_REPORT_BYTES {
+            return Err(format!(
+                "HLL register payload exceeds {MAX_HLL_REPORT_BYTES} bytes: {payload_bytes}"
+            ));
+        }
+
+        let windows = windows
+            .into_iter()
+            .map(|(window, duration)| HllWindowSchema {
+                window,
+                window_secs: duration.as_secs(),
+                bucket_bits,
+                register_count,
+            })
+            .collect();
+        Ok(Self { windows })
+    }
+
+    fn validate(&self, report: &HllNodeReport) -> Result<(), String> {
+        if report.windows.len() != self.windows.len() {
+            return Err(format!(
+                "HLL report has {} windows, expected {}",
+                report.windows.len(),
+                self.windows.len()
+            ));
+        }
+
+        for (index, (actual, expected)) in
+            report.windows.iter().zip(self.windows.iter()).enumerate()
+        {
+            if actual.window != expected.window
+                || actual.window_secs != expected.window_secs
+                || actual.bucket_bits != expected.bucket_bits
+            {
+                return Err(format!(
+                    "HLL window {index} schema mismatch: got {} ({}s, {} bits), expected {} ({}s, {} bits)",
+                    actual.window,
+                    actual.window_secs,
+                    actual.bucket_bits,
+                    expected.window,
+                    expected.window_secs,
+                    expected.bucket_bits
+                ));
+            }
+            if actual.registers.len() != expected.register_count {
+                return Err(format!(
+                    "HLL window {} registers length must be {}, got {}",
+                    actual.window,
+                    expected.register_count,
+                    actual.registers.len()
+                ));
+            }
+            let max_register = 65 - actual.bucket_bits;
+            if let Some(register) = actual
+                .registers
+                .iter()
+                .copied()
+                .find(|register| *register > max_register)
+            {
+                return Err(format!(
+                    "HLL window {} register value {register} exceeds 64-bit hash maximum {max_register}",
+                    actual.window
+                ));
+            }
+            if actual.total_requests == 0 && actual.registers.iter().any(|register| *register != 0)
+            {
+                return Err(format!(
+                    "HLL window {} has registers but zero total_requests",
+                    actual.window
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for HllSchema {
+    fn default() -> Self {
+        let windows = parse_hll_windows(DEFAULT_HLL_WINDOWS)
+            .expect("default HLL window configuration must be valid");
+        Self::new(windows, DEFAULT_HLL_BUCKET_BITS)
+            .expect("default HLL schema must fit the report payload limit")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReceivedHllReport {
+    received_at: Instant,
+    report: Arc<HllNodeReport>,
+}
+
+#[derive(Debug, Clone)]
+struct AggregatedWindow {
+    window: String,
+    cardinality: f64,
+    total_requests: u64,
+    estimated_hit_rate: f64,
+    active_nodes: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+struct AggregatedSnapshot {
+    windows: Vec<AggregatedWindow>,
+    oldest_received_at: Option<Instant>,
+}
+
+impl AggregatedSnapshot {
+    fn materialize(&self, now: Instant) -> ClusterHllSnapshot {
+        let snapshot_age_seconds = self
+            .oldest_received_at
+            .map(|received_at| now.saturating_duration_since(received_at).as_secs_f64())
+            .unwrap_or(0.0);
+        ClusterHllSnapshot {
+            windows: self
+                .windows
+                .iter()
+                .map(|window| ClusterHllWindowSnapshot {
+                    window: window.window.clone(),
+                    cardinality: window.cardinality,
+                    total_requests: window.total_requests,
+                    estimated_hit_rate: window.estimated_hit_rate,
+                    active_nodes: window.active_nodes,
+                    snapshot_age_seconds,
+                })
+                .collect(),
+        }
+    }
+}
+
+struct CachedAggregate {
+    generation: u64,
+    built_at: Instant,
+    expires_at: Option<Instant>,
+    snapshot: AggregatedSnapshot,
+}
+
+pub(crate) struct HllState {
+    schema: HllSchema,
+    stale_after: Duration,
+    generation: AtomicU64,
+    cache: Mutex<Option<CachedAggregate>>,
+}
+
+impl HllState {
+    pub(crate) fn new(schema: HllSchema, stale_after: Duration) -> Self {
+        Self {
+            schema,
+            stale_after,
+            generation: AtomicU64::new(0),
+            cache: Mutex::new(None),
+        }
+    }
+
+    pub(crate) fn receive(
+        &self,
+        report: HllNodeReport,
+        received_at: Instant,
+    ) -> Result<ReceivedHllReport, String> {
+        self.schema.validate(&report)?;
+        Ok(ReceivedHllReport {
+            received_at,
+            report: Arc::new(report),
+        })
+    }
+
+    pub(crate) fn mark_changed(&self) {
+        self.generation.fetch_add(1, Ordering::Release);
+    }
+
+    pub(crate) fn snapshot<F>(&self, collect_reports: F) -> ClusterHllSnapshot
+    where
+        F: FnOnce() -> Vec<ReceivedHllReport>,
+    {
+        let now = Instant::now();
+        let generation = self.generation.load(Ordering::Acquire);
+        let mut cache = self
+            .cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(cached) = cache.as_ref() {
+            let report_set_is_current = cached.generation == generation;
+            let refresh_is_coalesced =
+                now.saturating_duration_since(cached.built_at) < AGGREGATE_CACHE_LIFETIME;
+            let reports_are_fresh = cached.expires_at.is_none_or(|expires_at| now <= expires_at);
+            if reports_are_fresh && (report_set_is_current || refresh_is_coalesced) {
+                return cached.snapshot.materialize(now);
+            }
+        }
+
+        let reports: Vec<_> = collect_reports()
+            .into_iter()
+            .filter(|report| now.saturating_duration_since(report.received_at) <= self.stale_after)
+            .collect();
+        let snapshot = aggregate(&self.schema, &reports).unwrap_or_else(|error| {
+            log::warn!("MetaServer HLL aggregation skipped invalid report: {error}");
+            AggregatedSnapshot::default()
+        });
+        let expires_at = reports
+            .iter()
+            .filter_map(|report| report.received_at.checked_add(self.stale_after))
+            .min();
+        let materialized = snapshot.materialize(now);
+        *cache = Some(CachedAggregate {
+            generation,
+            built_at: now,
+            expires_at,
+            snapshot,
+        });
+        materialized
+    }
+}
+
+fn aggregate(
+    schema: &HllSchema,
+    reports: &[ReceivedHllReport],
+) -> Result<AggregatedSnapshot, String> {
+    if reports.is_empty() {
+        return Ok(AggregatedSnapshot::default());
+    }
+
+    let oldest_received_at = reports.iter().map(|report| report.received_at).min();
+    let mut windows = Vec::with_capacity(schema.windows.len());
+    for (index, expected) in schema.windows.iter().enumerate() {
+        let mut union = HyperLogLog::new(expected.bucket_bits);
+        let mut total_requests = 0u64;
+        for report in reports {
+            let actual = report.report.windows.get(index).ok_or_else(|| {
+                format!(
+                    "HLL report is missing configured window {}",
+                    expected.window
+                )
+            })?;
+            if actual.registers.len() != union.registers().len() {
+                return Err(format!(
+                    "cannot merge HLL window {} with {} registers into {} registers",
+                    expected.window,
+                    actual.registers.len(),
+                    union.registers().len()
+                ));
+            }
+            for (target, source) in union
+                .registers_mut()
+                .iter_mut()
+                .zip(actual.registers.iter())
+            {
+                *target = (*target).max(*source);
+            }
+            total_requests = total_requests.saturating_add(actual.total_requests);
+        }
+        let cardinality = union.cardinality();
+        let estimated_hit_rate = if total_requests == 0 {
+            0.0
+        } else {
+            1.0 - cardinality.min(total_requests as f64) / total_requests as f64
+        };
+        windows.push(AggregatedWindow {
+            window: expected.window.clone(),
+            cardinality,
+            total_requests,
+            estimated_hit_rate,
+            active_nodes: reports.len() as u64,
+        });
+    }
+
+    Ok(AggregatedSnapshot {
+        windows,
+        oldest_received_at,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+
+    use super::*;
+
+    fn schema(bucket_bits: u8) -> HllSchema {
+        HllSchema::new(
+            vec![("1m".to_string(), Duration::from_secs(60))],
+            bucket_bits,
+        )
+        .unwrap()
+    }
+
+    fn report(bucket_bits: u8, registers: Vec<u8>, total_requests: u64) -> HllNodeReport {
+        HllNodeReport {
+            windows: vec![HllWindowSnapshot {
+                window: "1m".to_string(),
+                window_secs: 60,
+                bucket_bits,
+                registers,
+                total_requests,
+            }],
+        }
+    }
+
+    #[test]
+    fn schema_requires_an_exact_match() {
+        let schema = schema(4);
+        assert!(schema.validate(&report(4, vec![0; 16], 0)).is_ok());
+
+        let mut wrong_duration = report(4, vec![0; 16], 0);
+        wrong_duration.windows[0].window_secs = 120;
+        assert!(schema.validate(&wrong_duration).is_err());
+        assert!(schema.validate(&report(5, vec![0; 32], 0)).is_err());
+    }
+
+    #[test]
+    fn schema_rejects_reordered_windows() {
+        let schema = HllSchema::new(
+            vec![
+                ("1m".to_string(), Duration::from_secs(60)),
+                ("2m".to_string(), Duration::from_secs(120)),
+            ],
+            4,
+        )
+        .unwrap();
+        let report = HllNodeReport {
+            windows: vec![
+                HllWindowSnapshot {
+                    window: "2m".to_string(),
+                    window_secs: 120,
+                    bucket_bits: 4,
+                    registers: vec![0; 16],
+                    total_requests: 0,
+                },
+                HllWindowSnapshot {
+                    window: "1m".to_string(),
+                    window_secs: 60,
+                    bucket_bits: 4,
+                    registers: vec![0; 16],
+                    total_requests: 0,
+                },
+            ],
+        };
+
+        assert!(schema.validate(&report).is_err());
+    }
+
+    #[test]
+    fn schema_rejects_invalid_or_duplicate_windows() {
+        assert!(HllSchema::new(vec![(String::new(), Duration::from_secs(60))], 4).is_err());
+        assert!(HllSchema::new(vec![("1s".to_string(), Duration::from_secs(1))], 4).is_err());
+        assert!(
+            HllSchema::new(
+                vec![
+                    ("1m".to_string(), Duration::from_secs(60)),
+                    ("one-minute".to_string(), Duration::from_secs(60)),
+                ],
+                4,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn impossible_64_bit_register_value_is_rejected() {
+        let schema = schema(4);
+        let mut registers = vec![0; 16];
+        registers[3] = 255;
+
+        let error = schema.validate(&report(4, registers, 1)).unwrap_err();
+        assert!(error.contains("64-bit hash maximum"), "{error}");
+    }
+
+    #[test]
+    fn aggregation_rejects_unequal_register_lengths() {
+        let schema = schema(4);
+        let received = ReceivedHllReport {
+            received_at: Instant::now(),
+            report: Arc::new(report(4, vec![0; 15], 0)),
+        };
+
+        let error = aggregate(&schema, &[received]).unwrap_err();
+        assert!(error.contains("cannot merge"), "{error}");
+    }
+
+    #[test]
+    fn cache_coalesces_generation_changes_within_collection_interval() {
+        let state = HllState::new(schema(4), Duration::from_secs(30));
+        let received = state
+            .receive(report(4, vec![0; 16], 0), Instant::now())
+            .unwrap();
+        state.mark_changed();
+        let collections = AtomicUsize::new(0);
+
+        for _ in 0..5 {
+            state.snapshot(|| {
+                collections.fetch_add(1, Ordering::Relaxed);
+                vec![received.clone()]
+            });
+        }
+        assert_eq!(collections.load(Ordering::Relaxed), 1);
+
+        state.mark_changed();
+        state.snapshot(|| {
+            collections.fetch_add(1, Ordering::Relaxed);
+            vec![received.clone()]
+        });
+        assert_eq!(collections.load(Ordering::Relaxed), 1);
+
+        std::thread::sleep(AGGREGATE_CACHE_LIFETIME + Duration::from_millis(10));
+        state.snapshot(|| {
+            collections.fetch_add(1, Ordering::Relaxed);
+            vec![received]
+        });
+        assert_eq!(collections.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn cache_does_not_keep_an_expired_report_active() {
+        let state = HllState::new(schema(4), Duration::from_millis(5));
+        let received = state
+            .receive(report(4, vec![0; 16], 0), Instant::now())
+            .unwrap();
+        state.mark_changed();
+        assert_eq!(state.snapshot(|| vec![received.clone()]).windows.len(), 1);
+
+        std::thread::sleep(Duration::from_millis(10));
+        assert!(state.snapshot(|| vec![received]).windows.is_empty());
+    }
+}

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod hll;
 pub mod http_server;
 pub mod metric;
 pub mod proto;
@@ -13,6 +14,10 @@ use opentelemetry::global;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use pegaflow_common::grpc::{
     GRPC_SERVER_HTTP2_KEEPALIVE_INTERVAL, GRPC_SERVER_HTTP2_KEEPALIVE_TIMEOUT,
+};
+use pegaflow_common::hll_config::{
+    DEFAULT_HLL_BUCKET_BITS, DEFAULT_HLL_WINDOWS, parse_hll_bucket_bits, parse_hll_windows,
+    parse_hll_windows_arg,
 };
 use pegaflow_proto::proto::engine::meta_server_server::MetaServerServer;
 use prometheus::Registry;
@@ -56,6 +61,14 @@ pub struct Cli {
     /// Seconds between lifecycle sweeps.
     #[arg(long, default_value_t = DEFAULT_SWEEP_INTERVAL_SECS)]
     pub sweep_interval_secs: u64,
+
+    /// HLL sliding-window list expected from every Pega server.
+    #[arg(long, default_value = DEFAULT_HLL_WINDOWS, value_parser = parse_hll_windows_arg)]
+    pub metric_hll_windows: String,
+
+    /// HLL bucket index bits expected from every Pega server.
+    #[arg(long, default_value_t = DEFAULT_HLL_BUCKET_BITS, value_parser = parse_hll_bucket_bits)]
+    pub metric_hll_bucket_bits: u8,
 }
 
 fn init_metrics() -> Result<(SdkMeterProvider, Registry), Box<dyn Error>> {
@@ -116,6 +129,10 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         "Node lifecycle: stale_after={}s ttl={}m sweep_interval={}s",
         cli.node_stale_secs, cli.ttl_minutes, cli.sweep_interval_secs
     );
+    info!(
+        "HLL schema: windows={} bucket_bits={}",
+        cli.metric_hll_windows, cli.metric_hll_bucket_bits
+    );
     let ttl_secs = cli
         .ttl_minutes
         .checked_mul(60)
@@ -137,10 +154,17 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     // Initialize metrics
     let (meter_provider, prometheus_registry) = init_metrics()?;
 
-    let store = Arc::new(BlockHashStore::with_config(store::StoreConfig {
-        node_stale_after: Duration::from_secs(cli.node_stale_secs),
-        ttl: Duration::from_secs(ttl_secs),
-    }));
+    let hll_windows = parse_hll_windows(&cli.metric_hll_windows)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+    let hll_schema = hll::HllSchema::new(hll_windows, cli.metric_hll_bucket_bits)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+    let store = Arc::new(BlockHashStore::with_config_and_hll_schema(
+        store::StoreConfig {
+            node_stale_after: Duration::from_secs(cli.node_stale_secs),
+            ttl: Duration::from_secs(ttl_secs),
+        },
+        hll_schema,
+    ));
 
     // Register store observable gauges
     metric::register_store_gauges(&store);
@@ -201,4 +225,38 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     info!("MetaServer shut down gracefully");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hll_cli_defaults_match_pegaflow_server() {
+        let cli = Cli::try_parse_from(["pegaflow-metaserver"]).unwrap();
+
+        assert_eq!(cli.metric_hll_windows, DEFAULT_HLL_WINDOWS);
+        assert_eq!(cli.metric_hll_bucket_bits, DEFAULT_HLL_BUCKET_BITS);
+    }
+
+    #[test]
+    fn hll_cli_accepts_explicit_schema() {
+        let cli = Cli::try_parse_from([
+            "pegaflow-metaserver",
+            "--metric-hll-windows",
+            "30m,2h",
+            "--metric-hll-bucket-bits",
+            "14",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            parse_hll_windows(&cli.metric_hll_windows).unwrap(),
+            vec![
+                ("30m".to_string(), Duration::from_secs(30 * 60)),
+                ("2h".to_string(), Duration::from_secs(2 * 60 * 60)),
+            ]
+        );
+        assert_eq!(cli.metric_hll_bucket_bits, 14);
+    }
 }

--- a/pegaflow-metaserver/src/metric.rs
+++ b/pegaflow-metaserver/src/metric.rs
@@ -86,9 +86,8 @@ pub fn register_store_gauges(store: &Arc<BlockHashStore>) {
                 observer.observe(avg, &[]);
             })
             .build();
-        // Each HLL gauge re-merges the cluster union in its own callback; at
-        // scrape frequency the merge cost (nodes x windows x registers) is
-        // negligible, and OTEL 0.31 no longer offers multi-instrument callbacks.
+        // The store cache makes these callbacks share one cluster union while
+        // preserving separate instruments in OpenTelemetry 0.31.
         let hll_cardinality_store = Arc::clone(&s);
         let hll_cardinality = meter
             .f64_observable_gauge("pegaflow_metaserver_hll_cardinality")

--- a/pegaflow-metaserver/src/metric.rs
+++ b/pegaflow-metaserver/src/metric.rs
@@ -16,6 +16,11 @@ struct StoreGaugeHandles {
     _nodes: ObservableGauge<u64>,
     _redundancy: ObservableGauge<u64>,
     _redundancy_avg: ObservableGauge<f64>,
+    _hll_cardinality: ObservableGauge<f64>,
+    _hll_total_requests: ObservableGauge<u64>,
+    _hll_estimated_hit_rate: ObservableGauge<f64>,
+    _hll_active_nodes: ObservableGauge<u64>,
+    _hll_snapshot_age: ObservableGauge<f64>,
 }
 
 static STORE_GAUGES: OnceLock<StoreGaugeHandles> = OnceLock::new();
@@ -81,12 +86,88 @@ pub fn register_store_gauges(store: &Arc<BlockHashStore>) {
                 observer.observe(avg, &[]);
             })
             .build();
+        // Each HLL gauge re-merges the cluster union in its own callback; at
+        // scrape frequency the merge cost (nodes x windows x registers) is
+        // negligible, and OTEL 0.31 no longer offers multi-instrument callbacks.
+        let hll_cardinality_store = Arc::clone(&s);
+        let hll_cardinality = meter
+            .f64_observable_gauge("pegaflow_metaserver_hll_cardinality")
+            .with_description("Estimated distinct cache-miss objects in the active-node HLL union")
+            .with_callback(move |observer| {
+                for window in hll_cardinality_store.cluster_hll_snapshot().windows {
+                    observer.observe(
+                        window.cardinality,
+                        &[KeyValue::new("window", window.window)],
+                    );
+                }
+            })
+            .build();
+        let hll_total_store = Arc::clone(&s);
+        let hll_total_requests = meter
+            .u64_observable_gauge("pegaflow_metaserver_hll_total_requests")
+            .with_description("Total queried cache objects across active nodes")
+            .with_callback(move |observer| {
+                for window in hll_total_store.cluster_hll_snapshot().windows {
+                    observer.observe(
+                        window.total_requests,
+                        &[KeyValue::new("window", window.window)],
+                    );
+                }
+            })
+            .build();
+        let hll_rate_store = Arc::clone(&s);
+        let hll_estimated_hit_rate = meter
+            .f64_observable_gauge("pegaflow_metaserver_hll_estimated_hit_rate")
+            .with_description(
+                "Miss-based infinite-cache theoretical reuse reference from the active-node HLL union",
+            )
+            .with_callback(move |observer| {
+                for window in hll_rate_store.cluster_hll_snapshot().windows {
+                    observer.observe(
+                        window.estimated_hit_rate,
+                        &[KeyValue::new("window", window.window)],
+                    );
+                }
+            })
+            .build();
+        let hll_nodes_store = Arc::clone(&s);
+        let hll_active_nodes = meter
+            .u64_observable_gauge("pegaflow_metaserver_hll_active_nodes")
+            .with_description("Active node sessions included in the cluster HLL union")
+            .with_callback(move |observer| {
+                for window in hll_nodes_store.cluster_hll_snapshot().windows {
+                    observer.observe(
+                        window.active_nodes,
+                        &[KeyValue::new("window", window.window)],
+                    );
+                }
+            })
+            .build();
+        let hll_age_store = Arc::clone(&s);
+        let hll_snapshot_age = meter
+            .f64_observable_gauge("pegaflow_metaserver_hll_snapshot_age")
+            .with_description("Age in seconds of the oldest active-node HLL snapshot")
+            .with_unit("s")
+            .with_callback(move |observer| {
+                for window in hll_age_store.cluster_hll_snapshot().windows {
+                    observer.observe(
+                        window.snapshot_age_seconds,
+                        &[KeyValue::new("window", window.window)],
+                    );
+                }
+            })
+            .build();
         StoreGaugeHandles {
             _entries: entries,
             _owners: owners,
             _nodes: nodes,
             _redundancy: redundancy,
             _redundancy_avg: redundancy_avg,
+            _hll_cardinality: hll_cardinality,
+            _hll_total_requests: hll_total_requests,
+            _hll_estimated_hit_rate: hll_estimated_hit_rate,
+            _hll_active_nodes: hll_active_nodes,
+            _hll_snapshot_age: hll_snapshot_age,
         }
     });
 }

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -56,6 +56,7 @@ impl GrpcMetaService {
             };
         };
 
+        let snapshot_at_unix_ms = report.snapshot_at_unix_ms;
         let mut windows = Vec::with_capacity(report.windows.len());
         for window in report.windows {
             let Ok(bucket_bits) = u8::try_from(window.bucket_bits) else {
@@ -64,7 +65,7 @@ impl GrpcMetaService {
                     window.bucket_bits
                 );
                 return HllNodeReport {
-                    snapshot_at_unix_ms: 0,
+                    snapshot_at_unix_ms,
                     windows: Vec::new(),
                 };
             };

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -1,3 +1,4 @@
+use crate::hll::HllNodeReport;
 use crate::metric::record_rpc_result;
 use crate::proto::engine::meta_server_server::MetaServer;
 use crate::proto::engine::{
@@ -6,7 +7,7 @@ use crate::proto::engine::{
     QueryPrefixBlocksResponse, RemoveBlockHashesRequest, RemoveBlockHashesResponse, ResponseStatus,
     UnregisterNodeRequest, UnregisterNodeResponse,
 };
-use crate::store::{BlockHashStore, HllNodeReport, StoreError};
+use crate::store::{BlockHashStore, StoreError};
 use log::{debug, warn};
 use pegaflow_common::hll::HllWindowSnapshot as CommonHllWindowSnapshot;
 use std::sync::Arc;
@@ -335,11 +336,20 @@ impl MetaServer for GrpcMetaService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hll::HllSchema;
     use crate::proto::engine::HllWindowSnapshot;
-    use crate::store::BlockHashStore;
+    use crate::store::{BlockHashStore, StoreConfig};
 
     fn make_service() -> GrpcMetaService {
-        GrpcMetaService::new(Arc::new(BlockHashStore::new()))
+        let schema = HllSchema::new(
+            vec![("1m".to_string(), std::time::Duration::from_secs(60))],
+            4,
+        )
+        .unwrap();
+        GrpcMetaService::new(Arc::new(BlockHashStore::with_config_and_hll_schema(
+            StoreConfig::default(),
+            schema,
+        )))
     }
 
     fn test_hll_report() -> HllSnapshotReport {
@@ -571,10 +581,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_old_session_insert_is_rejected_after_stale_takeover() {
-        let store = Arc::new(BlockHashStore::with_config(crate::store::StoreConfig {
-            node_stale_after: std::time::Duration::ZERO,
-            ttl: std::time::Duration::from_secs(60),
-        }));
+        let schema = HllSchema::new(
+            vec![("1m".to_string(), std::time::Duration::from_secs(60))],
+            4,
+        )
+        .unwrap();
+        let store = Arc::new(BlockHashStore::with_config_and_hll_schema(
+            StoreConfig {
+                node_stale_after: std::time::Duration::ZERO,
+                ttl: std::time::Duration::from_secs(60),
+            },
+            schema,
+        ));
         let svc = GrpcMetaService::new(store);
         let old_id = heartbeat_node(&svc, "node-a").await;
         let new_id = heartbeat_node(&svc, "node-a").await;

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -1,13 +1,14 @@
 use crate::metric::record_rpc_result;
 use crate::proto::engine::meta_server_server::MetaServer;
 use crate::proto::engine::{
-    HeartbeatNodeRequest, HeartbeatNodeResponse, InsertBlockHashesRequest,
+    HeartbeatNodeRequest, HeartbeatNodeResponse, HllSnapshotReport, InsertBlockHashesRequest,
     InsertBlockHashesResponse, NodePrefixResult, QueryPrefixBlocksRequest,
     QueryPrefixBlocksResponse, RemoveBlockHashesRequest, RemoveBlockHashesResponse, ResponseStatus,
     UnregisterNodeRequest, UnregisterNodeResponse,
 };
-use crate::store::{BlockHashStore, StoreError};
-use log::debug;
+use crate::store::{BlockHashStore, HllNodeReport, StoreError};
+use log::{debug, warn};
+use pegaflow_common::hll::HllWindowSnapshot as CommonHllWindowSnapshot;
 use std::sync::Arc;
 use std::time::Instant;
 use tonic::{Request, Response, Status, async_trait};
@@ -45,6 +46,42 @@ impl GrpcMetaService {
             StoreError::StaleSession => Status::failed_precondition("stale node session"),
         }
     }
+
+    fn parse_hll_report(report: Option<HllSnapshotReport>) -> HllNodeReport {
+        let Some(report) = report else {
+            warn!("MetaServer heartbeat missing HLL report; preserving node liveness");
+            return HllNodeReport {
+                snapshot_at_unix_ms: 0,
+                windows: Vec::new(),
+            };
+        };
+
+        let mut windows = Vec::with_capacity(report.windows.len());
+        for window in report.windows {
+            let Ok(bucket_bits) = u8::try_from(window.bucket_bits) else {
+                warn!(
+                    "MetaServer heartbeat received invalid HLL bucket_bits={}; preserving node liveness",
+                    window.bucket_bits
+                );
+                return HllNodeReport {
+                    snapshot_at_unix_ms: 0,
+                    windows: Vec::new(),
+                };
+            };
+            windows.push(CommonHllWindowSnapshot {
+                window: window.window,
+                window_secs: window.window_secs,
+                bucket_bits,
+                registers: window.registers,
+                total_requests: window.total_requests,
+            });
+        }
+
+        HllNodeReport {
+            snapshot_at_unix_ms: report.snapshot_at_unix_ms,
+            windows,
+        }
+    }
 }
 
 #[async_trait]
@@ -61,8 +98,9 @@ impl MetaServer for GrpcMetaService {
         );
         let result = async {
             let node_id = Self::parse_node_id(&req.node_id)?;
+            let hll_report = Self::parse_hll_report(req.hll_report);
             self.store
-                .heartbeat_node(&req.node, node_id)
+                .heartbeat_node(&req.node, node_id, hll_report)
                 .map_err(Self::store_error_status)?;
             Ok(Response::new(HeartbeatNodeResponse {
                 stale_after_secs: self.store.config().node_stale_after.as_secs(),
@@ -302,10 +340,24 @@ impl MetaServer for GrpcMetaService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::proto::engine::HllWindowSnapshot;
     use crate::store::BlockHashStore;
 
     fn make_service() -> GrpcMetaService {
         GrpcMetaService::new(Arc::new(BlockHashStore::new()))
+    }
+
+    fn test_hll_report() -> HllSnapshotReport {
+        HllSnapshotReport {
+            snapshot_at_unix_ms: 1,
+            windows: vec![HllWindowSnapshot {
+                window: "1m".into(),
+                window_secs: 60,
+                bucket_bits: 4,
+                registers: vec![0; 16],
+                total_requests: 0,
+            }],
+        }
     }
 
     async fn heartbeat_node(svc: &GrpcMetaService, node: &str) -> String {
@@ -313,6 +365,7 @@ mod tests {
         svc.heartbeat_node(Request::new(HeartbeatNodeRequest {
             node: node.into(),
             node_id: node_id.clone(),
+            hll_report: Some(test_hll_report()),
         }))
         .await
         .unwrap();
@@ -459,6 +512,7 @@ mod tests {
             .heartbeat_node(Request::new(HeartbeatNodeRequest {
                 node: "node-a".into(),
                 node_id,
+                hll_report: Some(test_hll_report()),
             }))
             .await
             .unwrap()
@@ -478,10 +532,47 @@ mod tests {
             .heartbeat_node(Request::new(HeartbeatNodeRequest {
                 node: "node-a".into(),
                 node_id: new_id,
+                hll_report: Some(test_hll_report()),
             }))
             .await
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat_without_hll_report_preserves_node_liveness() {
+        let svc = make_service();
+        let response = svc
+            .heartbeat_node(Request::new(HeartbeatNodeRequest {
+                node: "node-a".into(),
+                node_id: Uuid::new_v4().to_string(),
+                hll_report: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.stale_after_secs, 30);
+        assert_eq!(svc.store.node_counts(), (1, 0));
+        assert!(svc.store.cluster_hll_snapshot().windows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat_accepts_damaged_registers_but_excludes_from_cluster_hll() {
+        let svc = make_service();
+        let mut report = test_hll_report();
+        report.windows[0].registers.pop();
+        svc.heartbeat_node(Request::new(HeartbeatNodeRequest {
+            node: "node-a".into(),
+            node_id: Uuid::new_v4().to_string(),
+            hll_report: Some(report),
+        }))
+        .await
+        .unwrap();
+
+        // Node liveness is preserved; only the HLL contribution is dropped.
+        assert_eq!(svc.store.node_counts(), (1, 0));
+        assert!(svc.store.cluster_hll_snapshot().windows.is_empty());
     }
 
     #[tokio::test]

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -51,12 +51,10 @@ impl GrpcMetaService {
         let Some(report) = report else {
             warn!("MetaServer heartbeat missing HLL report; preserving node liveness");
             return HllNodeReport {
-                snapshot_at_unix_ms: 0,
                 windows: Vec::new(),
             };
         };
 
-        let snapshot_at_unix_ms = report.snapshot_at_unix_ms;
         let mut windows = Vec::with_capacity(report.windows.len());
         for window in report.windows {
             let Ok(bucket_bits) = u8::try_from(window.bucket_bits) else {
@@ -65,7 +63,6 @@ impl GrpcMetaService {
                     window.bucket_bits
                 );
                 return HllNodeReport {
-                    snapshot_at_unix_ms,
                     windows: Vec::new(),
                 };
             };
@@ -78,10 +75,7 @@ impl GrpcMetaService {
             });
         }
 
-        HllNodeReport {
-            snapshot_at_unix_ms: report.snapshot_at_unix_ms,
-            windows,
-        }
+        HllNodeReport { windows }
     }
 }
 
@@ -350,7 +344,6 @@ mod tests {
 
     fn test_hll_report() -> HllSnapshotReport {
         HllSnapshotReport {
-            snapshot_at_unix_ms: 1,
             windows: vec![HllWindowSnapshot {
                 window: "1m".into(),
                 window_secs: 60,

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -1,7 +1,10 @@
 use dashmap::{DashMap, mapref::entry::Entry};
 use log::{info, warn};
 use pegaflow_common::BlockKey;
-use pegaflow_common::hll::{HllWindowSnapshot, HyperLogLog, MAX_HLL_REPORT_BYTES, MAX_HLL_WINDOWS};
+use pegaflow_common::hll::{
+    HllWindowSnapshot, HyperLogLog, MAX_BUCKET_BITS, MAX_HLL_REPORT_BYTES, MAX_HLL_WINDOWS,
+    MIN_BUCKET_BITS,
+};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -102,23 +105,6 @@ pub struct ClusterHllWindowSnapshot {
     pub snapshot_age_seconds: f64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct HllWindowKey {
-    window: String,
-    window_secs: u64,
-    bucket_bits: u8,
-}
-
-impl HllWindowKey {
-    fn from_snapshot(snapshot: &HllWindowSnapshot) -> Self {
-        Self {
-            window: snapshot.window.clone(),
-            window_secs: snapshot.window_secs,
-            bucket_bits: snapshot.bucket_bits,
-        }
-    }
-}
-
 /// Snapshot of the session that wrote this block ownership. Query compares it
 /// with the current `NodeRecord.node_id` to filter owners left by old sessions.
 #[derive(Debug, Clone)]
@@ -127,12 +113,11 @@ struct OwnerRecord {
     key_register_time: Instant,
 }
 
-/// Authoritative current session for a node URL. `last_seen` is bumped on
-/// heartbeat/insert/remove and gates query visibility. `hll_report` is
-/// best-effort observability state carried by heartbeats; it never affects
-/// metadata liveness, and its own receipt time (not `last_seen`) gates its
-/// inclusion in the cluster union, so metadata writes cannot keep a stale
-/// report alive.
+/// Authoritative current session for a node URL. `last_seen` is refreshed only
+/// by heartbeats and gates query visibility. `hll_report` is best-effort
+/// observability state carried by heartbeats; it never affects metadata
+/// liveness, and its own receipt time (not `last_seen`) gates its inclusion in
+/// the cluster union, so metadata writes cannot keep a stale report alive.
 #[derive(Debug, Clone)]
 struct NodeRecord {
     node_id: Uuid,
@@ -195,7 +180,13 @@ impl BlockHashStore {
     ) -> Result<(), StoreError> {
         let now = Instant::now();
         let validated_report = match validate_hll_report(&hll_report) {
-            Ok(()) => Some((now, hll_report)),
+            Ok(()) if self.hll_schema_matches_active(&hll_report, now) => Some((now, hll_report)),
+            Ok(()) => {
+                warn!(
+                    "MetaServer heartbeat accepted with incompatible HLL window schema (observability degraded): node={node}"
+                );
+                None
+            }
             Err(e) => {
                 warn!(
                     "MetaServer heartbeat accepted with invalid HLL report (observability degraded): node={} error={}",
@@ -466,6 +457,18 @@ impl BlockHashStore {
         self.compute_cluster_hll(now, &active_reports)
     }
 
+    fn hll_schema_matches_active(&self, report: &HllNodeReport, now: Instant) -> bool {
+        for record in &self.nodes {
+            if now.duration_since(record.last_seen) <= self.config.node_stale_after
+                && let Some((_, active_report)) = record.hll_report.as_ref()
+                && !same_hll_schema(active_report, report)
+            {
+                return false;
+            }
+        }
+        true
+    }
+
     #[allow(
         dead_code,
         reason = "maintenance API reserved for explicit store cleanup"
@@ -497,10 +500,8 @@ impl BlockHashStore {
         Ok(())
     }
 
-    /// Union active-node registers per window. Nodes are grouped by
-    /// `(window label, duration, bucket_bits)` so heterogeneously configured
-    /// nodes each aggregate with their compatible peers instead of being
-    /// rejected; `hll_active_nodes` exposes per-window participation.
+    /// Union active-node registers per configured window. Heartbeat validation
+    /// requires every active report to use the same window schema.
     fn compute_cluster_hll(
         &self,
         _now: Instant,
@@ -520,10 +521,10 @@ impl BlockHashStore {
             total_requests: u64,
             active_nodes: u64,
         }
-        let mut groups: HashMap<HllWindowKey, WindowAccum> = HashMap::new();
+        let mut groups: HashMap<String, WindowAccum> = HashMap::new();
         for (_, report) in active_reports {
             for window in &report.windows {
-                let key = HllWindowKey::from_snapshot(window);
+                let key = window.window.clone();
                 let accum = groups.entry(key).or_insert_with(|| WindowAccum {
                     union: HyperLogLog::new(window.bucket_bits),
                     total_requests: 0,
@@ -554,7 +555,7 @@ impl BlockHashStore {
                     1.0 - cardinality.min(accum.total_requests as f64) / accum.total_requests as f64
                 };
                 ClusterHllWindowSnapshot {
-                    window: key.window,
+                    window: key,
                     cardinality,
                     total_requests: accum.total_requests,
                     estimated_hit_rate,
@@ -606,9 +607,6 @@ impl BlockHashStore {
 }
 
 fn validate_hll_report(report: &HllNodeReport) -> Result<(), String> {
-    if report.snapshot_at_unix_ms == 0 {
-        return Err("snapshot_at_unix_ms must be greater than zero".into());
-    }
     if report.windows.is_empty() || report.windows.len() > MAX_HLL_WINDOWS {
         return Err(format!(
             "HLL report window count must be in 1..={MAX_HLL_WINDOWS}, got {}",
@@ -636,8 +634,20 @@ fn validate_hll_report(report: &HllNodeReport) -> Result<(), String> {
             ));
         }
         payload_bytes = payload_bytes.saturating_add(window.registers.len());
-        HyperLogLog::from_registers(window.bucket_bits, window.registers.clone())
-            .map_err(|e| e.to_string())?;
+        if !(MIN_BUCKET_BITS..=MAX_BUCKET_BITS).contains(&window.bucket_bits) {
+            return Err(format!(
+                "HLL bucket_bits must be in {MIN_BUCKET_BITS}..={MAX_BUCKET_BITS}, got {}",
+                window.bucket_bits
+            ));
+        }
+        let expected_registers = 1usize << window.bucket_bits;
+        if window.registers.len() != expected_registers {
+            return Err(format!(
+                "HLL registers length must be {expected_registers} for bucket_bits={}, got {}",
+                window.bucket_bits,
+                window.registers.len()
+            ));
+        }
         if window.total_requests == 0 && window.registers.iter().any(|register| *register != 0) {
             return Err(format!(
                 "HLL window {} has registers but zero total_requests",
@@ -645,12 +655,26 @@ fn validate_hll_report(report: &HllNodeReport) -> Result<(), String> {
             ));
         }
     }
+    if report.snapshot_at_unix_ms == 0 {
+        return Err("snapshot_at_unix_ms must be greater than zero".into());
+    }
     if payload_bytes > MAX_HLL_REPORT_BYTES {
         return Err(format!(
             "HLL register payload exceeds {MAX_HLL_REPORT_BYTES} bytes: {payload_bytes}"
         ));
     }
     Ok(())
+}
+
+fn same_hll_schema(left: &HllNodeReport, right: &HllNodeReport) -> bool {
+    left.windows.len() == right.windows.len()
+        && left.windows.iter().all(|left_window| {
+            right.windows.iter().any(|right_window| {
+                left_window.window == right_window.window
+                    && left_window.window_secs == right_window.window_secs
+                    && left_window.bucket_bits == right_window.bucket_bits
+            })
+        })
 }
 
 fn unix_time_ms() -> u64 {
@@ -733,7 +757,7 @@ mod tests {
     }
 
     #[test]
-    fn cluster_hll_rejects_incompatible_bucket_bits_atomically() {
+    fn cluster_hll_rejects_incompatible_bucket_bits_without_affecting_liveness() {
         let store = BlockHashStore::new();
         store
             .heartbeat_node("node-a", Uuid::new_v4(), hll_report_for(&[1], 1, 14))
@@ -741,11 +765,17 @@ mod tests {
         store
             .heartbeat_node("node-b", Uuid::new_v4(), hll_report_for(&[2], 1, 13))
             .unwrap();
+        let mut incompatible_duration = hll_report_for(&[3], 1, 14);
+        incompatible_duration.windows[0].window_secs = 120;
+        store
+            .heartbeat_node("node-c", Uuid::new_v4(), incompatible_duration)
+            .unwrap();
 
         let cluster = store.cluster_hll_snapshot();
-        assert_eq!(store.node_counts(), (2, 0));
-        // Each window schema groups independently; they won't union together.
-        assert!(!cluster.windows.is_empty());
+        assert_eq!(store.node_counts(), (3, 0));
+        assert_eq!(cluster.windows.len(), 1);
+        assert_eq!(cluster.windows[0].active_nodes, 1);
+        assert_eq!(cluster.windows[0].total_requests, 1);
     }
 
     #[test]

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -1,9 +1,10 @@
 use dashmap::{DashMap, mapref::entry::Entry};
 use log::{info, warn};
 use pegaflow_common::BlockKey;
-use std::collections::HashMap;
+use pegaflow_common::hll::{HllWindowSnapshot, HyperLogLog, MAX_HLL_REPORT_BYTES, MAX_HLL_WINDOWS};
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 const MIN_RECLAIMABLE_OWNER_COUNT: usize = 3;
@@ -74,10 +75,48 @@ impl RedundancySnapshot {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StoreError {
     UnknownNode,
     StaleSession,
+}
+
+#[derive(Debug, Clone)]
+pub struct HllNodeReport {
+    pub snapshot_at_unix_ms: u64,
+    pub windows: Vec<HllWindowSnapshot>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ClusterHllSnapshot {
+    pub windows: Vec<ClusterHllWindowSnapshot>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClusterHllWindowSnapshot {
+    pub window: String,
+    pub cardinality: f64,
+    pub total_requests: u64,
+    pub estimated_hit_rate: f64,
+    pub active_nodes: u64,
+    pub snapshot_age_seconds: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct HllWindowKey {
+    window: String,
+    window_secs: u64,
+    bucket_bits: u8,
+}
+
+impl HllWindowKey {
+    fn from_snapshot(snapshot: &HllWindowSnapshot) -> Self {
+        Self {
+            window: snapshot.window.clone(),
+            window_secs: snapshot.window_secs,
+            bucket_bits: snapshot.bucket_bits,
+        }
+    }
 }
 
 /// Snapshot of the session that wrote this block ownership. Query compares it
@@ -89,11 +128,16 @@ struct OwnerRecord {
 }
 
 /// Authoritative current session for a node URL. `last_seen` is bumped on
-/// heartbeat/insert/remove and gates query visibility.
+/// heartbeat/insert/remove and gates query visibility. `hll_report` is
+/// best-effort observability state carried by heartbeats; it never affects
+/// metadata liveness, and its own receipt time (not `last_seen`) gates its
+/// inclusion in the cluster union, so metadata writes cannot keep a stale
+/// report alive.
 #[derive(Debug, Clone)]
 struct NodeRecord {
     node_id: Uuid,
     last_seen: Instant,
+    hll_report: Option<(Instant, HllNodeReport)>,
 }
 
 /// Both lifecycle decisions for one owner record, produced from a single `nodes`
@@ -143,16 +187,32 @@ impl BlockHashStore {
         self.config
     }
 
-    pub fn heartbeat_node(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
+    pub fn heartbeat_node(
+        &self,
+        node: &str,
+        node_id: Uuid,
+        hll_report: HllNodeReport,
+    ) -> Result<(), StoreError> {
         let now = Instant::now();
+        let validated_report = match validate_hll_report(&hll_report) {
+            Ok(()) => Some((now, hll_report)),
+            Err(e) => {
+                warn!(
+                    "MetaServer heartbeat accepted with invalid HLL report (observability degraded): node={} error={}",
+                    node, e
+                );
+                None
+            }
+        };
+
         match self.nodes.entry(Arc::from(node)) {
             Entry::Vacant(entry) => {
                 info!("MetaServer node registered: node={node} node_id={node_id}");
                 entry.insert(NodeRecord {
                     node_id,
                     last_seen: now,
+                    hll_report: validated_report,
                 });
-                Ok(())
             }
             Entry::Occupied(mut entry) => {
                 let record = entry.get_mut();
@@ -168,15 +228,17 @@ impl BlockHashStore {
                     }
                     record.node_id = node_id;
                     record.last_seen = now;
-                    return Ok(());
+                    record.hll_report = validated_report;
+                } else {
+                    warn!(
+                        "MetaServer heartbeat rejected stale session: node={} current_node_id={} rejected_node_id={}",
+                        node, record.node_id, node_id
+                    );
+                    return Err(StoreError::StaleSession);
                 }
-                warn!(
-                    "MetaServer heartbeat rejected stale session: node={} current_node_id={} rejected_node_id={}",
-                    node, record.node_id, node_id
-                );
-                Err(StoreError::StaleSession)
             }
         }
+        Ok(())
     }
 
     pub fn unregister_node(&self, node: &str, node_id: Uuid) -> Result<usize, StoreError> {
@@ -198,7 +260,8 @@ impl BlockHashStore {
             );
             return Err(StoreError::UnknownNode);
         }
-        Ok(self.remove_node_owners(node, node_id))
+        let removed = self.remove_node_owners(node, node_id);
+        Ok(removed)
     }
 
     pub fn insert_hashes(
@@ -384,6 +447,25 @@ impl BlockHashStore {
         (active, stale)
     }
 
+    pub fn cluster_hll_snapshot(&self) -> ClusterHllSnapshot {
+        let now = Instant::now();
+        let active_reports: Vec<(Instant, HllNodeReport)> = self
+            .nodes
+            .iter()
+            .filter(|record| now.duration_since(record.last_seen) <= self.config.node_stale_after)
+            .filter_map(|record| record.hll_report.clone())
+            .filter(|(report_time, _)| {
+                now.duration_since(*report_time) <= self.config.node_stale_after
+            })
+            .collect();
+
+        if active_reports.is_empty() {
+            return ClusterHllSnapshot::default();
+        }
+
+        self.compute_cluster_hll(now, &active_reports)
+    }
+
     #[allow(
         dead_code,
         reason = "maintenance API reserved for explicit store cleanup"
@@ -398,7 +480,7 @@ impl BlockHashStore {
     }
 
     fn touch_node_session(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
-        let Some(mut record) = self.nodes.get_mut(node) else {
+        let Some(record) = self.nodes.get(node) else {
             warn!(
                 "MetaServer metadata write rejected unknown node: node={} node_id={}",
                 node, node_id
@@ -412,8 +494,77 @@ impl BlockHashStore {
             );
             return Err(StoreError::StaleSession);
         }
-        record.last_seen = Instant::now();
         Ok(())
+    }
+
+    /// Union active-node registers per window. Nodes are grouped by
+    /// `(window label, duration, bucket_bits)` so heterogeneously configured
+    /// nodes each aggregate with their compatible peers instead of being
+    /// rejected; `hll_active_nodes` exposes per-window participation.
+    fn compute_cluster_hll(
+        &self,
+        _now: Instant,
+        active_reports: &[(Instant, HllNodeReport)],
+    ) -> ClusterHllSnapshot {
+        let now_unix_ms = unix_time_ms();
+        let oldest_snapshot_at_unix_ms = active_reports
+            .iter()
+            .map(|(_, report)| report.snapshot_at_unix_ms)
+            .min()
+            .unwrap_or(now_unix_ms);
+        let snapshot_age_seconds =
+            now_unix_ms.saturating_sub(oldest_snapshot_at_unix_ms) as f64 / 1000.0;
+
+        struct WindowAccum {
+            union: HyperLogLog,
+            total_requests: u64,
+            active_nodes: u64,
+        }
+        let mut groups: HashMap<HllWindowKey, WindowAccum> = HashMap::new();
+        for (_, report) in active_reports {
+            for window in &report.windows {
+                let key = HllWindowKey::from_snapshot(window);
+                let accum = groups.entry(key).or_insert_with(|| WindowAccum {
+                    union: HyperLogLog::new(window.bucket_bits),
+                    total_requests: 0,
+                    active_nodes: 0,
+                });
+                for (a, b) in accum
+                    .union
+                    .registers_mut()
+                    .iter_mut()
+                    .zip(window.registers.iter())
+                {
+                    if *b > *a {
+                        *a = *b;
+                    }
+                }
+                accum.total_requests = accum.total_requests.saturating_add(window.total_requests);
+                accum.active_nodes += 1;
+            }
+        }
+
+        let mut windows: Vec<ClusterHllWindowSnapshot> = groups
+            .into_iter()
+            .map(|(key, accum)| {
+                let cardinality = accum.union.cardinality();
+                let estimated_hit_rate = if accum.total_requests == 0 {
+                    0.0
+                } else {
+                    1.0 - cardinality.min(accum.total_requests as f64) / accum.total_requests as f64
+                };
+                ClusterHllWindowSnapshot {
+                    window: key.window,
+                    cardinality,
+                    total_requests: accum.total_requests,
+                    estimated_hit_rate,
+                    active_nodes: accum.active_nodes,
+                    snapshot_age_seconds,
+                }
+            })
+            .collect();
+        windows.sort_by(|a, b| a.window.cmp(&b.window));
+        ClusterHllSnapshot { windows }
     }
 
     fn remove_node_owners(&self, node: &str, node_id: Uuid) -> usize {
@@ -454,6 +605,63 @@ impl BlockHashStore {
     }
 }
 
+fn validate_hll_report(report: &HllNodeReport) -> Result<(), String> {
+    if report.snapshot_at_unix_ms == 0 {
+        return Err("snapshot_at_unix_ms must be greater than zero".into());
+    }
+    if report.windows.is_empty() || report.windows.len() > MAX_HLL_WINDOWS {
+        return Err(format!(
+            "HLL report window count must be in 1..={MAX_HLL_WINDOWS}, got {}",
+            report.windows.len()
+        ));
+    }
+
+    let mut labels = HashSet::new();
+    let mut durations = HashSet::new();
+    let mut payload_bytes = 0usize;
+    for window in &report.windows {
+        if window.window.is_empty() {
+            return Err("HLL window label must not be empty".into());
+        }
+        if window.window_secs == 0 {
+            return Err(format!(
+                "HLL window {} duration must be greater than zero",
+                window.window
+            ));
+        }
+        if !labels.insert(window.window.clone()) || !durations.insert(window.window_secs) {
+            return Err(format!(
+                "duplicate HLL window label or duration: {} ({}s)",
+                window.window, window.window_secs
+            ));
+        }
+        payload_bytes = payload_bytes.saturating_add(window.registers.len());
+        HyperLogLog::from_registers(window.bucket_bits, window.registers.clone())
+            .map_err(|e| e.to_string())?;
+        if window.total_requests == 0 && window.registers.iter().any(|register| *register != 0) {
+            return Err(format!(
+                "HLL window {} has registers but zero total_requests",
+                window.window
+            ));
+        }
+    }
+    if payload_bytes > MAX_HLL_REPORT_BYTES {
+        return Err(format!(
+            "HLL register payload exceeds {MAX_HLL_REPORT_BYTES} bytes: {payload_bytes}"
+        ));
+    }
+    Ok(())
+}
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
 impl Default for BlockHashStore {
     fn default() -> Self {
         Self::new()
@@ -466,8 +674,146 @@ mod tests {
 
     fn heartbeat_node(store: &BlockHashStore, node: &str) -> Uuid {
         let node_id = Uuid::new_v4();
-        store.heartbeat_node(node, node_id).unwrap();
+        store
+            .heartbeat_node(node, node_id, test_hll_report())
+            .unwrap();
         node_id
+    }
+
+    fn test_hll_report() -> HllNodeReport {
+        HllNodeReport {
+            snapshot_at_unix_ms: unix_time_ms().max(1),
+            windows: vec![HllWindowSnapshot {
+                window: "1m".into(),
+                window_secs: 60,
+                bucket_bits: 4,
+                registers: vec![0; 16],
+                total_requests: 0,
+            }],
+        }
+    }
+
+    fn hll_report_for(hashes: &[u64], total_requests: u64, bucket_bits: u8) -> HllNodeReport {
+        let mut hll = HyperLogLog::new(bucket_bits);
+        for hash in hashes {
+            let distributed = hash.wrapping_mul(0x9e37_79b9_7f4a_7c15);
+            hll.insert(&distributed.to_be_bytes());
+        }
+        HllNodeReport {
+            snapshot_at_unix_ms: unix_time_ms().max(1),
+            windows: vec![HllWindowSnapshot {
+                window: "1m".into(),
+                window_secs: 60,
+                bucket_bits,
+                registers: hll.registers().to_vec(),
+                total_requests,
+            }],
+        }
+    }
+
+    #[test]
+    fn cluster_hll_unions_registers_and_sums_observations() {
+        let store = BlockHashStore::new();
+        let node_a = Uuid::new_v4();
+        let node_b = Uuid::new_v4();
+        store
+            .heartbeat_node("node-a", node_a, hll_report_for(&[1, 2], 2, 14))
+            .unwrap();
+        store
+            .heartbeat_node("node-b", node_b, hll_report_for(&[2, 3], 2, 14))
+            .unwrap();
+
+        let cluster = store.cluster_hll_snapshot();
+        assert_eq!(cluster.windows.len(), 1);
+        let window = &cluster.windows[0];
+        assert_eq!(window.total_requests, 4);
+        assert_eq!(window.active_nodes, 2);
+        assert!((2.5..3.5).contains(&window.cardinality));
+        assert!((0.1..0.4).contains(&window.estimated_hit_rate));
+    }
+
+    #[test]
+    fn cluster_hll_rejects_incompatible_bucket_bits_atomically() {
+        let store = BlockHashStore::new();
+        store
+            .heartbeat_node("node-a", Uuid::new_v4(), hll_report_for(&[1], 1, 14))
+            .unwrap();
+        store
+            .heartbeat_node("node-b", Uuid::new_v4(), hll_report_for(&[2], 1, 13))
+            .unwrap();
+
+        let cluster = store.cluster_hll_snapshot();
+        assert_eq!(store.node_counts(), (2, 0));
+        // Each window schema groups independently; they won't union together.
+        assert!(!cluster.windows.is_empty());
+    }
+
+    #[test]
+    fn unregister_removes_hll_snapshot_from_cluster() {
+        let store = BlockHashStore::new();
+        let node_a = Uuid::new_v4();
+        let node_b = Uuid::new_v4();
+        store
+            .heartbeat_node("node-a", node_a, hll_report_for(&[1], 1, 14))
+            .unwrap();
+        store
+            .heartbeat_node("node-b", node_b, hll_report_for(&[2], 1, 14))
+            .unwrap();
+
+        store.unregister_node("node-b", node_b).unwrap();
+        let cluster = store.cluster_hll_snapshot();
+        assert_eq!(cluster.windows[0].active_nodes, 1);
+        assert_eq!(cluster.windows[0].total_requests, 1);
+        assert!((0.5..1.5).contains(&cluster.windows[0].cardinality));
+    }
+
+    #[test]
+    fn cluster_hll_snapshot_excludes_nodes_as_soon_as_they_become_stale() {
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::from_millis(10),
+            ttl: Duration::from_secs(60),
+        });
+        let node_id = Uuid::new_v4();
+        store
+            .heartbeat_node("node-a", node_id, hll_report_for(&[1], 1, 14))
+            .unwrap();
+
+        std::thread::sleep(Duration::from_millis(20));
+
+        assert!(store.cluster_hll_snapshot().windows.is_empty());
+    }
+
+    #[test]
+    fn cluster_hll_snapshot_age_advances_between_reads() {
+        let store = BlockHashStore::new();
+        store
+            .heartbeat_node("node-a", Uuid::new_v4(), hll_report_for(&[1], 1, 14))
+            .unwrap();
+        let first_age = store.cluster_hll_snapshot().windows[0].snapshot_age_seconds;
+
+        std::thread::sleep(Duration::from_millis(20));
+
+        let second_age = store.cluster_hll_snapshot().windows[0].snapshot_age_seconds;
+        assert!(second_age > first_age);
+    }
+
+    #[test]
+    fn metadata_writes_do_not_extend_hll_session_liveness() {
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::from_millis(10),
+            ttl: Duration::from_secs(60),
+        });
+        let node_id = heartbeat_node(&store, "node-a");
+        std::thread::sleep(Duration::from_millis(20));
+
+        store
+            .insert_hashes("ns", &[vec![1]], "node-a", node_id)
+            .unwrap();
+
+        // Metadata writes validate the session but do not refresh node liveness,
+        // so the node and its HLL report are stale together.
+        assert_eq!(store.node_counts(), (0, 1));
+        assert!(store.cluster_hll_snapshot().windows.is_empty());
     }
 
     #[test]
@@ -726,7 +1072,9 @@ mod tests {
         let new_id = Uuid::new_v4();
         assert_ne!(old_id, new_id);
 
-        let err = store.heartbeat_node("node-a", new_id).unwrap_err();
+        let err = store
+            .heartbeat_node("node-a", new_id, test_hll_report())
+            .unwrap_err();
         assert_eq!(err, StoreError::StaleSession);
     }
 
@@ -840,10 +1188,10 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_refreshes_node_liveness() {
+    fn test_insert_does_not_refresh_node_liveness() {
         let store = BlockHashStore::with_config(StoreConfig {
             node_stale_after: Duration::from_secs(60),
-            ttl: Duration::from_secs(60),
+            ttl: Duration::from_secs(120),
         });
         let node_id = heartbeat_node(&store, "node-a");
         store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(61);
@@ -852,17 +1200,16 @@ mod tests {
             .insert_hashes("ns", &[vec![1]], "node-a", node_id)
             .unwrap();
 
-        assert_eq!(store.node_counts(), (1, 0));
+        assert_eq!(store.node_counts(), (0, 1));
         let existing = store.query_prefix("ns", &[vec![1]]);
-        assert_eq!(existing.len(), 1);
-        assert_eq!(existing[0].nodes[0].as_ref(), "node-a");
+        assert!(existing.is_empty());
     }
 
     #[test]
-    fn test_remove_refreshes_node_liveness() {
+    fn test_remove_does_not_refresh_node_liveness() {
         let store = BlockHashStore::with_config(StoreConfig {
             node_stale_after: Duration::from_secs(60),
-            ttl: Duration::from_secs(60),
+            ttl: Duration::from_secs(120),
         });
         let node_id = heartbeat_node(&store, "node-a");
         store
@@ -874,7 +1221,7 @@ mod tests {
             .remove_hashes("ns", &[vec![2]], "node-a", node_id)
             .unwrap();
 
-        assert_eq!(store.node_counts(), (1, 0));
+        assert_eq!(store.node_counts(), (0, 1));
     }
 
     #[test]

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -7,7 +7,7 @@ use pegaflow_common::hll::{
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 const MIN_RECLAIMABLE_OWNER_COUNT: usize = 3;
@@ -86,7 +86,6 @@ pub enum StoreError {
 
 #[derive(Debug, Clone)]
 pub struct HllNodeReport {
-    pub snapshot_at_unix_ms: u64,
     pub windows: Vec<HllWindowSnapshot>,
 }
 
@@ -504,17 +503,13 @@ impl BlockHashStore {
     /// requires every active report to use the same window schema.
     fn compute_cluster_hll(
         &self,
-        _now: Instant,
+        now: Instant,
         active_reports: &[(Instant, HllNodeReport)],
     ) -> ClusterHllSnapshot {
-        let now_unix_ms = unix_time_ms();
-        let oldest_snapshot_at_unix_ms = active_reports
+        let snapshot_age_seconds = active_reports
             .iter()
-            .map(|(_, report)| report.snapshot_at_unix_ms)
-            .min()
-            .unwrap_or(now_unix_ms);
-        let snapshot_age_seconds =
-            now_unix_ms.saturating_sub(oldest_snapshot_at_unix_ms) as f64 / 1000.0;
+            .map(|(received_at, _)| now.duration_since(*received_at).as_secs_f64())
+            .fold(0.0, f64::max);
 
         struct WindowAccum {
             union: HyperLogLog,
@@ -655,9 +650,6 @@ fn validate_hll_report(report: &HllNodeReport) -> Result<(), String> {
             ));
         }
     }
-    if report.snapshot_at_unix_ms == 0 {
-        return Err("snapshot_at_unix_ms must be greater than zero".into());
-    }
     if payload_bytes > MAX_HLL_REPORT_BYTES {
         return Err(format!(
             "HLL register payload exceeds {MAX_HLL_REPORT_BYTES} bytes: {payload_bytes}"
@@ -675,15 +667,6 @@ fn same_hll_schema(left: &HllNodeReport, right: &HllNodeReport) -> bool {
                     && left_window.bucket_bits == right_window.bucket_bits
             })
         })
-}
-
-fn unix_time_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis()
-        .try_into()
-        .unwrap_or(u64::MAX)
 }
 
 impl Default for BlockHashStore {
@@ -706,7 +689,6 @@ mod tests {
 
     fn test_hll_report() -> HllNodeReport {
         HllNodeReport {
-            snapshot_at_unix_ms: unix_time_ms().max(1),
             windows: vec![HllWindowSnapshot {
                 window: "1m".into(),
                 window_secs: 60,
@@ -724,7 +706,6 @@ mod tests {
             hll.insert(&distributed.to_be_bytes());
         }
         HllNodeReport {
-            snapshot_at_unix_ms: unix_time_ms().max(1),
             windows: vec![HllWindowSnapshot {
                 window: "1m".into(),
                 window_secs: 60,

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -1,14 +1,12 @@
 use dashmap::{DashMap, mapref::entry::Entry};
 use log::{info, warn};
 use pegaflow_common::BlockKey;
-use pegaflow_common::hll::{
-    HllWindowSnapshot, HyperLogLog, MAX_BUCKET_BITS, MAX_HLL_REPORT_BYTES, MAX_HLL_WINDOWS,
-    MIN_BUCKET_BITS,
-};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
+
+use crate::hll::{ClusterHllSnapshot, HllNodeReport, HllSchema, HllState, ReceivedHllReport};
 
 const MIN_RECLAIMABLE_OWNER_COUNT: usize = 3;
 
@@ -84,26 +82,6 @@ pub enum StoreError {
     StaleSession,
 }
 
-#[derive(Debug, Clone)]
-pub struct HllNodeReport {
-    pub windows: Vec<HllWindowSnapshot>,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct ClusterHllSnapshot {
-    pub windows: Vec<ClusterHllWindowSnapshot>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ClusterHllWindowSnapshot {
-    pub window: String,
-    pub cardinality: f64,
-    pub total_requests: u64,
-    pub estimated_hit_rate: f64,
-    pub active_nodes: u64,
-    pub snapshot_age_seconds: f64,
-}
-
 /// Snapshot of the session that wrote this block ownership. Query compares it
 /// with the current `NodeRecord.node_id` to filter owners left by old sessions.
 #[derive(Debug, Clone)]
@@ -112,16 +90,16 @@ struct OwnerRecord {
     key_register_time: Instant,
 }
 
-/// Authoritative current session for a node URL. `last_seen` is refreshed only
-/// by heartbeats and gates query visibility. `hll_report` is best-effort
-/// observability state carried by heartbeats; it never affects metadata
-/// liveness, and its own receipt time (not `last_seen`) gates its inclusion in
-/// the cluster union, so metadata writes cannot keep a stale report alive.
+/// Authoritative current session for a node URL. `last_seen` gates metadata
+/// query visibility and is refreshed by a valid heartbeat or metadata write.
+/// `hll_report` is best-effort observability state carried by heartbeats; its
+/// own receipt time gates inclusion in the cluster union, so metadata writes
+/// cannot keep a stale report alive.
 #[derive(Debug, Clone)]
 struct NodeRecord {
     node_id: Uuid,
     last_seen: Instant,
-    hll_report: Option<(Instant, HllNodeReport)>,
+    hll_report: Option<ReceivedHllReport>,
 }
 
 /// Both lifecycle decisions for one owner record, produced from a single `nodes`
@@ -141,6 +119,7 @@ pub struct BlockHashStore {
     blocks: DashMap<BlockKey, HashMap<Arc<str>, OwnerRecord>>,
     nodes: DashMap<Arc<str>, NodeRecord>,
     config: StoreConfig,
+    hll: HllState,
     /// Latest live-owner redundancy distribution, refreshed each sweep and read
     /// by metric callbacks. Decouples the O(N) scan from the scrape path.
     redundancy: Mutex<RedundancySnapshot>,
@@ -152,10 +131,15 @@ impl BlockHashStore {
     }
 
     pub fn with_config(config: StoreConfig) -> Self {
+        Self::with_config_and_hll_schema(config, HllSchema::default())
+    }
+
+    pub fn with_config_and_hll_schema(config: StoreConfig, hll_schema: HllSchema) -> Self {
         Self {
             blocks: DashMap::new(),
             nodes: DashMap::new(),
             config,
+            hll: HllState::new(hll_schema, config.node_stale_after),
             redundancy: Mutex::new(RedundancySnapshot::default()),
         }
     }
@@ -178,18 +162,12 @@ impl BlockHashStore {
         hll_report: HllNodeReport,
     ) -> Result<(), StoreError> {
         let now = Instant::now();
-        let validated_report = match validate_hll_report(&hll_report) {
-            Ok(()) if self.hll_schema_matches_active(&hll_report, now) => Some((now, hll_report)),
-            Ok(()) => {
-                warn!(
-                    "MetaServer heartbeat accepted with incompatible HLL window schema (observability degraded): node={node}"
-                );
-                None
-            }
-            Err(e) => {
+        let validated_report = match self.hll.receive(hll_report, now) {
+            Ok(report) => Some(report),
+            Err(error) => {
                 warn!(
                     "MetaServer heartbeat accepted with invalid HLL report (observability degraded): node={} error={}",
-                    node, e
+                    node, error
                 );
                 None
             }
@@ -228,6 +206,7 @@ impl BlockHashStore {
                 }
             }
         }
+        self.hll.mark_changed();
         Ok(())
     }
 
@@ -250,6 +229,7 @@ impl BlockHashStore {
             );
             return Err(StoreError::UnknownNode);
         }
+        self.hll.mark_changed();
         let removed = self.remove_node_owners(node, node_id);
         Ok(removed)
     }
@@ -438,34 +418,12 @@ impl BlockHashStore {
     }
 
     pub fn cluster_hll_snapshot(&self) -> ClusterHllSnapshot {
-        let now = Instant::now();
-        let active_reports: Vec<(Instant, HllNodeReport)> = self
-            .nodes
-            .iter()
-            .filter(|record| now.duration_since(record.last_seen) <= self.config.node_stale_after)
-            .filter_map(|record| record.hll_report.clone())
-            .filter(|(report_time, _)| {
-                now.duration_since(*report_time) <= self.config.node_stale_after
-            })
-            .collect();
-
-        if active_reports.is_empty() {
-            return ClusterHllSnapshot::default();
-        }
-
-        self.compute_cluster_hll(now, &active_reports)
-    }
-
-    fn hll_schema_matches_active(&self, report: &HllNodeReport, now: Instant) -> bool {
-        for record in &self.nodes {
-            if now.duration_since(record.last_seen) <= self.config.node_stale_after
-                && let Some((_, active_report)) = record.hll_report.as_ref()
-                && !same_hll_schema(active_report, report)
-            {
-                return false;
-            }
-        }
-        true
+        self.hll.snapshot(|| {
+            self.nodes
+                .iter()
+                .filter_map(|record| record.hll_report.clone())
+                .collect()
+        })
     }
 
     #[allow(
@@ -475,6 +433,7 @@ impl BlockHashStore {
     pub fn invalidate_all(&self) {
         self.blocks.clear();
         self.nodes.clear();
+        self.hll.mark_changed();
         *self
             .redundancy
             .lock()
@@ -482,7 +441,7 @@ impl BlockHashStore {
     }
 
     fn touch_node_session(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
-        let Some(record) = self.nodes.get(node) else {
+        let Some(mut record) = self.nodes.get_mut(node) else {
             warn!(
                 "MetaServer metadata write rejected unknown node: node={} node_id={}",
                 node, node_id
@@ -496,71 +455,10 @@ impl BlockHashStore {
             );
             return Err(StoreError::StaleSession);
         }
+        // Metadata activity renews owner visibility only; HLL freshness is
+        // owned by the heartbeat report timestamp.
+        record.last_seen = Instant::now();
         Ok(())
-    }
-
-    /// Union active-node registers per configured window. Heartbeat validation
-    /// requires every active report to use the same window schema.
-    fn compute_cluster_hll(
-        &self,
-        now: Instant,
-        active_reports: &[(Instant, HllNodeReport)],
-    ) -> ClusterHllSnapshot {
-        let snapshot_age_seconds = active_reports
-            .iter()
-            .map(|(received_at, _)| now.duration_since(*received_at).as_secs_f64())
-            .fold(0.0, f64::max);
-
-        struct WindowAccum {
-            union: HyperLogLog,
-            total_requests: u64,
-            active_nodes: u64,
-        }
-        let mut groups: HashMap<String, WindowAccum> = HashMap::new();
-        for (_, report) in active_reports {
-            for window in &report.windows {
-                let key = window.window.clone();
-                let accum = groups.entry(key).or_insert_with(|| WindowAccum {
-                    union: HyperLogLog::new(window.bucket_bits),
-                    total_requests: 0,
-                    active_nodes: 0,
-                });
-                for (a, b) in accum
-                    .union
-                    .registers_mut()
-                    .iter_mut()
-                    .zip(window.registers.iter())
-                {
-                    if *b > *a {
-                        *a = *b;
-                    }
-                }
-                accum.total_requests = accum.total_requests.saturating_add(window.total_requests);
-                accum.active_nodes += 1;
-            }
-        }
-
-        let mut windows: Vec<ClusterHllWindowSnapshot> = groups
-            .into_iter()
-            .map(|(key, accum)| {
-                let cardinality = accum.union.cardinality();
-                let estimated_hit_rate = if accum.total_requests == 0 {
-                    0.0
-                } else {
-                    1.0 - cardinality.min(accum.total_requests as f64) / accum.total_requests as f64
-                };
-                ClusterHllWindowSnapshot {
-                    window: key,
-                    cardinality,
-                    total_requests: accum.total_requests,
-                    estimated_hit_rate,
-                    active_nodes: accum.active_nodes,
-                    snapshot_age_seconds,
-                }
-            })
-            .collect();
-        windows.sort_by(|a, b| a.window.cmp(&b.window));
-        ClusterHllSnapshot { windows }
     }
 
     fn remove_node_owners(&self, node: &str, node_id: Uuid) -> usize {
@@ -601,74 +499,6 @@ impl BlockHashStore {
     }
 }
 
-fn validate_hll_report(report: &HllNodeReport) -> Result<(), String> {
-    if report.windows.is_empty() || report.windows.len() > MAX_HLL_WINDOWS {
-        return Err(format!(
-            "HLL report window count must be in 1..={MAX_HLL_WINDOWS}, got {}",
-            report.windows.len()
-        ));
-    }
-
-    let mut labels = HashSet::new();
-    let mut durations = HashSet::new();
-    let mut payload_bytes = 0usize;
-    for window in &report.windows {
-        if window.window.is_empty() {
-            return Err("HLL window label must not be empty".into());
-        }
-        if window.window_secs == 0 {
-            return Err(format!(
-                "HLL window {} duration must be greater than zero",
-                window.window
-            ));
-        }
-        if !labels.insert(window.window.clone()) || !durations.insert(window.window_secs) {
-            return Err(format!(
-                "duplicate HLL window label or duration: {} ({}s)",
-                window.window, window.window_secs
-            ));
-        }
-        payload_bytes = payload_bytes.saturating_add(window.registers.len());
-        if !(MIN_BUCKET_BITS..=MAX_BUCKET_BITS).contains(&window.bucket_bits) {
-            return Err(format!(
-                "HLL bucket_bits must be in {MIN_BUCKET_BITS}..={MAX_BUCKET_BITS}, got {}",
-                window.bucket_bits
-            ));
-        }
-        let expected_registers = 1usize << window.bucket_bits;
-        if window.registers.len() != expected_registers {
-            return Err(format!(
-                "HLL registers length must be {expected_registers} for bucket_bits={}, got {}",
-                window.bucket_bits,
-                window.registers.len()
-            ));
-        }
-        if window.total_requests == 0 && window.registers.iter().any(|register| *register != 0) {
-            return Err(format!(
-                "HLL window {} has registers but zero total_requests",
-                window.window
-            ));
-        }
-    }
-    if payload_bytes > MAX_HLL_REPORT_BYTES {
-        return Err(format!(
-            "HLL register payload exceeds {MAX_HLL_REPORT_BYTES} bytes: {payload_bytes}"
-        ));
-    }
-    Ok(())
-}
-
-fn same_hll_schema(left: &HllNodeReport, right: &HllNodeReport) -> bool {
-    left.windows.len() == right.windows.len()
-        && left.windows.iter().all(|left_window| {
-            right.windows.iter().any(|right_window| {
-                left_window.window == right_window.window
-                    && left_window.window_secs == right_window.window_secs
-                    && left_window.bucket_bits == right_window.bucket_bits
-            })
-        })
-}
-
 impl Default for BlockHashStore {
     fn default() -> Self {
         Self::new()
@@ -677,7 +507,24 @@ impl Default for BlockHashStore {
 
 #[cfg(test)]
 mod tests {
+    use pegaflow_common::hll::{HllWindowSnapshot, HyperLogLog};
+    use pegaflow_common::hll_config::{
+        DEFAULT_HLL_BUCKET_BITS, DEFAULT_HLL_WINDOWS, parse_hll_windows,
+    };
+
     use super::*;
+
+    fn hll_schema(bucket_bits: u8) -> HllSchema {
+        HllSchema::new(
+            vec![("1m".to_string(), Duration::from_secs(60))],
+            bucket_bits,
+        )
+        .unwrap()
+    }
+
+    fn hll_store(config: StoreConfig, bucket_bits: u8) -> BlockHashStore {
+        BlockHashStore::with_config_and_hll_schema(config, hll_schema(bucket_bits))
+    }
 
     fn heartbeat_node(store: &BlockHashStore, node: &str) -> Uuid {
         let node_id = Uuid::new_v4();
@@ -689,13 +536,17 @@ mod tests {
 
     fn test_hll_report() -> HllNodeReport {
         HllNodeReport {
-            windows: vec![HllWindowSnapshot {
-                window: "1m".into(),
-                window_secs: 60,
-                bucket_bits: 4,
-                registers: vec![0; 16],
-                total_requests: 0,
-            }],
+            windows: parse_hll_windows(DEFAULT_HLL_WINDOWS)
+                .unwrap()
+                .into_iter()
+                .map(|(window, duration)| HllWindowSnapshot {
+                    window,
+                    window_secs: duration.as_secs(),
+                    bucket_bits: DEFAULT_HLL_BUCKET_BITS,
+                    registers: vec![0; 1 << DEFAULT_HLL_BUCKET_BITS],
+                    total_requests: 0,
+                })
+                .collect(),
         }
     }
 
@@ -718,7 +569,7 @@ mod tests {
 
     #[test]
     fn cluster_hll_unions_registers_and_sums_observations() {
-        let store = BlockHashStore::new();
+        let store = hll_store(StoreConfig::default(), 14);
         let node_a = Uuid::new_v4();
         let node_b = Uuid::new_v4();
         store
@@ -739,7 +590,7 @@ mod tests {
 
     #[test]
     fn cluster_hll_rejects_incompatible_bucket_bits_without_affecting_liveness() {
-        let store = BlockHashStore::new();
+        let store = hll_store(StoreConfig::default(), 14);
         store
             .heartbeat_node("node-a", Uuid::new_v4(), hll_report_for(&[1], 1, 14))
             .unwrap();
@@ -761,7 +612,7 @@ mod tests {
 
     #[test]
     fn unregister_removes_hll_snapshot_from_cluster() {
-        let store = BlockHashStore::new();
+        let store = hll_store(StoreConfig::default(), 14);
         let node_a = Uuid::new_v4();
         let node_b = Uuid::new_v4();
         store
@@ -780,10 +631,13 @@ mod tests {
 
     #[test]
     fn cluster_hll_snapshot_excludes_nodes_as_soon_as_they_become_stale() {
-        let store = BlockHashStore::with_config(StoreConfig {
-            node_stale_after: Duration::from_millis(10),
-            ttl: Duration::from_secs(60),
-        });
+        let store = hll_store(
+            StoreConfig {
+                node_stale_after: Duration::from_millis(10),
+                ttl: Duration::from_secs(60),
+            },
+            14,
+        );
         let node_id = Uuid::new_v4();
         store
             .heartbeat_node("node-a", node_id, hll_report_for(&[1], 1, 14))
@@ -796,7 +650,7 @@ mod tests {
 
     #[test]
     fn cluster_hll_snapshot_age_advances_between_reads() {
-        let store = BlockHashStore::new();
+        let store = hll_store(StoreConfig::default(), 14);
         store
             .heartbeat_node("node-a", Uuid::new_v4(), hll_report_for(&[1], 1, 14))
             .unwrap();
@@ -809,7 +663,37 @@ mod tests {
     }
 
     #[test]
-    fn metadata_writes_do_not_extend_hll_session_liveness() {
+    fn concurrent_initial_reports_use_the_configured_schema() {
+        let store = Arc::new(hll_store(StoreConfig::default(), 4));
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let valid_store = Arc::clone(&store);
+        let valid_barrier = Arc::clone(&barrier);
+        let valid = std::thread::spawn(move || {
+            valid_barrier.wait();
+            valid_store
+                .heartbeat_node("valid", Uuid::new_v4(), hll_report_for(&[1], 1, 4))
+                .unwrap();
+        });
+        let invalid_store = Arc::clone(&store);
+        let invalid_barrier = Arc::clone(&barrier);
+        let invalid = std::thread::spawn(move || {
+            invalid_barrier.wait();
+            invalid_store
+                .heartbeat_node("invalid", Uuid::new_v4(), hll_report_for(&[2], 1, 5))
+                .unwrap();
+        });
+        barrier.wait();
+        valid.join().unwrap();
+        invalid.join().unwrap();
+
+        assert_eq!(store.node_counts(), (2, 0));
+        let cluster = store.cluster_hll_snapshot();
+        assert_eq!(cluster.windows[0].active_nodes, 1);
+        assert_eq!(cluster.windows[0].total_requests, 1);
+    }
+
+    #[test]
+    fn metadata_writes_keep_metadata_live_without_extending_hll_liveness() {
         let store = BlockHashStore::with_config(StoreConfig {
             node_stale_after: Duration::from_millis(10),
             ttl: Duration::from_secs(60),
@@ -821,9 +705,10 @@ mod tests {
             .insert_hashes("ns", &[vec![1]], "node-a", node_id)
             .unwrap();
 
-        // Metadata writes validate the session but do not refresh node liveness,
-        // so the node and its HLL report are stale together.
-        assert_eq!(store.node_counts(), (0, 1));
+        // Metadata writes keep cache ownership visible, but only a heartbeat
+        // refreshes the HLL receipt time.
+        assert_eq!(store.node_counts(), (1, 0));
+        assert_eq!(store.query_prefix("ns", &[vec![1]]).len(), 1);
         assert!(store.cluster_hll_snapshot().windows.is_empty());
     }
 
@@ -1199,7 +1084,7 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_does_not_refresh_node_liveness() {
+    fn test_insert_refreshes_node_liveness() {
         let store = BlockHashStore::with_config(StoreConfig {
             node_stale_after: Duration::from_secs(60),
             ttl: Duration::from_secs(120),
@@ -1211,13 +1096,14 @@ mod tests {
             .insert_hashes("ns", &[vec![1]], "node-a", node_id)
             .unwrap();
 
-        assert_eq!(store.node_counts(), (0, 1));
+        assert_eq!(store.node_counts(), (1, 0));
         let existing = store.query_prefix("ns", &[vec![1]]);
-        assert!(existing.is_empty());
+        assert_eq!(existing.len(), 1);
+        assert_eq!(existing[0].nodes[0].as_ref(), "node-a");
     }
 
     #[test]
-    fn test_remove_does_not_refresh_node_liveness() {
+    fn test_remove_refreshes_node_liveness() {
         let store = BlockHashStore::with_config(StoreConfig {
             node_stale_after: Duration::from_secs(60),
             ttl: Duration::from_secs(120),
@@ -1232,7 +1118,7 @@ mod tests {
             .remove_hashes("ns", &[vec![2]], "node-a", node_id)
             .unwrap();
 
-        assert_eq!(store.node_counts(), (0, 1));
+        assert_eq!(store.node_counts(), (1, 0));
     }
 
     #[test]

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -316,9 +316,23 @@ message QueryPrefixBlocksResponse {
   repeated NodePrefixResult nodes = 1;
 }
 
+message HllWindowSnapshot {
+  string window = 1;
+  uint64 window_secs = 2;
+  uint32 bucket_bits = 3;
+  bytes registers = 4;
+  uint64 total_requests = 5;
+}
+
+message HllSnapshotReport {
+  uint64 snapshot_at_unix_ms = 1;
+  repeated HllWindowSnapshot windows = 2;
+}
+
 message HeartbeatNodeRequest {
   string node = 1;
   string node_id = 2;
+  HllSnapshotReport hll_report = 3;
 }
 
 message HeartbeatNodeResponse {

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -325,8 +325,7 @@ message HllWindowSnapshot {
 }
 
 message HllSnapshotReport {
-  uint64 snapshot_at_unix_ms = 1;
-  repeated HllWindowSnapshot windows = 2;
+  repeated HllWindowSnapshot windows = 1;
 }
 
 message HeartbeatNodeRequest {

--- a/pegaflow-server/examples/p2p_bench.rs
+++ b/pegaflow-server/examples/p2p_bench.rs
@@ -504,13 +504,7 @@ async fn run_holder(cli: &Cli, shape: &Shape, pool_bytes: usize) {
     // a bench that never registers IPC tensors.
     let registry = RegistryHandle::spawn(CudaTensorRegistry::empty());
     let shutdown = Arc::new(Notify::new());
-    let hll = Arc::new(std::sync::Mutex::new(
-        pegaflow_common::hll::MultiWindowHllTracker::new(
-            vec![("24h".into(), Duration::from_secs(86400))],
-            14,
-        ),
-    ));
-    let service = GrpcEngineService::new(Arc::clone(&engine), registry, shutdown, hll);
+    let service = GrpcEngineService::new(Arc::clone(&engine), registry, shutdown);
     let listen: SocketAddr = ([0, 0, 0, 0], cli.port).into();
     tokio::spawn(async move {
         Server::builder()

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -553,6 +553,9 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         advertise_addr,
         metaserver_queue_depth: cli.metaserver_queue_depth,
         pool_shards: cli.pool_shards,
+        hll_windows: parse_hll_windows(&cli.metric_hll_windows)
+            .map_err(|err| format!("invalid --metric-hll-windows: {err}"))?,
+        hll_bucket_bits: cli.metric_hll_bucket_bits,
     };
 
     if cli.pool_shards > 1 {
@@ -583,15 +586,6 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         )
     })?;
 
-    let hll_tracker = Arc::new(std::sync::Mutex::new(
-        pegaflow_common::hll::MultiWindowHllTracker::new(
-            parse_hll_windows(&cli.metric_hll_windows)
-                .map_err(|err| format!("invalid --metric-hll-windows: {err}"))?,
-            cli.metric_hll_bucket_bits,
-        ),
-    ));
-    crate::metric::register_hll_gauges(&hll_tracker);
-
     let shutdown = Arc::new(Notify::new());
 
     runtime.block_on(async move {
@@ -602,11 +596,12 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             storage_config,
         )?);
 
+        crate::metric::register_hll_gauges(engine.hll_tracker());
+
         let service = GrpcEngineService::new(
             Arc::clone(&engine),
             registry.clone(),
             Arc::clone(&shutdown),
-            Arc::clone(&hll_tracker),
         );
 
         // Spawn background GC task for stale inflight blocks and expired transfer locks

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -26,6 +26,10 @@ use opentelemetry_sdk::metrics::SdkMeterProvider;
 use pegaflow_common::grpc::{
     GRPC_SERVER_HTTP2_KEEPALIVE_INTERVAL, GRPC_SERVER_HTTP2_KEEPALIVE_TIMEOUT,
 };
+use pegaflow_common::hll_config::{
+    DEFAULT_HLL_BUCKET_BITS, DEFAULT_HLL_WINDOWS, parse_hll_bucket_bits, parse_hll_windows,
+    parse_hll_windows_arg,
+};
 use pegaflow_core::PegaEngine;
 use prometheus::Registry;
 use proto::engine::engine_server::EngineServer;
@@ -174,11 +178,11 @@ pub struct Cli {
     /// HLL sliding-window list for hit-rate estimation. Comma-separated humantime
     /// durations; each becomes a canonical `window` label in metrics (e.g. `15m,1h,1d`).
     /// Slot duration is derived as `clamp(window/24, 1min, 1h)`.
-    #[arg(long, default_value = "15m,1h,1d", value_parser = parse_hll_windows_arg)]
+    #[arg(long, default_value = DEFAULT_HLL_WINDOWS, value_parser = parse_hll_windows_arg)]
     pub metric_hll_windows: String,
 
     /// HLL bucket index bits 4–18 (default: 16 → 65536 buckets, ~0.4% error)
-    #[arg(long, default_value_t = 16, value_parser = parse_hll_bucket_bits)]
+    #[arg(long, default_value_t = DEFAULT_HLL_BUCKET_BITS, value_parser = parse_hll_bucket_bits)]
     pub metric_hll_bucket_bits: u8,
 
     /// Transfer lock timeout in seconds. Blocks held for cross-node RDMA transfer are
@@ -187,97 +191,12 @@ pub struct Cli {
     pub transfer_lock_timeout_secs: u64,
 }
 
-fn parse_hll_bucket_bits(s: &str) -> Result<u8, String> {
-    use pegaflow_common::hll::{MAX_BUCKET_BITS, MIN_BUCKET_BITS};
-    let v: u8 = s.parse().map_err(|e| format!("{e}"))?;
-    if !(MIN_BUCKET_BITS..=MAX_BUCKET_BITS).contains(&v) {
-        return Err(format!(
-            "HLL bucket_bits must be in {MIN_BUCKET_BITS}..={MAX_BUCKET_BITS}, got {v}"
-        ));
-    }
-    Ok(v)
-}
-
 fn parse_nic_name(s: &str) -> Result<String, String> {
     let name = s.trim();
     if name.is_empty() {
         return Err("--nics contains an empty NIC name".into());
     }
     Ok(name.to_string())
-}
-
-fn parse_hll_windows_arg(s: &str) -> Result<String, String> {
-    parse_hll_windows(s)?;
-    Ok(s.to_string())
-}
-
-/// Parse a comma-separated list of humantime windows (e.g. `15m,1h,1d`).
-/// Each entry becomes `(label, duration)` where label is canonicalized from
-/// the parsed duration.
-fn parse_hll_windows(s: &str) -> Result<Vec<(String, Duration)>, String> {
-    let mut out = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    for (idx, token) in s.split(',').map(str::trim).enumerate() {
-        if token.is_empty() {
-            return Err(format!(
-                "--metric-hll-windows contains an empty window at position {}",
-                idx + 1
-            ));
-        }
-        let dur = parse_humantime(token)?;
-        if dur < Duration::from_secs(60) {
-            return Err(format!("HLL window {token} must be at least 1 minute"));
-        }
-        if !seen.insert(dur) {
-            return Err(format!(
-                "duplicate HLL window duration: {token} ({})",
-                format_hll_window_label(dur)
-            ));
-        }
-        out.push((format_hll_window_label(dur), dur));
-    }
-    if out.is_empty() {
-        return Err("--metric-hll-windows must list at least one window".into());
-    }
-    Ok(out)
-}
-
-/// Minimal humantime parser: `<number><unit>` where unit ∈ {s, m, h, d}.
-fn parse_humantime(s: &str) -> Result<Duration, String> {
-    let (num_str, unit) = s.split_at(
-        s.find(|c: char| !c.is_ascii_digit())
-            .ok_or_else(|| format!("missing time unit in {s}"))?,
-    );
-    let n: u64 = num_str
-        .parse()
-        .map_err(|e| format!("invalid number in {s}: {e}"))?;
-    let unit_secs = match unit {
-        "s" => n,
-        "m" => n
-            .checked_mul(60)
-            .ok_or_else(|| format!("duration overflows seconds in {s}"))?,
-        "h" => n
-            .checked_mul(3600)
-            .ok_or_else(|| format!("duration overflows seconds in {s}"))?,
-        "d" => n
-            .checked_mul(86400)
-            .ok_or_else(|| format!("duration overflows seconds in {s}"))?,
-        _ => return Err(format!("unknown time unit {unit:?} in {s}; use s/m/h/d")),
-    };
-    Ok(Duration::from_secs(unit_secs))
-}
-
-fn format_hll_window_label(duration: Duration) -> String {
-    let secs = duration.as_secs();
-    if secs.is_multiple_of(86400) {
-        format!("{}d", secs / 86400)
-    } else if secs.is_multiple_of(3600) {
-        format!("{}h", secs / 3600)
-    } else if secs.is_multiple_of(60) {
-        format!("{}m", secs / 60)
-    } else {
-        format!("{secs}s")
-    }
 }
 
 fn parse_sample_rate(s: &str) -> Result<f64, String> {

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -26,7 +26,6 @@ pub struct GrpcEngineService {
     engine: Arc<PegaEngine>,
     registry: RegistryHandle,
     shutdown: Arc<Notify>,
-    hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::MultiWindowHllTracker>>,
     session_registry: Arc<SessionRegistry>,
 }
 
@@ -35,13 +34,11 @@ impl GrpcEngineService {
         engine: Arc<PegaEngine>,
         registry: RegistryHandle,
         shutdown: Arc<Notify>,
-        hll_tracker: Arc<std::sync::Mutex<pegaflow_common::hll::MultiWindowHllTracker>>,
     ) -> Self {
         Self {
             engine,
             registry,
             shutdown,
-            hll_tracker,
             session_registry: SessionRegistry::new(),
         }
     }
@@ -652,10 +649,8 @@ impl Engine for GrpcEngineService {
                         let miss_count = missing.min(req.block_hashes.len());
                         let miss_start = req.block_hashes.len() - miss_count;
                         debug_assert_eq!(hit + miss_count, req.block_hashes.len());
-                        if let Ok(namespace) = self.engine.instance_namespace(&req.instance_id)
-                            && let Ok(mut t) = self.hll_tracker.lock()
-                        {
-                            t.record_namespaced_misses(
+                        if let Ok(namespace) = self.engine.instance_namespace(&req.instance_id) {
+                            self.engine.record_hll_misses(
                                 &namespace,
                                 req.block_hashes.len() as u64,
                                 &req.block_hashes[miss_start..],

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -30,11 +30,7 @@ pub struct GrpcEngineService {
 }
 
 impl GrpcEngineService {
-    pub fn new(
-        engine: Arc<PegaEngine>,
-        registry: RegistryHandle,
-        shutdown: Arc<Notify>,
-    ) -> Self {
+    pub fn new(engine: Arc<PegaEngine>, registry: RegistryHandle, shutdown: Arc<Notify>) -> Self {
         Self {
             engine,
             registry,

--- a/pegaflow-server/tests/common/mod.rs
+++ b/pegaflow-server/tests/common/mod.rs
@@ -448,13 +448,7 @@ async fn spawn_engine_server(
     let addr: SocketAddr = ([127, 0, 0, 1], port).into();
     let registry = RegistryHandle::spawn(CudaTensorRegistry::empty());
     let shutdown = Arc::new(Notify::new());
-    let hll_tracker = Arc::new(std::sync::Mutex::new(
-        pegaflow_common::hll::MultiWindowHllTracker::new(
-            vec![("24h".into(), Duration::from_secs(86400))],
-            14,
-        ),
-    ));
-    let service = GrpcEngineService::new(engine, registry, shutdown, hll_tracker);
+    let service = GrpcEngineService::new(engine, registry, shutdown);
 
     let handle = tokio::spawn(async move {
         Server::builder()

--- a/pegaflow-server/tests/http_cleanup_hang_repro.rs
+++ b/pegaflow-server/tests/http_cleanup_hang_repro.rs
@@ -261,24 +261,14 @@ fn start_cluster(worker_threads: usize) -> TestCluster {
     let (engine, ctx) = build_engine();
     let registry = RegistryHandle::spawn(CudaTensorRegistry::empty());
     let shutdown = Arc::new(Notify::new());
-    let hll_tracker = Arc::new(std::sync::Mutex::new(
-        pegaflow_common::hll::MultiWindowHllTracker::new(
-            vec![("24h".into(), Duration::from_secs(86400))],
-            14,
-        ),
-    ));
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(worker_threads)
         .enable_all()
         .build()
         .expect("build server runtime");
 
-    let service = GrpcEngineService::new(
-        Arc::clone(&engine),
-        registry.clone(),
-        Arc::clone(&shutdown),
-        hll_tracker,
-    );
+    let service =
+        GrpcEngineService::new(Arc::clone(&engine), registry.clone(), Arc::clone(&shutdown));
     rt.spawn(async move {
         Server::builder()
             .add_service(EngineServer::new(service))

--- a/pegaflow-server/tests/p2p_rdma.rs
+++ b/pegaflow-server/tests/p2p_rdma.rs
@@ -155,13 +155,7 @@ async fn spawn_engine_server(engine: Arc<PegaEngine>, port: u16) {
     let registry = CudaTensorRegistry::new().expect("CudaTensorRegistry::new");
     let registry = RegistryHandle::spawn(registry);
     let shutdown = Arc::new(Notify::new());
-    let hll_tracker = Arc::new(std::sync::Mutex::new(
-        pegaflow_common::hll::MultiWindowHllTracker::new(
-            vec![("24h".into(), Duration::from_secs(86400))],
-            14,
-        ),
-    ));
-    let service = GrpcEngineService::new(engine, registry, shutdown, hll_tracker);
+    let service = GrpcEngineService::new(engine, registry, shutdown);
     let addr: SocketAddr = ([127, 0, 0, 1], port).into();
     tokio::spawn(async move {
         Server::builder()


### PR DESCRIPTION
## Summary
- send mergeable raw HLL window snapshots with node heartbeats
- union active node registers in MetaServer and export cluster HLL gauges
- keep HLL reporting best-effort; metadata liveness is not affected by invalid reports or metadata writes
- preserve the existing miss-only local HLL semantics and default windows

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p pegaflow-common` (51 passed)
- `cargo test -p pegaflow-metaserver` (42 passed)
- `cargo test -p pegaflow-core --no-default-features --features cuda-13,rdma internode::metaserver_client::tests` (8 passed)
- `cargo clippy -p pegaflow-common -p pegaflow-metaserver --all-targets -- -D warnings`
- `cargo clippy -p pegaflow-core -p pegaflow-server --no-default-features --features cuda-13,rdma --all-targets -- -D warnings`
- `cargo check -p pegaflow-core -p pegaflow-server --no-default-features --features cuda-13,rdma`

Full core unit tests were also attempted; CUDA-dependent tests cannot run on the remote environment because `libcudart` is unavailable.