### PR TITLE
feat(server): add SSD cache cleanup endpoint

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -32,6 +32,7 @@ pegaflow-server
 - `GET /instances`: List registered instance IDs.
 - `POST /instances/cleanup[?id=<instance_id>]`: Remove one instance, or all instances when `id` is omitted.
 - `POST /cache/memory/cleanup`: Evict resident in-memory cache blocks while preserving backing-store data. `evicted_bytes` is the cache footprint removed from residency; `reclaimed_bytes` is the pinned-pool memory actually released immediately.
+- `POST /cache/ssd/cleanup`: Remove SSD cache index entries after draining preceding saves and writes. The preallocated cache files and resident memory cache remain unchanged. Returns `409 Conflict` when SSD caching is disabled.
 
 ### SSD Cache
 

--- a/pegaflow-core/src/backing/mod.rs
+++ b/pegaflow-core/src/backing/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use ssd_cache::{DEFAULT_MAX_PREFETCH_BLOCKS, SSD_ALIGNMENT};
 )]
 pub use ssd_cache::{
     DEFAULT_SSD_PREFETCH_INFLIGHT, DEFAULT_SSD_PREFETCH_QUEUE_DEPTH, DEFAULT_SSD_WRITE_INFLIGHT,
-    DEFAULT_SSD_WRITE_QUEUE_DEPTH, SsdCacheConfig,
+    DEFAULT_SSD_WRITE_QUEUE_DEPTH, SsdCacheCleanupStats, SsdCacheConfig,
 };
 
 use crate::block::{BlockKey, SealedBlock};

--- a/pegaflow-core/src/backing/ssd.rs
+++ b/pegaflow-core/src/backing/ssd.rs
@@ -13,8 +13,8 @@ use pegaflow_common::NumaNode;
 
 use super::SsdCacheConfig;
 use super::ssd_cache::{
-    PrefetchBatch, PrefetchRequest, PreparedBatch, SsdRingBuffer, SsdWriteBatch, SsdWriteCommand,
-    ssd_prefetch_loop, ssd_writer_loop,
+    PrefetchBatch, PrefetchRequest, PreparedBatch, SsdCacheCleanupStats, SsdRingBuffer,
+    SsdWriteBatch, SsdWriteCommand, ssd_prefetch_loop, ssd_writer_loop,
 };
 use super::uring::{UringConfig, UringIoEngine};
 use super::{AllocateFn, PrefetchResult};
@@ -122,6 +122,10 @@ impl SsdBackingStore {
         self.inner.lock().ring.commit(key, success);
     }
 
+    pub(super) fn clear_index(&self) -> SsdCacheCleanupStats {
+        self.inner.lock().ring.clear()
+    }
+
     pub(super) fn is_numa(&self) -> bool {
         self.is_numa
     }
@@ -178,6 +182,20 @@ impl SsdBackingStore {
         if self.write_tx.send(SsdWriteCommand::Flush(tx)).await.is_ok() {
             let _ = rx.await;
         }
+    }
+
+    /// Wait for preceding writes, then remove every SSD index entry.
+    pub(crate) async fn cleanup(&self) -> SsdCacheCleanupStats {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if self
+            .write_tx
+            .send(SsdWriteCommand::Cleanup(tx))
+            .await
+            .is_err()
+        {
+            return SsdCacheCleanupStats::default();
+        }
+        rx.await.unwrap_or_default()
     }
 
     /// Count consecutive SSD-resident keys from the start of `keys`.

