### PR TITLE
Restore reconciled HMA local prefix cache hits

### DIFF
--- a/python/pegaflow/connector/hma_local_cache.py
+++ b/python/pegaflow/connector/hma_local_cache.py
@@ -1,0 +1,101 @@
+"""Scoped vLLM adapter for coherent HMA local prefix hits."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from threading import Lock
+from typing import Any
+
+_lock = Lock()
+_bound_pools: dict[int, tuple[object, int]] = {}
+_coordinator_type: type | None = None
+_original_lookup: Callable[..., Any] | None = None
+_adapted_lookup: Callable[..., Any] | None = None
+
+
+def enable_reconciled_hma_local_hits(block_pool: object) -> None:
+    """Make vLLM report only locally resumable hybrid prefixes for this pool."""
+    global _adapted_lookup, _coordinator_type, _original_lookup
+
+    with _lock:
+        pool_id = id(block_pool)
+        existing = _bound_pools.get(pool_id)
+        if existing is not None:
+            if existing[0] is not block_pool:
+                raise RuntimeError("HMA local-cache block-pool identity collision")
+            _bound_pools[pool_id] = (block_pool, existing[1] + 1)
+            return
+
+        if _coordinator_type is None:
+            from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
+
+            coordinator_type = HybridKVCacheCoordinator
+            original_lookup = coordinator_type.find_longest_cache_hit_per_group
+
+            def find_reconciled_cache_hit_per_group(
+                coordinator,
+                block_hashes,
+                max_cache_hit_length,
+            ):
+                with _lock:
+                    entry = _bound_pools.get(id(coordinator.block_pool))
+                    is_bound = entry is not None and entry[0] is coordinator.block_pool
+
+                if not is_bound:
+                    return original_lookup(
+                        coordinator,
+                        block_hashes,
+                        max_cache_hit_length,
+                    )
+
+                blocks, hit_length, _ = coordinator.find_longest_cache_hit(
+                    block_hashes,
+                    max_cache_hit_length,
+                )
+                group_count = len(coordinator.kv_cache_config.kv_cache_groups)
+                return blocks, (hit_length,) * group_count
+
+            coordinator_type.find_longest_cache_hit_per_group = find_reconciled_cache_hit_per_group
+            _coordinator_type = coordinator_type
+            _original_lookup = original_lookup
+            _adapted_lookup = find_reconciled_cache_hit_per_group
+        elif (
+            _adapted_lookup is None
+            or _coordinator_type.find_longest_cache_hit_per_group is not _adapted_lookup
+        ):
+            raise RuntimeError("vLLM HMA cache lookup changed while PegaFlow adapter was active")
+
+        _bound_pools[pool_id] = (block_pool, 1)
+
+
+def disable_reconciled_hma_local_hits(block_pool: object) -> None:
+    """Release one binding and restore vLLM after the final binding closes."""
+    global _adapted_lookup, _coordinator_type, _original_lookup
+
+    with _lock:
+        pool_id = id(block_pool)
+        existing = _bound_pools.get(pool_id)
+        if existing is None or existing[0] is not block_pool:
+            raise RuntimeError("HMA local-cache block pool is not bound")
+        if existing[1] > 1:
+            _bound_pools[pool_id] = (block_pool, existing[1] - 1)
+            return
+        del _bound_pools[pool_id]
+
+        if _bound_pools:
+            return
+        if _coordinator_type is None or _original_lookup is None or _adapted_lookup is None:
+            raise RuntimeError("HMA local-cache adapter lost its installation state")
+        if _coordinator_type.find_longest_cache_hit_per_group is not _adapted_lookup:
+            raise RuntimeError("vLLM HMA cache lookup changed while PegaFlow adapter was active")
+
+        _coordinator_type.find_longest_cache_hit_per_group = _original_lookup
+        _coordinator_type = None
+        _original_lookup = None
+        _adapted_lookup = None
+
+
+__all__ = [
+    "disable_reconciled_hma_local_hits",
+    "enable_reconciled_hma_local_hits",
+]

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -20,6 +20,10 @@ from pegaflow.connector.common import (
     reconcile_hybrid_hit,
 )
 from pegaflow.connector.connector_metrics import PrefetchTracker
+from pegaflow.connector.hma_local_cache import (
+    disable_reconciled_hma_local_hits,
+    enable_reconciled_hma_local_hits,
+)
 from pegaflow.connector.tp_shards import ShardedQueryReady, TpShardQueryClient
 from pegaflow.pegaflow import EngineRpcClient
 
@@ -122,6 +126,7 @@ class SchedulerConnector:
         if self._cache_groups.has_recurrent_state and (pd_tail_save or pd_tail_load):
             raise ValueError("P/D tail-block caching is not supported with HMA")
         self._get_local_cached_blocks = None
+        self._hma_local_cache_pool = None
 
         # P/D tail-block extension (`pegaflow.pd_tail_save`): vLLM only hashes
         # full blocks, so a prompt's partial tail block never enters the tier
@@ -195,17 +200,18 @@ class SchedulerConnector:
         self._held_requests: set[str] = set()
 
     def bind_gpu_block_pool(self, gpu_block_pool) -> None:
+        if self._hma_local_cache_pool is not None:
+            if self._hma_local_cache_pool is not gpu_block_pool:
+                raise RuntimeError("scheduler cannot bind multiple GPU block pools")
+            return
+
         self._get_local_cached_blocks = gpu_block_pool.get_cached_block
         if self._cache_groups.group_count <= 1:
             return
 
-        # vLLM can cache an async-loaded dense group and expose it to a sibling
-        # before the sparse group has a usable state. PegaFlow is the sole HMA
-        # prefix index until vLLM exposes an atomic all-group cache hook.
-        def no_local_hma_prefix_hit(*_args, **_kwargs) -> None:
-            return None
-
-        gpu_block_pool.get_cached_block = no_local_hma_prefix_hit
+        enable_reconciled_hma_local_hits(gpu_block_pool)
+        self._hma_local_cache_pool = gpu_block_pool
+        logger.info("[PegaKVConnector] enabled reconciled HMA local prefix hits")
 
     def get_num_new_matched_tokens(
         self,
@@ -1106,8 +1112,13 @@ class SchedulerConnector:
         return stats
 
     def shutdown(self) -> None:
-        for req_id in list(self._pending_query_probes):
-            self._release_pending_query_probe(req_id)
+        try:
+            for req_id in list(self._pending_query_probes):
+                self._release_pending_query_probe(req_id)
+        finally:
+            if self._hma_local_cache_pool is not None:
+                disable_reconciled_hma_local_hits(self._hma_local_cache_pool)
+                self._hma_local_cache_pool = None
 
     def _release_pending_query_probe(self, req_id: str) -> bool:
         probe = self._pending_query_probes.pop(req_id, None)

--- a/python/tests/test_combine_hashes.py
+++ b/python/tests/test_combine_hashes.py
@@ -172,12 +172,40 @@ def test_recurrent_save_preserves_vllm_null_block_for_worker_filtering():
     )
 
 
-def test_hma_binding_disables_local_prefix_lookup_before_scheduling():
+def test_hma_binding_reports_only_reconciled_local_prefix():
     scheduler = _make_recurrent_scheduler()
     block_pool = SimpleNamespace(get_cached_block=lambda *_args: object())
+    from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
+
+    coordinator = HybridKVCacheCoordinator()
+    coordinator.block_pool = block_pool
+    coordinator.kv_cache_config = SimpleNamespace(kv_cache_groups=(object(), object()))
+    coordinator.per_group_result = (([11, 12], [21]), (32, 16))
+    coordinator.reconciled_result = (([11], [21]), 16, 16)
+    other = HybridKVCacheCoordinator()
+    other.block_pool = SimpleNamespace(get_cached_block=lambda *_args: object())
+    other.kv_cache_config = coordinator.kv_cache_config
+    other.per_group_result = (([31, 32], [41]), (32, 16))
+    other.reconciled_result = (([31], [41]), 16, 16)
+
     scheduler.bind_gpu_block_pool(block_pool)
 
-    assert block_pool.get_cached_block(b"hash", [0, 1]) is None
+    assert coordinator.find_longest_cache_hit_per_group([_hash(0), _hash(1)], 32) == (
+        ([11], [21]),
+        (16, 16),
+    )
+    assert block_pool.get_cached_block(b"hash", [0, 1]) is not None
+    assert other.find_longest_cache_hit_per_group([_hash(0), _hash(1)], 32) == (
+        ([31, 32], [41]),
+        (32, 16),
+    )
+
+    scheduler.shutdown()
+
+    assert coordinator.find_longest_cache_hit_per_group([_hash(0), _hash(1)], 32) == (
+        ([11, 12], [21]),
+        (32, 16),
+    )
 
 
 def test_hma_accepts_different_allocator_block_counts():

--- a/python/tests/test_vllm_e2e_correctness.py
+++ b/python/tests/test_vllm_e2e_correctness.py
@@ -33,6 +33,7 @@ from .vllm_helpers import (
     e2e_max_tokens,
     fetch_pegaflow_metrics,
     fetch_pegaflow_rpc_failures,
+    uses_linear_attention,
 )
 
 # ---------------------------------------------------------------------------
@@ -165,7 +166,7 @@ EXECUTION_PLAN: list[tuple[str, str, str]] = [
     ("prefix_base", PREFIX_BASE, "cold"),
     ("rollback_long", ROLLBACK_LONG, "cold"),
     ("multi_r1", MULTI_ROUND[0], "cold"),
-    # Same-process warm hit proves vLLM's local HMA cache cannot mask PegaFlow.
+    # Same-process warm hit proves coherent HMA state can be reused from L1.
     ("short_same_process", SHORT_PROMPT, "warm-same-process"),
     # Round 2: warm hits — exact same prompts
     ("short_warm", SHORT_PROMPT, "warm"),
@@ -298,8 +299,10 @@ class TestE2ECorrectness:
         print("[Phase 2] PegaFlow vLLM — executing cache plan")
         pega_port = base_port + 1
         outputs: dict[str, str] = {}
+        same_process_usage: dict | None = None
         metrics_port = pegaflow_server.metrics_port
         metrics_start = fetch_pegaflow_metrics(metrics_port)
+        metrics_before_same_process: dict[str, float] | None = None
 
         with VLLMServer(
             model,
@@ -311,10 +314,13 @@ class TestE2ECorrectness:
             pipeline_parallel_size=pipeline_parallel_size,
             max_model_len=max_model_len,
             transfer_backend=pegaflow_transfer_backend,
+            extra_args=["--enable-prompt-tokens-details"],
         ):
             for label, prompt, expectation in EXECUTION_PLAN:
                 if expectation not in {"cold", "warm-same-process"}:
                     continue
+                if expectation == "warm-same-process":
+                    metrics_before_same_process = fetch_pegaflow_metrics(metrics_port)
                 result = call_openai_api(
                     pega_port,
                     model,
@@ -322,9 +328,14 @@ class TestE2ECorrectness:
                     max_tokens=e2e_max_tokens(model),
                 )
                 outputs[label] = result["text"]
+                if expectation == "warm-same-process":
+                    same_process_usage = result["usage"]
                 print(f"  [{label}] ({expectation}) {len(result['text'])} chars")
 
             metrics_same_process = fetch_pegaflow_metrics(metrics_port)
+
+        if metrics_before_same_process is None:
+            raise RuntimeError("execution plan has no same-process warm request")
 
         with VLLMServer(
             model,
@@ -337,6 +348,7 @@ class TestE2ECorrectness:
             max_model_len=max_model_len,
             transfer_backend=pegaflow_transfer_backend,
             server_label="PegaFlow load",
+            extra_args=["--enable-prompt-tokens-details"],
         ):
             for label, prompt, expectation in EXECUTION_PLAN:
                 if expectation in {"cold", "warm-same-process"}:
@@ -355,7 +367,9 @@ class TestE2ECorrectness:
         print("[Phase 2] Done\n")
         return {
             "outputs": outputs,
+            "same_process_usage": same_process_usage,
             "metrics_start": metrics_start,
+            "metrics_before_same_process": metrics_before_same_process,
             "metrics_same_process": metrics_same_process,
             "metrics_end": metrics_end,
         }
@@ -399,9 +413,15 @@ class TestE2ECorrectness:
             f"hits={hits:.0f} blocks ({load_bytes / 1e6:.1f}MB)"
         )
 
-    def test_same_process_hma_load_uses_pegaflow(self, pegaflow_results):
-        """The warm request in the first vLLM process must load from PegaFlow."""
-        m_start = pegaflow_results["metrics_start"]
+    def test_same_process_hma_hit_uses_local_cache(self, pegaflow_results, model: str):
+        """A coherent warm HMA prefix stays local instead of loading from PegaFlow."""
+        if not uses_linear_attention(model):
+            pytest.skip("model does not use the HMA cache path")
+
+        usage = pegaflow_results["same_process_usage"] or {}
+        prompt_details = usage.get("prompt_tokens_details") or {}
+        cached_tokens = prompt_details.get("cached_tokens", 0)
+        m_start = pegaflow_results["metrics_before_same_process"]
         m_end = pegaflow_results["metrics_same_process"]
         hit_delta = m_end.get("pegaflow_cache_block_hits_total", 0) - m_start.get(
             "pegaflow_cache_block_hits_total", 0
@@ -409,9 +429,10 @@ class TestE2ECorrectness:
         load_delta = m_end.get("pegaflow_load_bytes_total", 0) - m_start.get(
             "pegaflow_load_bytes_total", 0
         )
-        assert hit_delta > 0 or load_delta > 0, (
-            "same-process warm HMA request bypassed PegaFlow: "
-            f"hit_delta={hit_delta}, load_delta={load_delta}"
+        assert cached_tokens > 0, "same-process warm HMA request reported no cached tokens"
+        assert hit_delta == 0 and load_delta == 0, (
+            "same-process warm HMA request loaded from PegaFlow: "
+            f"cached_tokens={cached_tokens}, hit_delta={hit_delta}, load_delta={load_delta}"
         )
 
     def test_no_data_path_rpc_failures(self, pegaflow_results, pegaflow_server: PegaFlowServer):

--- a/python/tests/unit_stubs.py
+++ b/python/tests/unit_stubs.py
@@ -182,6 +182,16 @@ def _install_vllm_stubs() -> None:
     kv_cache_interface.MambaSpec = MambaSpec
     kv_cache_interface.SlidingWindowSpec = SlidingWindowSpec
     kv_cache_interface.UniformTypeKVCacheSpecs = UniformTypeKVCacheSpecs
+    kv_cache_coordinator = _ensure_module("vllm.v1.core.kv_cache_coordinator")
+
+    class HybridKVCacheCoordinator:
+        def find_longest_cache_hit_per_group(self, block_hashes, max_cache_hit_length):
+            return self.per_group_result
+
+        def find_longest_cache_hit(self, block_hashes, max_cache_hit_length):
+            return self.reconciled_result
+
+    kv_cache_coordinator.HybridKVCacheCoordinator = HybridKVCacheCoordinator
     _ensure_module("vllm.v1.metrics")
     _ensure_module("vllm.v1.metrics.utils").create_metric_per_engine = lambda *_args, **_kwargs: {}
 

--- a/python/tests/vllm_helpers.py
+++ b/python/tests/vllm_helpers.py
@@ -19,7 +19,7 @@ import requests
 DEFAULT_VLLM_SEED = 42
 
 
-def _uses_linear_attention(model: str) -> bool:
+def uses_linear_attention(model: str) -> bool:
     config_path = Path(model) / "config.json"
     if not config_path.is_file():
         return False
@@ -28,11 +28,13 @@ def _uses_linear_attention(model: str) -> bool:
     except (OSError, json.JSONDecodeError):
         return False
     text_config = config.get("text_config", config)
-    return "linear_attention" in (text_config.get("layer_types") or ())
+    return "linear_attention" in (text_config.get("layer_types") or ()) or bool(
+        text_config.get("linear_attn_config")
+    )
 
 
 def adapt_prompt_for_hybrid_cache(model: str, prompt: str) -> str:
-    if not _uses_linear_attention(model):
+    if not uses_linear_attention(model):
         return prompt
     family = hashlib.sha256(prompt[:80].encode()).hexdigest()[:8]
     prefix = f"Hybrid cache boundary {family} contains deterministic background context. " * 80
@@ -40,7 +42,7 @@ def adapt_prompt_for_hybrid_cache(model: str, prompt: str) -> str:
 
 
 def e2e_max_tokens(model: str) -> int:
-    return 8 if _uses_linear_attention(model) else 50
+    return 8 if uses_linear_attention(model) else 50
 
 
 def _detect_pegaflow_cargo_features() -> list[str]:
@@ -114,7 +116,7 @@ class VLLMServer:
 
         env = os.environ.copy()
         env["PYTHONHASHSEED"] = "0"
-        if _uses_linear_attention(self.model):
+        if uses_linear_attention(self.model):
             env.pop("VLLM_BATCH_INVARIANT", None)
         else:
             env["VLLM_BATCH_INVARIANT"] = "1"
@@ -138,7 +140,7 @@ class VLLMServer:
             "--trust-remote-code",
             (
                 "--enable-prefix-caching"
-                if _uses_linear_attention(self.model)
+                if uses_linear_attention(self.model)
                 else "--no-enable-prefix-caching"
             ),
             "--gpu-memory-utilization",
@@ -159,7 +161,7 @@ class VLLMServer:
 
         if self.max_model_len is not None:
             cmd.extend(["--max-model-len", str(self.max_model_len)])
-        if _uses_linear_attention(self.model):
+        if uses_linear_attention(self.model):
             cmd.extend(
                 [
                     "--max-num-seqs",


### PR DESCRIPTION
## Summary

- replace the HMA-wide local cache suppression with a scoped PegaFlow adapter
- reuse only the prefix already reconciled across attention and recurrent cache groups
- leave unbound vLLM block pools unchanged and restore the original coordinator method on shutdown
- fail early if another runtime patch changes the adapted vLLM lookup while PegaFlow is active
- extend the correctness E2E to verify that same-process HMA hits stay local while cross-process hits still load through PegaFlow

No vLLM source changes are required.

## Why

The previous connector replaced `BlockPool.get_cached_block` with a function that always returned `None` for HMA layouts. That avoided exposing a dense attention prefix before recurrent state was usable, but it also disabled every valid L1 prefix hit.

vLLM already exposes a reconciled hybrid lookup through `HybridKVCacheCoordinator.find_longest_cache_hit`. The adapter uses that result for PegaFlow-bound block pools and reports the same safe boundary for every cache group.

## Measured A/B

Qwen3.5-4B, one GPU, 3,168 cached prompt tokens, one output token, seven exact warm requests:

| Revision | Warm median | PegaFlow hits | PegaFlow load bytes | Matching outputs |
| --- | ---: | ---: | ---: | ---: |
| master | 101.90 ms | 42 blocks | 1,089,994,752 | 7/7 |
| this PR | 77.09 ms | 0 blocks | 0 | 7/7 |

Warm request latency decreased by 24.35% in this workload.

## Validation

- `cd python && uv run --extra test pytest`: 272 passed, 13 deselected
- source-only Python gate: 272 passed, 13 deselected
- Qwen3.5 correctness E2E: 5 passed
  - same-process HMA request reported a local cached-token hit with zero PegaFlow hit/load delta
  - cross-process phase reported 40 saved blocks / 692.1 MB and 10 hit blocks / 432.5 MB
  - output equality, RPC failure, and KV load failure checks passed
- `prek run`: passed, including `cargo test --release`, ruff, formatting, and typo checks

Example E2E command:

```bash
cd python
uv run --extra test pytest -m e2e tests/test_vllm_e2e_correctness.py \
  --model /path/to/Qwen3.5-4B --max-model-len 4096 --pegaflow-pool-size 2gb
```