### PR TITLE
fix(connector): ignore PCP in scheduler block size

### DIFF
--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -150,11 +150,11 @@ class ConnectorContext:
     def virtual_block_size(self) -> int:
         """Block size as seen by the scheduler.
 
-        vLLM computes scheduler_block_size = block_size * dcp * pcp.
-        request.block_hashes has one hash per scheduler_block_size tokens,
-        so all scheduler-side arithmetic must use this value.
+        vLLM's scheduler block size is ``block_size * dcp``. PCP changes
+        which ranks process a request, but does not change the token
+        granularity of scheduler block hashes.
         """
-        return self.block_size * self.dcp_world_size * self.pcp_world_size
+        return self.block_size * self.dcp_world_size
 
     @property
     def effective_tp_rank(self) -> int:

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -1,4 +1,4 @@
-"""Unit tests for DCP-aware block size logic in ConnectorContext."""
+"""Unit tests for scheduler block size logic in ConnectorContext."""
 
 from __future__ import annotations
 
@@ -219,11 +219,11 @@ def test_hma_loads_only_final_recurrent_state():
             16,
             id="smaller_physical_block",
         ),
-        pytest.param("pcp2", {"block_size": 16, "pcp_world_size": 2}, 32, id="pcp2"),
+        pytest.param("pcp2", {"block_size": 16, "pcp_world_size": 2}, 16, id="pcp2"),
         pytest.param(
             "dcp2_pcp2",
             {"block_size": 16, "dcp_world_size": 2, "pcp_world_size": 2},
-            64,
+            32,
             id="dcp2_pcp2",
         ),
     ],


### PR DESCRIPTION
## Summary

- Fix `ConnectorContext.virtual_block_size` to match vLLM's scheduler block-hash granularity.
- Keep DCP in the virtual block size, but do not multiply by PCP.
- Update unit coverage for PCP-only and DCP+PCP configurations.

Fixes #428.

## Why

vLLM scheduler block hashes use `block_size * dcp`; prefill context parallelism changes rank ownership, not token granularity. Pegaflow currently multiplies by `pcp_world_size` as well, making the expected block size 8x too large with PCP8 and causing the first prefix-cache hit to fail. PCP deployments currently work around this with a startup `sed` patch; this makes the behavior native to Pegaflow.

## Duplicate-work check

- Checked issue #428 and open PRs for `428`, `PCP`, `context parallel`, and `virtual_block_size`.
- No open PR covering this fix was found.

## Tests

- `UV_CACHE_DIR=/tmp/pegaflow-uv-cache uv run --isolated --no-project python -c '...'` (syntax compilation passed)
- `git diff --check` (passed)
- Full pytest could not run because the environment cannot resolve `pypi.org` to install test dependencies.

AI assistance was used to prepare this change; human review is required before merge.
