### PR TITLE
fix(connector): store HMA recurrent checkpoint once at request end

### DIFF
--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -521,11 +521,7 @@ class SchedulerConnector:
             # is reset on preemption — no connector-side bookkeeping can be
             # trusted across a preempt/resume cycle).
             written = req.num_computed_tokens + num_tokens
-            if save_intent := self._consume_save_intent(
-                req_id,
-                written,
-                req.num_computed_tokens,
-            ):
+            if save_intent := self._consume_save_intent(req_id, written):
                 potential_saves[req_id] = save_intent
 
         # Process cached (running) requests
@@ -568,11 +564,7 @@ class SchedulerConnector:
                 )
 
             written = cached_reqs.num_computed_tokens[idx] + num_tokens
-            if save_intent := self._consume_save_intent(
-                req_id,
-                written,
-                cached_reqs.num_computed_tokens[idx],
-            ):
+            if save_intent := self._consume_save_intent(req_id, written):
                 potential_saves[req_id] = save_intent
 
         save_intents = potential_saves
@@ -597,14 +589,15 @@ class SchedulerConnector:
         self,
         req_id: str,
         written: int,
-        computed_before_step: int = 0,
     ) -> SaveIntent | None:
         """Calculate and return SaveIntent for new blocks that need saving.
 
         `written` = positions with valid KV once this step's schedule runs
         (scheduler-authoritative num_computed_tokens + this step's tokens).
+        Hybrid (HMA) requests skip mid-flight saves; their checkpoint is
+        emitted from `request_finished` instead.
         """
-        regular = self._consume_full_block_saves(req_id, written, computed_before_step)
+        regular = self._consume_full_block_saves(req_id)
         tail = self._consume_tail_save(req_id, written)
         if tail is None:
             return regular
@@ -705,12 +698,14 @@ class SchedulerConnector:
             return query_hashes, 0
         return query_hashes + (tail[0],), tail[1]
 
-    def _consume_full_block_saves(
-        self,
-        req_id: str,
-        written: int,
-        computed_before_step: int | None = None,
-    ) -> SaveIntent | None:
+    def _consume_full_block_saves(self, req_id: str) -> SaveIntent | None:
+        # Hybrid models store one recurrent checkpoint, at request_finished.
+        # Align-mode mamba tables are mostly null blocks, so a mid-request
+        # all-group lookup either misses (and stalls attention saves) or,
+        # when chunk_size == block_size, dumps a linear state every step.
+        if self._cache_groups.has_recurrent_state:
+            return None
+
         # block_hashes are at virtual_block_size granularity, 1-to-1 with block_ids.
         block_hashes = self._block_hashes.get(req_id)
         if block_hashes is None:
@@ -725,33 +720,20 @@ class SchedulerConnector:
         # In external-hit cases, the prefix-loaded block IDs are still present at
         # the front, so save intents must slice by global block index rather than
         # rebasing to a local-only view.
-        if self._cache_groups.has_recurrent_state:
-            if computed_before_step is None:
-                computed_before_step = written
-            saveable_block_idx = min(
-                len(block_hashes),
-                computed_before_step // self._ctx.virtual_block_size,
-            )
-        else:
-            local_saveable = min(
-                min((len(group) for group in allocated), default=0),
-                scheduled // self._ctx.virtual_block_size,
-            )
-            saveable_block_idx = min(len(block_hashes), base_block_idx + local_saveable)
+        local_saveable = min(
+            min((len(group) for group in allocated), default=0),
+            scheduled // self._ctx.virtual_block_size,
+        )
+        saveable_block_idx = min(len(block_hashes), base_block_idx + local_saveable)
         new_blocks = saveable_block_idx - start_block_idx
         if new_blocks <= 0:
             return None
 
         hash_start = start_block_idx
         save_hashes = block_hashes[hash_start : hash_start + new_blocks]
-        if self._cache_groups.has_recurrent_state:
-            save_block_ids_by_group = self._local_cached_block_ids(save_hashes)
-            if save_block_ids_by_group is None:
-                return None
-        else:
-            save_block_ids_by_group = tuple(
-                tuple(group[hash_start : hash_start + new_blocks]) for group in allocated
-            )
+        save_block_ids_by_group = tuple(
+            tuple(group[hash_start : hash_start + new_blocks]) for group in allocated
+        )
         self._next_stored_block_idx[req_id] = saveable_block_idx
 
         logger.debug(
@@ -771,22 +753,35 @@ class SchedulerConnector:
             block_hashes=save_hashes,
         )
 
