### PR TITLE
feat(rdma): fetch KV prefixes across nodes

### DIFF
--- a/docs/p2p.md
+++ b/docs/p2p.md
@@ -132,9 +132,11 @@ P2P-related Prometheus metrics (on `:9091/metrics` by default):
 
 | Metric | Type | Description |
 |---|---|---|
-| `pegaflow_rdma_fetch_total` | Counter | Total RDMA fetch operations |
+| `pegaflow_rdma_fetch_total` | Counter | Total per-segment RDMA fetch operations |
 | `pegaflow_rdma_fetch_duration` | Histogram | RDMA fetch latency distribution |
 | `pegaflow_rdma_fetch_bytes` | Counter | Total bytes fetched via RDMA |
+| `pegaflow_rdma_fetch_plan_segments` | Histogram | Planned segment count per executed RDMA fetch plan |
+| `pegaflow_rdma_fetch_plan_completed_segments` | Histogram | Completed segment count before a plan stops |
 | `pegaflow_rdma_qps` | Gauge | Active RDMA queue pairs |
 | `pegaflow_transfer_lock_active` | UpDownCounter | Currently held transfer locks |
 | `pegaflow_transfer_lock_timeouts_total` | Counter | Transfer lock timeout events |

--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -263,6 +263,13 @@ impl RdmaFetchStore {
         };
         let (fetched, completed_segments, failure) =
             execute_fetch_plan(&fetcher, plan, namespace, hashes).await;
