### PR TITLE
fix(connector): key blocks by the hash that closes them (prefix-match-unit / hybrid hash_block_size)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "colored",
  "libc",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "axum",
  "clap",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-pd-wire"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "prost",
  "tonic",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "log",
  "mea",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "axum",
  "clap",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.24.2"
+version = "0.24.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -64,6 +64,23 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
                 dcp_world_size,
             )
 
+        block_size = vllm_config.cache_config.block_size
+        hash_block_size: int | None = None
+        if kv_cache_config is not None:
+            from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
+
+            scheduler_block_size, hash_block_size = resolve_kv_cache_block_sizes(
+                kv_cache_config, vllm_config
+            )
+            if (
+                scheduler_block_size != block_size * dcp_world_size
+                or scheduler_block_size % hash_block_size != 0
+            ):
+                raise ValueError(
+                    f"vLLM scheduler block {scheduler_block_size} / hash block "
+                    f"{hash_block_size} do not fit the connector block {block_size}"
+                )
+
         cross_layer_blocks = os.environ.get("PEGAFLOW_CROSS_LAYER_BLOCKS", "1") == "1"
         base_namespace = derive_namespace(
             vllm_config,
@@ -71,8 +88,8 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             dcp_world_size,
             pcp_world_size,
             cross_layer_blocks=cross_layer_blocks,
+            hash_block_size=hash_block_size,
         )
-        block_size = vllm_config.cache_config.block_size
 
         tp_rank: int | None = None
         device_id: int | None = None
@@ -161,6 +178,7 @@ class PegaKVConnector(KVConnectorBase_V1, SupportsHMA):
             mode=mode,
             wait_for_full_prefix=wait_for_full_prefix,
             tp_shards=tp_shards,