-    def _local_cached_block_ids(
+    def _cached_recurrent_checkpoint(
         self,
         block_hashes: tuple[bytes, ...],
-    ) -> tuple[tuple[int, ...], ...] | None:
+        lower: int,
+        upper: int,
+    ) -> tuple[int, tuple[int, ...]] | None:
+        """Newest recurrent state vLLM committed under a hash in [lower, upper).
+
+        Returns ``(hash_index, block_id_per_recurrent_group)``, or None when no
+        boundary in the window was committed.
+
+        Only a *cached* block is guaranteed to still hold the state its hash
+        names. In align mode the live block table's real entry is the running
+        state for the current (typically mid-block) token count, which is not
+        the boundary state ``hash[j]`` claims — saving that would fold the tail
+        tokens into the state twice on resume. vLLM commits a recurrent block
+        under ``hash[j]`` only when a scheduler step ended at exactly
+        ``(j + 1) * virtual_block_size`` computed tokens, which is precisely
+        this connector's checkpoint convention.
+        """
         if self._get_local_cached_blocks is None:
             raise RuntimeError("HMA block pool was not bound before building save metadata")
 
-        group_ids = list(range(self._cache_groups.group_count))
-        block_ids_by_group = [[] for _ in group_ids]
-        for block_hash in block_hashes:
-            cached_blocks = self._get_local_cached_blocks(block_hash, group_ids)
-            if cached_blocks is None:
-                return None
-            for block_ids, block in zip(block_ids_by_group, cached_blocks, strict=True):
-                block_ids.append(block.block_id)
-        return tuple(tuple(block_ids) for block_ids in block_ids_by_group)
+        recurrent_group_ids = sorted(self._cache_groups.recurrent_group_indices)
+        for hash_index in range(upper - 1, lower - 1, -1):
+            cached = self._get_local_cached_blocks(block_hashes[hash_index], recurrent_group_ids)
+            if cached is not None:
+                return hash_index, tuple(block.block_id for block in cached)
+        return None
 
     def _consume_finished_hma_save(
         self,
@@ -794,6 +789,13 @@ class SchedulerConnector:
         block_ids: tuple[list[int], ...],
         written: int,
     ) -> SaveIntent | None:
+        """Final hybrid save: attention pages plus one recurrent checkpoint.
+
+        Attention block ids come from the finished block table; the recurrent
+        checkpoint is resolved through vLLM's committed prefix cache (see
+        `_cached_recurrent_checkpoint`). Recurrent groups carry block id 0
+        (vLLM's null block) on every other row, which the worker filters out.
+        """
         block_hashes = self._block_hashes.get(req_id)
         if block_hashes is None:
             return None
@@ -806,27 +808,56 @@ class SchedulerConnector:
             return None
 
         groups = self._copy_block_ids_by_group(block_ids)
+        recurrent = self._cache_groups.recurrent_group_indices
+        # Only attention groups are indexed by hash position. Recurrent groups
+        # are addressed through the cache lookup below, and in align mode their
+        # table holds a handful of live entries regardless of sequence length.
         available = tuple(len(group) for group in groups)
-        required = tuple(
-            saveable_block_idx + 1
-            if group_index in self._cache_groups.recurrent_group_indices
-            else saveable_block_idx
-            for group_index in range(self._cache_groups.group_count)
-        )
-        if any(length < minimum for length, minimum in zip(available, required, strict=True)):
-            raise RuntimeError(
-                f"req {req_id} final HMA block table is shorter than its hash prefix: "
-                f"saveable={saveable_block_idx} available_by_group={available} "
-                f"required_by_group={required}"
-            )
+        for group_index, length in enumerate(available):
+            if group_index not in recurrent and length < saveable_block_idx:
+                raise RuntimeError(
+                    f"req {req_id} final HMA attention block table is shorter than its "
+                    f"hash prefix: saveable={saveable_block_idx} "
+                    f"available_by_group={available}"
+                )
 
         num_new_blocks = saveable_block_idx - start_block_idx