--- a/pegaflow-core/src/backing/ssd_cache.rs
+++ b/pegaflow-core/src/backing/ssd_cache.rs
@@ -76,6 +76,12 @@ pub struct SsdCacheConfig {
     pub prefetch_inflight: usize,
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SsdCacheCleanupStats {
+    pub removed_entries: usize,
+    pub invalidated_bytes: u64,
+}
+
 impl Default for SsdCacheConfig {
     fn default() -> Self {
         Self {
@@ -191,6 +197,33 @@ impl SsdRingBuffer {
             Some(SsdEntryState::Committed(e)) if self.is_offset_valid(e) => Some(e),
             _ => None,
         }
+    }
+
+    pub(super) fn clear(&mut self) -> SsdCacheCleanupStats {
+        let stats = SsdCacheCleanupStats {
+            removed_entries: self.entries.len(),
+            invalidated_bytes: self
+                .entries
+                .values()
+                .map(|state| state.entry().len)
+                .fold(0, u64::saturating_add),
+        };
+
+        self.entries.clear();
+        self.next_shard = 0;
+        for shard in &mut self.shards {
+            // Move to the next logical ring generation while preserving the
+            // physical offset. Prefetches submitted before cleanup then fail
+            // their post-I/O validity check.
+            shard.head = shard
+                .head
+                .checked_add(shard.capacity)
+                .expect("SSD ring logical offset overflow during cleanup");
+            shard.tail = shard.head;
+            shard.order.clear();
+        }
+
+        stats
     }
 
     /// Check if a logical offset is still valid (not yet overwritten).
@@ -387,6 +420,7 @@ pub(super) struct SsdWriteBatch {
 pub(super) enum SsdWriteCommand {
     Write(SsdWriteBatch),
     Flush(tokio::sync::oneshot::Sender<()>),
+    Cleanup(tokio::sync::oneshot::Sender<SsdCacheCleanupStats>),
 }
 
 /// Request to prefetch a block from SSD (metadata only, allocation done in worker)
@@ -480,6 +514,7 @@ pub(super) async fn ssd_writer_loop(
     let mut pending: VecDeque<WriteTask> = VecDeque::new();
     let mut inflight: FuturesOrdered<WriteFuture> = FuturesOrdered::new();
     let mut flush_waiters: Vec<tokio::sync::oneshot::Sender<()>> = Vec::new();
+    let mut cleanup_waiter: Option<tokio::sync::oneshot::Sender<SsdCacheCleanupStats>> = None;
 
     loop {
         // If a flush is pending and all work is drained, fire it.
@@ -487,6 +522,16 @@ pub(super) async fn ssd_writer_loop(
             for tx in flush_waiters.drain(..) {
                 let _ = tx.send(());
             }
+        }
+
+        if pending.is_empty()
+            && inflight.is_empty()
+            && let Some(tx) = cleanup_waiter.take()
+        {
+            let stats = store
+                .upgrade()
+                .map_or_else(SsdCacheCleanupStats::default, |store| store.clear_index());
+            let _ = tx.send(stats);
         }
 
         tokio::select! {
@@ -519,7 +564,7 @@ pub(super) async fn ssd_writer_loop(
             }
 
             // Priority 3: Receive new command
-            cmd = rx.recv(), if pending.is_empty() && flush_waiters.is_empty() => {
+            cmd = rx.recv(), if pending.is_empty() && flush_waiters.is_empty() && cleanup_waiter.is_none() => {
                 match cmd {
                     Some(SsdWriteCommand::Write(b)) => {
                         // Dequeue metric
@@ -555,6 +600,9 @@ pub(super) async fn ssd_writer_loop(
                     Some(SsdWriteCommand::Flush(tx)) => {
                         flush_waiters.push(tx);
                     }
+                    Some(SsdWriteCommand::Cleanup(tx)) => {
+                        cleanup_waiter = Some(tx);
+                    }
                     None => break,
                 }
             }
@@ -567,6 +615,9 @@ pub(super) async fn ssd_writer_loop(
     // Fire any remaining flush waiters
     for tx in flush_waiters.drain(..) {
         let _ = tx.send(());
+    }
+    if let Some(tx) = cleanup_waiter {
+        let _ = tx.send(SsdCacheCleanupStats::default());
     }
 
     debug!("SSD writer task exiting");
@@ -1067,6 +1118,34 @@ mod tests {
         ring.shards[0].tail = 50;
         assert!(!ring.is_offset_valid(&ring.test_entry(0, 49, 10)));
         assert!(ring.is_offset_valid(&ring.test_entry(0, 50, 10)));
+    }
+
+    #[test]
+    fn test_clear_invalidates_old_offsets_and_keeps_ring_writable() {
+        let mut ring = SsdRingBuffer::new(1000);
+        let (old_begin, _) = ring.allocate_contiguous(0, 100).unwrap();
+        let old_entry = ring.test_entry(0, old_begin, 100);
+        let key = make_key(1);
+        ring.entries
+            .insert(key.clone(), SsdEntryState::Committed(old_entry.clone()));
+        ring.shards[0].order.push_back(key);
+
+        let stats = ring.clear();
+
+        assert_eq!(
+            stats,
+            SsdCacheCleanupStats {
+                removed_entries: 1,
+                invalidated_bytes: 100,
+            }
+        );
+        assert!(!ring.is_offset_valid(&old_entry));
+        assert!(ring.entries.is_empty());
+        assert!(ring.shards[0].order.is_empty());
+
+        let (new_begin, _) = ring.allocate_contiguous(0, 100).unwrap();
+        assert!(new_begin > old_begin);
+        assert!(ring.is_offset_valid(&ring.test_entry(0, new_begin, 100)));
     }
 
     // ========================================================================

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -31,7 +31,7 @@ pub mod transfer;
 
 pub use backing::{
     DEFAULT_SSD_PREFETCH_INFLIGHT, DEFAULT_SSD_PREFETCH_QUEUE_DEPTH, DEFAULT_SSD_WRITE_INFLIGHT,
-    DEFAULT_SSD_WRITE_QUEUE_DEPTH, SsdCacheConfig,
+    DEFAULT_SSD_WRITE_QUEUE_DEPTH, SsdCacheCleanupStats, SsdCacheConfig,
 };
 pub use block::{
     BlockHash, BlockKey, LayerBlock, LayerSave, PrefetchStatus, RawBlock, SealedBlock,
@@ -636,6 +636,14 @@ impl PegaEngine {
     pub fn cleanup_memory_cache(&self) -> MemoryCacheCleanupStats {
         self.query_leases.sweep_expired();
         self.storage.cleanup_memory_cache()
+    }
+
+    /// Remove all SSD cache index entries after draining preceding saves and writes.
+    ///
+    /// The preallocated cache files remain unchanged. Returns `None` when SSD
+    /// caching is not configured.
+    pub async fn cleanup_ssd_cache(&self) -> Option<SsdCacheCleanupStats> {
+        self.storage.cleanup_ssd_cache().await
     }
 
     /// Best-effort graceful unregister from MetaServer, if configured.

--- a/pegaflow-core/src/storage/mod.rs
+++ b/pegaflow-core/src/storage/mod.rs
@@ -11,7 +11,9 @@ use std::num::NonZeroU64;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
-use crate::backing::{AllocateFn, DEFAULT_MAX_PREFETCH_BLOCKS, SsdBackingStore, SsdCacheConfig};
+use crate::backing::{
+    AllocateFn, DEFAULT_MAX_PREFETCH_BLOCKS, SsdBackingStore, SsdCacheCleanupStats, SsdCacheConfig,
+};
 #[cfg(feature = "rdma")]
 use crate::backing::{RdmaFetchStore, RdmaTransport};
 use crate::block::{BlockKey, PrefetchStatus, SealedBlock};
@@ -348,6 +350,12 @@ impl StorageEngine {
         if let Some(ssd) = &self.ssd_store {
             ssd.flush().await;
         }
+    }
+
+    pub(crate) async fn cleanup_ssd_cache(&self) -> Option<SsdCacheCleanupStats> {
+        let ssd = self.ssd_store.as_ref()?;
+        self.flush_write_pipeline().await;
+        Some(ssd.cleanup().await)
     }
 
     /// Flush the MetaServer registration queue: waits until every hash

--- a/pegaflow-core/tests/ssd_cache.rs
+++ b/pegaflow-core/tests/ssd_cache.rs
@@ -199,6 +199,35 @@ async fn ssd_write_persists_to_file() {
     );
 }
 
+/// Cleanup drains preceding writes, invalidates SSD hits, and leaves the ring reusable.
+#[tokio::test]
+async fn ssd_cleanup_invalidates_index_and_allows_new_writes() {
+    skip_without_io_uring!();
+    let (env, _cache_path, _temp_dir) = ssd_env("test-ssd-cleanup");
+    let target = env.hashes(1);
+
+    env.save_and_wait(&target).await;
+    let stats = env
+        .engine
+        .cleanup_ssd_cache()
+        .await
+        .expect("SSD cache is enabled");
+    assert_eq!(stats.removed_entries, target.len());
+    assert_eq!(stats.invalidated_bytes, (target.len() * BLOCK_SIZE) as u64);
+
+    cleanup_resident_memory(&env);
+    let (hit, missing) = wait_query_ready(&env, &target).await;
+    assert_eq!(hit, 0);
+    assert_eq!(missing, target.len());
+
+    env.save_and_wait(&target).await;
+    env.engine.flush_all().await;
+    cleanup_resident_memory(&env);
+    let (hit, missing) = wait_query_ready(&env, &target).await;
+    assert_eq!(hit, target.len());
+    assert_eq!(missing, 0);
+}
+
 /// Full SSD prefetch round-trip: save → flush to SSD → evict from memory →
 /// query (triggers SSD prefetch) → load → verify data integrity.
 #[tokio::test]

--- a/pegaflow-server/src/http_server.rs
+++ b/pegaflow-server/src/http_server.rs
@@ -66,6 +66,12 @@ struct MemoryCacheCleanupResponse {
     still_referenced_blocks: u64,
 }
 
+#[derive(Serialize)]
+struct SsdCacheCleanupResponse {
+    removed_entries: usize,
+    invalidated_bytes: u64,
+}
+
 /// POST /instances/cleanup[?id=<instance_id>]
 ///
 /// Without `id`: remove all instances and release all CUDA IPC tensors.
@@ -155,6 +161,32 @@ async fn cleanup_memory_cache_handler(
     })
 }
 
+/// POST /cache/ssd/cleanup
+///
+/// Removes SSD cache index entries without erasing the preallocated files.
+async fn cleanup_ssd_cache_handler(State(state): State<AppState>) -> impl IntoResponse {
+    match state.engine.cleanup_ssd_cache().await {
+        Some(stats) => {
+            info!(
+                "Cleaned SSD cache index: removed_entries={} invalidated_bytes={}",
+                stats.removed_entries, stats.invalidated_bytes
+            );
+            (
+                StatusCode::OK,
+                Json(SsdCacheCleanupResponse {
+                    removed_entries: stats.removed_entries,
+                    invalidated_bytes: stats.invalidated_bytes,
+                })
+                .into_response(),
+            )
+        }
+        None => (
+            StatusCode::CONFLICT,
+            "SSD cache is not enabled".into_response(),
+        ),
+    }
+}
+
 /// Start HTTP server for health check, optional Prometheus metrics, and instance management.
 pub async fn start_http_server(
     addr: std::net::SocketAddr,
@@ -180,17 +212,18 @@ pub async fn start_http_server(
         .route("/health", get(health_handler))
         .route("/instances", get(list_instances_handler))
         .route("/instances/cleanup", post(cleanup_handler))
-        .route("/cache/memory/cleanup", post(cleanup_memory_cache_handler));
+        .route("/cache/memory/cleanup", post(cleanup_memory_cache_handler))
+        .route("/cache/ssd/cleanup", post(cleanup_ssd_cache_handler));
 
     if enable_prometheus {
         app = app.route("/metrics", get(metrics_handler));
         info!(
-            "Starting HTTP server on {} (/health, /metrics, /instances, /instances/cleanup, /cache/memory/cleanup)",
+            "Starting HTTP server on {} (/health, /metrics, /instances, /instances/cleanup, /cache/memory/cleanup, /cache/ssd/cleanup)",
             addr
         );
     } else {
         info!(
-            "Starting HTTP server on {} (/health, /instances, /instances/cleanup, /cache/memory/cleanup)",
+            "Starting HTTP server on {} (/health, /instances, /instances/cleanup, /cache/memory/cleanup, /cache/ssd/cleanup)",
             addr
         );
     }


### PR DESCRIPTION
## Summary

- add `POST /cache/ssd/cleanup` to invalidate all SSD cache index entries without erasing preallocated files or resident memory
- serialize cleanup after preceding saves and SSD writes, and advance the logical ring generation so pre-cleanup prefetch snapshots are rejected
- return `409 Conflict` when SSD caching is disabled and document the endpoint

## Testing

- `prek run`
- `cargo test -p pegaflow-core --no-default-features --features cuda-13,rdma --lib`
- `cargo test -p pegaflow-core --no-default-features --features cuda-13,rdma --test ssd_cache ssd_cleanup_invalidates_index_and_allows_new_writes`
- `cargo check -p pegaflow-server --no-default-features --features cuda-13,rdma`
- `cargo clippy -p pegaflow-core -p pegaflow-server --no-default-features --features cuda-13,rdma --all-targets -- -D warnings`