### PR TITLE
feat(connector): cache linear state on GPU

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -109,6 +109,39 @@ vllm serve Qwen/Qwen3-0.6B \
 
 Valid values are `read_write` and `save_only`.
 
+#### Connector-Owned Linear-State Cache
+
+`pegaflow.linear_state_cache_size_bytes` enables a worker-local GPU LRU for the
+recurrent state in vLLM hybrid models. It defaults to `0`, preserving the existing
+PegaFlow recurrent query/load/save path and GPU memory use. The value must be a
+non-negative integer in bytes.
+
+The feature currently supports only TP-only hybrid layouts (`PP=1`, no DCP/PCP)
+whose recurrent groups are vLLM `MambaSpec` groups with
+`mamba_cache_mode="align"`. One atomic checkpoint contains every recurrent group
+and recurrent layer. Its size is the sum of vLLM's padded
+`MambaSpec.page_size_bytes` for those layers; each TP worker allocates
+`floor(configured_bytes / checkpoint_bytes)` slots. Startup rejects unsupported
+parallel layouts or a budget that cannot hold one complete checkpoint.
+
+When enabled, PegaFlow continues to query, lease, load, and save all non-recurrent
+attention KV. Recurrent state never goes to the PegaFlow server: workers copy full
+pages between vLLM's cache and the local pool with GPU-to-GPU copies. A request
+can resume only at the intersection of the remote attention prefix and a committed
+local recurrent checkpoint. A local recurrent miss releases the remote lease and
+recomputes from the beginning. Each worker reports an exact
+`(request, slot, generation, hash)` result through vLLM worker metadata. The
+scheduler publishes only after every TP worker ACKs the same checkpoint; failures
+cancel that exact reservation. `finished_sending` remains reserved for completed
+requests whose held blocks may be freed. In-flight loads pin their slot until
+`finished_recving`, so eviction cannot reuse data still being copied.
+
+This pool is allocated **after and outside vLLM's KV-cache memory planning**. The
+configured bytes therefore require additional free GPU memory beyond
+`gpu_memory_utilization`; startup raises an explicit error if allocation runs out
+of memory. Example: `{"pegaflow.linear_state_cache_size_bytes": 1073741824}`
+requests an additional allocation of up to 1 GiB on every TP worker.
+
 #### TP Shards Across Hosts
 
 CUDA IPC is host-local. When one tensor-parallel replica spans multiple hosts,

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -17,6 +17,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 from vllm.distributed.parallel_state import get_pp_group, get_tensor_model_parallel_rank
 
 from pegaflow.connector.common import (
+    CacheGroupLayout,
     ConnectorContext,
     PegaConnectorMetadata,
     PegaConnectorMode,
@@ -115,6 +116,34 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
                 "pegaflow.wait_for_full_prefix", False
             )
         )
+        linear_state_cache_size_bytes = vllm_config.kv_transfer_config.get_from_extra_config(
+            "pegaflow.linear_state_cache_size_bytes", 0
+        )
+        if type(linear_state_cache_size_bytes) is not int or linear_state_cache_size_bytes < 0:
+            raise ValueError(
+                "pegaflow.linear_state_cache_size_bytes must be a non-negative integer"
+            )
+        cache_layout = CacheGroupLayout.from_config(kv_cache_config)
+        if linear_state_cache_size_bytes:
+            if pp_size != 1 or world_size != tp_size or dcp_world_size != 1 or pcp_world_size != 1:
+                raise ValueError(
+                    "pegaflow.linear_state_cache_size_bytes currently supports TP-only "
+                    f"parallelism; got tp_size={tp_size}, world_size={world_size}, "
+                    f"pp_size={pp_size}, dcp_world_size={dcp_world_size}, "
+                    f"pcp_world_size={pcp_world_size}"
+                )
+            if not cache_layout.has_recurrent_state:
+                raise ValueError(
+                    "pegaflow.linear_state_cache_size_bytes requires an HMA MambaSpec layout"
+                )
+            compound_bytes = cache_layout.recurrent_compound_page_bytes
+            if compound_bytes <= 0:
+                raise ValueError("enabled linear-state cache requires MambaSpec.page_size_bytes")
+            if linear_state_cache_size_bytes < compound_bytes:
+                raise ValueError(
+                    "pegaflow.linear_state_cache_size_bytes cannot hold one compound "
+                    f"checkpoint: budget={linear_state_cache_size_bytes} required={compound_bytes}"
+                )
         default_endpoint = f"{server_host}:{server_port}"
         tp_shards = TpShardTopology.from_config(
             default_endpoint=default_endpoint,
@@ -161,6 +190,7 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             mode=mode,
             wait_for_full_prefix=wait_for_full_prefix,
             tp_shards=tp_shards,
+            linear_state_cache_size_bytes=linear_state_cache_size_bytes,
         )
 
         # MLA attention backends expose no num-layers stride dimension, so vLLM
@@ -213,6 +243,16 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
                 self._ctx,
                 vllm_config=vllm_config,
                 kv_cache_config=kv_cache_config,
+            )
+
+        if linear_state_cache_size_bytes:
+            logger.info(
+                "[PegaKVConnector] connector-owned linear-state cache enabled: "
+                "budget=%d compound_page_bytes=%d slots=%d role=%s",
+                linear_state_cache_size_bytes,
+                cache_layout.recurrent_compound_page_bytes,
+                linear_state_cache_size_bytes // cache_layout.recurrent_compound_page_bytes,
+                role.name,
             )
 
         logger.debug(
@@ -279,6 +319,11 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
         if not self._worker:
             return (None, None)
         return self._worker.get_finished(finished_req_ids)
+
+    def build_connector_worker_meta(self):
+        if not self._worker:
+            return None
+        return self._worker.build_connector_worker_meta()
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         if not self._worker:

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -5,13 +5,17 @@ Shared types and helpers for the PegaFlow vLLM connector.
 import hashlib
 import os
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+    KVConnectorWorkerMetadata,
+)
 
 from pegaflow.connector.connector_metrics import PegaKVConnectorStats, PegaPromMetrics
+from pegaflow.connector.linear_state_cache import LinearStateSlot
 from pegaflow.logging_utils import get_connector_logger
 from pegaflow.pegaflow import EngineRpcClient
 
@@ -141,6 +145,7 @@ class ConnectorContext:
     mode: PegaConnectorMode = PegaConnectorMode.READ_WRITE
     wait_for_full_prefix: bool = False
     tp_shards: TpShardTopology | None = None
+    linear_state_cache_size_bytes: int = 0
 
     @property
     def read_enabled(self) -> bool:
@@ -218,16 +223,67 @@ class ConnectorContext:
 
 
 @dataclass(frozen=True)
+class LocalRecurrentLoad:
+    """Worker-local recurrent load selected by the scheduler."""
+
+    source: LinearStateSlot
+    destination_block_ids: tuple[tuple[int, int], ...]
+
+
+@dataclass(frozen=True)
+class LocalRecurrentSave:
+    """Worker-local recurrent save reservation awaiting worker completion."""
+
+    target: LinearStateSlot
+    source_block_ids: tuple[tuple[int, int], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class LocalSaveRef:
+    """Exact cross-process identity for one local recurrent save transaction."""
+
+    req_id: str
+    slot: int
+    generation: int
+    block_hash: bytes
+
+    @classmethod
+    def from_save(cls, req_id: str, save: LocalRecurrentSave) -> "LocalSaveRef":
+        target = save.target
+        return cls(req_id, target.slot, target.generation, target.block_hash)
+
+    def slot_ref(self) -> LinearStateSlot:
+        return LinearStateSlot(self.slot, self.generation, self.block_hash)
+
+
+@dataclass
+class PegaWorkerMetadata(KVConnectorWorkerMetadata):
+    """Per-worker local-save terminal states aggregated by exact transaction."""
+
+    succeeded: dict[LocalSaveRef, int] = field(default_factory=dict)
+    failed: dict[LocalSaveRef, int] = field(default_factory=dict)
+
+    def aggregate(self, other: KVConnectorWorkerMetadata) -> KVConnectorWorkerMetadata:
+        assert isinstance(other, PegaWorkerMetadata)
+        succeeded = dict(self.succeeded)
+        failed = dict(self.failed)
+        for ref, count in other.succeeded.items():
+            succeeded[ref] = succeeded.get(ref, 0) + count
+        for ref, count in other.failed.items():
+            failed[ref] = failed.get(ref, 0) + count
+        return PegaWorkerMetadata(succeeded=succeeded, failed=failed)
+
+
+@dataclass(frozen=True)
 class LoadIntent:
     """Intent for a KV load operation."""
 
     block_ids_by_group: tuple[tuple[int | None, ...], ...]
     leases: tuple[bytes, ...]
     num_tokens: int
-    # Hybrid-cache loads carry one membership lease per recurrent storage
-    # group (pinned checkpoints in hit-positions order) on top of the
-    # attention prefix leases. See RecurrentLoadHold.
+    # Disabled local mode keeps the legacy Pega recurrent membership hold.
     recurrent_hold: "RecurrentLoadHold | None" = None
+    local_recurrent: LocalRecurrentLoad | None = None
 
 
 @dataclass(frozen=True)
@@ -287,10 +343,11 @@ def reconcile_hybrid_hit(
 
 @dataclass(frozen=True)
 class SaveIntent:
-    """Intent for a KV save operation."""
+    """Intent for remote KV and optional worker-local recurrent saves."""
 
     block_ids_by_group: tuple[tuple[int, ...], ...]
     block_hashes: tuple[bytes, ...]
+    local_recurrent_saves: tuple[LocalRecurrentSave, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -308,6 +365,7 @@ class CacheGroupLayout:
     has_recurrent_state: bool
     recurrent_group_indices: frozenset[int]
     recurrent_layer_names: frozenset[str]
+    recurrent_page_sizes_by_group: tuple[int, ...] = ()
     storage_group_ids: tuple[int, ...] = (0,)
 
     @classmethod
@@ -394,6 +452,12 @@ class CacheGroupLayout:
             for index, group in enumerate(groups)
             if isinstance(group.kv_cache_spec, MambaSpec)
         )
+        recurrent_page_sizes_by_group = tuple(
+            int(getattr(group.kv_cache_spec, "page_size_bytes", 0)) * len(group.layer_names)
+            if index in recurrent_group_indices
+            else 0
+            for index, group in enumerate(groups)
+        )
         # Attention-like groups all share storage group 0 (they advance in
         # per-block prefix cadence); each recurrent group gets a dense id
         # from 1. Engine keys are raw only for group 0, so this keeps every
@@ -416,12 +480,17 @@ class CacheGroupLayout:
                 if isinstance(group.kv_cache_spec, MambaSpec)
                 for layer_name in group.layer_names
             ),
+            recurrent_page_sizes_by_group=recurrent_page_sizes_by_group,
             storage_group_ids=storage_group_ids,
         )
 
     @property
     def group_count(self) -> int:
         return len(self.layer_names)