+            hash_block_size=hash_block_size,
         )
 
         # MLA attention backends expose no num-layers stride dimension, so vLLM

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -583,7 +583,8 @@ def derive_namespace(
       default full-slot registration.
     - `is_hma_enabled`: vLLM's hybrid cache manager changes whether hybrid
       cache layouts can share one logical block namespace.
-    - `hash_block_size`: decides which chained hash keys a block.
+    - `hash_block_size` / `block_size`: decide which chained hash keys a block
+      and how many tokens it spans; `mamba_*`: recurrent state layout.
     """
     model_config = vllm_config.model_config
     cache_config = vllm_config.cache_config
@@ -604,6 +605,9 @@ def derive_namespace(
         "cross_layer_blocks": cross_layer_blocks,
         "mla_layer_split_kv_cache": bool(additional_config.get("mla_layer_split_kv_cache", False)),
         "hash_block_size": hash_block_size,
+        "block_size": getattr(cache_config, "block_size", None),
+        "mamba_cache_mode": getattr(cache_config, "mamba_cache_mode", None),
+        "mamba_ssm_cache_dtype": getattr(cache_config, "mamba_ssm_cache_dtype", None),
     }
 
     factor_str = str(sorted(factors.items()))

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -144,6 +144,9 @@ class ConnectorContext:
     mode: PegaConnectorMode = PegaConnectorMode.READ_WRITE
     wait_for_full_prefix: bool = False
     tp_shards: TpShardTopology | None = None
+    # Token span of one `Request.block_hashes` entry; `None` means one per
+    # scheduler block.
+    hash_block_size: int | None = None
 
     @property
     def read_enabled(self) -> bool:
@@ -158,6 +161,17 @@ class ConnectorContext:
         granularity of scheduler block hashes.
         """
         return self.block_size * self.dcp_world_size
+
+    @property
+    def hash_scale(self) -> int:
+        """`Request.block_hashes` entries per scheduler block.
+
+        vLLM hashes every `hash_block_size` tokens, which is finer than the
+        scheduler block for hybrid models (GCD of the group block sizes, or
+        `--prefix-match-unit`). Each hash chains over its whole prefix, so the
+        last one inside a block is that block's key.
+        """
+        return self.virtual_block_size // (self.hash_block_size or self.virtual_block_size)
 
     @property
     def effective_tp_rank(self) -> int:
@@ -551,6 +565,7 @@ def derive_namespace(
     dcp_world_size: int = 1,
     pcp_world_size: int = 1,
     cross_layer_blocks: bool = False,
+    hash_block_size: int | None = None,
 ) -> str:
     """
     Derive namespace for storage isolation.
@@ -568,6 +583,7 @@ def derive_namespace(
       default full-slot registration.
     - `is_hma_enabled`: vLLM's hybrid cache manager changes whether hybrid
       cache layouts can share one logical block namespace.
+    - `hash_block_size`: decides which chained hash keys a block.
     """
     model_config = vllm_config.model_config
     cache_config = vllm_config.cache_config
@@ -587,6 +603,7 @@ def derive_namespace(
         "pcp_world_size": pcp_world_size,
         "cross_layer_blocks": cross_layer_blocks,
         "mla_layer_split_kv_cache": bool(additional_config.get("mla_layer_split_kv_cache", False)),
+        "hash_block_size": hash_block_size,
     }
 
     factor_str = str(sorted(factors.items()))

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -621,6 +621,10 @@ class SchedulerConnector:
                 self._allocated_blocks[req_id] = [
                     list(group) for group in self._copy_block_ids_by_group(req.block_ids)
                 ]
+            # The V2 model runner reports resumed requests here rather than in
+            # `scheduled_cached_reqs.resumed_req_ids`; for a fresh request the
+            # rebase is a no-op.
+            self._rebase_resumed_request(req_id)
 
             if self._ctx.read_enabled:
                 self._scheduled_tokens[req_id] += num_tokens
@@ -748,6 +752,12 @@ class SchedulerConnector:
             block_hashes = self._request_block_hashes(request)
             self._block_hashes[req_id] = block_hashes
             saved = self._saved_boundaries.setdefault(req_id, set())
+            # vLLM allocates a real recurrent block per externally loaded
+            # block but the load fills only the checkpoint; after the load it
+            # still caches (and offers) every block of the loaded prefix. Those
+            # blocks hold no state this request computed, so only boundaries
+            # past the loaded prefix may be saved.
+            loaded_blocks = self._external_matched_blocks.get(req_id, 0)
             rows: list[tuple[int, int, bytes]] = []
             for group_index, block_id, boundary_tokens in entries:
                 if group_index not in recurrent or block_id <= 0:
@@ -755,7 +765,7 @@ class SchedulerConnector:
                 if boundary_tokens <= 0 or boundary_tokens % vbs != 0:
                     continue
                 hash_index = boundary_tokens // vbs - 1
-                if hash_index >= len(block_hashes):
+                if hash_index < loaded_blocks or hash_index >= len(block_hashes):
                     continue
                 key = (group_index, hash_index)
                 if key in saved:

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -31,6 +31,15 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 
+def block_hashes_per_block(block_hashes, hash_scale: int) -> tuple[bytes, ...]:
+    """One chained hash per scheduler block: the last hash inside each block.
+
+    This is vLLM's own `BlockHashListWithBlockSize` rule. Trailing hashes of an
+    incomplete block are dropped; PegaFlow stores whole blocks only.
+    """
+    return tuple(block_hashes[hash_scale - 1 :: hash_scale])
+
+
 @dataclass(slots=True)
 class _QueryProbe:
     """One remote prefix-query snapshot.
@@ -229,6 +238,25 @@ class SchedulerConnector:
             return None
 
         gpu_block_pool.get_cached_block = no_local_hma_prefix_hit
+
+    def _request_block_hashes(self, request: "Request") -> tuple[bytes, ...]:
+        """Per-block keys from `Request.block_hashes` (see `ConnectorContext.hash_scale`).
+
+        vLLM hashes full spans only, so there can never be more keys than the
+        request has full blocks. More means the hashes are finer than the
+        scale says, and keying blocks by them would file block ``i`` under the
+        hash of a shorter prefix — any request sharing that prefix would then
+        load this request's blocks. Fail loudly instead.
+        """
+        per_block = block_hashes_per_block(request.block_hashes, self._ctx.hash_scale)
+        full_blocks = getattr(request, "num_tokens", 0) // self._ctx.virtual_block_size
+        if full_blocks and len(per_block) > full_blocks:
+            raise RuntimeError(
+                f"req {request.request_id}: {len(request.block_hashes)} block hashes give "
+                f"{len(per_block)} keys at scale {self._ctx.hash_scale} for {full_blocks} "
+                f"full blocks; vLLM's hash granularity is finer than the connector's"
+            )
+        return per_block
 
     def get_num_new_matched_tokens(
         self,
@@ -493,11 +521,8 @@ class SchedulerConnector:
         # (Request.block_hashes grows as new full blocks are completed).
         self._requests[req_id] = request
 
-        # request.block_hashes are already at virtual_block_size granularity
-        # (1 hash per scheduler block =
-        # block_size * dcp_world_size * pcp_world_size tokens).
-        # They are 1-to-1 with block_ids from the scheduler.
-        self._block_hashes[req_id] = tuple(request.block_hashes)
+        # One key per scheduler block, 1-to-1 with block_ids from the scheduler.
+        self._block_hashes[req_id] = self._request_block_hashes(request)
         if req_id not in self._allocated_blocks:
             # The first locally allocated block may be after an external-hit
             # prefix. Track that global block index explicitly.
@@ -623,7 +648,7 @@ class SchedulerConnector:
             # newly completed blocks during decode are also saved.
             req = self._requests.get(req_id)
             if req is not None:
-                self._block_hashes[req_id] = tuple(req.block_hashes)
+                self._block_hashes[req_id] = self._request_block_hashes(req)
 
             num_tokens = scheduler_output.num_scheduled_tokens.get(req_id, 0)
 
@@ -720,7 +745,7 @@ class SchedulerConnector:
             if request is None:
                 # Finished before this step's metadata; its blocks are going away.
                 continue
-            block_hashes = tuple(request.block_hashes)
+            block_hashes = self._request_block_hashes(request)
             self._block_hashes[req_id] = block_hashes
             saved = self._saved_boundaries.setdefault(req_id, set())
             rows: list[tuple[int, int, bytes]] = []
@@ -884,7 +909,7 @@ class SchedulerConnector:
         if tail_len <= 1:
             return None
         tail_idx = prompt_len // vbs
-        block_hashes = tuple(request.block_hashes)
+        block_hashes = self._request_block_hashes(request)
         if tail_idx > len(block_hashes):
             raise RuntimeError(
                 f"req {request.request_id} missing parent hash for tail block: "
@@ -898,7 +923,7 @@ class SchedulerConnector:
     def _build_query(
         self, request: "Request", computed_blocks: int
     ) -> tuple[tuple[bytes, ...], int]:
-        query_hashes = tuple(request.block_hashes[computed_blocks:])
+        query_hashes = self._request_block_hashes(request)[computed_blocks:]
         if not self._tail_load_enabled:
             return query_hashes, 0
 
@@ -929,7 +954,6 @@ class SchedulerConnector:
         )
 
     def _consume_full_block_saves(self, req_id: str) -> SaveIntent | None:
-        # block_hashes are at virtual_block_size granularity, 1-to-1 with block_ids.
         block_hashes = self._block_hashes.get(req_id)
         if block_hashes is None:
             return None

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.24.2"
+version = "0.24.3"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -114,6 +114,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.24.2"
+version = "0.24.3"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"

--- a/python/tests/test_hash_block_size_scale.py
+++ b/python/tests/test_hash_block_size_scale.py
@@ -1,0 +1,152 @@
+"""Block hashes finer than the scheduler block must be re-keyed per block.
+
+vLLM computes ``Request.block_hashes`` every ``hash_block_size`` tokens: the
+scheduler block for a single cache group, but the GCD of the group block sizes
+or ``--prefix-match-unit`` for hybrid models (K3 production: 128-token hashes
+over 1536-token blocks). Each hash chains over its whole prefix, so the hash
+closing a block is that block's key (vLLM's ``BlockHashListWithBlockSize``).
+
+Consuming the fine list 1-to-1 with block ids filed block ``i`` under the hash
+of the first ``(i + 1) * 128`` tokens, so two sessions sharing only a system
+prompt served each other's whole conversation.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: E402
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from .unit_stubs import install_connector_unit_stubs
+
+install_connector_unit_stubs()
+
+from pegaflow.connector.common import ConnectorContext, SaveIntent, derive_namespace
+from pegaflow.connector.scheduler import SchedulerConnector, block_hashes_per_block
+
+VBS = 1536
+HASH_BLOCK = 128
+SCALE = VBS // HASH_BLOCK
+
+
+def _hash(i: int) -> bytes:
+    return f"fine-{i}".encode()
+
+
+def _key(block: int) -> bytes:
+    return _hash(block * SCALE + SCALE - 1)
+
+
+def _scheduler(hash_block_size: int | None = HASH_BLOCK) -> SchedulerConnector:
+    ctx = ConnectorContext(
+        instance_id="i",
+        namespace="n",
+        block_size=VBS,
+        tp_size=1,
+        world_size=1,
+        tp_rank=0,
+        device_id=0,
+        engine_client=MagicMock(),
+        state_manager=MagicMock(),
+        hash_block_size=hash_block_size,
+    )
+    return SchedulerConnector(ctx)
+
+
+def _request(req_id: str, num_tokens: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        request_id=req_id,
+        num_tokens=num_tokens,
+        num_prompt_tokens=num_tokens,
+        block_hashes=[_hash(i) for i in range(num_tokens // HASH_BLOCK)],
+    )
+
+
+def _output(req_id: str, block_ids: list[int], num_tokens: int, offloads=None) -> SimpleNamespace:
+    output = SimpleNamespace(
+        scheduled_new_reqs=[
+            SimpleNamespace(req_id=req_id, block_ids=(block_ids,), num_computed_tokens=0)
+        ]
+        if block_ids
+        else [],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[], resumed_req_ids=set(), new_block_ids=[], num_computed_tokens=[]
+        ),
+        num_scheduled_tokens={req_id: num_tokens} if block_ids else {},
+        preempted_req_ids=set(),
+    )
+    if offloads is not None:
+        output.kv_connector_block_state = SimpleNamespace(
+            block_ids={}, boundary_state_offloads=offloads
+        )
+    return output
+
+
+def test_block_hashes_per_block_keeps_the_hash_closing_each_block():
+    fine = [_hash(i) for i in range(1245)]  # 159364 tokens // 128
+    per_block = block_hashes_per_block(fine, SCALE)
+    assert len(per_block) == 103  # 159364 // 1536
+    assert per_block[0] == _hash(11) and per_block[102] == _hash(102 * SCALE + 11)
+    assert block_hashes_per_block(fine, 1) == tuple(fine)
+
+
+def test_query_and_save_key_blocks_by_their_closing_hash():
+    scheduler = _scheduler()
+    req = _request("r1", 4 * VBS + 300)
+
+    assert scheduler._build_query(req, 1) == (tuple(_key(i) for i in range(1, 4)), 0)
+
+    scheduler.update_state_after_alloc(req, None, 0)
+    intent = scheduler.build_connector_meta(_output("r1", [10, 11, 12, 13, 14], req.num_tokens))
+    assert intent.save_intents["r1"] == SaveIntent(
+        block_ids_by_group=((10, 11, 12, 13),),
+        block_hashes=tuple(_key(i) for i in range(4)),
+    )
+
+
+def test_boundary_offload_uses_the_hash_closing_the_boundary_block():
+    scheduler = _scheduler()
+    scheduler._cache_groups = SimpleNamespace(
+        group_count=2,
+        hash_group_index=0,
+        has_recurrent_state=True,
+        recurrent_group_indices=frozenset({1}),
+    )
+    scheduler._gpu_block_pool = SimpleNamespace(
+        blocks=[SimpleNamespace(block_id=i) for i in range(64)],
+        touch=lambda blocks: None,
+        free_blocks=lambda blocks: None,
+    )
+    scheduler._requests["r1"] = _request("r1", 6 * VBS)
+
+    metadata = scheduler.build_connector_meta(_output("r1", [], 0, {"r1": [(1, 21, 3 * VBS)]}))
+    assert metadata.boundary_save_intents == {
+        0: SaveIntent(block_ids_by_group=((0,), (21,)), block_hashes=(_key(2),))
+    }
+
+
+def test_more_keys_than_full_blocks_is_rejected():
+    # Fine hashes consumed at scale 1 would alias requests; refuse instead.
+    with pytest.raises(RuntimeError, match="finer"):
+        _scheduler(hash_block_size=None)._build_query(_request("r1", 4 * VBS), 0)
+
+
+def test_hash_block_size_isolates_namespace():
+    cfg = SimpleNamespace(
+        model_config=SimpleNamespace(
+            model="/data/models/Kimi-K3",
+            dtype="bfloat16",
+            get_total_num_kv_heads=lambda: 1,
+            get_head_size=lambda: 576,
+            get_total_num_hidden_layers=lambda: 61,
+        ),
+        cache_config=SimpleNamespace(cache_dtype="fp8"),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        parallel_config=SimpleNamespace(pipeline_parallel_size=1),
+        additional_config={},
+    )
+    assert derive_namespace(cfg, 8, hash_block_size=VBS) != derive_namespace(
+        cfg, 8, hash_block_size=HASH_BLOCK
+    )

--- a/python/tests/test_hma_boundary_offloads.py
+++ b/python/tests/test_hma_boundary_offloads.py
@@ -371,3 +371,23 @@ def test_load_targets_cover_every_leased_block_when_the_hit_shrinks():
     assert intent.num_tokens == 4 * VBS
     assert intent.block_ids_by_group == ((10, 11, 12, 13, None), (None, None, None, 23, None))
     assert intent.recurrent_hold.checkpoint == 3
+
+
+def test_boundaries_inside_the_loaded_prefix_are_not_saved():
+    """vLLM offers every block of an externally loaded prefix after the load,
+    but only the checkpoint block was written; saving the rest would file
+    stale state under valid hashes."""
+    scheduler, pool = _make_scheduler()
+    _register_request(scheduler, "r1", 6)
+    scheduler._external_matched_blocks["r1"] = 3  # blocks 0..2 came from the store
+
+    metadata = scheduler.build_connector_meta(
+        _scheduler_output(
+            {"r1": [(1, 21, 1 * VBS), (1, 22, 2 * VBS), (1, 23, 3 * VBS), (1, 24, 4 * VBS)]}
+        )
+    )
+
+    assert metadata.boundary_save_intents == {
+        0: SaveIntent(block_ids_by_group=((0,), (24,)), block_hashes=(_hash(3),))
+    }
+    assert pool.touched == [24]

--- a/python/tests/test_save_intent_preempt_resume.py
+++ b/python/tests/test_save_intent_preempt_resume.py
@@ -26,7 +26,7 @@ from .unit_stubs import install_connector_unit_stubs
 
 install_connector_unit_stubs()
 
-from pegaflow.connector.common import ConnectorContext, PegaConnectorMode
+from pegaflow.connector.common import ConnectorContext, PegaConnectorMode, SaveIntent
 from pegaflow.connector.scheduler import SchedulerConnector
 
 VBS = 16
@@ -230,3 +230,54 @@ def test_full_block_saves_never_exceed_the_mirrored_table(scheduled_tokens: int)
     _assert_consistent(intent)
     assert intent.block_ids_by_group == ((200, 201),)
     assert intent.block_hashes == hashes[6:8]
+
+
+def test_resumed_request_reported_as_new_is_rebased():
+    """The V2 model runner moves resumed requests into `scheduled_new_reqs`;
+    the first life's accumulator must not place blocks in the new table."""
+    scheduler = _make_scheduler()
+    req = _make_request("r1", 19)
+    hashes = tuple(req.block_hashes)
+
+    scheduler._external_matched_blocks["r1"] = 0
+    scheduler.update_state_after_alloc(req, None, 0)
+    intent = _step(
+        scheduler,
+        "r1",
+        block_ids=list(range(0, 5)),
+        num_tokens=4 * VBS + 8,
+        num_computed_tokens=0,
+        new=True,
+    )
+    assert intent is not None and intent.block_hashes == hashes[:4]
+
+    # Preempted; resumed as a "new" request with a table covering the first chunk only.
+    scheduler._external_matched_blocks["r1"] = 0
+    scheduler.update_state_after_alloc(req, None, 0)
+    intent = _step(
+        scheduler,
+        "r1",
+        block_ids=list(range(10, 12)),
+        num_tokens=VBS + 8,
+        num_computed_tokens=0,
+        new=True,
+    )
+    assert intent is None  # blocks 0..3 already stored, block 1 only partially recomputed
+    # Without the rebase the first life's accumulator (4 blocks + 8) plus this
+    # chunk would claim 8 full blocks and save block 4 with 8 valid rows.
+    intent = _step(
+        scheduler,
+        "r1",
+        block_ids=list(range(12, 15)),
+        num_tokens=3 * VBS,
+        num_computed_tokens=VBS + 8,
+    )
+    assert intent is None
+    intent = _step(
+        scheduler,
+        "r1",
+        block_ids=[],
+        num_tokens=VBS - 8,
+        num_computed_tokens=4 * VBS + 8,
+    )
+    assert intent == SaveIntent(block_ids_by_group=((14,),), block_hashes=(hashes[4],))


### PR DESCRIPTION
## Symptom

K3 P/D prefill group (TP8 EP8, hybrid mamba-align + MLA, `--prefix-match-unit 128`, pegaflow 0.24.2): the user asks question A and the model fluently answers an unrelated question B. Hit rate looks healthy, nothing crashes.

## Root cause (commit 1)

vLLM computes `Request.block_hashes` every `hash_block_size` tokens (`resolve_kv_cache_block_sizes`). For a single cache group that is the scheduler block, but for hybrid models it is the GCD of the group block sizes, or the explicit `--prefix-match-unit` (128 tokens in production, against 1536-token scheduler blocks). vLLM maps the fine list onto blocks by taking the last hash inside each block (`BlockHashListWithBlockSize`).

The scheduler connector consumed the list 1-to-1 with block ids, so block `i` (tokens `1536*i .. 1536*(i+1)`) was filed under the hash of the first `128*(i+1)` tokens. Any two sessions sharing that much prefix (an agent system prompt of ~6k tokens covers 48 blocks = 73k tokens) served each other's whole conversation, recurrent checkpoint included, so the output was fluent but about the other session.

Log fingerprint from production:

```
cache_lookup: hit_blocks=87 computed_blocks=0 hit_tokens=133632 num_tokens=159364 ... total_query_hashes=1245
```

1245 = 159364 / 128 (fine hashes were sent as block keys), while 87 × 1536 = 133632.

Fix:
- `ConnectorContext.hash_scale` from vLLM's `resolve_kv_cache_block_sizes`; every consumer of `Request.block_hashes` (prefix query, full-block save intents, HMA boundary-state offloads, P/D tail keys) goes through `_request_block_hashes` = `hashes[scale-1::scale]`, vLLM's own rule.
- `_request_block_hashes` refuses more keys than the request has full blocks, so a finer granularity than the connector assumes fails loudly instead of aliasing.
- `hash_block_size` joins the namespace factors. Entries written under the old keys are unreachable after the upgrade: old block `12i+11` sat under exactly the key new block `i` uses, so a warm store would keep serving the wrong blocks.

## Two more ways stale recurrent state reached the store (commit 2)

Found while auditing the connector against the K3 vLLM fork, both verified in code:

- **Boundaries inside an externally loaded prefix.** vLLM allocates a real recurrent block per externally loaded block (`allocate_external_computed_blocks`), the load fills only the checkpoint, and after the load `_update_waiting_for_remote_kv` → `MambaManager.cache_blocks` still offers every block of the loaded prefix as a boundary state. The connector accepted them, saving n-1 never-written blocks under the prefix's own hashes. Boundaries at or below the externally matched prefix are now skipped.
- **Resumed requests under the V2 model runner** (forced by DSpark) arrive in `scheduled_new_reqs`, not `resumed_req_ids`, so the connector never rebased them: the first life's scheduled-token accumulator let it save a block whose recompute had only reached its first rows. The new-request branch now rebases too (a no-op for a fresh request).
- Namespace also gains `block_size`, `mamba_cache_mode`, `mamba_ssm_cache_dtype`: same hash granularity with a different block span yields identical chained hashes for different blocks, and the server's slot-count guard does not tell them apart.

Not in this PR (follow-up): the worker still raises on a hybrid load failure/timeout, taking the whole prefill group down; the K3 fork can recompute hybrid requests from scratch on load failure (`_update_requests_with_invalid_blocks`), so reporting the blocks via `get_block_ids_with_load_errors` instead would let it recover.

## Verification

- Unit tests: `python/tests/test_hash_block_size_scale.py`, new cases in `test_hma_boundary_offloads.py` and `test_save_intent_preempt_resume.py` (each fails with its fix reverted).
- Single-GPU e2e (Kimi-Linear, 1920-token blocks, `--prefix-match-unit 128`): two sessions sharing only a ~3.4k-token system prompt, each with a different codeword in its own document. master answers session A with session B's codeword (hit 7/7 blocks, `total_query_hashes=105` = 13521/128); with this PR A answers its own codeword and its repeat still gets a full hit (`total_query_hashes=7`). Details in the comment below.

Version bump to 0.24.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D88GoN8BhYDLCj9ALdf6uR
