### PR TITLE
fix(connector): keep full-block save intents inside the resumed block table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "colored",
  "libc",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "axum",
  "clap",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-pd-wire"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "prost",
  "tonic",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "log",
  "mea",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "axum",
  "clap",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.24.1"
+version = "0.24.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -66,6 +66,10 @@ class _QueryProbe:
     # Hybrid (HMA): attention-only prefix hit before the recurrent reconcile
     # shrank it; the junction hint needs it even when the hit drops to zero.
     attention_hit_blocks: int = 0
+    # Blocks pinned by `leases` on the server. `hit_blocks` may shrink below
+    # this after the hybrid reconcile or the last-token clamp; the load must
+    # still address every leased block (extra ones as `None` targets).
+    leased_blocks: int = 0
 
     @property
     def is_ready(self) -> bool:
@@ -91,6 +95,7 @@ class _QueryProbe:
                 f"{len(self.query_hashes)} hashes"
             )
         self.hit_blocks = hit_blocks
+        self.leased_blocks = hit_blocks
         self.leases = ready.leases
         self.recurrent_hold = ready.recurrent_hold
         self.usable_positions = frozenset(ready.usable_positions)
@@ -517,17 +522,22 @@ class SchedulerConnector:
             start_block_idx = num_computed_blocks
             vbs = self._ctx.virtual_block_size
             num_load_blocks = (num_external_tokens + vbs - 1) // vbs
+            pending_probe = self._pending_query_probes.get(req_id)
             try:
                 load_block_ids_by_group = self._load_block_ids_by_group(
                     block_ids_by_group,
                     start_block_idx,
                     num_load_blocks,
+                    leased_blocks=(
+                        pending_probe.leased_blocks
+                        if pending_probe is not None
+                        else num_load_blocks
+                    ),
                 )
             except RuntimeError:
                 self._release_pending_query_probe(req_id)
                 raise
 
-            pending_probe = self._pending_query_probes.get(req_id)
             load_intent = LoadIntent(
                 block_ids_by_group=load_block_ids_by_group,
                 leases=pending_probe.leases if pending_probe is not None else (),
@@ -1003,7 +1013,16 @@ class SchedulerConnector:
         block_ids_by_group: tuple[tuple[int, ...], ...],
         start_block_idx: int,
         num_load_blocks: int,
+        leased_blocks: int | None = None,
     ) -> tuple[tuple[int | None, ...], ...]:
+        """Destination block IDs per cache group, one entry per leased block.
+
+        The engine walks the lease and the destination vector in lock step,
+        so the vector must be exactly as long as the lease. A hit can end up
+        shorter than the lease (hybrid reconcile falls back to an earlier
+        checkpoint; the final prompt token is recomputed): the leased blocks
+        past `num_load_blocks` get `None` targets and are skipped.
+        """
         end_block_idx = start_block_idx + num_load_blocks
         available = [len(group) for group in block_ids_by_group]
         if any(length < end_block_idx for length in available):
@@ -1012,12 +1031,20 @@ class SchedulerConnector:
                 f"available_by_group={available}"
             )
 
+        if leased_blocks is None:
+            leased_blocks = num_load_blocks
+        if leased_blocks < num_load_blocks:
+            raise RuntimeError(
+                f"load block mismatch: leased={leased_blocks} count={num_load_blocks}"
+            )
+        padding = (None,) * (leased_blocks - num_load_blocks)
+
         result: list[tuple[int | None, ...]] = []
         for group_index, block_ids in enumerate(block_ids_by_group):
-            destinations = block_ids[start_block_idx:end_block_idx]
+            destinations: tuple[int | None, ...] = block_ids[start_block_idx:end_block_idx]
             if group_index in self._cache_groups.recurrent_group_indices and destinations:
                 destinations = (None,) * (len(destinations) - 1) + (destinations[-1],)
-            result.append(destinations)
+            result.append(destinations + padding)
         return tuple(result)
 
     def update_connector_output(self, connector_output: "KVConnectorOutput") -> None:

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -625,6 +625,7 @@ class SchedulerConnector:
                     if new_block_ids
                     else [[] for _ in range(self._cache_groups.group_count)]
                 )