+        checkpoint = self._cached_recurrent_checkpoint(
+            block_hashes, start_block_idx, saveable_block_idx
+        )
+        if checkpoint is None:
+            # No block boundary was committed inside the range this request
+            # computed, so it contributes no new resume point. Expected when a
+            # request advances less than one block; otherwise worth surfacing.
+            if num_new_blocks > 1:
+                logger.warning(
+                    "[PegaKVConnector] req=%s no recurrent checkpoint committed in "
+                    "blocks [%d,%d); saving attention pages only",
+                    req_id,
+                    start_block_idx,
+                    saveable_block_idx,
+                )
+            checkpoint_hash_idx, checkpoint_block_ids = -1, ()
+        else:
+            checkpoint_hash_idx, checkpoint_block_ids = checkpoint
+            logger.info(
+                "[PegaKVConnector] req=%s hma_checkpoint: hash_idx=%d tokens=%d "
+                "attention_blocks=%d",
+                req_id,
+                checkpoint_hash_idx,
+                (checkpoint_hash_idx + 1) * self._ctx.virtual_block_size,
+                num_new_blocks,
+            )
+
+        recurrent_order = sorted(recurrent)
         save_block_ids_by_group = []
         for group_index, group in enumerate(groups):
-            if group_index in self._cache_groups.recurrent_group_indices:
-                save_block_ids_by_group.append(
-                    (0,) * (num_new_blocks - 1) + (group[saveable_block_idx],)
-                )
+            if group_index in recurrent:
+                row = [0] * num_new_blocks
+                if checkpoint_hash_idx >= 0:
+                    slot = recurrent_order.index(group_index)
+                    row[checkpoint_hash_idx - start_block_idx] = checkpoint_block_ids[slot]
+                save_block_ids_by_group.append(tuple(row))
             else:
                 save_block_ids_by_group.append(group[start_block_idx:saveable_block_idx])
 

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -60,7 +60,16 @@ def _make_ctx(
     return ConnectorContext(**defaults)  # type: ignore[arg-type]
 
 
-def _make_recurrent_scheduler() -> SchedulerConnector:
+def _make_recurrent_scheduler(committed_recurrent: frozenset[int] | None = None):
+    """Two-group HMA scheduler over a 2-block request.
+
+    ``committed_recurrent`` is the set of hash indices whose *recurrent* block
+    vLLM has committed to its prefix cache. In align mode that is only the
+    boundaries where a scheduler step ended, not every full block, so the
+    lookup must be group-aware. Defaults to both blocks.
+    """
+    if committed_recurrent is None:
+        committed_recurrent = frozenset({0, 1})
     scheduler = SchedulerConnector(_make_ctx())
     scheduler._cache_groups = SimpleNamespace(
         group_count=2,
@@ -72,43 +81,38 @@ def _make_recurrent_scheduler() -> SchedulerConnector:
     scheduler._allocated_blocks["r1"] = [[11, 12], [21, 22]]
     scheduler._block_index_offsets["r1"] = 0
     scheduler._next_stored_block_idx["r1"] = 0
-    blocks = {
-        _hash(0): [SimpleNamespace(block_id=11), SimpleNamespace(block_id=21)],
-        _hash(1): [SimpleNamespace(block_id=12), SimpleNamespace(block_id=22)],
-    }
-    scheduler._get_local_cached_blocks = lambda block_hash, _group_ids: blocks.get(block_hash)
+    attention_ids = {_hash(0): 11, _hash(1): 12}
+    recurrent_ids = {_hash(0): 21, _hash(1): 22}
+    hash_index = {_hash(0): 0, _hash(1): 1}
+
+    def get_cached(block_hash, group_ids):
+        if block_hash not in hash_index:
+            return None
+        blocks = []
+        for group_id in group_ids:
+            if group_id == 1:
+                if hash_index[block_hash] not in committed_recurrent:
+                    return None
+                blocks.append(SimpleNamespace(block_id=recurrent_ids[block_hash]))
+            else:
+                blocks.append(SimpleNamespace(block_id=attention_ids[block_hash]))
+        return blocks
+
+    scheduler._get_local_cached_blocks = get_cached
     return scheduler
 
 
-def test_recurrent_save_uses_committed_local_hma_mapping():
+def test_recurrent_mid_request_saves_are_skipped():
     scheduler = _make_recurrent_scheduler()
 
-    first = scheduler._consume_full_block_saves("r1", written=23, computed_before_step=16)
-    second = scheduler._consume_full_block_saves("r1", written=39, computed_before_step=32)
-
-    assert first == SaveIntent(
-        block_ids_by_group=((11,), (21,)),
-        block_hashes=(_hash(0),),
-    )
-    assert second == SaveIntent(
-        block_ids_by_group=((12,), (22,)),
-        block_hashes=(_hash(1),),
-    )
-
-
-def test_recurrent_save_waits_until_vllm_commits_all_groups():
-    scheduler = _make_recurrent_scheduler()
-    scheduler._get_local_cached_blocks = lambda _block_hash, _group_ids: None
-
-    assert scheduler._consume_full_block_saves("r1", written=23, computed_before_step=16) is None
+    assert scheduler._consume_full_block_saves("r1") is None
     assert scheduler._next_stored_block_idx["r1"] == 0
 
 
-def test_recurrent_final_step_uses_finished_block_table():
+def test_recurrent_final_step_resolves_checkpoint_from_committed_cache():
     scheduler = _make_recurrent_scheduler()
-    scheduler._get_local_cached_blocks = lambda _block_hash, _group_ids: None
 
-    assert scheduler._consume_full_block_saves("r1", written=32, computed_before_step=0) is None
+    assert scheduler._consume_full_block_saves("r1") is None
     request = SimpleNamespace(
         request_id="r1",
         num_computed_tokens=32,
@@ -139,6 +143,8 @@ def test_recurrent_final_step_uses_finished_block_table():
             preempted_req_ids=set(),
         )
     )
+    # Attention ids come from the finished block table; the recurrent id is the
+    # boundary state vLLM committed under hash[1], NOT block_ids[1][2].
     assert metadata.ready_save_intents["r1"] == SaveIntent(
         block_ids_by_group=((11, 12), (0, 22)),
         block_hashes=(_hash(0), _hash(1)),
@@ -148,28 +154,6 @@ def test_recurrent_final_step_uses_finished_block_table():
     scheduler.update_connector_output(SimpleNamespace(finished_sending={"r1"}))
     assert "r1" not in scheduler._block_hashes
     assert "r1" not in scheduler._held_requests
-
-
-def test_recurrent_save_does_not_predict_current_step_state():
-    scheduler = _make_recurrent_scheduler()
-
-    assert scheduler._consume_full_block_saves("r1", written=16, computed_before_step=0) is None
-    assert scheduler._next_stored_block_idx["r1"] == 0
-
-
-def test_recurrent_save_preserves_vllm_null_block_for_worker_filtering():
-    scheduler = _make_recurrent_scheduler()
-    scheduler._get_local_cached_blocks = lambda _block_hash, _group_ids: [
-        SimpleNamespace(block_id=11),
-        SimpleNamespace(block_id=0),
-    ]
-
-    intent = scheduler._consume_full_block_saves("r1", written=23, computed_before_step=16)
-
-    assert intent == SaveIntent(
-        block_ids_by_group=((11,), (0,)),
-        block_hashes=(_hash(0),),
-    )
 
 
 def test_hma_binding_disables_local_prefix_lookup_before_scheduling():

--- a/python/tests/test_hma_checkpoint_index.py
+++ b/python/tests/test_hma_checkpoint_index.py
@@ -1,0 +1,186 @@
+"""Regression: the final HMA recurrent checkpoint must be a boundary state.
+
+A hybrid request stores exactly one recurrent checkpoint, at request_finished.
+Getting its *identity* wrong is silent: a later turn resumes from a state that
+does not match the hash it was filed under, folding some tokens into the
+recurrent state twice. Nothing crashes and the text stays plausible.
+
+These tests build the recurrent block table with vLLM's own align-mode
+formulas rather than a hand-written shape, and encode provenance in the block
+ids so a failure says *which* state was saved:
+
+    9000 + k -> block holding the running state after k tokens
+    7000 + i -> speculative block i (draft state, never a boundary)
+
+vLLM align mode, S = num_speculative_blocks
+(single_type_kv_cache_manager.MambaManager.allocate_new_blocks +
+worker/mamba_utils.preprocess_mamba):
+
+    num_required_blocks = cdiv(written, vbs) + S
+    null blocks         = indices [0, cdiv(written, vbs) - 1)
+    running state block = index cdiv(written, vbs) - 1
+    trailing S blocks   = speculative
+    table length        = cdiv(written, vbs) + S
+
+The connector's convention (RecurrentLoadHold): a state filed under hash index
+j means "state after (j + 1) * vbs tokens".
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from pegaflow.connector.common import ConnectorContext  # noqa: E402
+from pegaflow.connector.scheduler import SchedulerConnector  # noqa: E402
+
+VBS = 16
+
+
+def _hash(i: int) -> bytes:
+    return f"hash-{i}".encode()
+
+
+def _cdiv(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def _recurrent_table(written: int, num_speculative_blocks: int) -> list[int]:
+    """The recurrent block table vLLM align mode would present."""
+    state_idx = _cdiv(written, VBS) - 1
+    table = [0] * state_idx
+    table.append(9000 + written)
+    table.extend(7000 + i for i in range(num_speculative_blocks))
+    return table
+
+
+def _make_scheduler(num_hashes: int, committed_boundary: int | None):
+    """Scheduler whose prefix cache has committed `committed_boundary`.
+
+    `committed_boundary` is a hash index; vLLM commits a recurrent block there
+    only when a scheduler step ended at exactly (index + 1) * VBS tokens.
+    """
+    ctx = ConnectorContext(
+        instance_id="i",
+        namespace="n",
+        block_size=VBS,
+        tp_size=1,
+        world_size=1,
+        tp_rank=0,
+        device_id=0,
+        engine_client=MagicMock(),
+        state_manager=MagicMock(),
+    )
+    scheduler = SchedulerConnector(ctx)
+    scheduler._cache_groups = SimpleNamespace(
+        group_count=2,
+        hash_group_index=0,
+        has_recurrent_state=True,
+        recurrent_group_indices=frozenset({1}),
+    )
+    scheduler._block_hashes["r1"] = tuple(_hash(i) for i in range(num_hashes))
+    scheduler._block_index_offsets["r1"] = 0
+    scheduler._next_stored_block_idx["r1"] = 0
+
+    committed_hash = _hash(committed_boundary) if committed_boundary is not None else None
+
+    def get_cached(block_hash, group_ids):
+        blocks = []
+        for group_id in group_ids:
+            if group_id == 1:
+                if committed_hash is None or block_hash != committed_hash:
+                    return None
+                # The committed boundary state: 555 marks "correctly keyed".
+                blocks.append(SimpleNamespace(block_id=555))
+            else:
+                blocks.append(SimpleNamespace(block_id=100))
+        return blocks
+
+    scheduler._get_local_cached_blocks = get_cached
+    return scheduler
+
+
+@pytest.mark.parametrize(
+    ("written", "num_speculative_blocks"),
+    [
+        pytest.param(645, 0, id="mid_block_no_spec"),
+        pytest.param(645, 1, id="mid_block_spec1"),
+        pytest.param(645, 2, id="mid_block_spec2"),
+        pytest.param(640, 1, id="aligned_spec1"),
+        pytest.param(640, 2, id="aligned_spec2"),
+    ],
+)
+def test_checkpoint_is_committed_boundary_never_running_or_draft_state(
+    written: int, num_speculative_blocks: int
+):
+    """The saved recurrent id must be the committed boundary block.
+
+    Reading the live block table instead yields either the running state for a
+    mid-block token count (keyed off by `written % VBS` tokens) or, when
+    `written` is block-aligned, a speculative draft block.
+    """
+    num_hashes = _cdiv(written, VBS)
+    saveable = written // VBS
+    committed_boundary = saveable - 1
+
+    scheduler = _make_scheduler(num_hashes, committed_boundary)
+    attention_table = list(range(100, 100 + num_hashes + num_speculative_blocks))
+    recurrent_table = _recurrent_table(written, num_speculative_blocks)
+
+    intent = scheduler._consume_finished_hma_save("r1", (attention_table, recurrent_table), written)
+
+    assert intent is not None
+    recurrent_row = intent.block_ids_by_group[1]
+    saved = [block_id for block_id in recurrent_row if block_id != 0]
+
+    assert saved == [555], (
+        f"expected the committed boundary state, got {saved} "
+        f"(9000+k = running state after k tokens, 7000+i = speculative block)"
+    )
+
+    # And it must be filed under the hash naming that exact boundary.
+    position = recurrent_row.index(555)
+    assert intent.block_hashes[position] == _hash(committed_boundary)
+
+
+def test_no_committed_boundary_saves_no_recurrent_state():
+    """Better to store nothing than a state under the wrong hash."""
+    written = 645
+    num_hashes = _cdiv(written, VBS)
+    scheduler = _make_scheduler(num_hashes, committed_boundary=None)
+
+    intent = scheduler._consume_finished_hma_save(
+        "r1",
+        (list(range(100, 100 + num_hashes)), _recurrent_table(written, 1)),
+        written,
+    )
+
+    assert intent is not None
+    assert set(intent.block_ids_by_group[1]) == {0}
+
+
+def test_aligned_written_without_spec_blocks_does_not_index_past_table():
+    """`written` on a boundary with S=0 leaves no block past the state block.
+
+    Indexing at `written // vbs` would run off the end of the table.
+    """
+    written = 640
+    num_hashes = _cdiv(written, VBS)
+    saveable = written // VBS
+    scheduler = _make_scheduler(num_hashes, committed_boundary=saveable - 1)
+    recurrent_table = _recurrent_table(written, 0)
+
+    assert len(recurrent_table) == saveable  # no entry at index `saveable`
+
+    intent = scheduler._consume_finished_hma_save(
+        "r1", (list(range(100, 100 + num_hashes)), recurrent_table), written
+    )
+
+    assert intent is not None
+    assert [b for b in intent.block_ids_by_group[1] if b != 0] == [555]

--- a/python/tests/test_hma_checkpoint_index.py
+++ b/python/tests/test_hma_checkpoint_index.py
@@ -184,3 +184,40 @@ def test_aligned_written_without_spec_blocks_does_not_index_past_table():
 
     assert intent is not None
     assert [b for b in intent.block_ids_by_group[1] if b != 0] == [555]
+
+
+def test_finished_save_skips_when_prefix_already_stored():
+    """A later turn that does not cross a new block boundary must not re-save."""
+    written = 645
+    num_hashes = _cdiv(written, VBS)
+    saveable = written // VBS
+    scheduler = _make_scheduler(num_hashes, committed_boundary=saveable - 1)
+    scheduler._next_stored_block_idx["r1"] = saveable
+
+    intent = scheduler._consume_finished_hma_save(
+        "r1",
+        (list(range(100, 100 + num_hashes)), _recurrent_table(written, 1)),
+        written,
+    )
+
+    assert intent is None
+    assert scheduler._consume_full_block_saves("r1") is None
+
+
+def test_finished_save_after_prefix_only_files_the_new_boundary():
+    """After an external hit of block 0, the final save files only hash[1]."""
+    written = 32
+    num_hashes = _cdiv(written, VBS)
+    scheduler = _make_scheduler(num_hashes, committed_boundary=1)
+    scheduler._next_stored_block_idx["r1"] = 1
+    scheduler._block_index_offsets["r1"] = 1
+
+    intent = scheduler._consume_finished_hma_save(
+        "r1",
+        (list(range(100, 100 + num_hashes + 2)), _recurrent_table(written, 2)),
+        written,
+    )
+
+    assert intent is not None
+    assert intent.block_hashes == (_hash(1),)
+    assert intent.block_ids_by_group[1] == (555,)


### PR DESCRIPTION
## Summary
- Hybrid (HMA) requests now skip mid-flight saves and emit a single recurrent checkpoint from `request_finished`.
- That checkpoint is resolved through vLLM's committed prefix cache instead of the live align-mode block table, which otherwise stores a mid-block running state or a speculative draft block under the wrong hash.
- Regression tests build the recurrent table with vLLM's align-mode formulas and encode provenance in block ids so a wrong save is visible.

This is not duplicating an existing PR: the 5090 exploration session never landed a commit or PR.

## Test plan
- [x] `cd python && uv run --extra test pytest` — 278 passed, 13 deselected
- [x] `tests/test_hma_checkpoint_index.py` — 9 cases (mid-block / aligned / speculative, plus skip-when-stored and new-boundary-only)
- [x] Local Qwen3.5-4B GPU invariant script (`logs/k3-hma/verify_hma_invariants.py`): vbs=528, mid-block keys last committed boundary, short skip, warm hit no re-save with matching greedy text, prefix-extend files only the new boundary, independent miss, two-block checkpoint at 1056
- [x] `pytest -m e2e tests/test_vllm_e2e_correctness.py --model /data/models/Qwen3.5-4B --max-model-len 4096` — 5 passed (9m30s); same-process HMA load used PegaFlow; no data-path RPC / KV load failures