+        let metrics = core_metrics();
+        metrics
+            .rdma_fetch_plan_segments
+            .record(plan.segments.len() as u64, &[]);
+        metrics
+            .rdma_fetch_plan_completed_segments
+            .record(completed_segments as u64, &[]);
         let (failed_segment, failed_planned_blocks, failed_returned_blocks) = failure
             .map(|(index, planned, returned)| {
                 (index.to_string(), planned.to_string(), returned.to_string())

--- a/pegaflow-core/src/backing/rdma_fetch.rs
+++ b/pegaflow-core/src/backing/rdma_fetch.rs
@@ -10,8 +10,8 @@ use log::{debug, info, warn};
 use mea::singleflight::Group;
 use pegaflow_proto::proto::engine::engine_client::EngineClient;
 use pegaflow_proto::proto::engine::{
-    QueryBlocksForTransferRequest, QueryBlocksForTransferResponse, RdmaHandshakeRequest,
-    TransferBlockInfo,
+    FetchSegment, QueryBlocksForTransferRequest, QueryBlocksForTransferResponse,
+    RdmaHandshakeRequest, TransferBlockInfo,
 };
 use pegaflow_transfer::{ConnectionStatus, HandshakeMetadata, TransferDesc, TransferOp};
 use tonic::transport::{Channel, Endpoint};
@@ -58,6 +58,138 @@ pub(crate) struct RdmaFetchStore {
     connect_group: Arc<Group<String, ()>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FetchPlanSegment {
+    node: String,
+    start: usize,
+    end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FetchPlan {
+    segments: Vec<FetchPlanSegment>,
+    block_count: usize,
+}
+
+impl FetchPlan {
+    pub(crate) fn block_count(&self) -> usize {
+        self.block_count
+    }
+
+    fn segment_blocks_summary(&self) -> String {
+        self.segments
+            .iter()
+            .map(|segment| (segment.end - segment.start).to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+fn validate_fetch_plan(
+    segments: Vec<FetchSegment>,
+    hash_count: usize,
+    exclude_node: &str,
+) -> Result<Option<FetchPlan>, String> {
+    if segments.is_empty() {
+        return Ok(None);
+    }
+
+    let mut validated = Vec::with_capacity(segments.len());
+    let mut offset = 0usize;
+    for (index, segment) in segments.into_iter().enumerate() {
+        if segment.node.is_empty() {
+            return Err(format!("segment {index} has an empty node"));
+        }
+        if segment.node == exclude_node {
+            return Err(format!("segment {index} selects the excluded requester"));
+        }
+        if segment.block_count == 0 {
+            return Err(format!("segment {index} has zero blocks"));
+        }
+        if validated
+            .last()
+            .is_some_and(|previous: &FetchPlanSegment| previous.node == segment.node)
+        {
+            return Err(format!(
+                "segment {index} repeats the previous node instead of merging"
+            ));
+        }
+
+        let count = usize::try_from(segment.block_count)
+            .map_err(|_| format!("segment {index} block count exceeds usize"))?;
+        let end = offset
+            .checked_add(count)
+            .ok_or_else(|| format!("segment {index} block count overflows"))?;
+        if end > hash_count {
+            return Err(format!(
+                "segment {index} ends at block {end}, beyond request length {hash_count}"
+            ));
+        }
+        validated.push(FetchPlanSegment {
+            node: segment.node,
+            start: offset,
+            end,
+        });
+        offset = end;
+    }
+
+    Ok(Some(FetchPlan {
+        segments: validated,
+        block_count: offset,
+    }))
+}
+
+#[tonic::async_trait]
+trait SegmentFetcher {
+    async fn fetch_segment(&self, remote_addr: &str, hashes: &[Vec<u8>]) -> PrefetchResult;
+}
+
+struct RdmaSegmentFetcher<'a> {
+    store: &'a RdmaFetchStore,
+    req_id: &'a str,
+    namespace: &'a str,
+}
+
+#[tonic::async_trait]
+impl SegmentFetcher for RdmaSegmentFetcher<'_> {
+    async fn fetch_segment(&self, remote_addr: &str, hashes: &[Vec<u8>]) -> PrefetchResult {
+        self.store
+            .fetch_blocks(remote_addr, self.req_id, self.namespace, hashes)
+            .await
+    }
+}
+
+async fn execute_fetch_plan<F: SegmentFetcher>(
+    fetcher: &F,
+    plan: &FetchPlan,
+    namespace: &str,
+    hashes: &[Vec<u8>],
+) -> (PrefetchResult, usize, Option<(usize, usize, usize)>) {
+    let mut fetched = Vec::with_capacity(plan.block_count);
+    let mut completed_segments = 0usize;
+    let mut failed_segment = None;
+
+    for (index, segment) in plan.segments.iter().enumerate() {
+        let expected = &hashes[segment.start..segment.end];
+        let returned = fetcher.fetch_segment(&segment.node, expected).await;
+        let contiguous = returned
+            .iter()
+            .zip(expected)
+            .take_while(|((key, _), hash)| key.namespace == namespace && key.hash == **hash)
+            .count();
+        let returned_count = returned.len();
+        fetched.extend(returned.into_iter().take(contiguous));
+
+        if contiguous != expected.len() || returned_count != expected.len() {
+            failed_segment = Some((index, expected.len(), contiguous));
+            break;
+        }
+        completed_segments += 1;
+    }
+
+    (fetched, completed_segments, failed_segment)
+}
+
 impl RdmaFetchStore {
     pub(crate) fn new(
         metaserver_client: Arc<MetaServerClient>,
@@ -76,42 +208,82 @@ impl RdmaFetchStore {
         }
     }
 
-    /// Query MetaServer for the best remote node that holds a prefix of `hashes`.
-    /// Returns `(node_addr, prefix_len)`, or `None` if no remote node has any.
-    pub(crate) async fn query_prefix(
+    /// Query MetaServer for a validated ordered plan covering a prefix of `hashes`.
+    pub(crate) async fn query_plan(
         &self,
         namespace: &str,
         hashes: &[Vec<u8>],
-    ) -> Option<(String, usize)> {
+    ) -> Option<FetchPlan> {
         if hashes.is_empty() {
             return None;
         }
 
-        let nodes = match self.metaserver_client.query_prefix(namespace, hashes).await {
-            Ok(n) => n,
+        let segments = match self
+            .metaserver_client
+            .query_plan(namespace, hashes, &self.advertise_addr)
+            .await
+        {
+            Ok(segments) => segments,
             Err(e) => {
                 warn!("MetaServer query failed for remote fetch: {e}");
                 return None;
             }
         };
 
-        let best = nodes
-            .iter()
-            .filter(|n| n.node != self.advertise_addr)
-            .max_by_key(|n| n.prefix_len)?;
-
-        let prefix_len = best.prefix_len as usize;
-        if prefix_len == 0 {
-            return None;
-        }
+        let plan = match validate_fetch_plan(segments, hashes.len(), &self.advertise_addr) {
+            Ok(plan) => plan?,
+            Err(error) => {
+                warn!("MetaServer returned invalid remote fetch plan: {error}");
+                return None;
+            }
+        };
 
         debug!(
-            "Remote prefix query: namespace={namespace} best_node={} prefix={prefix_len}/{}",
-            best.node,
-            hashes.len()
+            "Remote prefix query: segments={} prefix={}/{}",
+            plan.segments.len(),
+            plan.block_count,
+            hashes.len(),
         );
 
-        Some((best.node.clone(), prefix_len))
+        Some(plan)
+    }
+
+    pub(crate) async fn fetch_plan(
+        &self,
+        plan: &FetchPlan,
+        req_id: &str,
+        namespace: &str,
+        hashes: &[Vec<u8>],
+    ) -> PrefetchResult {
+        let started_at = Instant::now();
+        let fetcher = RdmaSegmentFetcher {
+            store: self,
+            req_id,
+            namespace,
+        };
+        let (fetched, completed_segments, failure) =
+            execute_fetch_plan(&fetcher, plan, namespace, hashes).await;
+        let (failed_segment, failed_planned_blocks, failed_returned_blocks) = failure
+            .map(|(index, planned, returned)| {
+                (index.to_string(), planned.to_string(), returned.to_string())
+            })
+            .unwrap_or_else(|| ("none".into(), "none".into(), "none".into()));
+
+        info!(
+            "RDMA multi-node fetch plan summary: req_id={} planned_segments={} completed_segments={} planned_blocks={} segment_blocks={} fetched_blocks={} failed_segment={} failed_segment_planned_blocks={} failed_segment_returned_blocks={} total_ms={:.2}",
+            req_id,
+            plan.segments.len(),
+            completed_segments,
+            plan.block_count,
+            plan.segment_blocks_summary(),
+            fetched.len(),
+            failed_segment,
+            failed_planned_blocks,
+            failed_returned_blocks,
+            started_at.elapsed().as_secs_f64() * 1000.0,
+        );
+
+        fetched
     }
 
     /// Fetch `hashes` from `remote_addr`.
@@ -735,6 +907,7 @@ fn transfer_timeout_from_server(lock_timeout_secs: u32) -> Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
     use std::num::NonZeroU64;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
@@ -755,6 +928,153 @@ mod tests {
 
     fn remaining(bytes: u64) -> HashMap<NumaNode, u64> {
         HashMap::from([(NumaNode(0), bytes)])
+    }
+
+    fn segment(node: &str, block_count: u32) -> FetchSegment {
+        FetchSegment {
+            node: node.to_string(),
+            block_count,
+        }
+    }
+
+    fn fetched_block(hash: u8) -> (BlockKey, Arc<SealedBlock>) {
+        (
+            BlockKey::new("ns".to_string(), vec![hash]),
+            Arc::new(SealedBlock::from_slots(Vec::new())),
+        )
+    }
+
+    #[derive(Default)]
+    struct FakeSegmentFetcher {
+        calls: Mutex<Vec<(String, Vec<Vec<u8>>)>>,
+        responses: Mutex<VecDeque<PrefetchResult>>,
+    }
+
+    #[tonic::async_trait]
+    impl SegmentFetcher for FakeSegmentFetcher {
+        async fn fetch_segment(&self, remote_addr: &str, hashes: &[Vec<u8>]) -> PrefetchResult {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((remote_addr.to_string(), hashes.to_vec()));
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_default()
+        }
+    }
+
+    #[test]
+    fn validates_ordered_fetch_plan_offsets() {
+        let plan = validate_fetch_plan(
+            vec![segment("node-a", 2), segment("node-b", 1)],
+            3,
+            "requester",
+        )
+        .expect("plan should be valid")
+        .expect("plan should be non-empty");
+
+        assert_eq!(plan.block_count, 3);
+        assert_eq!(plan.segment_blocks_summary(), "2,1");
+        assert_eq!(
+            plan.segments,
+            vec![
+                FetchPlanSegment {
+                    node: "node-a".into(),
+                    start: 0,
+                    end: 2,
+                },
+                FetchPlanSegment {
+                    node: "node-b".into(),
+                    start: 2,
+                    end: 3,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_fetch_plans() {
+        for (segments, expected) in [
+            (vec![segment("", 1)], "empty node"),
+            (vec![segment("node-a", 0)], "zero blocks"),
+            (vec![segment("requester", 1)], "excluded requester"),
+            (vec![segment("node-a", 2)], "beyond request length"),
+            (
+                vec![segment("node-a", 1), segment("node-a", 1)],
+                "repeats the previous node",
+            ),
+        ] {
+            let error =
+                validate_fetch_plan(segments, 1, "requester").expect_err("plan should be rejected");
+            assert!(error.contains(expected), "unexpected error: {error}");
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_plan_executes_segments_in_order() {
+        let plan = validate_fetch_plan(
+            vec![segment("node-a", 2), segment("node-b", 1)],
+            3,
+            "requester",
+        )
+        .unwrap()
+        .unwrap();
+        let fetcher = FakeSegmentFetcher {
+            calls: Mutex::new(Vec::new()),
+            responses: Mutex::new(VecDeque::from([
+                vec![fetched_block(1), fetched_block(2)],
+                vec![fetched_block(3)],
+            ])),
+        };
+        let hashes = vec![vec![1], vec![2], vec![3]];
+
+        let (fetched, completed, failure) =
+            execute_fetch_plan(&fetcher, &plan, "ns", &hashes).await;
+
+        assert_eq!(fetched.len(), 3);
+        assert_eq!(completed, 2);
+        assert_eq!(failure, None);
+        assert_eq!(
+            *fetcher.calls.lock().unwrap(),
+            vec![
+                ("node-a".into(), vec![vec![1], vec![2]]),
+                ("node-b".into(), vec![vec![3]]),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_plan_stops_after_first_short_segment() {
+        let plan = validate_fetch_plan(
+            vec![
+                segment("node-a", 1),
+                segment("node-b", 1),
+                segment("node-c", 1),
+            ],
+            3,
+            "requester",
+        )
+        .unwrap()
+        .unwrap();
+        let fetcher = FakeSegmentFetcher {
+            calls: Mutex::new(Vec::new()),
+            responses: Mutex::new(VecDeque::from([
+                vec![fetched_block(1)],
+                Vec::new(),
+                vec![fetched_block(3)],
+            ])),
+        };
+        let hashes = vec![vec![1], vec![2], vec![3]];
+
+        let (fetched, completed, failure) =
+            execute_fetch_plan(&fetcher, &plan, "ns", &hashes).await;
+
+        assert_eq!(fetched.len(), 1);
+        assert_eq!(completed, 1);
+        assert_eq!(failure, Some((1, 1, 0)));
+        assert_eq!(fetcher.calls.lock().unwrap().len(), 2);
     }
 
     #[test]

--- a/pegaflow-core/src/internode/metaserver_client.rs
+++ b/pegaflow-core/src/internode/metaserver_client.rs
@@ -4,11 +4,11 @@ use std::sync::Weak;
 use log::{debug, error, info, warn};
 use pegaflow_common::grpc::{GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL, GRPC_CONNECT_TIMEOUT};
 use pegaflow_proto::proto::engine::meta_server_client::MetaServerClient as MetaServerGrpcClient;
+#[cfg(feature = "rdma")]
+use pegaflow_proto::proto::engine::{FetchSegment, QueryPrefixBlocksRequest};
 use pegaflow_proto::proto::engine::{
     HeartbeatNodeRequest, InsertBlockHashesRequest, RemoveBlockHashesRequest, UnregisterNodeRequest,
 };
-#[cfg(feature = "rdma")]
-use pegaflow_proto::proto::engine::{NodePrefixResult, QueryPrefixBlocksRequest};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Duration, Instant};
 use tonic::Code;
@@ -295,17 +295,18 @@ impl MetaServerClient {
         let _ = done_rx.await;
     }
 
-    /// Query MetaServer for the longest prefix of blocks that exist remotely.
-    /// Returns per-node prefix lengths.
+    /// Query MetaServer for an ordered remote fetch plan.
     #[cfg(feature = "rdma")]
-    pub(crate) async fn query_prefix(
+    pub(crate) async fn query_plan(
         &self,
         namespace: &str,
         hashes: &[Vec<u8>],
-    ) -> Result<Vec<NodePrefixResult>, ClientError> {
+        exclude_node: &str,
+    ) -> Result<Vec<FetchSegment>, ClientError> {
         let request = QueryPrefixBlocksRequest {
             namespace: namespace.to_string(),
             block_hashes: hashes.to_vec(),
+            exclude_node: exclude_node.to_string(),
         };
 
         let response = self
@@ -318,12 +319,12 @@ impl MetaServerClient {
         let resp = response.into_inner();
 
         debug!(
-            "MetaServer query_prefix: namespace={} nodes={}",
+            "MetaServer query_plan: namespace={} segments={}",
             namespace,
-            resp.nodes.len()
+            resp.segments.len()
         );
 
-        Ok(resp.nodes)
+        Ok(resp.segments)
     }
 }
 
@@ -850,6 +851,7 @@ mod tests {
         reclaimable_hashes: Mutex<Vec<Vec<u8>>>,
         insert_requests: RequestLog,
         remove_requests: RequestLog,
+        query_requests: Mutex<Vec<QueryPrefixBlocksRequest>>,
         heartbeat_notify: Notify,
         insert_notify: Notify,
         remove_notify: Notify,
@@ -949,9 +951,16 @@ mod tests {
 
         async fn query_prefix_blocks(
             &self,
-            _request: Request<QueryPrefixBlocksRequest>,
+            request: Request<QueryPrefixBlocksRequest>,
         ) -> Result<Response<QueryPrefixBlocksResponse>, Status> {
-            Ok(Response::new(QueryPrefixBlocksResponse { nodes: vec![] }))
+            self.state
+                .query_requests
+                .lock()
+                .unwrap()
+                .push(request.into_inner());
+            Ok(Response::new(QueryPrefixBlocksResponse {
+                segments: vec![],
+            }))
         }
     }
 
@@ -1124,6 +1133,34 @@ mod tests {
         // batch and the flush must still resolve instead of hanging.
         client.flush().await;
 
+        client.shutdown().await;
+        let _ = shutdown_tx.send(());
+    }
+
+    #[cfg(feature = "rdma")]
+    #[tokio::test]
+    async fn query_plan_sends_requester_as_excluded_node() {
+        let (addr, service, shutdown_tx) = start_fake_metaserver().await;
+        let client = MetaServerClient::new(
+            MetaServerClientConfig::new(addr, "node-a:50055".to_string()),
+            Weak::new(),
+        );
+        let hashes = vec![vec![1], vec![2]];
+
+        let segments = client
+            .query_plan("ns", &hashes, "node-a:50055")
+            .await
+            .expect("query should succeed");
+
+        assert!(segments.is_empty());
+        assert_eq!(
+            *service.query_requests.lock().unwrap(),
+            vec![QueryPrefixBlocksRequest {
+                namespace: "ns".to_string(),
+                block_hashes: hashes,
+                exclude_node: "node-a:50055".to_string(),
+            }]
+        );
         client.shutdown().await;
         let _ = shutdown_tx.send(());
     }

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -109,6 +109,10 @@ pub(crate) struct CoreMetrics {
     pub rdma_fetch_duration_seconds: Histogram<f64>,
     #[cfg(feature = "rdma")]
     pub rdma_fetch_bytes: Counter<u64>,
+    #[cfg(feature = "rdma")]
+    pub rdma_fetch_plan_segments: Histogram<u64>,
+    #[cfg(feature = "rdma")]
+    pub rdma_fetch_plan_completed_segments: Histogram<u64>,
 }
 
 fn init_meter() -> Meter {
@@ -133,6 +137,14 @@ fn rdma_fetch_duration_boundaries() -> Vec<f64> {
         0.5,  // 500ms
         1.0,  // 1s
         2.0,  // 2s
+    ]
+}
+
+/// Histogram boundaries for the number of segments in one RDMA fetch plan.
+#[cfg(feature = "rdma")]
+fn rdma_fetch_plan_segment_boundaries() -> Vec<f64> {
+    vec![
+        0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 16.0, 32.0, 64.0, 128.0,
     ]
 }
 
@@ -480,6 +492,20 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
                 .with_unit("bytes")
                 .with_description("Total bytes fetched via RDMA from remote nodes")
                 .build(),
+            #[cfg(feature = "rdma")]
+            rdma_fetch_plan_segments: meter
+                .u64_histogram("pegaflow_rdma_fetch_plan_segments")
+                .with_description("Number of segments planned per executed RDMA fetch plan")
+                .with_boundaries(rdma_fetch_plan_segment_boundaries())
+                .build(),
+            #[cfg(feature = "rdma")]
+            rdma_fetch_plan_completed_segments: meter
+                .u64_histogram("pegaflow_rdma_fetch_plan_completed_segments")
+                .with_description(
+                    "Number of segments completed before an RDMA fetch plan stopped",
+                )
+                .with_boundaries(rdma_fetch_plan_segment_boundaries())
+                .build(),
         }
     })
 }
@@ -508,6 +534,17 @@ mod tests {
         assert_eq!(
             &*CACHE_RESIDENCE_REASON_CLEANUP,
             &[KeyValue::new("reason", "cleanup")]
+        );
+    }
+
+    #[cfg(feature = "rdma")]
+    #[test]
+    fn rdma_fetch_plan_segment_boundaries_cover_failures_and_fragmented_plans() {
+        assert_eq!(
+            rdma_fetch_plan_segment_boundaries(),
+            vec![
+                0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 16.0, 32.0, 64.0, 128.0,
+            ]
         );
     }
 }

--- a/pegaflow-core/src/storage/prefetch.rs
+++ b/pegaflow-core/src/storage/prefetch.rs
@@ -44,23 +44,23 @@ impl RdmaFetch {
         remaining_hashes: &[Vec<u8>],
         require_full_prefix: bool,
     ) -> Option<(usize, PrefetchResult)> {
-        let (node, found) = self.0.query_prefix(namespace, remaining_hashes).await?;
+        let plan = self.0.query_plan(namespace, remaining_hashes).await?;
+        let found = plan.block_count();
         if require_full_prefix && found != remaining_hashes.len() {
             return None;
         }
         let blocks = self
             .0
-            .fetch_blocks(&node, req_id, namespace, &remaining_hashes[..found])
+            .fetch_plan(&plan, req_id, namespace, remaining_hashes)
             .await;
         if require_full_prefix && blocks.len() != found {
-            // The advertised owner served fewer blocks than the MetaServer
+            // One planned segment served fewer blocks than the MetaServer
             // promised (stale advertisement or failed fetch). Keep the partial
             // result so poll_existing blacklists RDMA for this request instead
             // of the wait loop retrying the same fetch until timeout.
             warn!(
-                "RDMA fetch returned fewer blocks than advertised: req_id={} node={} returned={} advertised={}",
+                "RDMA fetch returned fewer blocks than planned: req_id={} returned={} planned={}",
                 req_id,
-                node,
                 blocks.len(),
                 found
             );

--- a/pegaflow-metaserver/README.md
+++ b/pegaflow-metaserver/README.md
@@ -164,27 +164,35 @@ message RemoveBlockHashesResponse {
 
 ### 5. QueryPrefixBlocks
 
-Query the longest contiguous prefix of block hashes that exist, with per-node prefix lengths.
+Build an ordered fetch plan for the longest contiguous prefix that is available
+from live remote nodes. The requester is excluded from the owner candidates.
 
 **Request:**
 ```protobuf
 message QueryPrefixBlocksRequest {
   string namespace = 1;
   repeated bytes block_hashes = 2;  // Ordered list of block hashes
+  string exclude_node = 3;          // Requester address
 }
 ```
 
 **Response:**
 ```protobuf
-message NodePrefixResult {
+message FetchSegment {
   string node = 1;
-  uint32 prefix_len = 2;       // Consecutive hashes from h0 this node owns
+  uint32 block_count = 2;      // Consecutive hashes fetched from this node
 }
 
 message QueryPrefixBlocksResponse {
-  repeated NodePrefixResult nodes = 1;
+  reserved 1;
+  reserved "nodes";
+  repeated FetchSegment segments = 2;
 }
 ```
+
+Segments are ordered and contiguous. Their block counts are cumulative offsets
+into the request's `block_hashes`; planning stops at the first hash with no live
+remote owner.
 
 ### 6. Health
 
@@ -215,8 +223,8 @@ Graceful shutdown trigger.
 2. **During server lifetime**: Call `HeartbeatNode` periodically with the same `node_id`
 3. **On block save**: Call `InsertBlockHashes` with `{ node, node_id }`
 4. **On cache eviction**: Call `RemoveBlockHashes` with `{ node, node_id }`
-5. **On block query**: Call `QueryPrefixBlocks` to discover which live nodes hold a prefix
-6. **On block load**: Query metaserver, then fetch from the best remote node via RDMA
+5. **On block query**: Call `QueryPrefixBlocks` to build an ordered remote fetch plan
+6. **On block load**: Fetch each plan segment in order via RDMA, stopping on the first failure
 
 ## Environment Variables
 

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -1,17 +1,60 @@
 use crate::metric::record_rpc_result;
 use crate::proto::engine::meta_server_server::MetaServer;
 use crate::proto::engine::{
-    HeartbeatNodeRequest, HeartbeatNodeResponse, InsertBlockHashesRequest,
-    InsertBlockHashesResponse, NodePrefixResult, QueryPrefixBlocksRequest,
-    QueryPrefixBlocksResponse, RemoveBlockHashesRequest, RemoveBlockHashesResponse, ResponseStatus,
-    UnregisterNodeRequest, UnregisterNodeResponse,
+    FetchSegment, HeartbeatNodeRequest, HeartbeatNodeResponse, InsertBlockHashesRequest,
+    InsertBlockHashesResponse, QueryPrefixBlocksRequest, QueryPrefixBlocksResponse,
+    RemoveBlockHashesRequest, RemoveBlockHashesResponse, ResponseStatus, UnregisterNodeRequest,
+    UnregisterNodeResponse,
 };
-use crate::store::{BlockHashStore, StoreError};
+use crate::store::{BlockHashStore, PrefixEntry, StoreError};
 use log::debug;
 use std::sync::Arc;
 use std::time::Instant;
 use tonic::{Request, Response, Status, async_trait};
 use uuid::Uuid;
+
+fn plan_fetch_segments(
+    entries: &[PrefixEntry],
+    exclude_node: &str,
+) -> Result<Vec<FetchSegment>, &'static str> {
+    let mut segments = Vec::new();
+    let mut offset = 0usize;
+
+    while offset < entries.len() {
+        let mut best: Option<(&str, usize)> = None;
+        for candidate in &entries[offset].nodes {
+            let candidate = candidate.as_ref();
+            if candidate == exclude_node {
+                continue;
+            }
+
+            let end = entries[offset..]
+                .iter()
+                .take_while(|entry| entry.nodes.iter().any(|node| node.as_ref() == candidate))
+                .count()
+                + offset;
+
+            if best.is_none_or(|(best_node, best_end)| {
+                end > best_end || (end == best_end && candidate < best_node)
+            }) {
+                best = Some((candidate, end));
+            }
+        }
+
+        let Some((node, end)) = best else {
+            break;
+        };
+        let block_count =
+            u32::try_from(end - offset).map_err(|_| "fetch segment block count exceeds uint32")?;
+        segments.push(FetchSegment {
+            node: node.to_string(),
+            block_count,
+        });
+        offset = end;
+    }
+
+    Ok(segments)
+}
 
 #[derive(Clone)]
 pub struct GrpcMetaService {
@@ -236,9 +279,7 @@ impl MetaServer for GrpcMetaService {
         result
     }
 
-    /// Given an ordered list of block hashes, find the longest contiguous prefix
-    /// that exists in the store (stop at the first hash no node owns), then for
-    /// each node return how many consecutive hashes from h0 it holds.
+    /// Build an ordered plan that covers the longest remotely available prefix.
     async fn query_prefix_blocks(
         &self,
         request: Request<QueryPrefixBlocksRequest>,
@@ -271,29 +312,10 @@ impl MetaServer for GrpcMetaService {
             req.namespace, prefix_len, total_queried, elapsed
         );
 
-        // Per-node prefix: `existing[i]` maps to `block_hashes[i]`.
-        // A node's prefix = count of consecutive hashes from h0 it owns.
-        let mut node_prefix: std::collections::HashMap<&str, u32> =
-            std::collections::HashMap::new();
-        for (i, entry) in existing.iter().enumerate() {
-            for node in &entry.nodes {
-                let count = node_prefix.entry(node.as_ref()).or_insert(0);
-                // Only extend if every previous hash (0..i) was also on this node
-                if *count == i as u32 {
-                    *count += 1;
-                }
-            }
-        }
-        let nodes: Vec<NodePrefixResult> = node_prefix
-            .into_iter()
-            .filter(|(_, count)| *count > 0)
-            .map(|(node, count)| NodePrefixResult {
-                node: node.to_string(),
-                prefix_len: count,
-            })
-            .collect();
+        let segments =
+            plan_fetch_segments(&existing, &req.exclude_node).map_err(Status::invalid_argument)?;
 
-        let result = Ok(Response::new(QueryPrefixBlocksResponse { nodes }));
+        let result = Ok(Response::new(QueryPrefixBlocksResponse { segments }));
         record_rpc_result("query_prefix_blocks", &result, start);
         result
     }
@@ -381,11 +403,12 @@ mod tests {
             .query_prefix_blocks(Request::new(QueryPrefixBlocksRequest {
                 namespace: "ns".into(),
                 block_hashes: vec![vec![1, 2, 3]],
+                exclude_node: String::new(),
             }))
             .await
             .unwrap()
             .into_inner();
-        assert!(query_resp.nodes.is_empty());
+        assert!(query_resp.segments.is_empty());
     }
 
     #[tokio::test]
@@ -423,11 +446,12 @@ mod tests {
             .query_prefix_blocks(Request::new(QueryPrefixBlocksRequest {
                 namespace: "ns".into(),
                 block_hashes: vec![vec![1, 2, 3]],
+                exclude_node: String::new(),
             }))
             .await
             .unwrap()
             .into_inner();
-        assert_eq!(query_resp.nodes.len(), 1);
+        assert_eq!(query_resp.segments.len(), 1);
     }
 
     #[tokio::test]
@@ -537,11 +561,12 @@ mod tests {
             .query_prefix_blocks(Request::new(QueryPrefixBlocksRequest {
                 namespace: "ns".into(),
                 block_hashes: vec![vec![1]],
+                exclude_node: String::new(),
             }))
             .await
             .unwrap()
             .into_inner();
-        assert!(query_resp.nodes.is_empty());
+        assert!(query_resp.segments.is_empty());
     }
 
     #[tokio::test]
@@ -582,22 +607,85 @@ mod tests {
             .query_prefix_blocks(Request::new(QueryPrefixBlocksRequest {
                 namespace: namespace.into(),
                 block_hashes: vec![h1, h2, h3, h4],
+                exclude_node: String::new(),
             }))
             .await
             .unwrap()
             .into_inner();
 
-        let mut nodes: Vec<(String, u32)> = response
-            .nodes
+        let segments: Vec<(String, u32)> = response
+            .segments
             .into_iter()
-            .map(|entry| (entry.node, entry.prefix_len))
+            .map(|entry| (entry.node, entry.block_count))
             .collect();
-        nodes.sort();
 
-        // node-a owns h1..h4 (prefix 4), node-b owns h1..h3 (prefix 3)
+        assert_eq!(segments, vec![(node_a.to_string(), 4)]);
+    }
+
+    fn prefix_entry(hash: u8, nodes: &[&str]) -> PrefixEntry {
+        PrefixEntry {
+            block_hash: vec![hash],
+            nodes: nodes.iter().map(|node| Arc::<str>::from(*node)).collect(),
+        }
+    }
+
+    fn planned(entries: &[PrefixEntry], exclude_node: &str) -> Vec<(String, u32)> {
+        plan_fetch_segments(entries, exclude_node)
+            .expect("small test plan should fit uint32")
+            .into_iter()
+            .map(|segment| (segment.node, segment.block_count))
+            .collect()
+    }
+
+    #[test]
+    fn planner_combines_fragmented_remote_prefix() {
+        let entries = vec![
+            prefix_entry(1, &["node-a"]),
+            prefix_entry(2, &["node-a"]),
+            prefix_entry(3, &["node-b"]),
+            prefix_entry(4, &["node-b"]),
+        ];
+
         assert_eq!(
-            nodes,
-            vec![(node_a.to_string(), 4), (node_b.to_string(), 3),]
+            planned(&entries, "requester"),
+            vec![("node-a".into(), 2), ("node-b".into(), 2)]
         );
+    }
+
+    #[test]
+    fn planner_chooses_farthest_owner_and_stable_tie_break() {
+        let entries = vec![
+            prefix_entry(1, &["node-c", "node-b", "node-a"]),
+            prefix_entry(2, &["node-c", "node-b", "node-a"]),
+            prefix_entry(3, &["node-c"]),
+        ];
+
+        assert_eq!(planned(&entries, "requester"), vec![("node-c".into(), 3)]);
+        assert_eq!(
+            planned(&entries[..2], "requester"),
+            vec![("node-a".into(), 2)]
+        );
+    }
+
+    #[test]
+    fn planner_excludes_requester_and_stops_at_remote_gap() {
+        let entries = vec![
+            prefix_entry(1, &["requester", "node-a"]),
+            prefix_entry(2, &["requester"]),
+            prefix_entry(3, &["node-b"]),
+        ];
+
+        assert_eq!(planned(&entries, "requester"), vec![("node-a".into(), 1)]);
+    }
+
+    #[test]
+    fn planner_keeps_single_owner_prefix_in_one_segment() {
+        let entries = vec![
+            prefix_entry(1, &["node-a"]),
+            prefix_entry(2, &["node-a"]),
+            prefix_entry(3, &["node-a"]),
+        ];
+
+        assert_eq!(planned(&entries, "requester"), vec![("node-a".into(), 3)]);
     }
 }

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -305,15 +305,18 @@ message RemoveBlockHashesResponse {
 message QueryPrefixBlocksRequest {
   string namespace = 1;
   repeated bytes block_hashes = 2;  // ordered by prefix position
+  string exclude_node = 3;          // requester address; never return it as an owner
 }
 
-message NodePrefixResult {
+message FetchSegment {
   string node = 1;
-  uint32 prefix_len = 2;
+  uint32 block_count = 2;
 }
 
 message QueryPrefixBlocksResponse {
-  repeated NodePrefixResult nodes = 1;
+  reserved 1;
+  reserved "nodes";
+  repeated FetchSegment segments = 2;
 }
 
 message HeartbeatNodeRequest {


### PR DESCRIPTION
## Summary

- replace the single-owner prefix result with an ordered `FetchSegment` plan that covers the longest contiguous remote prefix
- exclude the requester from owner candidates and greedily choose the owner that reaches the farthest from each offset, with a stable node-name tie break
- validate and fetch segments serially in core; stop immediately on the first short read or RDMA failure, keep the already fetched contiguous prefix, and do not retry another owner or query MetaServer again
- preserve the single-owner fast path as one segment and add per-segment block counts to the fetch summary log
- reserve the old protobuf response field so mixed-version deployments degrade to a cache miss instead of misinterpreting the payload

## Why

In multi-turn workloads, an older prefix segment may survive only on one remote P node while a newer segment is stored on another. The previous API selected only one owner, so the requester could fetch the first segment but had to recompute the rest even though the full prefix existed across nodes.

## Validation

Executed on `192.168.172.117` with CUDA 13 and RDMA:

- `cargo fmt --all -- --check`
- `cargo test -p pegaflow-metaserver`: 38 passed
- `cargo test -p pegaflow-core rdma_fetch --no-default-features --features cuda-13,rdma`: 8 passed
- `cargo test -p pegaflow-core metaserver_client --no-default-features --features cuda-13,rdma`: 9 passed
- `cargo test -p pegaflow-proto`: passed
- `cargo clippy -p pegaflow-core -p pegaflow-metaserver --all-targets --no-default-features --features cuda-13,rdma -- -D warnings`
- `cargo build --release --no-default-features --features cuda-13,rdma`

The full core run passed 157/157 non-GPU unit tests and the integration suites reached `ssd_cache`; those 11 tests failed during harness setup with `pinned pool exhausted`. The same single test fails identically in the baseline workspace on this host, so it is an environment condition rather than a feature regression.

## 6P2D E2E evidence

Real fragmented multi-turn A/B, Qwen3-4B, 6P2D, 128-token blocks, 8 active conversations, no HTTP retry:

| Metric | Baseline | Feature |
| --- | ---: | ---: |
| Target RDMA blocks | 20/42 | 42/42 (20+22) |
| Target hit ratio | 47.6% | 100.0% |
| Mean target TTFT | 2776.2 ms | 2123.6 ms |
| Whole-workload hit ratio | 48.6% | 53.6% |

All four paired target requests returned HTTP 200 with identical prompt hashes. The feature recovered 88 additional RDMA blocks, avoided recomputing 88 blocks, and reduced mean target TTFT by 652.6 ms (23.5%).

A separate fixed-transcript 96 conversations x 12 turns run also used identical prompts and exercised many multi-segment plans. Its aggregate hit ratio was effectively flat (74.9645% vs 74.9586%) because target-path requests were diluted by 1152 total requests; median TTFT improved from 5019.7 ms to 4713.1 ms, while tail latency remained noisy. The fragmented paired A/B above isolates the mechanism without synthetic cache operations or retries.

Private benchmark harness and artifacts remain under `.local/` and are intentionally not part of this PR.