+                self._rebase_resumed_request(req_id)
             elif new_block_ids:
                 for allocated, new_group in zip(
                     self._allocated_blocks[req_id],
@@ -896,6 +897,27 @@ class SchedulerConnector:
             return query_hashes, 0
         return query_hashes + (tail[0],), tail[1]
 
+    def _rebase_resumed_request(self, req_id: str) -> None:
+        """Restart connector-side bookkeeping when vLLM resumes a preempted request.
+
+        Preemption frees the request's blocks and resets vLLM's
+        `num_computed_tokens`; on resume the request goes back through the
+        waiting queue, so `get_num_new_matched_tokens` has already refreshed
+        `_external_matched_blocks` and the block table mirror was rebuilt from
+        the resume step. Everything derived from the first life is stale:
+        the scheduled-token accumulator would place blocks the new table does
+        not hold yet (and, worse, mark a partially recomputed block as
+        saveable), and the offset of the first locally computed block may
+        have moved. Blocks already stored keep their progress: hashes did
+        not change, so `_next_stored_block_idx` only ever advances.
+        """
+        base_block_idx = self._external_matched_blocks.get(req_id, 0)
+        self._block_index_offsets[req_id] = base_block_idx
+        self._scheduled_tokens[req_id] = 0
+        self._next_stored_block_idx[req_id] = max(
+            self._next_stored_block_idx.get(req_id, 0), base_block_idx
+        )
+
     def _consume_full_block_saves(self, req_id: str) -> SaveIntent | None:
         # block_hashes are at virtual_block_size granularity, 1-to-1 with block_ids.
         block_hashes = self._block_hashes.get(req_id)
@@ -924,12 +946,16 @@ class SchedulerConnector:
         # _allocated_blocks tracks request block IDs in global request order.
         # In external-hit cases, the prefix-loaded block IDs are still present at
         # the front, so save intents must slice by global block index rather than
-        # rebasing to a local-only view.
-        local_saveable = min(
+        # rebasing to a local-only view. The table length is therefore a global
+        # bound of its own: `base_block_idx + scheduled` says which positions
+        # hold valid KV, the table says which of them we can address, and a
+        # full-block hash exists for the whole prompt from the start. Slicing
+        # past the table would silently drop block IDs but not hashes.
+        saveable_block_idx = min(
+            len(block_hashes),
             min(attention_lengths, default=0),
-            scheduled // self._ctx.virtual_block_size,
+            base_block_idx + scheduled // self._ctx.virtual_block_size,
         )
-        saveable_block_idx = min(len(block_hashes), base_block_idx + local_saveable)
         new_blocks = saveable_block_idx - start_block_idx
         if new_blocks <= 0:
             return None

--- a/python/pegaflow/connector/worker.py
+++ b/python/pegaflow/connector/worker.py
@@ -6,7 +6,7 @@ import pickle
 import queue
 import threading
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -855,7 +855,7 @@ class WorkerConnector:
                 try:
                     t = self._save_queue.get_nowait()
                     if t is None:
-                        self._process_save_batch(batch)
+                        self._run_save_batch(batch)
                         self._save_queue.task_done()
                         logger.debug("[PegaKVConnector] Save worker thread stopped")
                         return
@@ -863,122 +863,147 @@ class WorkerConnector:
                 except queue.Empty:
                     break
 
-            self._process_save_batch(batch)
+            self._run_save_batch(batch)
             for _ in batch:
                 self._save_queue.task_done()
 
         logger.debug("[PegaKVConnector] Save worker thread stopped")
 
+    def _run_save_batch(self, batch: list[SaveTask]) -> None:
+        # The save thread is the only consumer of the queue and the only
+        # path that reports save completion to the scheduler. If it died on
+        # an unexpected error every later request would stay held (blocks
+        # never freed) and the engine would bleed KV cache until restart.
+        try:
+            self._process_save_batch(batch)
+        except Exception:
+            logger.exception(
+                "[PegaKVConnector] save batch failed for %d task(s); blocks released without save",
+                len(batch),
+            )
+
     def _process_save_batch(self, batch: list[SaveTask]) -> None:
+        all_request_ids = [req_id for task in batch for req_id in task.request_ids]
+        all_boundary_job_ids = [job_id for task in batch for job_id in task.boundary_job_ids]
+        try:
+            self._save_batch(batch)
+        finally:
+            # Always complete the save lifecycle, even if save failed: the
+            # scheduler releases held/pinned blocks on completion, not success.
+            self._complete_save_requests(all_request_ids)
+            if all_boundary_job_ids:
+                with self._save_completion_lock:
+                    self._completed_boundary_jobs.extend(all_boundary_job_ids)
+
+    def _save_batch(self, batch: list[SaveTask]) -> None:
         saves_by_layer: dict[str, tuple[list[int], list[bytes]]] = {}
-        all_request_ids: list[str] = []
-        all_boundary_job_ids: list[int] = []
 
         for task in batch:
-            all_request_ids.extend(task.request_ids)
-            all_boundary_job_ids.extend(task.boundary_job_ids)
-
-            for save_intent in task.metadata.save_intents.values():
-                if not any(save_intent.block_ids_by_group):
+            for req_id, save_intent in task.metadata.save_intents.items():
+                try:
+                    layer_saves = tuple(self._layer_saves(save_intent))
+                except Exception:
+                    # A malformed intent is a scheduler-side bug; drop this
+                    # request's save rather than the whole batch (or thread).
+                    logger.exception(
+                        "[PegaKVConnector] req=%s malformed save intent skipped", req_id
+                    )
                     continue
-
-                if self._cross_layer_mode:
-                    target_layers = (self._cross_layer_key,)
-                elif self._page_first:
-                    assert self._registered_layers, (
-                        "KV caches must be registered before submitting save intents"
-                    )
-                    target_layers = tuple(self._registered_layers)
-                else:
-                    assert self._registered_layers, (
-                        "KV caches must be registered before submitting save intents"
-                    )
-                    target_layers = tuple(self._registered_layers)
-
-                for layer_name in target_layers:
-                    group_index = self._layer_to_group.get(layer_name, 0)
-                    try:
-                        block_ids = save_intent.block_ids_by_group[group_index]
-                    except IndexError as exc:
-                        raise RuntimeError(
-                            f"save intent is missing cache group {group_index} for {layer_name}"
-                        ) from exc
-                    block_hashes = save_intent.block_hashes
-                    if len(block_ids) != len(block_hashes):
-                        raise RuntimeError(
-                            f"save block/hash count mismatch for {layer_name}: "
-                            f"blocks={len(block_ids)} hashes={len(block_hashes)}"
-                        )
-                    non_null = tuple(
-                        (block_id, block_hash)
-                        for block_id, block_hash in zip(block_ids, block_hashes, strict=True)
-                        if block_id != 0
-                    )
-                    block_ids = tuple(block_id for block_id, _ in non_null)
-                    block_hashes = tuple(block_hash for _, block_hash in non_null)
-                    if self._page_first and not self._use_mla_layer_split_registration:
-                        # Full-replica (one shard): every rank holds all layers,
-                        # so spread the whole-page writes across ranks by block
-                        # stripe. Layer-split ranks are each the sole writer of
-                        # their shard and keep the full block set (no striping).
-                        block_ids, block_hashes = self._block_shard(block_ids, block_hashes)
-                    if not block_ids:
-                        continue
+                for layer_name, block_ids, block_hashes in layer_saves:
                     if layer_name not in saves_by_layer:
                         saves_by_layer[layer_name] = ([], [])
-
                     saves_by_layer[layer_name][0].extend(block_ids)
                     saves_by_layer[layer_name][1].extend(block_hashes)
 
-        if saves_by_layer:
-            # Ensure all GPU kernels have completed before reading KV cache
-            # Otherwise we may copy uninitialized memory (attention kernel is async)
-            torch.cuda.synchronize(self._torch_device)
+        if not saves_by_layer:
+            return
 
-            saves_list = [(name, ids, hashes) for name, (ids, hashes) in saves_by_layer.items()]
-            total_blocks = sum(len(ids) for _, ids, _ in saves_list)
+        # Ensure all GPU kernels have completed before reading KV cache
+        # Otherwise we may copy uninitialized memory (attention kernel is async)
+        torch.cuda.synchronize(self._torch_device)
 
-            save_start = time.perf_counter()
-            success = False
+        saves_list = [(name, ids, hashes) for name, (ids, hashes) in saves_by_layer.items()]
+        total_blocks = sum(len(ids) for _, ids, _ in saves_list)
 
-            try:
-                ok, message = self._ctx.engine_client.save(
-                    self._ctx.instance_id,
-                    self._ctx.effective_tp_rank,
-                    self._ctx.pp_rank,
-                    self._ctx.device_id,
-                    saves_list,
-                )
+        save_start = time.perf_counter()
+        success = False
 
-                if not ok:
-                    logger.error(
-                        "[PegaKVConnector] Save batch failed: %s (continuing without save)",
-                        message,
-                    )
-                else:
-                    success = True
-                    logger.debug(
-                        "[PegaKVConnector] Batch saved %d layers, %d total blocks",
-                        len(saves_list),
-                        total_blocks,
-                    )
-            except Exception as e:
+        try:
+            ok, message = self._ctx.engine_client.save(
+                self._ctx.instance_id,
+                self._ctx.effective_tp_rank,
+                self._ctx.pp_rank,
+                self._ctx.device_id,
+                saves_list,
+            )
+
+            if not ok:
                 logger.error(
-                    "[PegaKVConnector] Save RPC exception: %s (continuing without save)",
-                    e,
+                    "[PegaKVConnector] Save batch failed: %s (continuing without save)",
+                    message,
                 )
+            else:
+                success = True
+                logger.debug(
+                    "[PegaKVConnector] Batch saved %d layers, %d total blocks",
+                    len(saves_list),
+                    total_blocks,
+                )
+        except Exception as e:
+            logger.error(
+                "[PegaKVConnector] Save RPC exception: %s (continuing without save)",
+                e,
+            )
 
-            save_duration = time.perf_counter() - save_start
+        save_duration = time.perf_counter() - save_start
 
-            with self._stats_lock:
-                self._stats.record_save(save_duration, total_blocks, success)
+        with self._stats_lock:
+            self._stats.record_save(save_duration, total_blocks, success)
 
-        # Always complete the save lifecycle, even if save failed: the
-        # scheduler releases held/pinned blocks on completion, not success.
-        self._complete_save_requests(all_request_ids)
-        if all_boundary_job_ids:
-            with self._save_completion_lock:
-                self._completed_boundary_jobs.extend(all_boundary_job_ids)
+    def _layer_saves(
+        self, save_intent: SaveIntent
+    ) -> Iterator[tuple[str, tuple[int, ...], tuple[bytes, ...]]]:
+        """Yield `(layer, block_ids, block_hashes)` this rank writes for one intent."""
+        if not any(save_intent.block_ids_by_group):
+            return
+
+        if self._cross_layer_mode:
+            target_layers = (self._cross_layer_key,)
+        else:
+            assert self._registered_layers, (
+                "KV caches must be registered before submitting save intents"
+            )
+            target_layers = tuple(self._registered_layers)
+
+        for layer_name in target_layers:
+            group_index = self._layer_to_group.get(layer_name, 0)
+            try:
+                block_ids = save_intent.block_ids_by_group[group_index]
+            except IndexError as exc:
+                raise RuntimeError(
+                    f"save intent is missing cache group {group_index} for {layer_name}"
+                ) from exc
+            block_hashes = save_intent.block_hashes
+            if len(block_ids) != len(block_hashes):
+                raise RuntimeError(
+                    f"save block/hash count mismatch for {layer_name}: "
+                    f"blocks={len(block_ids)} hashes={len(block_hashes)}"
+                )
+            non_null = tuple(
+                (block_id, block_hash)
+                for block_id, block_hash in zip(block_ids, block_hashes, strict=True)
+                if block_id != 0
+            )
+            block_ids = tuple(block_id for block_id, _ in non_null)
+            block_hashes = tuple(block_hash for _, block_hash in non_null)
+            if self._page_first and not self._use_mla_layer_split_registration:
+                # Full-replica (one shard): every rank holds all layers,
+                # so spread the whole-page writes across ranks by block
+                # stripe. Layer-split ranks are each the sole writer of
+                # their shard and keep the full block set (no striping).
+                block_ids, block_hashes = self._block_shard(block_ids, block_hashes)
+            if block_ids:
+                yield layer_name, block_ids, block_hashes
 
     def _complete_save_requests(self, request_ids: list[str]) -> None:
         completed_reqs: list[str] = []

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.24.1"
+version = "0.24.2"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -114,6 +114,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.24.1"
+version = "0.24.2"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"

--- a/python/tests/test_connector_save_lifecycle.py
+++ b/python/tests/test_connector_save_lifecycle.py
@@ -223,3 +223,40 @@ def test_preemption_waits_for_every_save_task():
             preemption_thread.join(timeout=1)
 
     assert not preemption_thread.is_alive()
+
+
+def test_malformed_save_intent_is_skipped_and_still_completes():
+    """A scheduler bug must not take the save thread down with it: the
+    request's blocks are released (unsaved) and other intents in the batch
+    still reach the store."""
+    worker = make_worker()
+    worker._registered_layers = ["layer"]
+    worker._ctx.engine_client.save.return_value = (True, "")
+    worker._current_metadata = PegaConnectorMetadata(
+        save_intents={
+            "torn": SaveIntent(block_ids_by_group=((1,),), block_hashes=(b"h0", b"h1")),
+            "good": SaveIntent(block_ids_by_group=((2,),), block_hashes=(b"h2",)),
+        }
+    )
+    worker.wait_for_save()
+
+    process_next_save(worker)
+
+    (_, _, _, _, saves), _ = worker._ctx.engine_client.save.call_args
+    assert saves == [("layer", [2], [b"h2"])]
+    finished_sending, _ = worker.get_finished({"torn", "good"})
+    assert finished_sending == {"torn", "good"}
+
+
+def test_save_worker_survives_a_failing_batch():
+    worker = make_worker()
+    worker._registered_layers = ["layer"]
+    completion = enqueue_save(worker)
+    worker._save_queue.put(None)
+
+    with patch("torch.cuda.synchronize", side_effect=RuntimeError("device lost")):
+        worker._save_worker()
+
+    assert completion.is_set()
+    finished_sending, _ = worker.get_finished({"request"})
+    assert finished_sending == {"request"}

--- a/python/tests/test_hma_boundary_offloads.py
+++ b/python/tests/test_hma_boundary_offloads.py
@@ -334,3 +334,40 @@ def test_junction_hint_is_hma_only():
     scheduler._hint_shared_prefix_boundary(request, 0, 8, 0)
 
     assert request.shared_prefix_boundary == 0
+
+
+def test_load_targets_cover_every_leased_block_when_the_hit_shrinks():
+    """The server pins `num_hit_blocks` blocks under the query lease and walks
+    lease and destination vector in lock step. An exact-prompt repeat clamps
+    the hit by the recomputed final token, the reconcile drops to the
+    previous checkpoint, and the load must still send one target per leased
+    block (`None` for the ones it no longer wants) or the engine rejects it:
+    `query lease block count 5 does not match destination block count 4`."""
+    scheduler, _ = _make_scheduler()
+    scheduler._count_available_block_prefix = MagicMock(
+        return_value=ShardedQueryReady(
+            5,
+            (b"lease",),
+            recurrent_hold=RecurrentLoadHold(
+                leases=((b"membership",),),
+                hit_positions=(((3, 4),),),
+                checkpoint=4,
+            ),
+            usable_positions=(3, 4),
+            attention_hit_blocks=5,
+        )
+    )
+    request = _request(num_tokens=5 * VBS, num_hashes=5)
+
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (4 * VBS, True)
+
+    blocks = SimpleNamespace(
+        get_block_ids=lambda: ([10, 11, 12, 13, 14], [20, 21, 22, 23, 24]),
+        blocks=[[SimpleNamespace(block_hash=None)] * 5] * 2,
+    )
+    scheduler.update_state_after_alloc(request, blocks, 4 * VBS)
+
+    intent = scheduler._pending_load_intents["r1"]
+    assert intent.num_tokens == 4 * VBS
+    assert intent.block_ids_by_group == ((10, 11, 12, 13, None), (None, None, None, 23, None))
+    assert intent.recurrent_hold.checkpoint == 3

--- a/python/tests/test_save_intent_preempt_resume.py
+++ b/python/tests/test_save_intent_preempt_resume.py
@@ -1,0 +1,232 @@
+"""Full-block save intents across a preempt/resume cycle.
+
+vLLM frees a preempted request's blocks and resets its `num_computed_tokens`;
+on resume the request re-enters the waiting queue, gets a fresh external-hit
+lookup and a fresh block table that (under chunked prefill) covers only the
+resume chunk. The connector's per-request bookkeeping from the first life is
+stale by then. Before the fix, `_consume_full_block_saves` bounded the save
+window by `base_block_idx + len(table)` — double-counting the external prefix
+already inside the table — so a resumed request sliced block IDs past the
+end of its table (silently short) while the prompt hashes, known up front,
+were not: `save block/hash count mismatch ... blocks=1 hashes=10` on every
+attention layer, which killed the save thread and leaked every later
+request's blocks.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: E402
+import hashlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from pegaflow.connector.common import ConnectorContext, PegaConnectorMode
+from pegaflow.connector.scheduler import SchedulerConnector
+
+VBS = 16
+
+
+def _hash(i: int) -> bytes:
+    return hashlib.sha256(f"block_{i}".encode()).digest()
+
+
+def _make_scheduler(mode: PegaConnectorMode | None = None) -> SchedulerConnector:
+    kwargs = {} if mode is None else {"mode": mode}
+    ctx = ConnectorContext(
+        instance_id="test",
+        namespace="ns",
+        block_size=VBS,
+        tp_size=1,
+        world_size=1,
+        tp_rank=0,
+        device_id=0,
+        engine_client=MagicMock(),
+        state_manager=MagicMock(),
+        **kwargs,
+    )  # type: ignore[arg-type]
+    return SchedulerConnector(ctx)
+
+
+def _make_request(req_id: str, num_full_blocks: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        request_id=req_id,
+        num_prompt_tokens=num_full_blocks * VBS,
+        block_hashes=[_hash(i) for i in range(num_full_blocks)],
+    )
+
+
+def _step(
+    scheduler: SchedulerConnector,
+    req_id: str,
+    *,
+    block_ids: list[int],
+    num_tokens: int,
+    num_computed_tokens: int,
+    new: bool = False,
+    resumed: bool = False,
+):
+    if new:
+        scheduled_new_reqs = [
+            SimpleNamespace(
+                req_id=req_id,
+                block_ids=(block_ids,),
+                num_computed_tokens=num_computed_tokens,
+            )
+        ]
+        cached = SimpleNamespace(
+            req_ids=[], resumed_req_ids=set(), new_block_ids=[], num_computed_tokens=[]
+        )
+    else:
+        scheduled_new_reqs = []
+        cached = SimpleNamespace(
+            req_ids=[req_id],
+            resumed_req_ids={req_id} if resumed else set(),
+            new_block_ids=[(block_ids,)],
+            num_computed_tokens=[num_computed_tokens],
+        )
+    output = SimpleNamespace(
+        scheduled_new_reqs=scheduled_new_reqs,
+        scheduled_cached_reqs=cached,
+        num_scheduled_tokens={req_id: num_tokens},
+        preempted_req_ids=set(),
+    )
+    return scheduler.build_connector_meta(output).save_intents.get(req_id)
+
+
+def _assert_consistent(intent) -> None:
+    assert intent is not None
+    for group in intent.block_ids_by_group:
+        assert len(group) == len(intent.block_hashes)
+
+
+def test_resumed_external_hit_request_keeps_block_and_hash_counts_aligned():
+    """The production shape: 19-block prompt, 9 blocks loaded from PegaFlow,
+    preempted after a sub-block first chunk, resumed with a chunk that the
+    stale accumulator places well past the rebuilt table."""
+    scheduler = _make_scheduler()
+    req = _make_request("r1", 19)
+    hashes = tuple(req.block_hashes)
+
+    # Life 1: external hit of 9 blocks, first chunk shorter than one block.
+    scheduler._external_matched_blocks["r1"] = 9
+    scheduler.update_state_after_alloc(req, None, 0)
+    assert (
+        _step(
+            scheduler,
+            "r1",
+            block_ids=list(range(100, 110)),
+            num_tokens=VBS // 2,
+            num_computed_tokens=9 * VBS,
+            new=True,
+        )
+        is None
+    )
+
+    # Preempted, resumed: same external hit, table rebuilt for a 9.5-block chunk.
+    scheduler._external_matched_blocks["r1"] = 9
+    resumed_table = list(range(200, 210))
+    intent = _step(
+        scheduler,
+        "r1",
+        block_ids=resumed_table,
+        num_tokens=9 * VBS + VBS // 2,
+        num_computed_tokens=9 * VBS,
+        resumed=True,
+    )
+
+    _assert_consistent(intent)
+    # Global indices 9..18 are the rebuilt table's own entries; the block
+    # holding the half-written chunk tail is not saved.
+    assert intent.block_ids_by_group == (tuple(resumed_table[9:10]),)
+    assert intent.block_hashes == hashes[9:10]
+    assert scheduler._next_stored_block_idx["r1"] == 10
+
+
+def test_resume_does_not_save_partially_recomputed_block():
+    """Save-only mode carries `num_computed_tokens + scheduled` forward with
+    max(); after preemption that watermark is ahead of what the resume chunk
+    has actually recomputed."""
+    scheduler = _make_scheduler(PegaConnectorMode.SAVE_ONLY)
+    req = _make_request("r1", 4)
+    hashes = tuple(req.block_hashes)
+    scheduler.update_state_after_alloc(req, None, 0)
+
+    # Life 1 wrote every block but nothing was consumed (say the save was
+    # gated), then the request was preempted.
+    scheduler._scheduled_tokens["r1"] = 4 * VBS
+
+    # Resume recomputes from scratch, this chunk covers 2.5 blocks.
+    intent = _step(
+        scheduler,
+        "r1",
+        block_ids=[10, 11, 12],
+        num_tokens=2 * VBS + VBS // 2,
+        num_computed_tokens=0,
+        resumed=True,
+    )
+
+    _assert_consistent(intent)
+    assert intent.block_ids_by_group == ((10, 11),)
+    assert intent.block_hashes == hashes[:2]
+
+
+def test_resume_rebases_on_the_refreshed_external_hit():
+    """Blocks stored in the first life count as external hits on resume; the
+    save window restarts after them, never re-saving or skipping."""
+    scheduler = _make_scheduler()
+    req = _make_request("r1", 8)
+    hashes = tuple(req.block_hashes)
+
+    scheduler._external_matched_blocks["r1"] = 2
+    scheduler.update_state_after_alloc(req, None, 0)
+    first = _step(
+        scheduler,
+        "r1",
+        block_ids=list(range(100, 106)),
+        num_tokens=4 * VBS,
+        num_computed_tokens=2 * VBS,
+        new=True,
+    )
+    _assert_consistent(first)
+    assert first.block_hashes == hashes[2:6]
+    assert first.block_ids_by_group == ((102, 103, 104, 105),)
+
+    # Resume finds blocks 0..5 in PegaFlow now and loads them all.
+    scheduler._external_matched_blocks["r1"] = 6
+    second = _step(
+        scheduler,
+        "r1",
+        block_ids=list(range(200, 209)),
+        num_tokens=2 * VBS + 1,
+        num_computed_tokens=6 * VBS,
+        resumed=True,
+    )
+    _assert_consistent(second)
+    assert second.block_hashes == hashes[6:8]
+    assert second.block_ids_by_group == ((206, 207),)
+    assert scheduler._block_index_offsets["r1"] == 6
+
+
+@pytest.mark.parametrize("scheduled_tokens", [3 * VBS, 100 * VBS])
+def test_full_block_saves_never_exceed_the_mirrored_table(scheduled_tokens: int):
+    """Direct check of the bound: whatever the accumulator says, the window
+    ends at the table, and block IDs and hashes always pair up."""
+    scheduler = _make_scheduler()
+    hashes = tuple(_hash(i) for i in range(12))
+    scheduler._block_hashes["r1"] = hashes
+    scheduler._block_index_offsets["r1"] = 6
+    scheduler._next_stored_block_idx["r1"] = 6
+    scheduler._scheduled_tokens["r1"] = scheduled_tokens
+    scheduler._allocated_blocks["r1"] = [[100, 101, 102, 103, 104, 105, 200, 201]]
+
+    intent = scheduler._consume_full_block_saves("r1")
+
+    _assert_consistent(intent)
+    assert intent.block_ids_by_group == ((200, 201),)
+    assert intent.block_hashes == hashes[6:8]


### PR DESCRIPTION
## Summary

Production K3 (TP8, MTP, PegaFlow master with #448) hit this on every attention layer once KV pressure started preempting requests:

```
RuntimeError: save block/hash count mismatch for language_model.model.layers.3.self_attn: blocks=1 hashes=10
```

- **Root cause** (`scheduler.py::_consume_full_block_saves`): the save window was bounded by `base_block_idx + len(table)`, but the mirrored table already contains the externally loaded prefix, so the external offset was counted twice. It stayed masked while the scheduled-token accumulator only covered the current life. After a preemption vLLM resets `num_computed_tokens` and rebuilds the table from the resume chunk, while the accumulator and the first life's offset stay: the window runs past the rebuilt table, Python slicing silently shortens the block IDs, and the prompt hashes (known up front) are not shortened. In save-only mode the same stale watermark could save a partially recomputed block under a valid hash.
- **Fix**: bound the window by the table itself; on resume restart the per-request bookkeeping from the refreshed external hit (`_rebase_resumed_request`), keeping already-stored progress.
- **Blast radius fix** (`worker.py`): the raise killed the save thread, so nothing drained the queue afterwards, every later request stayed held for a save that never completed, and the engine leaked KV cache until restart (2 running / 18 waiting / 2 tok/s in the incident). The save worker now survives a failing batch, a malformed intent drops only its own request's save, and completion is always reported so blocks get released.
- **Second bug, found while reproducing under preemption on Kimi-Linear** (`scheduler.py::_load_block_ids_by_group`): the load's destination vector was sized by the *usable* hit, but the engine walks it in lock step with the query lease. When the hybrid reconcile fell back to an earlier checkpoint (an exact-repeat prompt whose final token must be recomputed), the load carried one target fewer than the lease and the engine rejected it with `query lease block count 5 does not match destination block count 4`, which the worker escalated to "Service unavailable" and the engine died. The probe now keeps the leased block count and the load pads unwanted leased blocks with `None` targets (already skipped by the engine).
- Bumps the version to 0.24.2.

## Test plan

- [x] `tests/test_save_intent_preempt_resume.py`: the production shape (19-block prompt, 9 loaded, preempted after a sub-block chunk, resumed) plus save-only partial-block and rebase cases. All 5 fail on master, pass here.
- [x] `tests/test_connector_save_lifecycle.py`: malformed intent is skipped and the request still completes; save worker survives a failing batch.
- [x] `tests/test_hma_boundary_offloads.py::test_load_targets_cover_every_leased_block_when_the_hit_shrinks`: fails on master, passes here.
- [x] `cd python && uv run --isolated --no-project --with pytest --with numpy --with 'requests>=2.26.0' pytest` on the connector suites (109 passed), ruff check/format clean.
- [x] Single-GPU Kimi-Linear e2e (tray08, 512 GiB pool, 400-block GPU KV budget to force preemption, 2048-token chunks): master died on the lease/destination mismatch under a warm-prefix + 96 long-decode fillers + long-tail scenario; this branch completes 3 rounds (294 requests, 3908 preemptions, 0 save mismatches, 0 load failures). Multi-turn vllm-bench load (128 conv, 3 turns, 2000+ preemptions) is clean on both. The exact save-mismatch sequence from production was not reproduced e2e on this model (its resume hits cover everything stored, so the rebuilt table is never shorter than the hashes); the unit test pins that shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXoijrttVSfhrQF6EAq5CC