+
+    @property
+    def recurrent_compound_page_bytes(self) -> int:
+        return sum(self.recurrent_page_sizes_by_group)
 
     def layer_to_group(self) -> dict[str, int]:
         result: dict[str, int] = {}
@@ -543,6 +612,12 @@ def derive_namespace(
     model_config = vllm_config.model_config
     cache_config = vllm_config.cache_config
     additional_config = getattr(vllm_config, "additional_config", None) or {}
+    kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
+    local_linear_state = (
+        kv_transfer_config.get_from_extra_config("pegaflow.linear_state_cache_size_bytes", 0)
+        if kv_transfer_config is not None
+        else 0
+    )
 
     factors = {
         "model": model_config.model,
@@ -559,6 +634,11 @@ def derive_namespace(
         "cross_layer_blocks": cross_layer_blocks,
         "mla_layer_split_kv_cache": bool(additional_config.get("mla_layer_split_kv_cache", False)),
     }
+    # Enabled mode excludes recurrent tensors from Pega registration, which
+    # changes the server-side slot layout even though the pool itself is local.
+    # Omit the factor when disabled to preserve existing namespace hashes.
+    if local_linear_state:
+        factors["connector_owned_linear_state"] = True
 
     factor_str = str(sorted(factors.items()))
     hash_suffix = hashlib.sha256(factor_str.encode()).hexdigest()[:8]
@@ -597,10 +677,14 @@ def resolve_transfer_backend(is_mla: bool, override: str | None) -> str:
 __all__ = [
     "ConnectorContext",
     "LoadIntent",
+    "LocalRecurrentLoad",
+    "LocalRecurrentSave",
+    "LocalSaveRef",
     "PegaConnectorMode",
     "PegaConnectorMetadata",
     "PegaKVConnectorStats",
     "PegaPromMetrics",
+    "PegaWorkerMetadata",
     "RecurrentLoadHold",
     "SaveIntent",
     "TpShardTopology",

--- a/python/pegaflow/connector/linear_state_cache.py
+++ b/python/pegaflow/connector/linear_state_cache.py
@@ -1,0 +1,130 @@
+"""Scheduler-side index for connector-owned recurrent-state GPU slots."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class LinearStateSlot:
+    """Stable reference to one generation of a compound recurrent-state slot."""
+
+    slot: int
+    generation: int
+    block_hash: bytes
+
+
+@dataclass(slots=True)
+class _Entry:
+    ref: LinearStateSlot
+    pins: int = 0
+
+
+class LinearStateCache:
+    """Fixed-capacity LRU with explicit save reservation and load pinning.
+
+    Reservations are intentionally invisible to lookup until ``commit``. This is
+    the scheduler half of the worker-completion protocol: every TP worker reports
+    an exact slot-generation result through connector worker metadata, and only a
+    unanimous success lets the scheduler publish the hash as reusable.
+    """
+
+    def __init__(self, capacity: int):
+        if capacity <= 0:
+            raise ValueError(f"linear-state cache capacity must be positive, got {capacity}")
+        self.capacity = capacity
+        self._entries: dict[bytes, _Entry] = {}
+        self._slots: list[_Entry | None] = [None] * capacity
+        self._generations = [0] * capacity
+        self._lru: OrderedDict[int, None] = OrderedDict()
+        self._reservations: dict[tuple[int, int], LinearStateSlot] = {}
+        self._pending_hashes: set[bytes] = set()
+
+    def lookup(self, block_hash: bytes, *, pin: bool = False) -> LinearStateSlot | None:
+        entry = self._entries.get(block_hash)
+        if entry is None:
+            return None
+        self._touch_slot(entry.ref.slot)
+        if pin:
+            entry.pins += 1
+        return entry.ref
+
+    def unpin(self, ref: LinearStateSlot) -> None:
+        entry = self._entry_for_ref(ref)
+        if entry.pins <= 0:
+            raise RuntimeError(f"linear-state slot {ref.slot}/{ref.generation} is not pinned")
+        entry.pins -= 1
+
+    def reserve(self, block_hash: bytes) -> LinearStateSlot | None:
+        """Reserve an unpublished slot, or return ``None`` when saving is skipped."""
+        existing = self._entries.get(block_hash)
+        if existing is not None:
+            self._touch_slot(existing.ref.slot)
+            return None
+        if block_hash in self._pending_hashes:
+            return None
+
+        slot = self._find_reservable_slot()
+        if slot is None:
+            return None
+
+        victim = self._slots[slot]
+        if victim is not None:
+            del self._entries[victim.ref.block_hash]
+            self._lru.pop(slot, None)
+            self._slots[slot] = None
+
+        self._generations[slot] += 1
+        ref = LinearStateSlot(slot, self._generations[slot], block_hash)
+        self._reservations[(slot, ref.generation)] = ref
+        self._pending_hashes.add(block_hash)
+        return ref
+
+    def commit(self, ref: LinearStateSlot) -> None:
+        reserved = self._pop_reservation(ref)
+        entry = _Entry(reserved)
+        self._entries[reserved.block_hash] = entry
+        self._slots[reserved.slot] = entry
+        self._touch_slot(reserved.slot)
+
+    def cancel(self, ref: LinearStateSlot) -> None:
+        self._pop_reservation(ref)
+
+    def clear(self) -> None:
+        self._entries.clear()
+        self._slots = [None] * self.capacity
+        self._lru.clear()
+        self._reservations.clear()
+        self._pending_hashes.clear()
+
+    def _find_reservable_slot(self) -> int | None:
+        reserved_slots = {slot for slot, _generation in self._reservations}
+        for slot, entry in enumerate(self._slots):
+            if entry is None and slot not in reserved_slots:
+                return slot
+        for slot in self._lru:
+            entry = self._slots[slot]
+            if entry is not None and entry.pins == 0 and slot not in reserved_slots:
+                return slot
+        return None
+
+    def _entry_for_ref(self, ref: LinearStateSlot) -> _Entry:
+        if ref.slot < 0 or ref.slot >= self.capacity:
+            raise RuntimeError(f"linear-state slot {ref.slot} is out of range")
+        entry = self._slots[ref.slot]
+        if entry is None or entry.ref != ref:
+            raise RuntimeError(f"stale linear-state slot reference {ref.slot}/{ref.generation}")
+        return entry
+
+    def _pop_reservation(self, ref: LinearStateSlot) -> LinearStateSlot:
+        key = (ref.slot, ref.generation)
+        reserved = self._reservations.pop(key, None)
+        if reserved != ref:
+            raise RuntimeError(f"stale linear-state reservation {ref.slot}/{ref.generation}")
+        self._pending_hashes.remove(ref.block_hash)
+        return reserved
+
+    def _touch_slot(self, slot: int) -> None:
+        self._lru.pop(slot, None)
+        self._lru[slot] = None

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -12,14 +12,19 @@ from pegaflow.connector.common import (
     CacheGroupLayout,
     ConnectorContext,
     LoadIntent,
+    LocalRecurrentLoad,
+    LocalRecurrentSave,
+    LocalSaveRef,
     PegaConnectorMetadata,
     PegaKVConnectorStats,
+    PegaWorkerMetadata,
     RecurrentLoadHold,
     SaveIntent,
     logger,
     reconcile_hybrid_hit,
 )
 from pegaflow.connector.connector_metrics import PrefetchTracker
+from pegaflow.connector.linear_state_cache import LinearStateCache, LinearStateSlot
 from pegaflow.connector.tp_shards import ShardedQueryReady, TpShardQueryClient
 from pegaflow.pegaflow import EngineRpcClient
 
@@ -62,6 +67,8 @@ class _QueryProbe:
     # recurrent groups and shards, below the attention prefix). Used to
     # re-derive a legal boundary when the token budget shrinks the hit.
     usable_positions: frozenset[int] = frozenset()
+    # Connector-owned recurrent checkpoint pinned until local D2D load completes.
+    local_recurrent: LinearStateSlot | None = None
 
     @property
     def is_ready(self) -> bool:
@@ -90,6 +97,7 @@ class _QueryProbe:
         self.leases = ready.leases
         self.recurrent_hold = ready.recurrent_hold
         self.usable_positions = frozenset(ready.usable_positions)
+        self.local_recurrent = ready.local_recurrent
 
     def require_hit_blocks(self) -> int:
         if self.hit_blocks is None:
@@ -122,6 +130,14 @@ class SchedulerConnector:
         if self._cache_groups.has_recurrent_state and (pd_tail_save or pd_tail_load):
             raise ValueError("P/D tail-block caching is not supported with HMA")
         self._get_local_cached_blocks = None
+        self._linear_state_cache: LinearStateCache | None = None
+        if context.linear_state_cache_size_bytes:
+            compound_bytes = self._cache_groups.recurrent_compound_page_bytes
+            if compound_bytes <= 0:
+                raise ValueError("enabled linear-state cache requires MambaSpec.page_size_bytes")
+            self._linear_state_cache = LinearStateCache(
+                context.linear_state_cache_size_bytes // compound_bytes
+            )
 
         # P/D tail-block extension (`pegaflow.pd_tail_save`): vLLM only hashes
         # full blocks, so a prompt's partial tail block never enters the tier
@@ -192,6 +208,10 @@ class SchedulerConnector:
         # Completion tracking
         self._deferred_save_intents: dict[str, SaveIntent] = {}
         self._pending_saves: set[str] = set()
+        self._pending_local_saves: dict[LocalSaveRef, LinearStateSlot] = {}
+        self._local_saves_by_req: dict[str, set[LocalSaveRef]] = {}
+        self._local_save_ack_counts: dict[LocalSaveRef, int] = {}
+        self._pending_local_loads: dict[str, LinearStateSlot] = {}
         self._held_requests: set[str] = set()
 
     def bind_gpu_block_pool(self, gpu_block_pool) -> None:
@@ -288,6 +308,9 @@ class SchedulerConnector:
             if ready.recurrent_hold is not None:
                 for group_index, group_leases in enumerate(ready.recurrent_hold.leases):
                     self._tp_shard_client.release(group_leases, f"{req_id}:g{group_index}")
+            if ready.local_recurrent is not None:
+                assert self._linear_state_cache is not None
+                self._linear_state_cache.unpin(ready.local_recurrent)
             self._pending_query_probes.pop(req_id, None)
             return (None, False)
 
@@ -335,11 +358,10 @@ class SchedulerConnector:
         locally_computed_tokens = computed_blocks * vbs
         hit_tokens = min(hit_tokens, max(0, num_tokens - locally_computed_tokens - 1))
 
-        if probe.recurrent_hold is not None:
+        if probe.recurrent_hold is not None or probe.local_recurrent is not None:
             # A mamba checkpoint is valid only at its own block boundary. If
             # the token budget cut inside the reconciled span, fall back to
-            # the best earlier boundary; if none survives, drop the hit (a
-            # partial mamba resume cannot exist).
+            # the best earlier boundary; if none survives, drop the hit.
             boundary_blocks = hit_tokens // vbs
             usable = [p for p in probe.usable_positions if p < boundary_blocks]
             if not usable:
@@ -347,10 +369,38 @@ class SchedulerConnector:
                     self._release_pending_query_probe(req_id)
                 return (0, False)
             checkpoint = max(usable)
-            hit_blocks = checkpoint + 1
+            reduced_hit_blocks = checkpoint + 1
+            if reduced_hit_blocks < hit_blocks:
+                exact = self._tp_shard_client.query(
+                    self._ctx.instance_id,
+                    list(probe.query_hashes[:reduced_hit_blocks]),
+                    f"{req_id}:hma-budget-exact-{reduced_hit_blocks}",
+                    False,
+                )
+                self._release_leases(probe.leases, req_id)
+                probe.leases = ()
+                if exact is None or exact.num_hit_blocks != reduced_hit_blocks:
+                    if exact is not None:
+                        self._release_leases(exact.leases, req_id)
+                    self._release_pending_query_probe(req_id)
+                    return (0, False)
+                probe.leases = exact.leases
+            hit_blocks = reduced_hit_blocks
             hit_tokens = hit_blocks * vbs
             probe.hit_blocks = hit_blocks
-            probe.recurrent_hold = replace(probe.recurrent_hold, checkpoint=checkpoint)
+            if probe.recurrent_hold is not None:
+                probe.recurrent_hold = replace(probe.recurrent_hold, checkpoint=checkpoint)
+            elif probe.local_recurrent is not None:
+                assert self._linear_state_cache is not None
+                if probe.local_recurrent.block_hash != probe.query_hashes[checkpoint]:
+                    replacement = self._linear_state_cache.lookup(
+                        probe.query_hashes[checkpoint], pin=True
+                    )
+                    if replacement is None:
+                        self._release_pending_query_probe(req_id)
+                        return (0, False)
+                    self._linear_state_cache.unpin(probe.local_recurrent)
+                    probe.local_recurrent = replacement
 
         # Cacheable tails contain at least two tokens, so recomputing the final
         # prompt token cannot remove the last leased block from the load.
@@ -446,6 +496,27 @@ class SchedulerConnector:
                 raise
 
             pending_probe = self._pending_query_probes.get(req_id)
+            local_recurrent = None
+            if pending_probe is not None and pending_probe.local_recurrent is not None:
+                destinations = tuple(
+                    (group_index, block_ids_by_group[group_index][-1])
+                    for group_index in sorted(self._cache_groups.recurrent_group_indices)
+                    if block_ids_by_group[group_index]
+                    and block_ids_by_group[group_index][-1] is not None
+                )
+                if len(destinations) != len(self._cache_groups.recurrent_group_indices):
+                    self._release_pending_query_probe(req_id)
+                    raise RuntimeError(f"req {req_id} missing local recurrent destination")
+                local_recurrent = LocalRecurrentLoad(
+                    source=pending_probe.local_recurrent,
+                    destination_block_ids=destinations,
+                )
+                load_block_ids_by_group = tuple(
+                    (None,) * len(group)
+                    if index in self._cache_groups.recurrent_group_indices
+                    else group
+                    for index, group in enumerate(load_block_ids_by_group)
+                )
             load_intent = LoadIntent(
                 block_ids_by_group=load_block_ids_by_group,
                 leases=pending_probe.leases if pending_probe is not None else (),
@@ -453,6 +524,7 @@ class SchedulerConnector:
                 recurrent_hold=(
                     pending_probe.recurrent_hold if pending_probe is not None else None
                 ),
+                local_recurrent=local_recurrent,
             )
             if pending_probe is not None:
                 query_hashes, tail_tokens = self._build_query(request, num_computed_blocks)
@@ -469,6 +541,8 @@ class SchedulerConnector:
             if not load_intent.leases or any(not lease for lease in load_intent.leases):
                 raise RuntimeError(f"req {req_id} missing query lease for external load")
             self._pending_load_intents[req_id] = load_intent
+            if local_recurrent is not None:
+                self._pending_local_loads[req_id] = local_recurrent.source
             self._pending_query_probes.pop(req_id, None)
             logger.debug(
                 "[PegaKVConnector] req=%s alloc: total_blocks=%d computed_blocks=%d "
@@ -483,13 +557,19 @@ class SchedulerConnector:
             )
 
     def build_connector_meta(self, scheduler_output: "SchedulerOutput") -> PegaConnectorMetadata:
-        # Collect all save intents that became available this scheduler step.
-        ready_save_intents = self._deferred_save_intents
-        self._deferred_save_intents = {}
-        potential_saves: dict[str, SaveIntent] = {}
+        reservations_before = set(self._pending_local_saves)
+        try:
+            return self._build_connector_meta(scheduler_output)
+        except Exception:
+            for ref in set(self._pending_local_saves) - reservations_before:
+                self._cancel_local_save(ref)
+            raise
 
-        load_intents = self._pending_load_intents
-        self._pending_load_intents = {}
+    def _build_connector_meta(self, scheduler_output: "SchedulerOutput") -> PegaConnectorMetadata:
+        # Leave deferred work in place until metadata construction succeeds.
+        ready_save_intents = dict(self._deferred_save_intents)
+        potential_saves: dict[str, SaveIntent] = {}
+        load_intents = dict(self._pending_load_intents)
 
         # Process new requests
         for req in scheduler_output.scheduled_new_reqs:
@@ -576,9 +656,9 @@ class SchedulerConnector:
                 potential_saves[req_id] = save_intent
 
         save_intents = potential_saves
-
-        # Track requests with pending saves
         self._pending_saves.update(save_intents.keys())
+        self._pending_load_intents.clear()
+        self._deferred_save_intents.clear()
 
         logger.debug(
             "[PegaKVConnector] build_connector_meta: %d loads, %d saves",
@@ -766,9 +846,45 @@ class SchedulerConnector:
             len(block_hashes),
         )
 
+        return self._build_hma_save_intent(req_id, save_block_ids_by_group, save_hashes)
+
+    def _build_hma_save_intent(
+        self,
+        req_id: str,
+        block_ids_by_group: tuple[tuple[int, ...], ...],
+        block_hashes: tuple[bytes, ...],
+    ) -> SaveIntent:
+        if self._linear_state_cache is None:
+            return SaveIntent(block_ids_by_group=block_ids_by_group, block_hashes=block_hashes)
+
+        local_saves: list[LocalRecurrentSave] = []
+        for position, block_hash in enumerate(block_hashes):
+            ref = self._linear_state_cache.reserve(block_hash)
+            if ref is None:
+                continue
+            save_ref = LocalSaveRef(req_id, ref.slot, ref.generation, ref.block_hash)
+            self._pending_local_saves[save_ref] = ref
+            self._local_saves_by_req.setdefault(req_id, set()).add(save_ref)
+            sources = tuple(
+                (group_index, block_ids_by_group[group_index][position])
+                for group_index in sorted(self._cache_groups.recurrent_group_indices)
+                if block_ids_by_group[group_index][position] != 0
+            )
+            if len(sources) != len(self._cache_groups.recurrent_group_indices):
+                self._cancel_local_save(save_ref)
+                continue
+            local_saves.append(LocalRecurrentSave(target=ref, source_block_ids=sources))
+
+        remote_groups = tuple(
+            (0,) * len(block_hashes)
+            if index in self._cache_groups.recurrent_group_indices
+            else group
+            for index, group in enumerate(block_ids_by_group)
+        )
         return SaveIntent(
-            block_ids_by_group=save_block_ids_by_group,
-            block_hashes=save_hashes,
+            block_ids_by_group=remote_groups,
+            block_hashes=block_hashes,
+            local_recurrent_saves=tuple(local_saves),
         )
 
     def _local_cached_block_ids(
@@ -831,9 +947,10 @@ class SchedulerConnector:
                 save_block_ids_by_group.append(group[start_block_idx:saveable_block_idx])
 
         self._next_stored_block_idx[req_id] = saveable_block_idx
-        return SaveIntent(
-            block_ids_by_group=tuple(save_block_ids_by_group),
-            block_hashes=block_hashes[start_block_idx:saveable_block_idx],
+        return self._build_hma_save_intent(
+            req_id,
+            tuple(save_block_ids_by_group),
+            block_hashes[start_block_idx:saveable_block_idx],
         )
 
     def _copy_block_ids_by_group(self, block_ids) -> tuple[tuple[int, ...], ...]:
@@ -870,6 +987,18 @@ class SchedulerConnector:
         return tuple(result)
 
     def update_connector_output(self, connector_output: "KVConnectorOutput") -> None:
+        for req_id in getattr(connector_output, "finished_recving", None) or []:
+            ref = self._pending_local_loads.pop(req_id, None)
+            if ref is not None:
+                assert self._linear_state_cache is not None
+                self._linear_state_cache.unpin(ref)
+
+        worker_meta = getattr(connector_output, "kv_connector_worker_meta", None)
+        if worker_meta is not None:
+            if not isinstance(worker_meta, PegaWorkerMetadata):
+                raise TypeError(f"unexpected PegaFlow worker metadata {type(worker_meta)!r}")
+            self._apply_local_save_acks(worker_meta)
+
         for req_id in connector_output.finished_sending or []:
             self._pending_saves.discard(req_id)
             logger.debug("[PegaKVConnector] Request %s save completed", req_id)
@@ -878,6 +1007,50 @@ class SchedulerConnector:
             if req_id in self._held_requests and req_id not in self._deferred_save_intents:
                 self._cleanup_request(req_id)
                 self._held_requests.discard(req_id)
+
+    def _apply_local_save_acks(self, metadata: PegaWorkerMetadata) -> None:
+        for ref, count in metadata.failed.items():
+            if count > 0 and ref in self._pending_local_saves:
+                logger.error(
+                    "[PegaKVConnector] local recurrent save failed: req=%s slot=%d generation=%d",
+                    ref.req_id,
+                    ref.slot,
+                    ref.generation,
+                )
+                self._cancel_local_save(ref)
+
+        for ref, count in metadata.succeeded.items():
+            if ref not in self._pending_local_saves:
+                continue
+            total = self._local_save_ack_counts.get(ref, 0) + count
+            if total > self._ctx.tp_size:
+                raise RuntimeError(
+                    f"duplicate local recurrent ACKs for {ref}: "
+                    f"received={total} expected={self._ctx.tp_size}"
+                )
+            if total == self._ctx.tp_size:
+                assert self._linear_state_cache is not None
+                slot_ref = self._pending_local_saves.pop(ref)
+                self._linear_state_cache.commit(slot_ref)
+                self._forget_local_save(ref)
+            else:
+                self._local_save_ack_counts[ref] = total
+
+    def _cancel_local_save(self, ref: LocalSaveRef) -> None:
+        slot_ref = self._pending_local_saves.pop(ref, None)
+        if slot_ref is not None:
+            assert self._linear_state_cache is not None
+            self._linear_state_cache.cancel(slot_ref)
+        self._forget_local_save(ref)
+
+    def _forget_local_save(self, ref: LocalSaveRef) -> None:
+        self._local_save_ack_counts.pop(ref, None)
+        request_refs = self._local_saves_by_req.get(ref.req_id)
+        if request_refs is None:
+            return
+        request_refs.discard(ref)
+        if not request_refs:
+            self._local_saves_by_req.pop(ref.req_id, None)
 
     def request_finished(
         self,
@@ -922,6 +1095,11 @@ class SchedulerConnector:
         self._next_stored_block_idx.pop(req_id, None)
         self._deferred_save_intents.pop(req_id, None)
         self._pending_saves.discard(req_id)
+        if self._linear_state_cache is not None:
+            # A committed local load remains pinned even if the request aborts;
+            # only finished_recving proves every worker's D2D read is complete.
+            for save_ref in tuple(self._local_saves_by_req.get(req_id, ())):
+                self._cancel_local_save(save_ref)
         self._tail_saved.discard(req_id)
 
     def _count_available_block_prefix(
@@ -986,6 +1164,45 @@ class SchedulerConnector:
         """
         if ready.num_hit_blocks == 0:
             return ready
+        if self._linear_state_cache is not None:
+            usable = tuple(
+                index
+                for index, block_hash in enumerate(block_hashes[: ready.num_hit_blocks])
+                if self._linear_state_cache.lookup(block_hash) is not None
+            )
+            if not usable:
+                self._release_leases(ready.leases, req_id)
+                logger.info(
+                    "[PegaKVConnector] req=%s attention prefix of %d blocks has no "
+                    "committed local recurrent checkpoint; recomputing instead",
+                    req_id,
+                    ready.num_hit_blocks,
+                )
+                return ShardedQueryReady(0, tuple(b"" for _ in ready.leases))
+            checkpoint = max(usable)
+            local_ref = self._linear_state_cache.lookup(block_hashes[checkpoint], pin=True)
+            assert local_ref is not None
+            hybrid_hit = checkpoint + 1
+            if hybrid_hit < ready.num_hit_blocks:
+                exact = self._tp_shard_client.query(
+                    self._ctx.instance_id,
+                    block_hashes[:hybrid_hit],
+                    f"{req_id}:hma-local-exact-{hybrid_hit}",
+                    False,
+                )
+                self._release_leases(ready.leases, req_id)
+                if exact is None or exact.num_hit_blocks != hybrid_hit:
+                    if exact is not None:
+                        self._release_leases(exact.leases, req_id)
+                    self._linear_state_cache.unpin(local_ref)
+                    return ShardedQueryReady(0, tuple(b"" for _ in ready.leases))
+                ready = exact
+            return ShardedQueryReady(
+                hybrid_hit,
+                ready.leases,
+                usable_positions=usable,
+                local_recurrent=local_ref,
+            )
 
         group_ids = tuple(
             self._cache_groups.storage_group_ids[index]
@@ -1108,6 +1325,12 @@ class SchedulerConnector:
     def shutdown(self) -> None:
         for req_id in list(self._pending_query_probes):
             self._release_pending_query_probe(req_id)
+        if self._linear_state_cache is not None:
+            self._pending_local_loads.clear()
+            self._pending_local_saves.clear()
+            self._local_saves_by_req.clear()
+            self._local_save_ack_counts.clear()
+            self._linear_state_cache.clear()
 
     def _release_pending_query_probe(self, req_id: str) -> bool:
         probe = self._pending_query_probes.pop(req_id, None)
@@ -1127,6 +1350,9 @@ class SchedulerConnector:
             for group_index, group_leases in enumerate(hold.leases):
                 if not self._tp_shard_client.release(group_leases, f"{req_id}:g{group_index}"):
                     released = False
+        if probe.local_recurrent is not None:
+            assert self._linear_state_cache is not None
+            self._linear_state_cache.unpin(probe.local_recurrent)
         return released
 
     def _release_leases(self, leases: tuple[bytes, ...], req_id: str) -> bool:

--- a/python/pegaflow/connector/tp_shards.py
+++ b/python/pegaflow/connector/tp_shards.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from pegaflow.connector.common import RecurrentLoadHold, logger
+from pegaflow.connector.linear_state_cache import LinearStateSlot
 from pegaflow.pegaflow import EngineRpcClient, QueryLoading, QueryReady
 
 
@@ -17,6 +18,7 @@ class ShardedQueryReady:
     # recurrent group holds a checkpoint there on every shard, below the
     # attention prefix). Drives boundary re-derivation under token clamps.
     usable_positions: tuple[int, ...] = ()
+    local_recurrent: LinearStateSlot | None = None
 
 
 class TpShardQueryClient:

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -15,8 +15,12 @@ import torch
 from pegaflow.connector.common import (
     CacheGroupLayout,
     ConnectorContext,
+    LocalRecurrentLoad,
+    LocalRecurrentSave,
+    LocalSaveRef,
     PegaConnectorMetadata,
     PegaKVConnectorStats,
+    PegaWorkerMetadata,
     SaveIntent,
     logger,
     parse_env_int,
@@ -60,6 +64,32 @@ class _KVCacheRegistrationInfo:
     kv_stride_bytes: int
     segments: int
     physical_blocks_per_logical_block: int
+
+
+@dataclass
+class _LocalRecurrentLayer:
+    group_index: int
+    pages: torch.Tensor
+    pool: torch.Tensor
+    generations: list[int]
+
+
+def _raw_page_view(tensor: torch.Tensor, page_size_bytes: int) -> torch.Tensor:
+    """Expose a block-first tensor allocation as ``[num_blocks, page_bytes]``."""
+    registration_tensor = _registration_tensor(tensor)
+    actual_page_bytes = registration_tensor.stride(0) * registration_tensor.element_size()
+    if actual_page_bytes != page_size_bytes:
+        raise RuntimeError(
+            "recurrent-state page stride does not match MambaSpec.page_size_bytes: "
+            f"actual={actual_page_bytes} declared={page_size_bytes}"
+        )
+    pages = torch.empty(0, dtype=torch.uint8, device=registration_tensor.device)
+    return pages.set_(
+        registration_tensor.untyped_storage(),
+        registration_tensor.storage_offset() * registration_tensor.element_size(),
+        (registration_tensor.shape[0], page_size_bytes),
+        (page_size_bytes, 1),
+    )
 
 
 def _infer_kv_cache_registration(
@@ -211,6 +241,8 @@ class WorkerConnector:
         self._completed_saves: set[str] = set()
         self._save_completion_lock = threading.Lock()
         self._save_completion_events: dict[str, threading.Event] = {}
+        self._worker_meta = PegaWorkerMetadata()
+        self._worker_meta_lock = threading.Lock()
         self._current_metadata: PegaConnectorMetadata | None = None
 
         self._pending_loads: dict[str, PyLoadState] = {}
@@ -218,6 +250,8 @@ class WorkerConnector:
         self._pending_load_meta: dict[
             str, tuple[float, int, list[int]]
         ] = {}  # shm_name -> (start_time, num_blocks, block_ids)
+        self._pending_local_load_events: dict[str, torch.cuda.Event] = {}
+        self._remote_load_completed: set[str] = set()
         self._load_completion_lock = threading.Lock()
 
         # Failure surface for vLLM's get_block_ids_with_load_errors / get_finished.
@@ -228,6 +262,7 @@ class WorkerConnector:
         self._failed_load_reqs: set[str] = set()
 
         self._registered_layers: list[str] = []
+        self._local_recurrent_layers: dict[str, _LocalRecurrentLayer] = {}
         # Page-first storage: all layers of a block in one host page, one slot
         # per tp_rank. Saves distribute by block stripe instead of by layer.
         self._page_first: bool = False
@@ -243,9 +278,15 @@ class WorkerConnector:
         self._stats_lock = threading.Lock()
 
     def shutdown(self) -> None:
-        self.unregister_context()
         self._save_queue.put(None)
         self._save_thread.join()
+        if self._pending_local_load_events:
+            torch.cuda.synchronize(self._torch_device)
+            self._pending_local_load_events.clear()
+        with self._worker_meta_lock:
+            self._worker_meta = PegaWorkerMetadata()
+        self.unregister_context()
+        self._local_recurrent_layers.clear()
 
     def unregister_context(self) -> None:
         if not self._registered_layers:
@@ -319,6 +360,14 @@ class WorkerConnector:
         split_layer_count = 0
         split_blocks_per_logical = 1
         split_logical_blocks = 0
+        local_mode = bool(self._ctx.linear_state_cache_size_bytes)
+        local_slots = (
+            self._ctx.linear_state_cache_size_bytes
+            // self._cache_groups.recurrent_compound_page_bytes
+            if local_mode
+            else 0
+        )
+        groups = tuple(getattr(self._kv_cache_config, "kv_cache_groups", ()) or ())
 
         for layer_name, kv_cache in kv_caches.items():
             is_recurrent_state = (
@@ -329,6 +378,32 @@ class WorkerConnector:
             assert registration_tensor.storage_offset() == 0, (
                 f"KV cache for {layer_name} must have zero storage offset"
             )
+            if local_mode and is_recurrent_state:
+                group_index = self._layer_to_group[layer_name]
+                page_size_bytes = int(groups[group_index].kv_cache_spec.page_size_bytes)
+                pages = _raw_page_view(kv_cache, page_size_bytes)
+                pool = None
+                try:
+                    pool = torch.empty(
+                        (local_slots, page_size_bytes),
+                        dtype=torch.uint8,
+                        device=registration_tensor.device,
+                    )
+                except torch.OutOfMemoryError as exc:
+                    self._local_recurrent_layers.clear()
+                    torch.cuda.empty_cache()
+                    raise RuntimeError(
+                        "failed to allocate connector-owned linear-state GPU pool; "
+                        "pegaflow.linear_state_cache_size_bytes is additional memory "
+                        "outside vLLM KV-cache planning"
+                    ) from exc
+                self._local_recurrent_layers[layer_name] = _LocalRecurrentLayer(
+                    group_index=group_index,
+                    pages=pages,
+                    pool=pool,
+                    generations=[0] * local_slots,
+                )
+                continue
 
             wrapper = CudaIPCWrapper(registration_tensor)
             wrapper_bytes = pickle.dumps(wrapper)
@@ -516,8 +591,18 @@ class WorkerConnector:
                 completed_reqs.update(self._failed_load_reqs)
                 self._failed_load_reqs = set()
 
-            if completed_reqs:
-                finished_recving = completed_reqs
+            self._remote_load_completed.update(completed_reqs)
+            jointly_completed = {
+                req_id
+                for req_id in self._remote_load_completed
+                if req_id not in self._pending_local_load_events
+                or self._pending_local_load_events[req_id].query()
+            }
+            for req_id in jointly_completed:
+                self._pending_local_load_events.pop(req_id, None)
+            self._remote_load_completed -= jointly_completed
+            if jointly_completed:
+                finished_recving = jointly_completed
 
         if timeout_triggered:
             self._ctx.state_manager.mark_unavailable("load timeout")
@@ -570,6 +655,8 @@ class WorkerConnector:
         request_ids: list[str] = []
 
         for req_id, load_intent in metadata.load_intents.items():
+            if load_intent.local_recurrent is not None:
+                self._start_local_recurrent_load(req_id, load_intent.local_recurrent)
             if len(load_intent.leases) != self._ctx.tp_shard_count:
                 raise RuntimeError(
                     f"load intent has {len(load_intent.leases)} TP shard leases; "
@@ -709,6 +796,51 @@ class WorkerConnector:
             shm_name,
         )
 
+    def _start_local_recurrent_load(self, req_id: str, intent: LocalRecurrentLoad) -> None:
+        if not self._local_recurrent_layers:
+            raise RuntimeError("local recurrent load requested before GPU pool registration")
+        destinations = dict(intent.destination_block_ids)
+        for layer_name, layer in self._local_recurrent_layers.items():
+            ref = intent.source
+            if ref.slot < 0 or ref.slot >= layer.pool.shape[0]:
+                raise RuntimeError(f"req {req_id}: local recurrent slot {ref.slot} is out of range")
+            if layer.generations[ref.slot] != ref.generation:
+                raise RuntimeError(
+                    f"req {req_id}: stale local recurrent slot {ref.slot}/{ref.generation} "
+                    f"for layer {layer_name}; worker has generation {layer.generations[ref.slot]}"
+                )
+            destination = destinations.get(layer.group_index)
+            if destination is None or destination < 0 or destination >= layer.pages.shape[0]:
+                raise RuntimeError(
+                    f"req {req_id}: recurrent destination {destination} is out of range "
+                    f"for layer {layer_name}"
+                )
+            layer.pages[destination].copy_(layer.pool[ref.slot], non_blocking=True)
+        event = torch.cuda.Event()
+        event.record()
+        self._pending_local_load_events[req_id] = event
+
+    def _save_local_recurrent(self, save: LocalRecurrentSave) -> None:
+        if not self._local_recurrent_layers:
+            raise RuntimeError("local recurrent save requested before GPU pool registration")
+        sources = dict(save.source_block_ids)
+        for layer_name, layer in self._local_recurrent_layers.items():
+            ref = save.target
+            if ref.slot < 0 or ref.slot >= layer.pool.shape[0]:
+                raise RuntimeError(f"local recurrent slot {ref.slot} is out of range")
+            if ref.generation <= layer.generations[ref.slot]:
+                raise RuntimeError(
+                    f"stale local recurrent save {ref.slot}/{ref.generation} for layer "
+                    f"{layer_name}; worker has generation {layer.generations[ref.slot]}"
+                )
+            source = sources.get(layer.group_index)
+            if source is None or source < 0 or source >= layer.pages.shape[0]:
+                raise RuntimeError(
+                    f"recurrent source {source} is out of range for layer {layer_name}"
+                )
+            layer.pool[ref.slot].copy_(layer.pages[source], non_blocking=True)
+            layer.generations[ref.slot] = ref.generation
+
     def wait_for_layer_load(self, layer_name: str) -> None:
         pass
 
@@ -824,13 +956,31 @@ class WorkerConnector:
         logger.debug("[PegaKVConnector] Save worker thread stopped")
 
     def _process_save_batch(self, batch: list[SaveTask]) -> None:
+        request_ids = [req_id for task in batch for req_id in task.request_ids]
+        local_refs = [
+            LocalSaveRef.from_save(req_id, save)
+            for task in batch
+            for req_id, intent in task.metadata.save_intents.items()
+            for save in intent.local_recurrent_saves
+        ]
+        try:
+            self._process_save_batch_inner(batch)
+        except Exception:
+            logger.exception("[PegaKVConnector] local/remote save batch failed")
+            self._record_local_save_results(failed=local_refs)
+        finally:
+            self._complete_save_requests(request_ids)
+
+    def _process_save_batch_inner(self, batch: list[SaveTask]) -> None:
         saves_by_layer: dict[str, tuple[list[int], list[bytes]]] = {}
-        all_request_ids: list[str] = []
+        local_saves: list[tuple[LocalSaveRef, LocalRecurrentSave]] = []
 
         for task in batch:
-            all_request_ids.extend(task.request_ids)
-
-            for save_intent in task.metadata.save_intents.values():
+            for req_id, save_intent in task.metadata.save_intents.items():
+                local_saves.extend(
+                    (LocalSaveRef.from_save(req_id, save), save)
+                    for save in save_intent.local_recurrent_saves
+                )
                 if not any(save_intent.block_ids_by_group):
                     continue
 
@@ -882,11 +1032,18 @@ class WorkerConnector:
                     saves_by_layer[layer_name][0].extend(block_ids)
                     saves_by_layer[layer_name][1].extend(block_hashes)
 
-        if saves_by_layer:
-            # Ensure all GPU kernels have completed before reading KV cache
-            # Otherwise we may copy uninitialized memory (attention kernel is async)
+        if saves_by_layer or local_saves:
+            # Recurrent source blocks can be reused immediately after this
+            # callback, so both remote D2H submission and local D2D copies share
+            # one forward-completion barrier.
             torch.cuda.synchronize(self._torch_device)
+        for _ref, save in local_saves:
+            self._save_local_recurrent(save)
+        if local_saves:
+            torch.cuda.synchronize(self._torch_device)
+            self._record_local_save_results(succeeded=[ref for ref, _save in local_saves])
 
+        if saves_by_layer:
             saves_list = [(name, ids, hashes) for name, (ids, hashes) in saves_by_layer.items()]
             total_blocks = sum(len(ids) for _, ids, _ in saves_list)
 
@@ -925,8 +1082,25 @@ class WorkerConnector:
             with self._stats_lock:
                 self._stats.record_save(save_duration, total_blocks, success)
 
-        # Always complete the request save lifecycle, even if save failed.
-        self._complete_save_requests(all_request_ids)
+    def _record_local_save_results(
+        self,
+        *,
+        succeeded: Iterable[LocalSaveRef] = (),
+        failed: Iterable[LocalSaveRef] = (),
+    ) -> None:
+        with self._worker_meta_lock:
+            for ref in succeeded:
+                self._worker_meta.succeeded[ref] = 1
+            for ref in failed:
+                self._worker_meta.failed[ref] = 1
+
+    def build_connector_worker_meta(self) -> PegaWorkerMetadata | None:
+        with self._worker_meta_lock:
+            if not self._worker_meta.succeeded and not self._worker_meta.failed:
+                return None
+            metadata = self._worker_meta
+            self._worker_meta = PegaWorkerMetadata()
+            return metadata
 
     def _complete_save_requests(self, request_ids: list[str]) -> None:
         completed_reqs: list[str] = []

--- a/python/tests/test_cache_group_layout.py
+++ b/python/tests/test_cache_group_layout.py
@@ -35,10 +35,11 @@ def _full_attention(block_size=16):
     return spec
 
 
-def _mamba(block_size=16, mode="align"):
+def _mamba(block_size=16, mode="align", page_size_bytes=1024):
     spec = MambaSpec()
     spec.block_size = block_size
     spec.mamba_cache_mode = mode
+    spec.page_size_bytes = page_size_bytes
     return spec
 
 

--- a/python/tests/test_connector_fault_tolerance.py
+++ b/python/tests/test_connector_fault_tolerance.py
@@ -23,7 +23,7 @@ from .unit_stubs import install_connector_unit_stubs
 
 install_connector_unit_stubs()
 
-from vllm.v1.kv_cache_interface import FullAttentionSpec  # noqa: E402
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec  # noqa: E402
 
 from pegaflow.connector.common import (  # noqa: E402
     ConnectorContext,
@@ -527,4 +527,56 @@ def test_register_version_mismatch_rpc_error_stops_startup(monkeypatch):
     assert "server=0.22.5" in str(exc_info.value)
     assert len(client.register_calls) == 1
 
+    worker.shutdown()
+
+
+def test_local_recurrent_pool_oom_is_explicit_and_cleans_partial_state(monkeypatch):
+    recurrent = MambaSpec()
+    recurrent.block_size = 16
+    recurrent.mamba_cache_mode = "align"
+    recurrent.page_size_bytes = 32
+    recurrent_2 = MambaSpec()
+    recurrent_2.block_size = 16
+    recurrent_2.mamba_cache_mode = "align"
+    recurrent_2.page_size_bytes = 32
+    attention = FullAttentionSpec()
+    attention.block_size = 16
+    kv_cache_config = MagicMock(
+        kv_cache_groups=(
+            MagicMock(layer_names=("recurrent",), kv_cache_spec=recurrent),
+            MagicMock(layer_names=("recurrent_2",), kv_cache_spec=recurrent_2),
+            MagicMock(layer_names=("attention",), kv_cache_spec=attention),
+        )
+    )
+    worker, client, _ = _make_worker(
+        kv_cache_config=kv_cache_config,
+        linear_state_cache_size_bytes=64,
+    )
+    monkeypatch.setattr(
+        "pegaflow.connector.worker._raw_page_view",
+        lambda _tensor, _page_bytes: object(),
+    )
+    monkeypatch.setattr(
+        "pegaflow.connector.worker.torch.empty",
+        MagicMock(side_effect=[object(), __import__("torch").OutOfMemoryError("oom")]),
+        raising=False,
+    )
+    empty_cache = MagicMock()
+    monkeypatch.setattr(
+        "pegaflow.connector.worker.torch.cuda.empty_cache",
+        empty_cache,
+    )
+
+    with pytest.raises(RuntimeError, match="outside vLLM KV-cache planning"):
+        worker.register_kv_caches(
+            {
+                "recurrent": FakeTensor(),
+                "recurrent_2": FakeTensor(),
+                "attention": FakeTensor(),
+            }
+        )
+
+    assert worker._local_recurrent_layers == {}
+    assert client.register_calls == []
+    empty_cache.assert_called_once()
     worker.shutdown()

--- a/python/tests/test_connector_save_lifecycle.py
+++ b/python/tests/test_connector_save_lifecycle.py
@@ -10,13 +10,16 @@ install_connector_unit_stubs()
 
 from pegaflow.connector.common import (  # noqa: E402
     ConnectorContext,
+    LocalRecurrentSave,
+    LocalSaveRef,
     PegaConnectorMetadata,
     SaveIntent,
 )
+from pegaflow.connector.linear_state_cache import LinearStateSlot  # noqa: E402
 from pegaflow.connector.worker import WorkerConnector  # noqa: E402
 
 
-def make_worker() -> WorkerConnector:
+def make_worker(linear_state_cache_size_bytes: int = 0) -> WorkerConnector:
     context = ConnectorContext(
         instance_id="test",
         namespace="test",
@@ -27,6 +30,7 @@ def make_worker() -> WorkerConnector:
         device_id=0,
         engine_client=MagicMock(),
         state_manager=MagicMock(),
+        linear_state_cache_size_bytes=linear_state_cache_size_bytes,
     )
     with patch("pegaflow.connector.worker.threading.Thread.start"):
         return WorkerConnector(
@@ -189,3 +193,76 @@ def test_preemption_waits_for_every_save_task():
             preemption_thread.join(timeout=1)
 
     assert not preemption_thread.is_alive()
+
+
+def _local_save_intent(req_id: str = "request"):
+    ref = LocalSaveRef(req_id, 0, 1, b"checkpoint")
+    save = LocalRecurrentSave(
+        target=LinearStateSlot(ref.slot, ref.generation, ref.block_hash),
+        source_block_ids=((1, 2),),
+    )
+    return ref, SaveIntent(
+        block_ids_by_group=((), ()),
+        block_hashes=(ref.block_hash,),
+        local_recurrent_saves=(save,),
+    )
+
+
+def test_running_local_save_ack_does_not_enter_finished_sending():
+    worker = make_worker(linear_state_cache_size_bytes=1024)
+    worker._cache_groups = SimpleNamespace(has_recurrent_state=True)
+    ref, intent = _local_save_intent()
+    worker._current_metadata = PegaConnectorMetadata(save_intents={"request": intent})
+
+    with (
+        patch("torch.cuda.synchronize"),
+        patch.object(worker, "_save_local_recurrent"),
+    ):
+        worker.wait_for_save()
+
+    finished_sending, _ = worker.get_finished(set())
+    metadata = worker.build_connector_worker_meta()
+    assert finished_sending is None
+    assert metadata is not None
+    assert metadata.succeeded == {ref: 1}
+    assert metadata.failed == {}
+
+
+def test_local_d2d_failure_acks_failure_and_reaches_request_terminal_state():
+    worker = make_worker(linear_state_cache_size_bytes=1024)
+    worker._cache_groups = SimpleNamespace(has_recurrent_state=True)
+    ref, intent = _local_save_intent()
+    worker._current_metadata = PegaConnectorMetadata(save_intents={"request": intent})
+
+    with (
+        patch("torch.cuda.synchronize"),
+        patch.object(worker, "_save_local_recurrent", side_effect=RuntimeError("copy failed")),
+    ):
+        worker.wait_for_save()
+
+    metadata = worker.build_connector_worker_meta()
+    assert metadata is not None
+    assert metadata.failed == {ref: 1}
+    assert "request" not in worker._req_pending_save_tasks
+    worker.handle_preemptions({"request"})
+    finished_sending, _ = worker.get_finished({"request"})
+    assert finished_sending == {"request"}
+
+
+def test_local_sync_failure_acks_failure_and_unblocks_preemption():
+    worker = make_worker(linear_state_cache_size_bytes=1024)
+    worker._cache_groups = SimpleNamespace(has_recurrent_state=True)
+    ref, intent = _local_save_intent()
+    worker._current_metadata = PegaConnectorMetadata(save_intents={"request": intent})
+
+    with (
+        patch("torch.cuda.synchronize", side_effect=RuntimeError("sync failed")),
+        patch.object(worker, "_save_local_recurrent"),
+    ):
+        worker.wait_for_save()
+
+    metadata = worker.build_connector_worker_meta()
+    assert metadata is not None
+    assert metadata.failed == {ref: 1}
+    assert "request" not in worker._req_pending_save_tasks
+    worker.handle_preemptions({"request"})

--- a/python/tests/test_hybrid_reconcile.py
+++ b/python/tests/test_hybrid_reconcile.py
@@ -12,14 +12,29 @@ Pure-function contract covering the scheduler-side hit derivation:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
 from .unit_stubs import install_connector_unit_stubs
 
 install_connector_unit_stubs()
 
+from vllm.distributed.kv_transfer.kv_connector.utils import (  # noqa: E402
+    KVOutputAggregator,
+)
+from vllm.v1.outputs import KVConnectorOutput, ModelRunnerOutput  # noqa: E402
+
 from pegaflow.connector.common import (  # noqa: E402
     CacheGroupLayout,
+    ConnectorContext,
+    LocalSaveRef,
+    PegaWorkerMetadata,
     reconcile_hybrid_hit,
 )
+from pegaflow.connector.scheduler import SchedulerConnector  # noqa: E402
+from pegaflow.connector.tp_shards import ShardedQueryReady  # noqa: E402
 
 from .test_cache_group_layout import (  # noqa: E402
     _config,
@@ -126,3 +141,148 @@ class TestStorageGroupIds:
         layout = CacheGroupLayout.from_config(config)
         assert layout.storage_group_ids == (0, 1, 2)
         assert layout.recurrent_group_indices == frozenset({1, 2})
+
+
+def _local_scheduler(tp_size: int = 1) -> SchedulerConnector:
+    config = _config(
+        _group("attention", _full_attention()),
+        _group("recurrent", _mamba(page_size_bytes=1024)),
+    )
+    context = ConnectorContext(
+        instance_id="test",
+        namespace="ns",
+        block_size=16,
+        tp_size=tp_size,
+        world_size=tp_size,
+        tp_rank=0,
+        device_id=0,
+        engine_client=MagicMock(),
+        state_manager=MagicMock(),
+        linear_state_cache_size_bytes=2048,
+    )
+    return SchedulerConnector(context, kv_cache_config=config)
+
+
+def _commit_hash(scheduler: SchedulerConnector, block_hash: bytes):
+    assert scheduler._linear_state_cache is not None
+    ref = scheduler._linear_state_cache.reserve(block_hash)
+    assert ref is not None
+    scheduler._linear_state_cache.commit(ref)
+    return ref
+
+
+def test_local_recurrent_reconcile_uses_rightmost_checkpoint_inside_remote_prefix():
+    scheduler = _local_scheduler()
+    hashes = [b"h0", b"h1", b"h2"]
+    _commit_hash(scheduler, hashes[0])
+    rightmost = _commit_hash(scheduler, hashes[2])
+    scheduler._tp_shard_client = MagicMock()
+
+    result = scheduler._reconcile_hybrid(
+        hashes,
+        ShardedQueryReady(3, (b"remote-lease",)),
+        "req",
+    )
+
+    assert result.num_hit_blocks == 3
+    assert result.local_recurrent == rightmost
+    assert result.usable_positions == (0, 2)
+    scheduler._tp_shard_client.query_group_membership.assert_not_called()
+
+
+def test_remote_attention_hit_without_local_recurrent_checkpoint_is_a_miss():
+    scheduler = _local_scheduler()
+    scheduler._tp_shard_client = MagicMock()
+
+    result = scheduler._reconcile_hybrid(
+        [b"h0", b"h1"],
+        ShardedQueryReady(2, (b"remote-lease",)),
+        "req",
+    )
+
+    assert result.num_hit_blocks == 0
+    scheduler._tp_shard_client.release.assert_called_once_with((b"remote-lease",), "req")
+
+
+def _worker_output(metadata: PegaWorkerMetadata) -> ModelRunnerOutput:
+    return ModelRunnerOutput(
+        kv_connector_output=KVConnectorOutput(kv_connector_worker_meta=metadata)
+    )
+
+
+def test_tp2_interleaved_local_save_acks_commit_only_matching_refs():
+    scheduler = _local_scheduler(tp_size=2)
+    assert scheduler._linear_state_cache is not None
+    first = scheduler._build_hma_save_intent(
+        "req", ((11,), (21,)), (b"checkpoint-1",)
+    ).local_recurrent_saves[0]
+    second = scheduler._build_hma_save_intent(
+        "req", ((12,), (22,)), (b"checkpoint-2",)
+    ).local_recurrent_saves[0]
+    first_ref = LocalSaveRef.from_save("req", first)
+    second_ref = LocalSaveRef.from_save("req", second)
+    aggregator = KVOutputAggregator(expected_finished_count=2)
+
+    interleaved = aggregator.aggregate(
+        [
+            _worker_output(PegaWorkerMetadata(succeeded={first_ref: 1})),
+            _worker_output(PegaWorkerMetadata(succeeded={second_ref: 1})),
+        ]
+    ).kv_connector_output
+    assert interleaved is not None
+    assert interleaved.finished_sending is None
+    scheduler.update_connector_output(interleaved)
+    assert scheduler._linear_state_cache.lookup(b"checkpoint-1") is None
+    assert scheduler._linear_state_cache.lookup(b"checkpoint-2") is None
+
+    matched = aggregator.aggregate(
+        [
+            _worker_output(PegaWorkerMetadata(succeeded={second_ref: 1})),
+            _worker_output(PegaWorkerMetadata(succeeded={first_ref: 1})),
+        ]
+    ).kv_connector_output
+    assert matched is not None
+    assert matched.finished_sending is None
+    scheduler.update_connector_output(matched)
+    assert scheduler._linear_state_cache.lookup(b"checkpoint-1") == first.target
+    assert scheduler._linear_state_cache.lookup(b"checkpoint-2") == second.target
+
+
+def test_local_save_failure_ack_cancels_exact_reservation():
+    scheduler = _local_scheduler()
+    assert scheduler._linear_state_cache is not None
+    save = scheduler._build_hma_save_intent(
+        "req", ((11,), (21,)), (b"failed-checkpoint",)
+    ).local_recurrent_saves[0]
+    ref = LocalSaveRef.from_save("req", save)
+    other = scheduler._build_hma_save_intent(
+        "req", ((12,), (22,)), (b"other-checkpoint",)
+    ).local_recurrent_saves[0]
+    other_ref = LocalSaveRef.from_save("req", other)
+
+    scheduler.update_connector_output(
+        KVConnectorOutput(kv_connector_worker_meta=PegaWorkerMetadata(failed={ref: 1}))
+    )
+
+    assert ref not in scheduler._pending_local_saves
+    assert other_ref in scheduler._pending_local_saves
+    assert scheduler._linear_state_cache.lookup(ref.block_hash) is None
+    replacement = scheduler._linear_state_cache.reserve(b"replacement")
+    assert replacement is not None
+
+
+def test_metadata_construction_exception_rolls_back_new_reservations(monkeypatch):
+    scheduler = _local_scheduler()
+    assert scheduler._linear_state_cache is not None
+
+    def fail_after_reserve(_scheduler_output):
+        scheduler._build_hma_save_intent("req", ((11,), (21,)), (b"unpublished",))
+        raise RuntimeError("metadata failed")
+
+    monkeypatch.setattr(scheduler, "_build_connector_meta", fail_after_reserve)
+    with pytest.raises(RuntimeError, match="metadata failed"):
+        scheduler.build_connector_meta(SimpleNamespace())
+
+    assert scheduler._pending_local_saves == {}
+    assert scheduler._local_saves_by_req == {}
+    assert scheduler._linear_state_cache.lookup(b"unpublished") is None

--- a/python/tests/test_linear_state_cache.py
+++ b/python/tests/test_linear_state_cache.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import pytest
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from pegaflow.connector.linear_state_cache import LinearStateCache  # noqa: E402
+
+
+def test_reservations_are_invisible_until_committed():
+    cache = LinearStateCache(1)
+    ref = cache.reserve(b"a")
+
+    assert ref is not None
+    assert cache.lookup(b"a") is None
+
+    cache.commit(ref)
+    assert cache.lookup(b"a") == ref
+
+
+def test_lru_evicts_oldest_unpinned_entry():
+    cache = LinearStateCache(2)
+    a = cache.reserve(b"a")
+    b = cache.reserve(b"b")
+    assert a is not None and b is not None
+    cache.commit(a)
+    cache.commit(b)
+    cache.lookup(b"a")
+
+    c = cache.reserve(b"c")
+    assert c is not None
+    cache.commit(c)
+
+    assert cache.lookup(b"a") == a
+    assert cache.lookup(b"b") is None
+    assert cache.lookup(b"c") == c
+
+
+def test_pinned_and_reserved_slots_are_not_reused():
+    cache = LinearStateCache(2)
+    a = cache.reserve(b"a")
+    b = cache.reserve(b"b")
+    assert a is not None and b is not None
+    cache.commit(a)
+    cache.commit(b)
+    assert cache.lookup(b"a", pin=True) == a
+    assert cache.lookup(b"b", pin=True) == b
+
+    assert cache.reserve(b"c") is None
+    cache.unpin(a)
+    c = cache.reserve(b"c")
+    assert c is not None
+    assert cache.reserve(b"d") is None
+
+
+def test_generation_rejects_stale_reference_after_reuse():
+    cache = LinearStateCache(1)
+    first = cache.reserve(b"first")
+    assert first is not None
+    cache.commit(first)
+    second = cache.reserve(b"second")
+    assert second is not None
+    cache.commit(second)
+
+    assert second.slot == first.slot
+    assert second.generation == first.generation + 1
+    with pytest.raises(RuntimeError, match="stale"):
+        cache.unpin(first)
+
+
+def test_duplicate_hash_touches_without_overwrite():
+    cache = LinearStateCache(2)
+    a = cache.reserve(b"a")
+    b = cache.reserve(b"b")
+    assert a is not None and b is not None
+    cache.commit(a)
+    cache.commit(b)
+
+    assert cache.reserve(b"a") is None
+    c = cache.reserve(b"c")
+    assert c is not None
+    cache.commit(c)
+    assert cache.lookup(b"a") == a
+    assert cache.lookup(b"b") is None
+
+
+def test_cancel_and_clear_remove_unpublished_state():
+    cache = LinearStateCache(1)
+    ref = cache.reserve(b"a")
+    assert ref is not None
+    cache.cancel(ref)
+    replacement = cache.reserve(b"b")
+    assert replacement is not None
+    cache.commit(replacement)
+
+    cache.clear()
+    assert cache.lookup(b"b") is None
+    assert cache.reserve(b"c") is not None

--- a/python/tests/test_tp_shards.py
+++ b/python/tests/test_tp_shards.py
@@ -14,6 +14,7 @@ install_connector_unit_stubs()
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (  # noqa: E402
     KVConnectorRole,
 )
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec  # noqa: E402
 
 from pegaflow.connector import PegaKVConnector  # noqa: E402
 from pegaflow.connector.common import (  # noqa: E402
@@ -53,12 +54,13 @@ def _context(**kwargs) -> ConnectorContext:
     return ConnectorContext(**defaults)  # type: ignore[arg-type]
 
 
-def _vllm_config(**parallel_overrides):
+def _vllm_config(extra_config_overrides=None, **parallel_overrides):
     extra_config = {
         "pegaflow.tp_shard_endpoints": [
             "http://node-a:50055",
             "http://node-b:50055",
-        ]
+        ],
+        **(extra_config_overrides or {}),
     }
     kv_transfer_config = SimpleNamespace(
         engine_id="instance",
@@ -351,3 +353,30 @@ def test_each_tp_shard_has_a_local_unregister_leader():
             engine_client.unregister_context.assert_called_once_with("instance")
         else:
             engine_client.unregister_context.assert_not_called()
+
+
+def test_linear_state_cache_rejects_pipeline_parallelism(monkeypatch):
+    attention = FullAttentionSpec()
+    attention.block_size = 16
+    recurrent = MambaSpec()
+    recurrent.block_size = 16
+    recurrent.mamba_cache_mode = "align"
+    recurrent.page_size_bytes = 1024
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=(
+            SimpleNamespace(layer_names=("attention",), kv_cache_spec=attention),
+            SimpleNamespace(layer_names=("recurrent",), kv_cache_spec=recurrent),
+        )
+    )
+    monkeypatch.setattr("pegaflow.connector.EngineRpcClient", MagicMock())
+
+    with pytest.raises(ValueError, match="supports TP-only parallelism"):
+        PegaKVConnector(
+            _vllm_config(
+                {"pegaflow.linear_state_cache_size_bytes": 2048},
+                pipeline_parallel_size=2,
+                world_size=16,
+            ),
+            KVConnectorRole.SCHEDULER,
+            kv_cache_config,
+        )

--- a/python/tests/test_worker_kv_layout.py
+++ b/python/tests/test_worker_kv_layout.py
@@ -8,7 +8,12 @@ from .unit_stubs import install_connector_unit_stubs
 
 install_connector_unit_stubs()
 
-from pegaflow.connector.worker import _infer_kv_cache_registration  # noqa: E402
+from pegaflow.connector.common import LocalRecurrentLoad, LocalRecurrentSave  # noqa: E402
+from pegaflow.connector.linear_state_cache import LinearStateSlot  # noqa: E402
+from pegaflow.connector.worker import (  # noqa: E402
+    WorkerConnector,
+    _infer_kv_cache_registration,
+)
 
 
 class FakeTensor:
@@ -215,3 +220,71 @@ def test_bytes_per_block_must_be_nonzero():
             logical_block_size=128,
             is_mla=True,
         )
+
+
+class _Page:
+    def __init__(self, value: bytes):
+        self.value = value
+
+    def copy_(self, other: _Page, non_blocking: bool = False):
+        assert non_blocking
+        self.value = other.value
+
+
+class _Pages:
+    def __init__(self, *values: bytes):
+        self.rows = [_Page(value) for value in values]
+        self.shape = (len(values), len(values[0]))
+
+    def __getitem__(self, index: int) -> _Page:
+        return self.rows[index]
+
+
+def _local_worker_for_copy():
+    worker = WorkerConnector.__new__(WorkerConnector)
+    worker._local_recurrent_layers = {
+        "recurrent": type(
+            "Layer",
+            (),
+            {
+                "group_index": 1,
+                "pages": _Pages(b"src0", b"src1", b"empty"),
+                "pool": _Pages(b"pool0", b"pool1"),
+                "generations": [1, 0],
+            },
+        )()
+    }
+    worker._pending_local_load_events = {}
+    return worker
+
+
+def test_local_recurrent_save_copies_full_page_and_advances_generation():
+    worker = _local_worker_for_copy()
+    ref = LinearStateSlot(slot=1, generation=2, block_hash=b"hash")
+
+    worker._save_local_recurrent(LocalRecurrentSave(target=ref, source_block_ids=((1, 1),)))
+
+    layer = worker._local_recurrent_layers["recurrent"]
+    assert layer.pool[0].value == b"pool0"
+    assert layer.pool[1].value == b"src1"
+    assert layer.generations == [1, 2]
+
+
+def test_local_recurrent_load_rejects_stale_generation(monkeypatch):
+    worker = _local_worker_for_copy()
+    monkeypatch.setattr(
+        "pegaflow.connector.worker.torch.cuda.Event",
+        lambda: type("Event", (), {"record": lambda self: None})(),
+        raising=False,
+    )
+
+    with pytest.raises(RuntimeError, match="stale local recurrent slot"):
+        worker._start_local_recurrent_load(
+            "req",
+            LocalRecurrentLoad(
+                source=LinearStateSlot(slot=0, generation=2, block_hash=b"hash"),
+                destination_block_ids=((1, 2),),
+            ),
+        )
+
+    assert worker._local_recurrent_layers["recurrent"].pages[2].value == b"empty"

--- a/python/tests/unit_stubs.py
+++ b/python/tests/unit_stubs.py
@@ -58,9 +58,11 @@ def _install_torch_stub() -> None:
     torch.cuda = _Cuda()  # type: ignore[attr-defined]
     torch.random = _Random()  # type: ignore[attr-defined]
     torch.Tensor = object  # type: ignore[attr-defined]
+    torch.OutOfMemoryError = type("OutOfMemoryError", (RuntimeError,), {})  # type: ignore[attr-defined]
     torch.dtype = object  # type: ignore[attr-defined]
     torch.device = lambda value: value  # type: ignore[attr-defined]
     torch.bfloat16 = "bfloat16"  # type: ignore[attr-defined]
+    torch.uint8 = "uint8"  # type: ignore[attr-defined]
     sys.modules["torch"] = torch
 
 
@@ -98,6 +100,69 @@ def _install_vllm_stubs() -> None:
     base.KVConnectorMetadata = KVConnectorMetadata
     base.KVConnectorWorkerMetadata = KVConnectorWorkerMetadata
     base.SupportsHMA = SupportsHMA
+
+    outputs = _ensure_module("vllm.v1.outputs")
+
+    @dataclass
+    class KVConnectorOutput:
+        finished_sending: set[str] | None = None
+        finished_recving: set[str] | None = None
+        kv_connector_stats: object | None = None
+        kv_cache_events: object | None = None
+        kv_connector_worker_meta: object | None = None
+        invalid_block_ids: set[int] = field(default_factory=set)
+        expected_finished_count: int = 0
+
+    @dataclass
+    class ModelRunnerOutput:
+        kv_connector_output: KVConnectorOutput | None = None
+
+    outputs.KVConnectorOutput = KVConnectorOutput
+    outputs.ModelRunnerOutput = ModelRunnerOutput
+
+    connector_utils = _ensure_module("vllm.distributed.kv_transfer.kv_connector.utils")
+
+    class KVOutputAggregator:
+        def __init__(self, expected_finished_count: int):
+            self._expected_finished_count = expected_finished_count
+            self._send_remaining_count: dict[str, int] = {}
+            self._recv_remaining_count: dict[str, int] = {}
+
+        def aggregate(self, model_outputs, output_rank: int = 0):
+            output = model_outputs[output_rank]
+            assert output is not None
+            worker_meta = None
+            finished_sending: set[str] = set()
+            finished_recving: set[str] = set()
+
+            def update(req_ids, counts, finished):
+                for req_id in req_ids or ():
+                    counts[req_id] = counts.get(req_id, self._expected_finished_count) - 1
+                    if counts[req_id] == 0:
+                        finished.add(req_id)
+                        del counts[req_id]
+
+            for model_output in model_outputs:
+                assert model_output is not None
+                kv_output = model_output.kv_connector_output
+                if kv_output is None:
+                    continue
+                update(kv_output.finished_sending, self._send_remaining_count, finished_sending)
+                update(kv_output.finished_recving, self._recv_remaining_count, finished_recving)
+                if worker_meta is None:
+                    worker_meta = kv_output.kv_connector_worker_meta
+                elif kv_output.kv_connector_worker_meta is not None:
+                    worker_meta = worker_meta.aggregate(kv_output.kv_connector_worker_meta)
+
+            output.kv_connector_output = KVConnectorOutput(
+                finished_sending=finished_sending or None,
+                finished_recving=finished_recving or None,
+                kv_connector_worker_meta=worker_meta,
+                expected_finished_count=self._expected_finished_count,
+            )
+            return output
+
+    connector_utils.KVOutputAggregator = KVOutputAggregator
 
     metrics = _ensure_module("vllm.distributed.kv_transfer.kv_connector.v1.metrics")
 


### PR DESCRIPTION
The idea is to create a small mamba state pool backed by HBM so that pegaflow can focus on MLA cache.

The pool should work as long as the number of slots is larger than the number of on-going sessions, which is less than 100 for a prefill node so that the total size of the pool is around 50GB.