### PR TITLE
fix(metaserver): preserve active blocks and skip healthy sweep scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,8 +1952,10 @@ dependencies = [
  "pegaflow-common",
  "pegaflow-proto",
  "prometheus",
+ "serde",
  "tokio",
  "tonic",
+ "tower",
  "uuid",
 ]
 

--- a/pegaflow-metaserver/Cargo.toml
+++ b/pegaflow-metaserver/Cargo.toml
@@ -29,9 +29,11 @@ opentelemetry_sdk.workspace = true
 opentelemetry-prometheus.workspace = true
 prometheus.workspace = true
 axum.workspace = true
+serde.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+tower = "0.5"
 
 [[bench]]
 name = "unregister_node"

--- a/pegaflow-metaserver/README.md
+++ b/pegaflow-metaserver/README.md
@@ -63,8 +63,8 @@ cargo run -p pegaflow-metaserver -- --log-level debug
 # Custom node lifecycle timings
 cargo run -p pegaflow-metaserver -- --node-stale-secs 30 --ttl-minutes 120 --sweep-interval-secs 600
 
-# All options combined
-cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056 --node-stale-secs 30 --ttl-minutes 120 --sweep-interval-secs 600 --log-level info
+# Configure public HTTP and localhost-only maintenance ports
+cargo run -p pegaflow-metaserver -- --addr 0.0.0.0:50056 --http-addr 0.0.0.0:9092 --admin-http-addr 127.0.0.1:9093
 
 # Show all options
 cargo run -p pegaflow-metaserver -- --help
@@ -72,10 +72,12 @@ cargo run -p pegaflow-metaserver -- --help
 
 ### Server Options
 
-- `--addr <ADDR>`: Bind address (default: `127.0.0.1:50056`)
+- `--addr <ADDR>`: gRPC bind address (default: `127.0.0.1:50056`)
+- `--http-addr <ADDR>`: HTTP health and metrics bind address (default: `0.0.0.0:9092`)
+- `--admin-http-addr <ADDR>`: HTTP maintenance bind address; must be loopback (default: `127.0.0.1:9093`)
 - `--log-level <LEVEL>`: Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`)
 - `--node-stale-secs <SECONDS>`: Hide nodes from query after this many seconds without heartbeat (default: `30`)
-- `--ttl-minutes <MINUTES>`: Purge ownership and node records after this many minutes (default: `120`)
+- `--ttl-minutes <MINUTES>`: Delete nodes and their owners after this many minutes without node activity (default: `120`); does not expire blocks by registration age
 - `--sweep-interval-secs <SECONDS>`: Run the lifecycle sweep at this interval (default: `600`)
 
 ### Storage Configuration
@@ -84,10 +86,62 @@ The MetaServer uses a DashMap-based in-memory store with the following character
 
 - **Multi-owner**: A block hash can be registered by multiple nodes simultaneously
 - **Node lifecycle**: Servers generate a `node_id`, announce it with `HeartbeatNode`, heartbeat periodically, and include the same `node_id` in insert/remove RPCs.
-- **Stale filtering**: Nodes stop appearing in query results after 30 seconds without heartbeat by default.
-- **TTL sweep**: A background task runs every `--sweep-interval-secs` and removes expired owners and nodes after `--ttl-minutes`.
+- **Stale filtering**: Nodes stop appearing in query results after 30 seconds without activity by default. Their records remain until node TTL cleanup; the same session can recover before cleanup without reinserting its blocks.
+- **Lifecycle sweep**: A background task runs every `--sweep-interval-secs`. It scans the block directory only after deleting an inactive node past `--ttl-minutes`, or when a session takeover needs reconciliation. Otherwise it only inspects nodes. Block registration age never causes automatic deletion.
 - **Conditional removal**: `RemoveBlockHashes` only removes the requesting node's ownership; other nodes' entries are untouched.
-- **Memory**: Scales with unique blocks across all nodes. No hard capacity cap — memory is naturally bounded by the total number of blocks in the cluster.
+- **Memory**: Scales with retained block and owner records; there is no hard capacity cap. Use the manual cleanup endpoint below for explicit maintenance.
+
+## HTTP APIs
+
+Health and metrics use `--http-addr`; manual cleanup uses the separate
+`--admin-http-addr` listener. The admin address must be loopback (for example,
+`127.0.0.1:9093` or `[::1]:9093`); a non-loopback address makes startup fail.
+Choose distinct available ports when running multiple MetaServers on one host.
+
+| Default address | Method and path | Purpose |
+| --- | --- | --- |
+| `0.0.0.0:9092` | `GET /health` | Returns `ok` |
+| `0.0.0.0:9092` | `GET /metrics` | Prometheus metrics |
+| `127.0.0.1:9093` | `POST /admin/cleanup-expired-blocks` | Remove owner registrations older than one hour |
+
+### Manual block cleanup
+
+Run this on the MetaServer host, or inside its container when using container
+networking. No request body or authentication is required:
+
+```bash
+curl --fail-with-body --silent --show-error --request POST \
+  http://127.0.0.1:9093/admin/cleanup-expired-blocks
+```
+
+The threshold is fixed at one hour and independent of `--ttl-minutes`. The
+cleanup pass scans all namespaces and removes owners whose last
+`InsertBlockHashes` registration was **strictly more than 3,600 seconds ago**
+when the pass started. Reinserting an owner refreshes its registration time;
+heartbeats and queries do not.
+
+Cleanup applies even to active nodes and blocks whose KV data still exists.
+It removes MetaServer metadata, leaves node records and physical KV data in
+place, and removes a block key only when its last owner is deleted. Fresh or
+refreshed owners remain. A deleted owner becomes discoverable again after
+`InsertBlockHashes` registers it; a heartbeat alone does not restore it.
+
+A successful call waits for the scan to complete and returns HTTP 200, for
+example:
+
+```json
+{"removed_owners":2,"removed_keys":1}
+```
+
+`removed_owners` counts deleted ownership records; `removed_keys` counts block
+keys left without any owner. Both are zero if no registration is old enough.
+The public HTTP listener returns 404 for this admin route; GET on the admin
+route returns 405. A cleanup worker failure returns HTTP 500.
+
+Manual cleanup scans the entire block directory on a blocking worker. It
+holds a block shard write lock while processing that shard, so concurrent
+RPCs accessing the same shard can experience increased latency. Use it for
+explicit maintenance and monitor RPC latency during the call.
 
 ## gRPC APIs
 
@@ -213,7 +267,7 @@ Graceful shutdown trigger.
 - **Data structure**: `blocks: DashMap<BlockKey, HashMap<Arc<str>, OwnerRecord>>` and `nodes: DashMap<Arc<str>, NodeRecord>`
 - **BlockKey**: `{ namespace: String, hash: Vec<u8> }` — matches pegaflow-core's BlockKey
 - **Multi-owner**: Multiple nodes can register the same block hash (e.g., after replication or shared prefill)
-- **Lifecycle sweep**: Background task runs periodically to remove owners whose node record is missing or whose ownership TTL expired; superseded sessions are hidden from queries by `node_id` matching and purged by TTL.
+- **Lifecycle sweep**: An inactive-node deletion or pending takeover triggers a block scan that removes owners with a missing node or a mismatched session. Superseded sessions are immediately hidden from queries and reconciled by the next sweep, even while the replacement session stays active.
 - **Concurrency**: DashMap uses shard-level locking for high-throughput concurrent access
 - **Persistence**: In-memory only (restart clears state)
 

--- a/pegaflow-metaserver/src/http_server.rs
+++ b/pegaflow-metaserver/src/http_server.rs
@@ -138,29 +138,49 @@ mod tests {
     use tower::ServiceExt;
 
     #[tokio::test]
-    async fn cleanup_route_accepts_post_and_returns_stats() {
-        let response = admin_app(AppState {
+    async fn cleanup_route_removes_old_owners_and_preserves_fresh_replicas() {
+        let store = Arc::new(crate::store::tests::manual_cleanup_fixture());
+        let app = admin_app(AppState {
             prometheus_registry: Registry::new(),
-            store: Arc::new(BlockHashStore::new()),
-        })
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/admin/cleanup-expired-blocks")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(
-            axum::body::to_bytes(response.into_body(), usize::MAX)
+            store: Arc::clone(&store),
+        });
+        for expected in [
+            br#"{"removed_owners":2,"removed_keys":1}"#.as_slice(),
+            br#"{"removed_owners":0,"removed_keys":0}"#.as_slice(),
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/admin/cleanup-expired-blocks")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
                 .await
-                .unwrap()
-                .as_ref(),
-            br#"{"removed_owners":0,"removed_keys":0}"#
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(
+                axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap()
+                    .as_ref(),
+                expected,
+            );
+        }
+        assert!(store.query_prefix("ns", &[vec![1]]).is_empty());
+        assert_eq!(
+            store.query_prefix("ns", &[vec![2]])[0].nodes[0].as_ref(),
+            "b"
         );
+        assert_eq!(
+            store.query_prefix("ns", &[vec![3]])[0].nodes[0].as_ref(),
+            "a"
+        );
+        assert_eq!(store.owner_count(), 2);
+        assert_eq!(store.entry_count(), 2);
+        assert_eq!(store.node_counts(), (2, 0));
+        assert_eq!(store.redundancy_snapshot().keys_1, 2);
     }
 
     #[tokio::test]

--- a/pegaflow-metaserver/src/http_server.rs
+++ b/pegaflow-metaserver/src/http_server.rs
@@ -41,20 +41,36 @@ async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
     )
 }
 
-async fn cleanup_expired_blocks_handler(State(state): State<AppState>) -> Json<CleanupResponse> {
-    let stats = state
-        .store
-        .remove_owners_older_than(std::time::Duration::from_secs(MANUAL_CLEANUP_AGE_SECS));
-    Json(CleanupResponse {
+async fn cleanup_expired_blocks_handler(
+    State(state): State<AppState>,
+) -> Result<Json<CleanupResponse>, StatusCode> {
+    let store = Arc::clone(&state.store);
+    let stats = match tokio::task::spawn_blocking(move || {
+        store.remove_owners_older_than(std::time::Duration::from_secs(MANUAL_CLEANUP_AGE_SECS))
+    })
+    .await
+    {
+        Ok(stats) => stats,
+        Err(err) => {
+            warn!("manual cleanup worker failed: {err}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+    Ok(Json(CleanupResponse {
         removed_owners: stats.removed_owners,
         removed_keys: stats.removed_keys,
-    })
+    }))
 }
 
-fn app(state: AppState) -> Router {
+fn public_app(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health_handler))
         .route("/metrics", get(metrics_handler))
+        .with_state(state)
+}
+
+fn admin_app(state: AppState) -> Router {
+    Router::new()
         .route(
             "/admin/cleanup-expired-blocks",
             post(cleanup_expired_blocks_handler),
@@ -64,32 +80,50 @@ fn app(state: AppState) -> Router {
 
 pub async fn start_http_server(
     addr: std::net::SocketAddr,
+    admin_addr: std::net::SocketAddr,
     prometheus_registry: Registry,
     store: Arc<BlockHashStore>,
     shutdown: Arc<Notify>,
 ) -> Result<tokio::task::JoinHandle<()>, std::io::Error> {
+    if !admin_addr.ip().is_loopback() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("admin HTTP address must be loopback, got {admin_addr}"),
+        ));
+    }
     let listener = TcpListener::bind(addr).await?;
+    let admin_listener = TcpListener::bind(admin_addr).await?;
 
     let state = AppState {
+        prometheus_registry: prometheus_registry.clone(),
+        store: Arc::clone(&store),
+    };
+    let admin_state = AppState {
         prometheus_registry,
         store,
     };
 
-    let app = app(state);
-
     info!(
-        "Starting HTTP server on {} (/health, /metrics, POST /admin/cleanup-expired-blocks)",
-        addr
+        "Starting HTTP server on {} (/health, /metrics); admin cleanup on {} (localhost only)",
+        addr, admin_addr
     );
 
     let handle = tokio::spawn(async move {
-        if let Err(err) = axum::serve(listener, app)
-            .with_graceful_shutdown(async move {
+        let public_shutdown = Arc::clone(&shutdown);
+        let public = axum::serve(listener, public_app(state)).with_graceful_shutdown(async move {
+            public_shutdown.notified().await;
+        });
+        let admin = axum::serve(admin_listener, admin_app(admin_state)).with_graceful_shutdown(
+            async move {
                 shutdown.notified().await;
-            })
-            .await
-        {
+            },
+        );
+        let (public_result, admin_result) = tokio::join!(public, admin);
+        if let Err(err) = public_result {
             warn!("HTTP server stopped with error: {err}");
+        }
+        if let Err(err) = admin_result {
+            warn!("Admin HTTP server stopped with error: {err}");
         }
     });
 
@@ -105,7 +139,7 @@ mod tests {
 
     #[tokio::test]
     async fn cleanup_route_accepts_post_and_returns_stats() {
-        let response = app(AppState {
+        let response = admin_app(AppState {
             prometheus_registry: Registry::new(),
             store: Arc::new(BlockHashStore::new()),
         })
@@ -127,5 +161,24 @@ mod tests {
                 .as_ref(),
             br#"{"removed_owners":0,"removed_keys":0}"#
         );
+    }
+
+    #[tokio::test]
+    async fn public_route_does_not_expose_admin_cleanup() {
+        let response = public_app(AppState {
+            prometheus_registry: Registry::new(),
+            store: Arc::new(BlockHashStore::new()),
+        })
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/cleanup-expired-blocks")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/pegaflow-metaserver/src/http_server.rs
+++ b/pegaflow-metaserver/src/http_server.rs
@@ -1,16 +1,29 @@
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::{Router, routing::get};
+use axum::{
+    Json, Router,
+    routing::{get, post},
+};
 use log::{info, warn};
 use prometheus::{Registry, TextEncoder};
+use serde::Serialize;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 
+use crate::store::{BlockHashStore, MANUAL_CLEANUP_AGE_SECS};
+
 #[derive(Clone)]
 struct AppState {
     prometheus_registry: Registry,
+    store: Arc<BlockHashStore>,
+}
+
+#[derive(Debug, Serialize)]
+struct CleanupResponse {
+    removed_owners: usize,
+    removed_keys: usize,
 }
 
 async fn health_handler() -> &'static str {
@@ -28,23 +41,46 @@ async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
     )
 }
 
+async fn cleanup_expired_blocks_handler(State(state): State<AppState>) -> Json<CleanupResponse> {
+    let stats = state
+        .store
+        .remove_owners_older_than(std::time::Duration::from_secs(MANUAL_CLEANUP_AGE_SECS));
+    Json(CleanupResponse {
+        removed_owners: stats.removed_owners,
+        removed_keys: stats.removed_keys,
+    })
+}
+
+fn app(state: AppState) -> Router {
+    Router::new()
+        .route("/health", get(health_handler))
+        .route("/metrics", get(metrics_handler))
+        .route(
+            "/admin/cleanup-expired-blocks",
+            post(cleanup_expired_blocks_handler),
+        )
+        .with_state(state)
+}
+
 pub async fn start_http_server(
     addr: std::net::SocketAddr,
     prometheus_registry: Registry,
+    store: Arc<BlockHashStore>,
     shutdown: Arc<Notify>,
 ) -> Result<tokio::task::JoinHandle<()>, std::io::Error> {
     let listener = TcpListener::bind(addr).await?;
 
     let state = AppState {
         prometheus_registry,
+        store,
     };
 
-    let app = Router::new()
-        .route("/health", get(health_handler))
-        .route("/metrics", get(metrics_handler))
-        .with_state(state);
+    let app = app(state);
 
-    info!("Starting HTTP server on {} (/health, /metrics)", addr);
+    info!(
+        "Starting HTTP server on {} (/health, /metrics, POST /admin/cleanup-expired-blocks)",
+        addr
+    );
 
     let handle = tokio::spawn(async move {
         if let Err(err) = axum::serve(listener, app)
@@ -58,4 +94,38 @@ pub async fn start_http_server(
     });
 
     Ok(handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn cleanup_route_accepts_post_and_returns_stats() {
+        let response = app(AppState {
+            prometheus_registry: Registry::new(),
+            store: Arc::new(BlockHashStore::new()),
+        })
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/cleanup-expired-blocks")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .as_ref(),
+            br#"{"removed_owners":0,"removed_keys":0}"#
+        );
+    }
 }

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -62,19 +62,6 @@ pub struct Cli {
     pub sweep_interval_secs: u64,
 }
 
-impl Cli {
-    fn node_ttl(&self) -> Result<Duration, &'static str> {
-        let seconds = self
-            .ttl_minutes
-            .checked_mul(60)
-            .ok_or("ttl-minutes is too large")?;
-        if seconds == 0 || seconds < self.node_stale_secs {
-            return Err("ttl-minutes must be positive and >= node-stale-secs");
-        }
-        Ok(Duration::from_secs(seconds))
-    }
-}
-
 fn init_metrics() -> Result<(SdkMeterProvider, Registry), Box<dyn Error>> {
     let registry = Registry::new();
     let exporter = opentelemetry_prometheus::exporter()
@@ -133,16 +120,30 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         "Node lifecycle: stale_after={}s manual_cleanup_age=1h sweep_interval={}s node_ttl_minutes={}",
         cli.node_stale_secs, cli.sweep_interval_secs, cli.ttl_minutes
     );
-    let ttl = cli.node_ttl()?;
+    let ttl_secs = cli
+        .ttl_minutes
+        .checked_mul(60)
+        .ok_or("ttl-minutes is too large")?;
+    if cli.ttl_minutes == 0 {
+        return Err("ttl-minutes must be greater than 0".into());
+    }
     if cli.sweep_interval_secs == 0 {
         return Err("sweep-interval-secs must be greater than 0".into());
     }
+    if ttl_secs < cli.node_stale_secs {
+        return Err(format!(
+            "ttl-minutes ({}) must be >= node-stale-secs ({})",
+            cli.ttl_minutes, cli.node_stale_secs
+        )
+        .into());
+    }
+
     // Initialize metrics
     let (meter_provider, prometheus_registry) = init_metrics()?;
 
     let store = Arc::new(BlockHashStore::with_config(store::StoreConfig {
         node_stale_after: Duration::from_secs(cli.node_stale_secs),
-        ttl,
+        ttl: Duration::from_secs(ttl_secs),
     }));
 
     // Register store observable gauges
@@ -217,31 +218,4 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     info!("MetaServer shut down gracefully");
     Ok(())
-}
-
-#[cfg(test)]
-mod cli_tests {
-    use super::*;
-
-    #[test]
-    fn node_ttl_has_finite_default_and_validates_override() {
-        let cli = Cli::try_parse_from(["metaserver"]).unwrap();
-        assert_eq!(cli.node_ttl().unwrap(), Duration::from_secs(7200));
-        for (minutes, stale, valid) in [
-            ("1", "30", true),
-            ("0", "30", false),
-            ("1", "61", false),
-            ("18446744073709551615", "30", false),
-        ] {
-            let cli = Cli::try_parse_from([
-                "metaserver",
-                "--ttl-minutes",
-                minutes,
-                "--node-stale-secs",
-                stale,
-            ])
-            .unwrap();
-            assert_eq!(cli.node_ttl().is_ok(), valid, "{minutes}/{stale}");
-        }
-    }
 }

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -53,13 +53,26 @@ pub struct Cli {
     #[arg(long, default_value_t = store::DEFAULT_NODE_STALE_SECS)]
     pub node_stale_secs: u64,
 
-    /// Deprecated compatibility setting. Background sweep no longer purges by owner age.
+    /// Minutes without node activity before lifecycle cleanup (not block age).
     #[arg(long, default_value_t = store::DEFAULT_TTL_MINUTES)]
     pub ttl_minutes: u64,
 
     /// Seconds between lifecycle sweeps.
     #[arg(long, default_value_t = DEFAULT_SWEEP_INTERVAL_SECS)]
     pub sweep_interval_secs: u64,
+}
+
+impl Cli {
+    fn node_ttl(&self) -> Result<Duration, &'static str> {
+        let seconds = self
+            .ttl_minutes
+            .checked_mul(60)
+            .ok_or("ttl-minutes is too large")?;
+        if seconds == 0 || seconds < self.node_stale_secs {
+            return Err("ttl-minutes must be positive and >= node-stale-secs");
+        }
+        Ok(Duration::from_secs(seconds))
+    }
 }
 
 fn init_metrics() -> Result<(SdkMeterProvider, Registry), Box<dyn Error>> {
@@ -117,9 +130,10 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     info!("Starting PegaFlow MetaServer");
     info!("Binding to address: {}", cli.addr);
     info!(
-        "Node lifecycle: stale_after={}s manual_cleanup_age=1h sweep_interval={}s (ttl_minutes={} retained for compatibility)",
+        "Node lifecycle: stale_after={}s manual_cleanup_age=1h sweep_interval={}s node_ttl_minutes={}",
         cli.node_stale_secs, cli.sweep_interval_secs, cli.ttl_minutes
     );
+    let ttl = cli.node_ttl()?;
     if cli.sweep_interval_secs == 0 {
         return Err("sweep-interval-secs must be greater than 0".into());
     }
@@ -128,7 +142,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     let store = Arc::new(BlockHashStore::with_config(store::StoreConfig {
         node_stale_after: Duration::from_secs(cli.node_stale_secs),
-        ttl: Duration::MAX,
+        ttl,
     }));
 
     // Register store observable gauges
@@ -203,4 +217,31 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     info!("MetaServer shut down gracefully");
     Ok(())
+}
+
+#[cfg(test)]
+mod cli_tests {
+    use super::*;
+
+    #[test]
+    fn node_ttl_has_finite_default_and_validates_override() {
+        let cli = Cli::try_parse_from(["metaserver"]).unwrap();
+        assert_eq!(cli.node_ttl().unwrap(), Duration::from_secs(7200));
+        for (minutes, stale, valid) in [
+            ("1", "30", true),
+            ("0", "30", false),
+            ("1", "61", false),
+            ("18446744073709551615", "30", false),
+        ] {
+            let cli = Cli::try_parse_from([
+                "metaserver",
+                "--ttl-minutes",
+                minutes,
+                "--node-stale-secs",
+                stale,
+            ])
+            .unwrap();
+            assert_eq!(cli.node_ttl().is_ok(), valid, "{minutes}/{stale}");
+        }
+    }
 }

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -49,7 +49,7 @@ pub struct Cli {
     #[arg(long, default_value_t = store::DEFAULT_NODE_STALE_SECS)]
     pub node_stale_secs: u64,
 
-    /// Minutes before block ownership records are purged by the lifecycle sweep.
+    /// Deprecated compatibility setting. Background sweep no longer purges by owner age.
     #[arg(long, default_value_t = store::DEFAULT_TTL_MINUTES)]
     pub ttl_minutes: u64,
 
@@ -113,33 +113,18 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     info!("Starting PegaFlow MetaServer");
     info!("Binding to address: {}", cli.addr);
     info!(
-        "Node lifecycle: stale_after={}s ttl={}m sweep_interval={}s",
-        cli.node_stale_secs, cli.ttl_minutes, cli.sweep_interval_secs
+        "Node lifecycle: stale_after={}s manual_cleanup_age=1h sweep_interval={}s (ttl_minutes={} retained for compatibility)",
+        cli.node_stale_secs, cli.sweep_interval_secs, cli.ttl_minutes
     );
-    let ttl_secs = cli
-        .ttl_minutes
-        .checked_mul(60)
-        .ok_or("ttl-minutes is too large")?;
-    if cli.ttl_minutes == 0 {
-        return Err("ttl-minutes must be greater than 0".into());
-    }
     if cli.sweep_interval_secs == 0 {
         return Err("sweep-interval-secs must be greater than 0".into());
     }
-    if ttl_secs < cli.node_stale_secs {
-        return Err(format!(
-            "ttl-minutes ({}) must be >= node-stale-secs ({})",
-            cli.ttl_minutes, cli.node_stale_secs
-        )
-        .into());
-    }
-
     // Initialize metrics
     let (meter_provider, prometheus_registry) = init_metrics()?;
 
     let store = Arc::new(BlockHashStore::with_config(store::StoreConfig {
         node_stale_after: Duration::from_secs(cli.node_stale_secs),
-        ttl: Duration::from_secs(ttl_secs),
+        ttl: Duration::MAX,
     }));
 
     // Register store observable gauges
@@ -172,9 +157,13 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     let shutdown = Arc::new(Notify::new());
 
     // Start HTTP server for health check and metrics
-    let _http_handle =
-        http_server::start_http_server(cli.http_addr, prometheus_registry, Arc::clone(&shutdown))
-            .await?;
+    let _http_handle = http_server::start_http_server(
+        cli.http_addr,
+        prometheus_registry,
+        Arc::clone(&store),
+        Arc::clone(&shutdown),
+    )
+    .await?;
 
     // Create the gRPC service
     let service = GrpcMetaService::new(store.clone());

--- a/pegaflow-metaserver/src/lib.rs
+++ b/pegaflow-metaserver/src/lib.rs
@@ -41,6 +41,10 @@ pub struct Cli {
     #[arg(long, default_value = "0.0.0.0:9092")]
     pub http_addr: SocketAddr,
 
+    /// Loopback-only HTTP address for destructive operator maintenance.
+    #[arg(long, default_value = "127.0.0.1:9093")]
+    pub admin_http_addr: SocketAddr,
+
     /// Log level (trace, debug, info, warn, error)
     #[arg(long, default_value = "info")]
     pub log_level: String,
@@ -138,7 +142,15 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
             let mut interval = tokio::time::interval(sweep_interval);
             loop {
                 interval.tick().await;
-                let stats = store.sweep_expired();
+                let sweep_store = Arc::clone(&store);
+                let stats =
+                    match tokio::task::spawn_blocking(move || sweep_store.sweep_expired()).await {
+                        Ok(stats) => stats,
+                        Err(err) => {
+                            error!("Node sweep worker failed: {err}");
+                            continue;
+                        }
+                    };
                 if !stats.is_empty() {
                     metric::record_sweep(stats);
                     info!(
@@ -159,6 +171,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     // Start HTTP server for health check and metrics
     let _http_handle = http_server::start_http_server(
         cli.http_addr,
+        cli.admin_http_addr,
         prometheus_registry,
         Arc::clone(&store),
         Arc::clone(&shutdown),

--- a/pegaflow-metaserver/src/metric.rs
+++ b/pegaflow-metaserver/src/metric.rs
@@ -54,7 +54,9 @@ pub fn register_store_gauges(store: &Arc<BlockHashStore>) {
         let redundancy_store = Arc::clone(&s);
         let redundancy = meter
             .u64_observable_gauge("pegaflow_metaserver_block_redundancy")
-            .with_description("Block keys bucketed by live owner count (replication factor)")
+            .with_description(
+                "Block keys by stored owner count; stale and old sessions count until cleanup",
+            )
             .with_callback(move |observer| {
                 let snap = redundancy_store.redundancy_snapshot();
                 observer.observe(snap.keys_1, &[KeyValue::new("owners", "1")]);
@@ -67,8 +69,7 @@ pub fn register_store_gauges(store: &Arc<BlockHashStore>) {
         let redundancy_avg = meter
             .f64_observable_gauge("pegaflow_metaserver_block_redundancy_avg")
             .with_description(
-                "Average live owners per block key with at least one live owner \
-                 (cluster replication factor / cache capacity shrink factor)",
+                "Average stored owners per block key; stale and old sessions count until cleanup",
             )
             .with_callback(move |observer| {
                 let snap = redundancy_avg_store.redundancy_snapshot();

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -104,8 +104,11 @@ impl MetaServer for GrpcMetaService {
         );
         let result = async {
             let node_id = Self::parse_node_id(&req.node_id)?;
-            self.store
-                .heartbeat_node(&req.node, node_id)
+            let store = Arc::clone(&self.store);
+            let node = req.node.clone();
+            tokio::task::spawn_blocking(move || store.heartbeat_node(&node, node_id))
+                .await
+                .map_err(|err| Status::internal(format!("heartbeat worker failed: {err}")))?
                 .map_err(Self::store_error_status)?;
             Ok(Response::new(HeartbeatNodeResponse {
                 stale_after_secs: self.store.config().node_stale_after.as_secs(),
@@ -128,10 +131,13 @@ impl MetaServer for GrpcMetaService {
         );
         let result = async {
             let node_id = Self::parse_node_id(&req.node_id)?;
-            let removed = self
-                .store
-                .unregister_node(&req.node, node_id)
-                .map_err(Self::store_error_status)?;
+            let store = Arc::clone(&self.store);
+            let node = req.node.clone();
+            let removed =
+                tokio::task::spawn_blocking(move || store.unregister_node(&node, node_id))
+                    .await
+                    .map_err(|err| Status::internal(format!("unregister worker failed: {err}")))?
+                    .map_err(Self::store_error_status)?;
             Ok(Response::new(UnregisterNodeResponse {
                 removed_owners: removed as u64,
             }))
@@ -186,18 +192,30 @@ impl MetaServer for GrpcMetaService {
         };
 
         let inserted_count = req.block_hashes.len() as u64;
-        let reclaimable_hashes =
-            match self
-                .store
-                .insert_hashes(&req.namespace, &req.block_hashes, &req.node, node_id)
-            {
+        let store = Arc::clone(&self.store);
+        let namespace = req.namespace.clone();
+        let hashes = req.block_hashes;
+        let node = req.node.clone();
+        let reclaimable_hashes = match tokio::task::spawn_blocking(move || {
+            store.insert_hashes(&namespace, &hashes, &node, node_id)
+        })
+        .await
+        .map_err(|err| Status::internal(format!("insert worker failed: {err}")))
+        {
+            Ok(result) => match result {
                 Ok(reclaimable_hashes) => reclaimable_hashes,
                 Err(err) => {
                     let result = Err(Self::store_error_status(err));
                     record_rpc_result("insert_block_hashes", &result, start);
                     return result;
                 }
-            };
+            },
+            Err(status) => {
+                let result: Result<Response<InsertBlockHashesResponse>, Status> = Err(status);
+                record_rpc_result("insert_block_hashes", &result, start);
+                return result;
+            }
+        };
 
         let elapsed = start.elapsed();
         debug!(
@@ -252,18 +270,30 @@ impl MetaServer for GrpcMetaService {
             }
         };
 
-        let removed =
-            match self
-                .store
-                .remove_hashes(&req.namespace, &req.block_hashes, &req.node, node_id)
-            {
+        let store = Arc::clone(&self.store);
+        let namespace = req.namespace.clone();
+        let hashes = req.block_hashes;
+        let node = req.node.clone();
+        let removed = match tokio::task::spawn_blocking(move || {
+            store.remove_hashes(&namespace, &hashes, &node, node_id)
+        })
+        .await
+        .map_err(|err| Status::internal(format!("remove worker failed: {err}")))
+        {
+            Ok(result) => match result {
                 Ok(removed) => removed,
                 Err(err) => {
                     let result = Err(Self::store_error_status(err));
                     record_rpc_result("remove_block_hashes", &result, start);
                     return result;
                 }
-            };
+            },
+            Err(status) => {
+                let result: Result<Response<RemoveBlockHashesResponse>, Status> = Err(status);
+                record_rpc_result("remove_block_hashes", &result, start);
+                return result;
+            }
+        };
 
         let elapsed = start.elapsed();
         debug!(

--- a/pegaflow-metaserver/src/service.rs
+++ b/pegaflow-metaserver/src/service.rs
@@ -104,11 +104,8 @@ impl MetaServer for GrpcMetaService {
         );
         let result = async {
             let node_id = Self::parse_node_id(&req.node_id)?;
-            let store = Arc::clone(&self.store);
-            let node = req.node.clone();
-            tokio::task::spawn_blocking(move || store.heartbeat_node(&node, node_id))
-                .await
-                .map_err(|err| Status::internal(format!("heartbeat worker failed: {err}")))?
+            self.store
+                .heartbeat_node(&req.node, node_id)
                 .map_err(Self::store_error_status)?;
             Ok(Response::new(HeartbeatNodeResponse {
                 stale_after_secs: self.store.config().node_stale_after.as_secs(),
@@ -192,30 +189,18 @@ impl MetaServer for GrpcMetaService {
         };
 
         let inserted_count = req.block_hashes.len() as u64;
-        let store = Arc::clone(&self.store);
-        let namespace = req.namespace.clone();
-        let hashes = req.block_hashes;
-        let node = req.node.clone();
-        let reclaimable_hashes = match tokio::task::spawn_blocking(move || {
-            store.insert_hashes(&namespace, &hashes, &node, node_id)
-        })
-        .await
-        .map_err(|err| Status::internal(format!("insert worker failed: {err}")))
-        {
-            Ok(result) => match result {
+        let reclaimable_hashes =
+            match self
+                .store
+                .insert_hashes(&req.namespace, &req.block_hashes, &req.node, node_id)
+            {
                 Ok(reclaimable_hashes) => reclaimable_hashes,
                 Err(err) => {
                     let result = Err(Self::store_error_status(err));
                     record_rpc_result("insert_block_hashes", &result, start);
                     return result;
                 }
-            },
-            Err(status) => {
-                let result: Result<Response<InsertBlockHashesResponse>, Status> = Err(status);
-                record_rpc_result("insert_block_hashes", &result, start);
-                return result;
-            }
-        };
+            };
 
         let elapsed = start.elapsed();
         debug!(
@@ -270,30 +255,18 @@ impl MetaServer for GrpcMetaService {
             }
         };
 
-        let store = Arc::clone(&self.store);
-        let namespace = req.namespace.clone();
-        let hashes = req.block_hashes;
-        let node = req.node.clone();
-        let removed = match tokio::task::spawn_blocking(move || {
-            store.remove_hashes(&namespace, &hashes, &node, node_id)
-        })
-        .await
-        .map_err(|err| Status::internal(format!("remove worker failed: {err}")))
-        {
-            Ok(result) => match result {
+        let removed =
+            match self
+                .store
+                .remove_hashes(&req.namespace, &req.block_hashes, &req.node, node_id)
+            {
                 Ok(removed) => removed,
                 Err(err) => {
                     let result = Err(Self::store_error_status(err));
                     record_rpc_result("remove_block_hashes", &result, start);
                     return result;
                 }
-            },
-            Err(status) => {
-                let result: Result<Response<RemoveBlockHashesResponse>, Status> = Err(status);
-                record_rpc_result("remove_block_hashes", &result, start);
-                return result;
-            }
-        };
+            };
 
         let elapsed = start.elapsed();
         debug!(

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -1,16 +1,15 @@
-use dashmap::DashMap;
+use dashmap::{DashMap, mapref::entry::Entry};
 use log::{info, warn};
 use pegaflow_common::BlockKey;
 use std::collections::HashMap;
 use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicU64, Ordering},
+    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
 };
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 const MIN_RECLAIMABLE_OWNER_COUNT: usize = 3;
-const MUTATION_BATCH_SIZE: usize = 256;
 
 pub const DEFAULT_NODE_STALE_SECS: u64 = 30;
 pub const DEFAULT_TTL_MINUTES: u64 = 120;
@@ -133,19 +132,6 @@ impl RedundancyCounters {
             self.copies.fetch_sub(before - after, Ordering::Relaxed);
         }
     }
-
-    fn reset(&self) {
-        self.keys_1.store(0, Ordering::Relaxed);
-        self.keys_2.store(0, Ordering::Relaxed);
-        self.keys_3.store(0, Ordering::Relaxed);
-        self.keys_4plus.store(0, Ordering::Relaxed);
-        self.copies.store(0, Ordering::Relaxed);
-    }
-}
-
-#[derive(Default)]
-struct MutationState {
-    reconcile_needed: bool,
 }
 
 /// Async thread-safe block hash storage using DashMap.
@@ -156,10 +142,7 @@ pub struct BlockHashStore {
     blocks: DashMap<BlockKey, HashMap<Arc<str>, OwnerRecord>>,
     nodes: DashMap<Arc<str>, NodeRecord>,
     config: StoreConfig,
-    /// Serializes metadata mutations and reconciliation scheduling; per-key
-    /// owner changes update aggregate counters within the same boundary.
-    mutation_lock: Mutex<MutationState>,
-    owners_total: AtomicU64,
+    reconcile_needed: AtomicBool,
     /// Incremental stored-owner redundancy counters read by metric callbacks.
     redundancy: RedundancyCounters,
 }
@@ -174,8 +157,7 @@ impl BlockHashStore {
             blocks: DashMap::new(),
             nodes: DashMap::new(),
             config,
-            mutation_lock: Mutex::new(MutationState::default()),
-            owners_total: AtomicU64::new(0),
+            reconcile_needed: AtomicBool::new(false),
             redundancy: RedundancyCounters::default(),
         }
     }
@@ -192,71 +174,60 @@ impl BlockHashStore {
     }
 
     pub fn heartbeat_node(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
-        let mut mutation = self.mutation_lock.lock().expect("mutation lock poisoned");
         let now = Instant::now();
-        let Some(current) = self.nodes.get(node).map(|record| record.clone()) else {
-            info!("MetaServer node registered: node={node} node_id={node_id}");
-            self.nodes.insert(
-                Arc::from(node),
-                NodeRecord {
+        match self.nodes.entry(Arc::from(node)) {
+            Entry::Vacant(entry) => {
+                info!("MetaServer node registered: node={node} node_id={node_id}");
+                entry.insert(NodeRecord {
                     node_id,
                     last_seen: now,
-                },
-            );
-            return Ok(());
-        };
-
-        let same_session = current.node_id == node_id;
-        if same_session {
-            return self.touch_node_session(node, node_id);
+                });
+                Ok(())
+            }
+            Entry::Occupied(mut entry) => {
+                let record = entry.get_mut();
+                let same_session = record.node_id == node_id;
+                let stale_session =
+                    now.duration_since(record.last_seen) > self.config.node_stale_after;
+                if same_session || stale_session {
+                    if stale_session && !same_session {
+                        self.reconcile_needed.store(true, Ordering::Release);
+                        info!(
+                            "MetaServer node session takeover: node={} old_node_id={} new_node_id={}",
+                            node, record.node_id, node_id
+                        );
+                    }
+                    record.node_id = node_id;
+                    record.last_seen = now;
+                    return Ok(());
+                }
+                warn!(
+                    "MetaServer heartbeat rejected stale session: node={} current_node_id={} rejected_node_id={}",
+                    node, record.node_id, node_id
+                );
+                Err(StoreError::StaleSession)
+            }
         }
-        let stale_session = now.duration_since(current.last_seen) > self.config.node_stale_after;
-        if stale_session {
-            info!(
-                "MetaServer node session takeover: node={} old_node_id={} new_node_id={}",
-                node, current.node_id, node_id
-            );
-            let mut record = self
-                .nodes
-                .get_mut(node)
-                .expect("node disappeared under mutation lock");
-            record.node_id = node_id;
-            record.last_seen = now;
-            drop(record);
-            mutation.reconcile_needed = true;
-            return Ok(());
-        }
-
-        warn!(
-            "MetaServer heartbeat rejected stale session: node={} current_node_id={} rejected_node_id={}",
-            node, current.node_id, node_id
-        );
-        Err(StoreError::StaleSession)
     }
 
     pub fn unregister_node(&self, node: &str, node_id: Uuid) -> Result<usize, StoreError> {
-        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
-        let Some(record) = self.nodes.get(node) else {
-            warn!(
-                "MetaServer unregister rejected unknown node: node={} node_id={}",
-                node, node_id
-            );
-            return Err(StoreError::UnknownNode);
-        };
-        if record.node_id != node_id {
-            warn!(
-                "MetaServer unregister rejected stale session: node={} rejected_node_id={}",
-                node, node_id
-            );
-            return Err(StoreError::StaleSession);
+        match self.nodes.entry(Arc::from(node)) {
+            Entry::Vacant(_) => return Err(StoreError::UnknownNode),
+            Entry::Occupied(entry) => {
+                if entry.get().node_id != node_id {
+                    return Err(StoreError::StaleSession);
+                }
+                entry.remove();
+            }
         }
-        drop(record);
-
-        // Session validation above also authorizes removal of this address's
-        // historical owners, so removing the node cannot leave orphan records.
-        let removed = self.retain_owners(|owner_node, _| owner_node.as_ref() != node);
-        self.nodes
-            .remove_if(node, |_, record| record.node_id == node_id);
+        // A concurrent registration may already have written new owners.
+        let removed = self.retain_owners(|owner_node, owner| {
+            owner_node.as_ref() != node
+                || self
+                    .nodes
+                    .get(node)
+                    .is_some_and(|record| record.node_id == owner.node_id)
+        });
         Ok(removed.removed_owners)
     }
 
@@ -267,38 +238,43 @@ impl BlockHashStore {
         node: &str,
         node_id: Uuid,
     ) -> Result<Vec<Vec<u8>>, StoreError> {
+        self.touch_node_session(node, node_id)?;
         let node: Arc<str> = Arc::from(node);
+        let now = Instant::now();
         let mut reclaimable_hashes = Vec::new();
-        for batch in hashes.chunks(MUTATION_BATCH_SIZE) {
-            let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
-            self.touch_node_session(&node, node_id)?;
-            let now = Instant::now();
-            for hash in batch {
-                let key = BlockKey::new(namespace.to_string(), hash.clone());
-                let mut owners = self.blocks.entry(key).or_default();
-                let before_count = owners.len();
-                let previous = owners.insert(
-                    Arc::clone(&node),
-                    OwnerRecord {
-                        node_id,
-                        key_register_time: now,
-                    },
-                );
-                let is_new_owner = previous
-                    .as_ref()
-                    .is_none_or(|owner| owner.node_id != node_id);
-                if is_new_owner
-                    && owners
-                        .iter()
-                        .filter(|(node, owner)| self.is_owner_visible(node, owner, now))
-                        .take(MIN_RECLAIMABLE_OWNER_COUNT)
-                        .count()
-                        == MIN_RECLAIMABLE_OWNER_COUNT
-                {
-                    reclaimable_hashes.push(hash.clone());
-                }
-                self.record_owner_change(before_count, owners.len());
-                drop(owners);
+        for hash in hashes {
+            let key = BlockKey::new(namespace.to_string(), hash.clone());
+            // Lock blocks before nodes, and keep session validation valid through the write.
+            let entry = self.blocks.entry(key);
+            let record = self
+                .nodes
+                .get(node.as_ref())
+                .ok_or(StoreError::UnknownNode)?;
+            if record.node_id != node_id {
+                return Err(StoreError::StaleSession);
+            }
+            let mut owners = entry.or_default();
+            let before = owners.len();
+            let previous = owners.insert(
+                Arc::clone(&node),
+                OwnerRecord {
+                    node_id,
+                    key_register_time: now,
+                },
+            );
+            self.redundancy.adjust(before as u64, owners.len() as u64);
+            // Reclaim hints perform their own node lookups; never nest node guards.
+            drop(record);
+            let is_new_owner = previous.is_none_or(|owner| owner.node_id != node_id);
+            if is_new_owner
+                && owners
+                    .iter()
+                    .filter(|(node, owner)| self.is_owner_visible(node, owner, now))
+                    .take(MIN_RECLAIMABLE_OWNER_COUNT)
+                    .count()
+                    == MIN_RECLAIMABLE_OWNER_COUNT
+            {
+                reclaimable_hashes.push(hash.clone());
             }
         }
         Ok(reclaimable_hashes)
@@ -311,37 +287,26 @@ impl BlockHashStore {
         node: &str,
         node_id: Uuid,
     ) -> Result<usize, StoreError> {
+        self.touch_node_session(node, node_id)?;
         let mut removed = 0;
-        for batch in hashes.chunks(MUTATION_BATCH_SIZE) {
-            let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
-            self.touch_node_session(node, node_id)?;
-            for hash in batch {
-                let key = BlockKey::new(namespace.to_string(), hash.clone());
-                let change = if let Some(mut owners) = self.blocks.get_mut(&key) {
-                    let before_count = owners.len();
-                    if owners
-                        .get(node)
-                        .is_some_and(|owner| owner.node_id == node_id)
-                    {
-                        owners.remove(node);
-                        removed += 1;
-                        Some((before_count, owners.len()))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-                if let Some((before_count, after_count)) = change {
-                    self.record_owner_change(before_count, after_count);
-                }
-                if self
-                    .blocks
-                    .get(&key)
-                    .is_some_and(|owners| owners.is_empty())
+        for hash in hashes {
+            let key = BlockKey::new(namespace.to_string(), hash.clone());
+            let should_remove_key = if let Some(mut owners) = self.blocks.get_mut(&key) {
+                let before = owners.len();
+                if owners
+                    .get(node)
+                    .is_some_and(|owner| owner.node_id == node_id)
                 {
-                    self.blocks.remove_if(&key, |_, owners| owners.is_empty());
+                    owners.remove(node);
+                    removed += 1;
                 }
+                self.redundancy.adjust(before as u64, owners.len() as u64);
+                owners.is_empty()
+            } else {
+                false
+            };
+            if should_remove_key {
+                self.blocks.remove_if(&key, |_, owners| owners.is_empty());
             }
         }
         Ok(removed)
@@ -383,38 +348,33 @@ impl BlockHashStore {
     /// Healthy sweeps only inspect nodes. A takeover or node TTL expiry triggers
     /// one block scan; owner registration age never causes background deletion.
     pub fn sweep_expired(&self) -> SweepStats {
-        let mut mutation = self.mutation_lock.lock().expect("mutation lock poisoned");
+        // Consume before scanning so a concurrent takeover remains pending.
+        let reconcile = self.reconcile_needed.swap(false, Ordering::AcqRel);
         let now = Instant::now();
-        let node_expired = self
-            .nodes
-            .iter()
-            .any(|record| now.duration_since(record.last_seen) > self.config.ttl);
-        if !node_expired && !mutation.reconcile_needed {
-            return SweepStats::default();
-        }
-
-        let mut stats = self.retain_owners(|node, owner| {
-            self.nodes.get(node.as_ref()).is_some_and(|record| {
-                record.node_id == owner.node_id
-                    && now.duration_since(record.last_seen) <= self.config.ttl
-            })
-        });
+        let mut removed_nodes = 0;
         self.nodes.retain(|node, record| {
-            let keep = now.duration_since(record.last_seen) <= self.config.ttl;
+            let age = now.saturating_duration_since(record.last_seen);
+            let keep = age <= self.config.ttl;
             if !keep {
-                stats.removed_nodes += 1;
+                removed_nodes += 1;
                 info!(
                     "MetaServer node swept: node={} node_id={} last_seen_age_secs={}",
                     node,
                     record.node_id,
-                    now.duration_since(record.last_seen).as_secs()
+                    age.as_secs()
                 );
             }
             keep
         });
-        // The same mutex serializes session changes and consuming the flag.
-        // A takeover after this scan sets the flag for the next sweep.
-        mutation.reconcile_needed = false;
+        if removed_nodes == 0 && !reconcile {
+            return SweepStats::default();
+        }
+        let mut stats = self.retain_owners(|node, owner| {
+            self.nodes
+                .get(node.as_ref())
+                .is_some_and(|record| record.node_id == owner.node_id)
+        });
+        stats.removed_nodes = removed_nodes;
         stats
     }
 
@@ -422,32 +382,9 @@ impl BlockHashStore {
     /// liveness. This is reserved for explicit operator maintenance.
     pub fn remove_owners_older_than(&self, max_age: Duration) -> SweepStats {
         let now = Instant::now();
-        let mut stats = SweepStats::default();
-
-        let keys: Vec<BlockKey> = self
-            .blocks
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect();
-        for batch in keys.chunks(MUTATION_BATCH_SIZE) {
-            let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
-            for key in batch {
-                if let Some(mut owners) = self.blocks.get_mut(key) {
-                    let before_count = owners.len();
-                    owners.retain(|_, owner| {
-                        now.saturating_duration_since(owner.key_register_time) <= max_age
-                    });
-                    self.record_owner_change(before_count, owners.len());
-                    stats.removed_owners += before_count - owners.len();
-                }
-                if self.blocks.get(key).is_some_and(|owners| owners.is_empty()) {
-                    self.blocks.remove_if(key, |_, owners| owners.is_empty());
-                    stats.removed_keys += 1;
-                }
-            }
-        }
-
-        stats
+        self.retain_owners(|_, owner| {
+            now.saturating_duration_since(owner.key_register_time) <= max_age
+        })
     }
 
     /// Latest incrementally maintained stored-owner redundancy distribution.
@@ -460,7 +397,7 @@ impl BlockHashStore {
     }
 
     pub fn owner_count(&self) -> u64 {
-        self.owners_total.load(Ordering::Relaxed)
+        self.redundancy.copies.load(Ordering::Relaxed)
     }
 
     pub fn node_counts(&self) -> (u64, u64) {
@@ -483,12 +420,8 @@ impl BlockHashStore {
         reason = "maintenance API reserved for explicit store cleanup"
     )]
     pub fn invalidate_all(&self) {
-        let mut mutation = self.mutation_lock.lock().expect("mutation lock poisoned");
-        self.blocks.clear();
         self.nodes.clear();
-        mutation.reconcile_needed = false;
-        self.redundancy.reset();
-        self.owners_total.store(0, Ordering::Relaxed);
+        self.retain_owners(|_, _| false);
     }
 
     fn touch_node_session(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
@@ -510,27 +443,13 @@ impl BlockHashStore {
         Ok(())
     }
 
-    /// Called under mutation_lock. Counts follow retained records, so a session
-    /// change cannot invalidate a subsequent mutation's before-count.
-    fn record_owner_change(&self, before: usize, after: usize) {
-        if after > before {
-            self.owners_total
-                .fetch_add((after - before) as u64, Ordering::Relaxed);
-        } else if before > after {
-            self.owners_total
-                .fetch_sub((before - after) as u64, Ordering::Relaxed);
-        }
-        self.redundancy.adjust(before as u64, after as u64);
-    }
-
-    /// Lifecycle and explicit node removal share one accounting boundary.
-    /// Callers must hold mutation_lock throughout the scan.
+    /// Owner changes and accounting share the block shard's write guard.
     fn retain_owners(&self, mut keep: impl FnMut(&Arc<str>, &OwnerRecord) -> bool) -> SweepStats {
         let mut stats = SweepStats::default();
         self.blocks.retain(|_, owners| {
             let before = owners.len();
             owners.retain(|node, owner| keep(node, owner));
-            self.record_owner_change(before, owners.len());
+            self.redundancy.adjust(before as u64, owners.len() as u64);
             stats.removed_owners += before - owners.len();
             if owners.is_empty() {
                 stats.removed_keys += 1;
@@ -593,6 +512,93 @@ pub(crate) mod tests {
         assert_eq!(store.redundancy_snapshot(), expected);
     }
 
+    fn wait_until(mut ready: impl FnMut() -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !ready() {
+            assert!(
+                Instant::now() < deadline,
+                "concurrent operation did not progress"
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn insert_rechecks_session_after_waiting_for_block_lock() {
+        for occupied in [false, true] {
+            let store = BlockHashStore::new();
+            let old = heartbeat_node(&store, "a");
+            if occupied {
+                store.insert_hashes("ns", &[vec![1]], "a", old).unwrap();
+            }
+            let stale = Instant::now() - Duration::from_secs(31);
+            store.nodes.get_mut("a").unwrap().last_seen = stale;
+            std::thread::scope(|scope| {
+                let mut entry = store.blocks.entry(BlockKey::new("ns".into(), vec![1]));
+                let insert = scope.spawn(|| store.insert_hashes("ns", &[vec![1]], "a", old));
+                wait_until(|| store.nodes.get("a").unwrap().last_seen > stale);
+                store.nodes.get_mut("a").unwrap().last_seen = stale;
+                let current = heartbeat_node(&store, "a");
+                if let Entry::Occupied(ref mut entry) = entry {
+                    // Model a new-session write that wins the block lock first.
+                    entry.get_mut().get_mut("a").unwrap().node_id = current;
+                }
+                drop(entry);
+                assert_eq!(insert.join().unwrap(), Err(StoreError::StaleSession));
+                assert_eq!(
+                    store.query_prefix("ns", &[vec![1]]).len(),
+                    usize::from(occupied)
+                );
+            });
+            assert_stored_counts(&store);
+        }
+    }
+
+    #[test]
+    fn takeover_during_sweep_remains_pending() {
+        let store = BlockHashStore::new();
+        let old = heartbeat_node(&store, "a");
+        store.insert_hashes("ns", &[vec![1]], "a", old).unwrap();
+        store.reconcile_needed.store(true, Ordering::Release);
+        std::thread::scope(|scope| {
+            let guard = store
+                .blocks
+                .get_mut(&BlockKey::new("ns".into(), vec![1]))
+                .unwrap();
+            let sweep = scope.spawn(|| store.sweep_expired());
+            wait_until(|| !store.reconcile_needed.load(Ordering::Acquire));
+            store.nodes.get_mut("a").unwrap().last_seen = Instant::now() - Duration::from_secs(31);
+            heartbeat_node(&store, "a");
+            drop(guard);
+            assert_eq!(sweep.join().unwrap().removed_owners, 1);
+        });
+        assert!(store.reconcile_needed.load(Ordering::Acquire));
+        assert!(store.sweep_expired().is_empty());
+        assert!(!store.reconcile_needed.load(Ordering::Acquire));
+        assert_stored_counts(&store);
+    }
+
+    #[test]
+    fn unregister_preserves_concurrent_registration() {
+        let store = BlockHashStore::new();
+        let old = heartbeat_node(&store, "a");
+        store.insert_hashes("ns", &[vec![1]], "a", old).unwrap();
+        std::thread::scope(|scope| {
+            let mut owners = store
+                .blocks
+                .get_mut(&BlockKey::new("ns".into(), vec![1]))
+                .unwrap();
+            let unregister = scope.spawn(|| store.unregister_node("a", old));
+            wait_until(|| !store.nodes.contains_key("a"));
+            let current = heartbeat_node(&store, "a");
+            owners.get_mut("a").unwrap().node_id = current;
+            drop(owners);
+            assert_eq!(unregister.join().unwrap(), Ok(0));
+        });
+        assert_eq!(store.query_prefix("ns", &[vec![1]]).len(), 1);
+        assert_stored_counts(&store);
+    }
+
     #[test]
     fn stale_node_survives_sweep_and_recovers_without_insert() {
         let store = BlockHashStore::new();
@@ -615,6 +621,7 @@ pub(crate) mod tests {
             assert_eq!(result.unwrap(), SweepStats::default());
         });
         assert_eq!(store.node_counts(), (0, 1));
+        assert_stored_counts(&store);
         store.heartbeat_node("node-a", id).unwrap();
         assert_eq!(store.query_prefix("ns", &[vec![1]]).len(), 1);
         assert_stored_counts(&store);
@@ -1003,33 +1010,8 @@ pub(crate) mod tests {
         assert_eq!(removed.removed_keys, 1);
         assert_eq!(removed.removed_nodes, 0);
         assert_eq!(store.owner_count(), 0);
+        assert_stored_counts(&store);
         assert!(store.query_prefix("ns", &[vec![1]]).is_empty());
-    }
-
-    #[test]
-    fn test_sweep_removes_superseded_owner_after_key_purge_age() {
-        let store = BlockHashStore::with_config(StoreConfig {
-            node_stale_after: Duration::ZERO,
-            ttl: Duration::ZERO,
-        });
-        let old_id = heartbeat_node(&store, "node-a");
-        store
-            .insert_hashes("ns", &[vec![1]], "node-a", old_id)
-            .unwrap();
-        store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(1);
-        let new_id = heartbeat_node(&store, "node-a");
-        assert_ne!(old_id, new_id);
-
-        let removed = store.sweep_expired();
-        assert_eq!(
-            removed,
-            SweepStats {
-                removed_owners: 1,
-                removed_keys: 1,
-                removed_nodes: 1,
-            }
-        );
-        assert_eq!(store.owner_count(), 0);
     }
 
     #[test]
@@ -1078,30 +1060,6 @@ pub(crate) mod tests {
         assert!(existing.is_empty());
         assert_eq!(store.entry_count(), 1);
         assert_eq!(store.owner_count(), 1);
-    }
-
-    #[test]
-    fn takeover_reconciles_old_session_owners_on_next_sweep() {
-        let store = BlockHashStore::with_config(StoreConfig {
-            node_stale_after: Duration::ZERO,
-            ttl: Duration::from_secs(60),
-        });
-        let old_id = heartbeat_node(&store, "node-a");
-        store
-            .insert_hashes("ns", &[vec![1]], "node-a", old_id)
-            .unwrap();
-        store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(1);
-
-        let new_id = heartbeat_node(&store, "node-a");
-        assert!(store.query_prefix("ns", &[vec![1]]).is_empty());
-        assert_eq!(store.owner_count(), 1);
-
-        let stats = store.sweep_expired();
-        assert_eq!(stats.removed_owners, 1);
-        assert_eq!(stats.removed_nodes, 0);
-        assert_eq!(store.owner_count(), 0);
-        assert!(store.query_prefix("ns", &[vec![1]]).is_empty());
-        assert_eq!(store.nodes.get("node-a").unwrap().node_id, new_id);
     }
 
     #[test]
@@ -1183,59 +1141,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_sweep_keeps_old_owner_on_active_node() {
-        let store = BlockHashStore::with_config(StoreConfig {
-            node_stale_after: Duration::from_secs(60),
-            ttl: Duration::from_secs(1),
-        });
-        let node_id = heartbeat_node(&store, "node-a");
-        store
-            .insert_hashes("ns", &[vec![1]], "node-a", node_id)
-            .unwrap();
-        store
-            .blocks
-            .get_mut(&BlockKey::new("ns".to_string(), vec![1]))
-            .unwrap()
-            .get_mut("node-a")
-            .unwrap()
-            .key_register_time = Instant::now() - Duration::from_secs(2);
-
-        let removed = store.sweep_expired();
-        assert_eq!(removed, SweepStats::default());
-        assert_eq!(store.owner_count(), 1);
-        assert_eq!(store.query_prefix("ns", &[vec![1]]).len(), 1);
-    }
-
-    #[test]
-    fn test_remove_owners_older_than_removes_only_expired_owners() {
-        let store = BlockHashStore::new();
-        let node_id = heartbeat_node(&store, "node-a");
-        store
-            .insert_hashes("ns", &[vec![1], vec![2]], "node-a", node_id)
-            .unwrap();
-        store
-            .blocks
-            .get_mut(&BlockKey::new("ns".to_string(), vec![1]))
-            .unwrap()
-            .get_mut("node-a")
-            .unwrap()
-            .key_register_time = Instant::now() - Duration::from_secs(3601);
-
-        let removed = store.remove_owners_older_than(Duration::from_secs(3600));
-        assert_eq!(
-            removed,
-            SweepStats {
-                removed_owners: 1,
-                removed_keys: 1,
-                removed_nodes: 0,
-            }
-        );
-        assert_eq!(store.owner_count(), 1);
-        assert_eq!(store.entry_count(), 1);
-    }
-
-    #[test]
-    fn test_concurrent_insert_and_remove() {
+    fn test_concurrent_insert_remove_and_cleanup() {
         use std::sync::Arc;
 
         let store = Arc::new(BlockHashStore::new());
@@ -1247,6 +1153,13 @@ pub(crate) mod tests {
             store
                 .insert_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a_id)
                 .unwrap();
+            store
+                .blocks
+                .get_mut(&BlockKey::new("ns".into(), hash.clone()))
+                .unwrap()
+                .get_mut("node-a")
+                .unwrap()
+                .key_register_time = Instant::now() - Duration::from_secs(3601);
 
             let store_a = Arc::clone(&store);
             let store_b = Arc::clone(&store);
@@ -1254,6 +1167,7 @@ pub(crate) mod tests {
             let hash_b = hash.clone();
 
             std::thread::scope(|s| {
+                s.spawn(|| store.remove_owners_older_than(Duration::from_secs(3600)));
                 s.spawn(|| {
                     store_a
                         .remove_hashes("ns", &[hash_a], "node-a", node_a_id)
@@ -1273,7 +1187,9 @@ pub(crate) mod tests {
                 "node-b must be present"
             );
 
+            assert_stored_counts(&store);
             store.invalidate_all();
+            assert_stored_counts(&store);
         }
     }
 
@@ -1332,27 +1248,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_redundancy_snapshot_excludes_superseded_owner() {
-        // A block whose only owner is a superseded session is removed by the
-        // next reconciliation sweep.
-        let store = BlockHashStore::new();
-        let old_id = heartbeat_node(&store, "node-a");
-        store
-            .insert_hashes("ns", &[vec![1]], "node-a", old_id)
-            .unwrap();
-        store.nodes.get_mut("node-a").unwrap().last_seen =
-            Instant::now() - Duration::from_secs(DEFAULT_NODE_STALE_SECS + 1);
-        let new_id = heartbeat_node(&store, "node-a");
-        assert_ne!(old_id, new_id);
-
-        store.sweep_expired();
-
-        assert_eq!(store.owner_count(), 0);
-        assert_eq!(store.entry_count(), 0);
-        assert_eq!(store.redundancy_snapshot(), RedundancySnapshot::default());
-    }
-
-    #[test]
     fn test_redundancy_counters_follow_owner_mutations() {
         let store = BlockHashStore::new();
         let node_a = heartbeat_node(&store, "node-a");
@@ -1387,28 +1282,5 @@ pub(crate) mod tests {
         let cleanup = store.remove_owners_older_than(Duration::from_secs(3600));
         assert_eq!(cleanup.removed_owners, 1);
         assert_eq!(store.redundancy_snapshot(), RedundancySnapshot::default());
-    }
-
-    #[test]
-    fn heartbeat_does_not_recount_unswept_stale_owners() {
-        let store = BlockHashStore::with_config(StoreConfig {
-            node_stale_after: Duration::from_secs(30),
-            ..StoreConfig::default()
-        });
-        let node_a = heartbeat_node(&store, "node-a");
-        let node_b = heartbeat_node(&store, "node-b");
-        let hash = vec![7];
-        store
-            .insert_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a)
-            .unwrap();
-        store
-            .insert_hashes("ns", std::slice::from_ref(&hash), "node-b", node_b)
-            .unwrap();
-        let before = store.redundancy_snapshot();
-
-        store.nodes.get_mut("node-b").unwrap().last_seen = Instant::now() - Duration::from_secs(31);
-        store.heartbeat_node("node-a", node_a).unwrap();
-
-        assert_eq!(store.redundancy_snapshot(), before);
     }
 }

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -1,7 +1,7 @@
 use dashmap::DashMap;
 use log::{info, warn};
 use pegaflow_common::BlockKey;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicU64, Ordering},
@@ -26,6 +26,7 @@ pub struct PrefixEntry {
 #[derive(Debug, Clone, Copy)]
 pub struct StoreConfig {
     pub node_stale_after: Duration,
+    /// Node inactivity grace period; never applies to owner registration age.
     pub ttl: Duration,
 }
 
@@ -51,14 +52,9 @@ impl SweepStats {
     }
 }
 
-/// Owner redundancy distribution over block keys, maintained incrementally so
-/// metric scrapes stay O(1). Node liveness transitions are settled by the
-/// periodic sweep, so a scrape before that sweep can briefly include a stale
-/// node. Keys are bucketed by their number of accounted owners (1, 2, 3, >=4);
-/// keys with zero accounted owners are excluded from every bucket. `copies` is
-/// the exact total of accounted owners, so average redundancy (the cache
-/// capacity shrink factor) is
-/// `copies / (keys_1 + keys_2 + keys_3 + keys_4plus)`.
+/// Incremental distribution of stored owner records, not query-visible owners.
+/// Stale nodes remain counted until TTL cleanup, and superseded sessions until
+/// reconciliation. Reads of separate atomic fields may straddle a mutation.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RedundancySnapshot {
     pub keys_1: u64,
@@ -147,20 +143,24 @@ impl RedundancyCounters {
     }
 }
 
+#[derive(Default)]
+struct MutationState {
+    reconcile_needed: bool,
+}
+
 /// Async thread-safe block hash storage using DashMap.
 ///
 /// `blocks` maps each block key to node URL ownership records. `nodes` tracks
 /// the current MetaServer session and liveness for each node URL.
 pub struct BlockHashStore {
     blocks: DashMap<BlockKey, HashMap<Arc<str>, OwnerRecord>>,
-    node_blocks: DashMap<Arc<str>, HashSet<BlockKey>>,
     nodes: DashMap<Arc<str>, NodeRecord>,
     config: StoreConfig,
-    /// Serializes metadata mutations so per-key visibility transitions and
-    /// aggregate redundancy counters stay consistent with one another.
-    mutation_lock: Mutex<()>,
+    /// Serializes metadata mutations and reconciliation scheduling; per-key
+    /// owner changes update aggregate counters within the same boundary.
+    mutation_lock: Mutex<MutationState>,
     owners_total: AtomicU64,
-    /// Incremental live-owner redundancy counters read by metric callbacks.
+    /// Incremental stored-owner redundancy counters read by metric callbacks.
     redundancy: RedundancyCounters,
 }
 
@@ -172,10 +172,9 @@ impl BlockHashStore {
     pub fn with_config(config: StoreConfig) -> Self {
         Self {
             blocks: DashMap::new(),
-            node_blocks: DashMap::new(),
             nodes: DashMap::new(),
             config,
-            mutation_lock: Mutex::new(()),
+            mutation_lock: Mutex::new(MutationState::default()),
             owners_total: AtomicU64::new(0),
             redundancy: RedundancyCounters::default(),
         }
@@ -193,7 +192,7 @@ impl BlockHashStore {
     }
 
     pub fn heartbeat_node(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
-        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
+        let mut mutation = self.mutation_lock.lock().expect("mutation lock poisoned");
         let now = Instant::now();
         let Some(current) = self.nodes.get(node).map(|record| record.clone()) else {
             info!("MetaServer node registered: node={node} node_id={node_id}");
@@ -217,20 +216,6 @@ impl BlockHashStore {
                 "MetaServer node session takeover: node={} old_node_id={} new_node_id={}",
                 node, current.node_id, node_id
             );
-            let keys = self
-                .node_blocks
-                .get(node)
-                .map(|keys| keys.iter().cloned().collect::<Vec<_>>())
-                .unwrap_or_default();
-            let before: Vec<(BlockKey, u64)> = keys
-                .iter()
-                .filter_map(|key| {
-                    self.blocks
-                        .get(key)
-                        .map(|owners| (key.clone(), self.accounted_owner_count(&owners)))
-                })
-                .collect();
-
             let mut record = self
                 .nodes
                 .get_mut(node)
@@ -238,13 +223,7 @@ impl BlockHashStore {
             record.node_id = node_id;
             record.last_seen = now;
             drop(record);
-
-            for (key, before_visible) in before {
-                if let Some(owners) = self.blocks.get(&key) {
-                    let after_visible = self.accounted_owner_count(&owners);
-                    self.redundancy.adjust(before_visible, after_visible);
-                }
-            }
+            mutation.reconcile_needed = true;
             return Ok(());
         }
 
@@ -273,12 +252,12 @@ impl BlockHashStore {
         }
         drop(record);
 
-        // Remove owners while the node record is still present so the
-        // redundancy counters observe the same visibility as queries.
-        let removed = self.remove_node_owners(node, node_id);
+        // Session validation above also authorizes removal of this address's
+        // historical owners, so removing the node cannot leave orphan records.
+        let removed = self.retain_owners(|owner_node, _| owner_node.as_ref() != node);
         self.nodes
             .remove_if(node, |_, record| record.node_id == node_id);
-        Ok(removed)
+        Ok(removed.removed_owners)
     }
 
     pub fn insert_hashes(
@@ -297,7 +276,7 @@ impl BlockHashStore {
             for hash in batch {
                 let key = BlockKey::new(namespace.to_string(), hash.clone());
                 let mut owners = self.blocks.entry(key).or_default();
-                let before_visible = self.accounted_owner_count(&owners);
+                let before_count = owners.len();
                 let previous = owners.insert(
                     Arc::clone(&node),
                     OwnerRecord {
@@ -305,9 +284,6 @@ impl BlockHashStore {
                         key_register_time: now,
                     },
                 );
-                if previous.is_none() {
-                    self.owners_total.fetch_add(1, Ordering::Relaxed);
-                }
                 let is_new_owner = previous
                     .as_ref()
                     .is_none_or(|owner| owner.node_id != node_id);
@@ -321,14 +297,8 @@ impl BlockHashStore {
                 {
                     reclaimable_hashes.push(hash.clone());
                 }
-                let after_visible = self.accounted_owner_count(&owners);
-                self.redundancy.adjust(before_visible, after_visible);
-                let key = BlockKey::new(namespace.to_string(), hash.clone());
+                self.record_owner_change(before_count, owners.len());
                 drop(owners);
-                self.node_blocks
-                    .entry(Arc::clone(&node))
-                    .or_default()
-                    .insert(key);
             }
         }
         Ok(reclaimable_hashes)
@@ -341,7 +311,6 @@ impl BlockHashStore {
         node: &str,
         node_id: Uuid,
     ) -> Result<usize, StoreError> {
-        let node_key: Arc<str> = Arc::from(node);
         let mut removed = 0;
         for batch in hashes.chunks(MUTATION_BATCH_SIZE) {
             let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
@@ -349,25 +318,22 @@ impl BlockHashStore {
             for hash in batch {
                 let key = BlockKey::new(namespace.to_string(), hash.clone());
                 let change = if let Some(mut owners) = self.blocks.get_mut(&key) {
-                    let before_visible = self.accounted_owner_count(&owners);
+                    let before_count = owners.len();
                     if owners
                         .get(node)
                         .is_some_and(|owner| owner.node_id == node_id)
                     {
                         owners.remove(node);
-                        self.owners_total.fetch_sub(1, Ordering::Relaxed);
                         removed += 1;
-                        let after_visible = self.accounted_owner_count(&owners);
-                        Some((before_visible, after_visible))
+                        Some((before_count, owners.len()))
                     } else {
                         None
                     }
                 } else {
                     None
                 };
-                if let Some((before_visible, after_visible)) = change {
-                    self.remove_reverse_index_key(&node_key, &key);
-                    self.redundancy.adjust(before_visible, after_visible);
+                if let Some((before_count, after_count)) = change {
+                    self.record_owner_change(before_count, after_count);
                 }
                 if self
                     .blocks
@@ -414,83 +380,46 @@ impl BlockHashStore {
         result
     }
 
-    /// Sweep owners belonging to nodes that are missing or no longer active.
-    /// The reverse index limits work to keys owned by those nodes.
+    /// Healthy sweeps only inspect nodes. A takeover or node TTL expiry triggers
+    /// one block scan; owner registration age never causes background deletion.
     pub fn sweep_expired(&self) -> SweepStats {
+        let mut mutation = self.mutation_lock.lock().expect("mutation lock poisoned");
         let now = Instant::now();
-        let mut stats = SweepStats::default();
-        let stale_nodes: Vec<(Arc<str>, Uuid, u64)> = self
+        let node_expired = self
             .nodes
             .iter()
-            .filter_map(|entry| {
-                let age = now.duration_since(entry.last_seen);
-                (age > self.config.node_stale_after)
-                    .then(|| (Arc::clone(entry.key()), entry.node_id, age.as_secs()))
+            .any(|record| now.duration_since(record.last_seen) > self.config.ttl);
+        if !node_expired && !mutation.reconcile_needed {
+            return SweepStats::default();
+        }
+
+        let mut stats = self.retain_owners(|node, owner| {
+            self.nodes.get(node.as_ref()).is_some_and(|record| {
+                record.node_id == owner.node_id
+                    && now.duration_since(record.last_seen) <= self.config.ttl
             })
-            .collect();
-
-        for (node, node_id, last_seen_age_secs) in stale_nodes {
-            let keys = self
-                .node_blocks
-                .get(&node)
-                .map(|keys| keys.iter().cloned().collect::<Vec<_>>())
-                .unwrap_or_default();
-            for batch in keys.chunks(MUTATION_BATCH_SIZE) {
-                let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
-                if !self.nodes.get(&node).is_some_and(|record| {
-                    record.node_id == node_id
-                        && record.last_seen.elapsed() > self.config.node_stale_after
-                }) {
-                    break;
-                }
-                for key in batch {
-                    if let Some((before_visible, after_visible, empty)) =
-                        self.remove_any_owner_for_key(key, &node)
-                    {
-                        stats.removed_owners += 1;
-                        stats.removed_keys += usize::from(empty);
-                        self.redundancy.adjust(before_visible, after_visible);
-                        self.remove_reverse_index_key(&node, key);
-                    } else if self.owner_for_node(key, &node).is_none() {
-                        self.remove_reverse_index_key(&node, key);
-                    }
-                }
-            }
-
-            let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
-            if self
-                .nodes
-                .remove_if(&node, |_, record| {
-                    record.node_id == node_id
-                        && record.last_seen.elapsed() > self.config.node_stale_after
-                })
-                .is_some()
-            {
+        });
+        self.nodes.retain(|node, record| {
+            let keep = now.duration_since(record.last_seen) <= self.config.ttl;
+            if !keep {
                 stats.removed_nodes += 1;
                 info!(
                     "MetaServer node swept: node={} node_id={} last_seen_age_secs={}",
-                    node, node_id, last_seen_age_secs
+                    node,
+                    record.node_id,
+                    now.duration_since(record.last_seen).as_secs()
                 );
             }
-        }
-
-        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
-        let empty_nodes: Vec<Arc<str>> = self
-            .node_blocks
-            .iter()
-            .filter(|entry| entry.is_empty())
-            .map(|entry| Arc::clone(entry.key()))
-            .collect();
-        for node in empty_nodes {
-            self.node_blocks.remove_if(&node, |_, keys| keys.is_empty());
-        }
-
+            keep
+        });
+        // The same mutex serializes session changes and consuming the flag.
+        // A takeover after this scan sets the flag for the next sweep.
+        mutation.reconcile_needed = false;
         stats
     }
 
     /// Remove ownership records older than `max_age`, regardless of node
-    /// liveness. This is reserved for explicit operator maintenance; the
-    /// periodic lifecycle sweep intentionally does not use owner age.
+    /// liveness. This is reserved for explicit operator maintenance.
     pub fn remove_owners_older_than(&self, max_age: Duration) -> SweepStats {
         let now = Instant::now();
         let mut stats = SweepStats::default();
@@ -500,31 +429,16 @@ impl BlockHashStore {
             .iter()
             .map(|entry| entry.key().clone())
             .collect();
-        // Snapshot keys without holding the mutation lock, then recheck owner
-        // timestamps in bounded batches so concurrent refreshes are preserved.
         for batch in keys.chunks(MUTATION_BATCH_SIZE) {
             let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
             for key in batch {
-                let mut removed_nodes = Vec::new();
                 if let Some(mut owners) = self.blocks.get_mut(key) {
-                    let before_visible = self.accounted_owner_count(&owners);
-                    owners.retain(|node, owner| {
-                        if now.saturating_duration_since(owner.key_register_time) > max_age {
-                            removed_nodes.push(Arc::clone(node));
-                            false
-                        } else {
-                            true
-                        }
+                    let before_count = owners.len();
+                    owners.retain(|_, owner| {
+                        now.saturating_duration_since(owner.key_register_time) <= max_age
                     });
-                    let after_visible = self.accounted_owner_count(&owners);
-                    stats.removed_owners += removed_nodes.len();
-                    self.owners_total
-                        .fetch_sub(removed_nodes.len() as u64, Ordering::Relaxed);
-                    self.redundancy.adjust(before_visible, after_visible);
-                    drop(owners);
-                }
-                for node in removed_nodes {
-                    self.remove_reverse_index_key(&node, key);
+                    self.record_owner_change(before_count, owners.len());
+                    stats.removed_owners += before_count - owners.len();
                 }
                 if self.blocks.get(key).is_some_and(|owners| owners.is_empty()) {
                     self.blocks.remove_if(key, |_, owners| owners.is_empty());
@@ -536,7 +450,7 @@ impl BlockHashStore {
         stats
     }
 
-    /// Latest incrementally maintained live-owner redundancy distribution.
+    /// Latest incrementally maintained stored-owner redundancy distribution.
     pub fn redundancy_snapshot(&self) -> RedundancySnapshot {
         self.redundancy.snapshot()
     }
@@ -569,10 +483,10 @@ impl BlockHashStore {
         reason = "maintenance API reserved for explicit store cleanup"
     )]
     pub fn invalidate_all(&self) {
-        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
+        let mut mutation = self.mutation_lock.lock().expect("mutation lock poisoned");
         self.blocks.clear();
-        self.node_blocks.clear();
         self.nodes.clear();
+        mutation.reconcile_needed = false;
         self.redundancy.reset();
         self.owners_total.store(0, Ordering::Relaxed);
     }
@@ -596,97 +510,35 @@ impl BlockHashStore {
         Ok(())
     }
 
-    fn remove_node_owners(&self, node: &str, node_id: Uuid) -> usize {
-        let node: Arc<str> = Arc::from(node);
-        let keys = self
-            .node_blocks
-            .get(&node)
-            .map(|keys| keys.iter().cloned().collect::<Vec<_>>())
-            .unwrap_or_default();
-        let mut removed = 0;
-        for key in keys {
-            if let Some((before_visible, after_visible, _empty)) =
-                self.remove_owner_for_key(&key, &node, node_id)
-            {
-                removed += 1;
-                self.redundancy.adjust(before_visible, after_visible);
-                self.remove_reverse_index_key(&node, &key);
+    /// Called under mutation_lock. Counts follow retained records, so a session
+    /// change cannot invalidate a subsequent mutation's before-count.
+    fn record_owner_change(&self, before: usize, after: usize) {
+        if after > before {
+            self.owners_total
+                .fetch_add((after - before) as u64, Ordering::Relaxed);
+        } else if before > after {
+            self.owners_total
+                .fetch_sub((before - after) as u64, Ordering::Relaxed);
+        }
+        self.redundancy.adjust(before as u64, after as u64);
+    }
+
+    /// Lifecycle and explicit node removal share one accounting boundary.
+    /// Callers must hold mutation_lock throughout the scan.
+    fn retain_owners(&self, mut keep: impl FnMut(&Arc<str>, &OwnerRecord) -> bool) -> SweepStats {
+        let mut stats = SweepStats::default();
+        self.blocks.retain(|_, owners| {
+            let before = owners.len();
+            owners.retain(|node, owner| keep(node, owner));
+            self.record_owner_change(before, owners.len());
+            stats.removed_owners += before - owners.len();
+            if owners.is_empty() {
+                stats.removed_keys += 1;
+                return false;
             }
-        }
-        removed
-    }
-
-    /// Counter visibility intentionally ignores node age. A stale node remains
-    /// represented until the lifecycle sweep removes it, so ordinary mutations
-    /// do not make aggregate counters disagree with the records they describe.
-    fn accounted_owner_count(&self, owners: &HashMap<Arc<str>, OwnerRecord>) -> u64 {
-        owners
-            .iter()
-            .filter(|(node, owner)| {
-                self.nodes
-                    .get(node.as_ref())
-                    .is_some_and(|record| record.node_id == owner.node_id)
-            })
-            .count() as u64
-    }
-
-    fn remove_owner_for_key(
-        &self,
-        key: &BlockKey,
-        node: &Arc<str>,
-        node_id: Uuid,
-    ) -> Option<(u64, u64, bool)> {
-        let mut owners = self.blocks.get_mut(key)?;
-        if !owners
-            .get(node)
-            .is_some_and(|owner| owner.node_id == node_id)
-        {
-            return None;
-        }
-        let before_visible = self.accounted_owner_count(&owners);
-        owners.remove(node);
-        self.owners_total.fetch_sub(1, Ordering::Relaxed);
-        let after_visible = self.accounted_owner_count(&owners);
-        let empty = owners.is_empty();
-        drop(owners);
-        if empty {
-            self.blocks.remove_if(key, |_, owners| owners.is_empty());
-        }
-        Some((before_visible, after_visible, empty))
-    }
-
-    fn remove_any_owner_for_key(
-        &self,
-        key: &BlockKey,
-        node: &Arc<str>,
-    ) -> Option<(u64, u64, bool)> {
-        let mut owners = self.blocks.get_mut(key)?;
-        if !owners.contains_key(node) {
-            return None;
-        }
-        let before_visible = self.accounted_owner_count(&owners);
-        owners.remove(node);
-        self.owners_total.fetch_sub(1, Ordering::Relaxed);
-        let after_visible = self.accounted_owner_count(&owners);
-        let empty = owners.is_empty();
-        drop(owners);
-        if empty {
-            self.blocks.remove_if(key, |_, owners| owners.is_empty());
-        }
-        Some((before_visible, after_visible, empty))
-    }
-
-    fn owner_for_node(&self, key: &BlockKey, node: &Arc<str>) -> Option<Uuid> {
-        self.blocks
-            .get(key)
-            .and_then(|owners| owners.get(node).map(|owner| owner.node_id))
-    }
-
-    fn remove_reverse_index_key(&self, node: &Arc<str>, key: &BlockKey) {
-        if let Some(mut keys) = self.node_blocks.get_mut(node) {
-            keys.remove(key);
-        }
-        self.node_blocks.remove_if(node, |_, keys| keys.is_empty());
+            true
+        });
+        stats
     }
 
     fn is_owner_visible(&self, node: &Arc<str>, owner: &OwnerRecord, now: Instant) -> bool {
@@ -705,8 +557,151 @@ impl Default for BlockHashStore {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
+
+    pub(crate) fn manual_cleanup_fixture() -> BlockHashStore {
+        let store = BlockHashStore::new();
+        let a = heartbeat_node(&store, "a");
+        let b = heartbeat_node(&store, "b");
+        store
+            .insert_hashes("ns", &[vec![1], vec![2], vec![3]], "a", a)
+            .unwrap();
+        for mut owners in store.blocks.iter_mut() {
+            owners.get_mut("a").unwrap().key_register_time =
+                Instant::now() - Duration::from_secs(MANUAL_CLEANUP_AGE_SECS + 1);
+        }
+        // Refresh one old owner and add a fresh replica to another old key.
+        store.insert_hashes("ns", &[vec![3]], "a", a).unwrap();
+        store.insert_hashes("ns", &[vec![2]], "b", b).unwrap();
+        store
+    }
+
+    fn assert_stored_counts(store: &BlockHashStore) {
+        let mut expected = RedundancySnapshot::default();
+        for owners in &store.blocks {
+            match owners.len() {
+                0 => panic!("empty key retained"),
+                1 => expected.keys_1 += 1,
+                2 => expected.keys_2 += 1,
+                3 => expected.keys_3 += 1,
+                _ => expected.keys_4plus += 1,
+            }
+            expected.copies += owners.len() as u64;
+        }
+        assert_eq!(store.owner_count(), expected.copies);
+        assert_eq!(store.redundancy_snapshot(), expected);
+    }
+
+    #[test]
+    fn stale_node_survives_sweep_and_recovers_without_insert() {
+        let store = BlockHashStore::new();
+        let id = heartbeat_node(&store, "node-a");
+        store.insert_hashes("ns", &[vec![1]], "node-a", id).unwrap();
+        store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(31);
+        assert!(store.query_prefix("ns", &[vec![1]]).is_empty());
+
+        // A held block shard must not prevent the healthy-node-table fast path.
+        let guard = store
+            .blocks
+            .get_mut(&BlockKey::new("ns".into(), vec![1]))
+            .unwrap();
+        std::thread::scope(|scope| {
+            let (tx, rx) = std::sync::mpsc::channel();
+            let store_ref = &store;
+            scope.spawn(move || tx.send(store_ref.sweep_expired()).unwrap());
+            let result = rx.recv_timeout(Duration::from_secs(2));
+            drop(guard);
+            assert_eq!(result.unwrap(), SweepStats::default());
+        });
+        assert_eq!(store.node_counts(), (0, 1));
+        store.heartbeat_node("node-a", id).unwrap();
+        assert_eq!(store.query_prefix("ns", &[vec![1]]).len(), 1);
+        assert_stored_counts(&store);
+    }
+
+    #[test]
+    fn node_ttl_cleanup_preserves_old_blocks_on_active_nodes() {
+        let store = BlockHashStore::new();
+        let a = heartbeat_node(&store, "a");
+        let b = heartbeat_node(&store, "b");
+        store
+            .insert_hashes("ns", &[vec![1], vec![2]], "a", a)
+            .unwrap();
+        store.insert_hashes("ns", &[vec![1]], "b", b).unwrap();
+        let old = Instant::now() - store.config.ttl - Duration::from_secs(1);
+        for mut owners in store.blocks.iter_mut() {
+            for owner in owners.values_mut() {
+                owner.key_register_time = old;
+            }
+        }
+        store.nodes.get_mut("a").unwrap().last_seen = old;
+        assert_eq!(
+            store.sweep_expired(),
+            SweepStats {
+                removed_owners: 2,
+                removed_keys: 1,
+                removed_nodes: 1,
+            }
+        );
+        assert_eq!(
+            store.query_prefix("ns", &[vec![1]])[0].nodes[0].as_ref(),
+            "b"
+        );
+        assert_stored_counts(&store);
+    }
+
+    #[test]
+    fn mutations_between_takeovers_and_reconciliation_keep_counts_consistent() {
+        let store = BlockHashStore::new();
+        let mut a = heartbeat_node(&store, "a");
+        let b = heartbeat_node(&store, "b");
+        store
+            .insert_hashes("ns", &[vec![1], vec![2], vec![3]], "a", a)
+            .unwrap();
+        store
+            .insert_hashes("ns", &[vec![1], vec![2], vec![3]], "b", b)
+            .unwrap();
+        for _ in 0..2 {
+            store.nodes.get_mut("a").unwrap().last_seen = Instant::now() - Duration::from_secs(31);
+            a = heartbeat_node(&store, "a");
+            store
+                .insert_hashes("ns", &[vec![1], vec![1]], "a", a)
+                .unwrap();
+            store.remove_hashes("ns", &[vec![1]], "b", b).unwrap();
+            assert_stored_counts(&store);
+        }
+        assert_eq!(store.sweep_expired().removed_owners, 2);
+        assert_eq!(store.owner_count(), 3);
+        assert_stored_counts(&store);
+        // A later takeover must set a new flag, even after one sweep consumed it.
+        store.nodes.get_mut("a").unwrap().last_seen = Instant::now() - Duration::from_secs(31);
+        let new_a = heartbeat_node(&store, "a");
+        assert_ne!(a, new_a);
+        assert_eq!(store.sweep_expired().removed_owners, 1);
+        assert_stored_counts(&store);
+        assert!(store.sweep_expired().is_empty());
+    }
+
+    #[test]
+    fn unregister_after_takeover_cleans_historical_owners() {
+        let store = BlockHashStore::new();
+        let old = heartbeat_node(&store, "a");
+        store
+            .insert_hashes("ns", &[vec![1], vec![2]], "a", old)
+            .unwrap();
+        store.nodes.get_mut("a").unwrap().last_seen = Instant::now() - Duration::from_secs(31);
+        let current = heartbeat_node(&store, "a");
+        store.insert_hashes("ns", &[vec![1]], "a", current).unwrap();
+        assert_eq!(
+            store.unregister_node("a", old),
+            Err(StoreError::StaleSession)
+        );
+        assert_eq!(store.unregister_node("a", current), Ok(2));
+        assert!(store.sweep_expired().is_empty());
+        assert_stored_counts(&store);
+        assert_eq!(store.node_counts(), (0, 0));
+    }
 
     fn heartbeat_node(store: &BlockHashStore, node: &str) -> Uuid {
         let node_id = Uuid::new_v4();
@@ -992,7 +987,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sweep_keeps_superseded_owner_until_ttl() {
+    fn test_sweep_reconciles_superseded_owner_before_ttl() {
         let store = BlockHashStore::new();
         let old_id = heartbeat_node(&store, "node-a");
         store
@@ -1004,8 +999,10 @@ mod tests {
         assert_ne!(old_id, new_id);
 
         let removed = store.sweep_expired();
-        assert_eq!(removed, SweepStats::default());
-        assert_eq!(store.owner_count(), 1);
+        assert_eq!(removed.removed_owners, 1);
+        assert_eq!(removed.removed_keys, 1);
+        assert_eq!(removed.removed_nodes, 0);
+        assert_eq!(store.owner_count(), 0);
         assert!(store.query_prefix("ns", &[vec![1]]).is_empty());
     }
 
@@ -1081,6 +1078,30 @@ mod tests {
         assert!(existing.is_empty());
         assert_eq!(store.entry_count(), 1);
         assert_eq!(store.owner_count(), 1);
+    }
+
+    #[test]
+    fn takeover_reconciles_old_session_owners_on_next_sweep() {
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::ZERO,
+            ttl: Duration::from_secs(60),
+        });
+        let old_id = heartbeat_node(&store, "node-a");
+        store
+            .insert_hashes("ns", &[vec![1]], "node-a", old_id)
+            .unwrap();
+        store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(1);
+
+        let new_id = heartbeat_node(&store, "node-a");
+        assert!(store.query_prefix("ns", &[vec![1]]).is_empty());
+        assert_eq!(store.owner_count(), 1);
+
+        let stats = store.sweep_expired();
+        assert_eq!(stats.removed_owners, 1);
+        assert_eq!(stats.removed_nodes, 0);
+        assert_eq!(store.owner_count(), 0);
+        assert!(store.query_prefix("ns", &[vec![1]]).is_empty());
+        assert_eq!(store.nodes.get("node-a").unwrap().node_id, new_id);
     }
 
     #[test]
@@ -1281,7 +1302,7 @@ mod tests {
     }
 
     #[test]
-    fn test_redundancy_snapshot_buckets_live_owners() {
+    fn test_redundancy_snapshot_buckets_stored_owners() {
         let store = BlockHashStore::new();
         let a = heartbeat_node(&store, "n-a");
         let b = heartbeat_node(&store, "n-b");
@@ -1312,9 +1333,8 @@ mod tests {
 
     #[test]
     fn test_redundancy_snapshot_excludes_superseded_owner() {
-        // A block whose only owner is a superseded session has zero *visible*
-        // owners, so it must not appear in any bucket even though the raw record
-        // survives until the TTL purge.
+        // A block whose only owner is a superseded session is removed by the
+        // next reconciliation sweep.
         let store = BlockHashStore::new();
         let old_id = heartbeat_node(&store, "node-a");
         store
@@ -1327,7 +1347,8 @@ mod tests {
 
         store.sweep_expired();
 
-        assert_eq!(store.owner_count(), 1, "raw record still present");
+        assert_eq!(store.owner_count(), 0);
+        assert_eq!(store.entry_count(), 0);
         assert_eq!(store.redundancy_snapshot(), RedundancySnapshot::default());
     }
 

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -1,8 +1,11 @@
-use dashmap::{DashMap, mapref::entry::Entry};
+use dashmap::DashMap;
 use log::{info, warn};
 use pegaflow_common::BlockKey;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::collections::{HashMap, HashSet};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
@@ -47,11 +50,13 @@ impl SweepStats {
     }
 }
 
-/// Live-owner redundancy distribution over block keys, recomputed each sweep and
-/// cached so metric scrapes stay O(1). Keys are bucketed by their number of
-/// query-visible owners (1, 2, 3, >=4); keys with zero visible owners are
-/// excluded from every bucket. `copies` is the exact total of visible owners, so
-/// average redundancy (the cache capacity shrink factor) is
+/// Owner redundancy distribution over block keys, maintained incrementally so
+/// metric scrapes stay O(1). Node liveness transitions are settled by the
+/// periodic sweep, so a scrape before that sweep can briefly include a stale
+/// node. Keys are bucketed by their number of accounted owners (1, 2, 3, >=4);
+/// keys with zero accounted owners are excluded from every bucket. `copies` is
+/// the exact total of accounted owners, so average redundancy (the cache
+/// capacity shrink factor) is
 /// `copies / (keys_1 + keys_2 + keys_3 + keys_4plus)`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RedundancySnapshot {
@@ -60,19 +65,6 @@ pub struct RedundancySnapshot {
     pub keys_3: u64,
     pub keys_4plus: u64,
     pub copies: u64,
-}
-
-impl RedundancySnapshot {
-    fn record(&mut self, visible_owners: u64) {
-        match visible_owners {
-            0 => {}
-            1 => self.keys_1 += 1,
-            2 => self.keys_2 += 1,
-            3 => self.keys_3 += 1,
-            _ => self.keys_4plus += 1,
-        }
-        self.copies += visible_owners;
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,13 +89,61 @@ struct NodeRecord {
     last_seen: Instant,
 }
 
-/// Both lifecycle decisions for one owner record, produced from a single `nodes`
-/// lookup: `keep` (survives the node-liveness sweep) and `visible` (query-visible:
-/// current session and node still fresh). Lets the sweep tally live redundancy
-/// without probing the node map twice per owner.
-struct OwnerEval {
-    keep: bool,
-    visible: bool,
+#[derive(Default)]
+struct RedundancyCounters {
+    keys_1: AtomicU64,
+    keys_2: AtomicU64,
+    keys_3: AtomicU64,
+    keys_4plus: AtomicU64,
+    copies: AtomicU64,
+}
+
+impl RedundancyCounters {
+    fn snapshot(&self) -> RedundancySnapshot {
+        RedundancySnapshot {
+            keys_1: self.keys_1.load(Ordering::Relaxed),
+            keys_2: self.keys_2.load(Ordering::Relaxed),
+            keys_3: self.keys_3.load(Ordering::Relaxed),
+            keys_4plus: self.keys_4plus.load(Ordering::Relaxed),
+            copies: self.copies.load(Ordering::Relaxed),
+        }
+    }
+
+    fn adjust_bucket(&self, count: u64, delta: i64) {
+        let counter = match count {
+            1 => &self.keys_1,
+            2 => &self.keys_2,
+            3 => &self.keys_3,
+            _ if count >= 4 => &self.keys_4plus,
+            _ => return,
+        };
+        if delta > 0 {
+            counter.fetch_add(delta as u64, Ordering::Relaxed);
+        } else {
+            counter.fetch_sub((-delta) as u64, Ordering::Relaxed);
+        }
+    }
+
+    fn adjust(&self, before: u64, after: u64) {
+        if before == after {
+            return;
+        }
+        self.adjust_bucket(before, -1);
+        self.adjust_bucket(after, 1);
+        if after > before {
+            self.copies.fetch_add(after - before, Ordering::Relaxed);
+        } else {
+            self.copies.fetch_sub(before - after, Ordering::Relaxed);
+        }
+    }
+
+    fn reset(&self) {
+        self.keys_1.store(0, Ordering::Relaxed);
+        self.keys_2.store(0, Ordering::Relaxed);
+        self.keys_3.store(0, Ordering::Relaxed);
+        self.keys_4plus.store(0, Ordering::Relaxed);
+        self.copies.store(0, Ordering::Relaxed);
+    }
 }
 
 /// Async thread-safe block hash storage using DashMap.
@@ -112,11 +152,14 @@ struct OwnerEval {
 /// the current MetaServer session and liveness for each node URL.
 pub struct BlockHashStore {
     blocks: DashMap<BlockKey, HashMap<Arc<str>, OwnerRecord>>,
+    node_blocks: DashMap<Arc<str>, HashSet<BlockKey>>,
     nodes: DashMap<Arc<str>, NodeRecord>,
     config: StoreConfig,
-    /// Latest live-owner redundancy distribution, refreshed each sweep and read
-    /// by metric callbacks. Decouples the O(N) scan from the scrape path.
-    redundancy: Mutex<RedundancySnapshot>,
+    /// Serializes metadata mutations so per-key visibility transitions and
+    /// aggregate redundancy counters stay consistent with one another.
+    mutation_lock: Mutex<()>,
+    /// Incremental live-owner redundancy counters read by metric callbacks.
+    redundancy: RedundancyCounters,
 }
 
 impl BlockHashStore {
@@ -127,9 +170,11 @@ impl BlockHashStore {
     pub fn with_config(config: StoreConfig) -> Self {
         Self {
             blocks: DashMap::new(),
+            node_blocks: DashMap::new(),
             nodes: DashMap::new(),
             config,
-            redundancy: Mutex::new(RedundancySnapshot::default()),
+            mutation_lock: Mutex::new(()),
+            redundancy: RedundancyCounters::default(),
         }
     }
 
@@ -145,61 +190,99 @@ impl BlockHashStore {
     }
 
     pub fn heartbeat_node(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
+        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
         let now = Instant::now();
-        match self.nodes.entry(Arc::from(node)) {
-            Entry::Vacant(entry) => {
-                info!("MetaServer node registered: node={node} node_id={node_id}");
-                entry.insert(NodeRecord {
+        let Some(current) = self.nodes.get(node).map(|record| record.clone()) else {
+            info!("MetaServer node registered: node={node} node_id={node_id}");
+            self.nodes.insert(
+                Arc::from(node),
+                NodeRecord {
                     node_id,
                     last_seen: now,
-                });
-                Ok(())
-            }
-            Entry::Occupied(mut entry) => {
-                let record = entry.get_mut();
-                let same_session = record.node_id == node_id;
-                let stale_session =
-                    now.duration_since(record.last_seen) > self.config.node_stale_after;
-                if same_session || stale_session {
-                    if stale_session && !same_session {
-                        info!(
-                            "MetaServer node session takeover: node={} old_node_id={} new_node_id={}",
-                            node, record.node_id, node_id
-                        );
-                    }
-                    record.node_id = node_id;
-                    record.last_seen = now;
-                    return Ok(());
-                }
-                warn!(
-                    "MetaServer heartbeat rejected stale session: node={} current_node_id={} rejected_node_id={}",
-                    node, record.node_id, node_id
+                },
+            );
+            return Ok(());
+        };
+
+        let same_session = current.node_id == node_id;
+        let stale_session = now.duration_since(current.last_seen) > self.config.node_stale_after;
+        if same_session || stale_session {
+            if stale_session && !same_session {
+                info!(
+                    "MetaServer node session takeover: node={} old_node_id={} new_node_id={}",
+                    node, current.node_id, node_id
                 );
-                Err(StoreError::StaleSession)
             }
+            let keys = self
+                .node_blocks
+                .get(node)
+                .map(|keys| keys.iter().cloned().collect::<Vec<_>>())
+                .unwrap_or_default();
+            let before: Vec<(BlockKey, u64)> = keys
+                .iter()
+                .filter_map(|key| {
+                    self.blocks.get(key).map(|owners| {
+                        (
+                            key.clone(),
+                            self.visible_owner_count_before_heartbeat(
+                                &owners,
+                                node,
+                                current.node_id,
+                                now,
+                            ),
+                        )
+                    })
+                })
+                .collect();
+
+            let mut record = self
+                .nodes
+                .get_mut(node)
+                .expect("node disappeared under mutation lock");
+            record.node_id = node_id;
+            record.last_seen = now;
+            drop(record);
+
+            for (key, before_visible) in before {
+                if let Some(owners) = self.blocks.get(&key) {
+                    let after_visible = self.accounted_owner_count(&owners);
+                    self.redundancy.adjust(before_visible, after_visible);
+                }
+            }
+            return Ok(());
         }
+
+        warn!(
+            "MetaServer heartbeat rejected stale session: node={} current_node_id={} rejected_node_id={}",
+            node, current.node_id, node_id
+        );
+        Err(StoreError::StaleSession)
     }
 
     pub fn unregister_node(&self, node: &str, node_id: Uuid) -> Result<usize, StoreError> {
-        if self
-            .nodes
-            .remove_if(node, |_, record| record.node_id == node_id)
-            .is_none()
-        {
-            if self.nodes.contains_key(node) {
-                warn!(
-                    "MetaServer unregister rejected stale session: node={} rejected_node_id={}",
-                    node, node_id
-                );
-                return Err(StoreError::StaleSession);
-            }
+        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
+        let Some(record) = self.nodes.get(node) else {
             warn!(
                 "MetaServer unregister rejected unknown node: node={} node_id={}",
                 node, node_id
             );
             return Err(StoreError::UnknownNode);
+        };
+        if record.node_id != node_id {
+            warn!(
+                "MetaServer unregister rejected stale session: node={} rejected_node_id={}",
+                node, node_id
+            );
+            return Err(StoreError::StaleSession);
         }
-        Ok(self.remove_node_owners(node, node_id))
+        drop(record);
+
+        // Remove owners while the node record is still present so the
+        // redundancy counters observe the same visibility as queries.
+        let removed = self.remove_node_owners(node, node_id);
+        self.nodes
+            .remove_if(node, |_, record| record.node_id == node_id);
+        Ok(removed)
     }
 
     pub fn insert_hashes(
@@ -209,6 +292,7 @@ impl BlockHashStore {
         node: &str,
         node_id: Uuid,
     ) -> Result<Vec<Vec<u8>>, StoreError> {
+        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
         self.touch_node_session(node, node_id)?;
         let node: Arc<str> = Arc::from(node);
         let now = Instant::now();
@@ -216,6 +300,7 @@ impl BlockHashStore {
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
             let mut owners = self.blocks.entry(key).or_default();
+            let before_visible = self.accounted_owner_count(&owners);
             let previous = owners.insert(
                 Arc::clone(&node),
                 OwnerRecord {
@@ -234,6 +319,14 @@ impl BlockHashStore {
             {
                 reclaimable_hashes.push(hash.clone());
             }
+            let after_visible = self.accounted_owner_count(&owners);
+            self.redundancy.adjust(before_visible, after_visible);
+            let key = BlockKey::new(namespace.to_string(), hash.clone());
+            drop(owners);
+            self.node_blocks
+                .entry(Arc::clone(&node))
+                .or_default()
+                .insert(key);
         }
         Ok(reclaimable_hashes)
     }
@@ -245,23 +338,37 @@ impl BlockHashStore {
         node: &str,
         node_id: Uuid,
     ) -> Result<usize, StoreError> {
+        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
         self.touch_node_session(node, node_id)?;
+        let node_key: Arc<str> = Arc::from(node);
         let mut removed = 0;
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
-            let should_remove_key = if let Some(mut owners) = self.blocks.get_mut(&key) {
+            let change = if let Some(mut owners) = self.blocks.get_mut(&key) {
+                let before_visible = self.accounted_owner_count(&owners);
                 if owners
                     .get(node)
                     .is_some_and(|owner| owner.node_id == node_id)
                 {
                     owners.remove(node);
                     removed += 1;
+                    let after_visible = self.accounted_owner_count(&owners);
+                    Some((before_visible, after_visible))
+                } else {
+                    None
                 }
-                owners.is_empty()
             } else {
-                false
+                None
             };
-            if should_remove_key {
+            if let Some((before_visible, after_visible)) = change {
+                self.remove_reverse_index_key(&node_key, &key);
+                self.redundancy.adjust(before_visible, after_visible);
+            }
+            if self
+                .blocks
+                .get(&key)
+                .is_some_and(|owners| owners.is_empty())
+            {
                 self.blocks.remove_if(&key, |_, owners| owners.is_empty());
             }
         }
@@ -301,52 +408,65 @@ impl BlockHashStore {
         result
     }
 
-    /// Sweep owners whose node is missing or no longer active, and refresh the
-    /// cached live-owner redundancy snapshot in the same walk.
+    /// Sweep owners belonging to nodes that are missing or no longer active.
+    /// The reverse index limits work to keys owned by those nodes.
     pub fn sweep_expired(&self) -> SweepStats {
+        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
         let now = Instant::now();
         let mut stats = SweepStats::default();
-        let mut snapshot = RedundancySnapshot::default();
+        let stale_nodes: Vec<(Arc<str>, Uuid, u64)> = self
+            .nodes
+            .iter()
+            .filter_map(|entry| {
+                let age = now.duration_since(entry.last_seen);
+                (age > self.config.node_stale_after)
+                    .then(|| (Arc::clone(entry.key()), entry.node_id, age.as_secs()))
+            })
+            .collect();
 
-        self.blocks.retain(|_, owners| {
-            let before = owners.len();
-            let mut visible = 0u64;
-            owners.retain(|node, owner| {
-                let eval = self.eval_owner(node, owner, now);
-                if eval.keep && eval.visible {
-                    visible += 1;
+        for (node, node_id, last_seen_age_secs) in stale_nodes {
+            let keys = self
+                .node_blocks
+                .get(&node)
+                .map(|keys| keys.iter().cloned().collect::<Vec<_>>())
+                .unwrap_or_default();
+            for key in keys {
+                if let Some((before_visible, after_visible, empty)) =
+                    self.remove_any_owner_for_key(&key, &node)
+                {
+                    stats.removed_owners += 1;
+                    stats.removed_keys += usize::from(empty);
+                    self.redundancy.adjust(before_visible, after_visible);
+                    self.remove_reverse_index_key(&node, &key);
+                } else if self.owner_for_node(&key, &node).is_none() {
+                    // Clean an index entry left behind by an earlier remove.
+                    // Keep it when a newer session has re-registered the owner.
+                    self.remove_reverse_index_key(&node, &key);
                 }
-                eval.keep
-            });
-            stats.removed_owners += before.saturating_sub(owners.len());
-            if owners.is_empty() {
-                stats.removed_keys += 1;
-                return false;
             }
-            snapshot.record(visible);
-            true
-        });
 
-        let node_before = self.nodes.len();
-        let node_stale_after = self.config.node_stale_after;
-        self.nodes.retain(|node, record| {
-            let keep = now.duration_since(record.last_seen) <= node_stale_after;
-            if !keep {
+            if self
+                .nodes
+                .remove_if(&node, |_, record| record.node_id == node_id)
+                .is_some()
+            {
+                stats.removed_nodes += 1;
                 info!(
                     "MetaServer node swept: node={} node_id={} last_seen_age_secs={}",
-                    node,
-                    record.node_id,
-                    now.duration_since(record.last_seen).as_secs()
+                    node, node_id, last_seen_age_secs
                 );
             }
-            keep
-        });
-        stats.removed_nodes = node_before.saturating_sub(self.nodes.len());
+        }
 
-        *self
-            .redundancy
-            .lock()
-            .expect("redundancy snapshot mutex poisoned") = snapshot;
+        let empty_nodes: Vec<Arc<str>> = self
+            .node_blocks
+            .iter()
+            .filter(|entry| entry.is_empty())
+            .map(|entry| Arc::clone(entry.key()))
+            .collect();
+        for node in empty_nodes {
+            self.node_blocks.remove_if(&node, |_, keys| keys.is_empty());
+        }
 
         stats
     }
@@ -355,30 +475,51 @@ impl BlockHashStore {
     /// liveness. This is reserved for explicit operator maintenance; the
     /// periodic lifecycle sweep intentionally does not use owner age.
     pub fn remove_owners_older_than(&self, max_age: Duration) -> SweepStats {
+        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
         let now = Instant::now();
         let mut stats = SweepStats::default();
 
-        self.blocks.retain(|_, owners| {
-            let before = owners.len();
-            owners.retain(|_, owner| now.duration_since(owner.key_register_time) <= max_age);
-            stats.removed_owners += before.saturating_sub(owners.len());
-            if owners.is_empty() {
-                stats.removed_keys += 1;
-                false
-            } else {
-                true
+        let keys: Vec<BlockKey> = self
+            .blocks
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect();
+        for key in keys {
+            let mut removed_nodes = Vec::new();
+            if let Some(mut owners) = self.blocks.get_mut(&key) {
+                let before_visible = self.accounted_owner_count(&owners);
+                owners.retain(|node, owner| {
+                    if now.duration_since(owner.key_register_time) > max_age {
+                        removed_nodes.push(Arc::clone(node));
+                        false
+                    } else {
+                        true
+                    }
+                });
+                let after_visible = self.accounted_owner_count(&owners);
+                stats.removed_owners += removed_nodes.len();
+                self.redundancy.adjust(before_visible, after_visible);
+                drop(owners);
             }
-        });
+            for node in removed_nodes {
+                self.remove_reverse_index_key(&node, &key);
+            }
+            if self
+                .blocks
+                .get(&key)
+                .is_some_and(|owners| owners.is_empty())
+            {
+                self.blocks.remove_if(&key, |_, owners| owners.is_empty());
+                stats.removed_keys += 1;
+            }
+        }
 
         stats
     }
 
-    /// Latest cached live-owner redundancy distribution (refreshed each sweep).
+    /// Latest incrementally maintained live-owner redundancy distribution.
     pub fn redundancy_snapshot(&self) -> RedundancySnapshot {
-        *self
-            .redundancy
-            .lock()
-            .expect("redundancy snapshot mutex poisoned")
+        self.redundancy.snapshot()
     }
 
     pub fn entry_count(&self) -> u64 {
@@ -412,12 +553,11 @@ impl BlockHashStore {
         reason = "maintenance API reserved for explicit store cleanup"
     )]
     pub fn invalidate_all(&self) {
+        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
         self.blocks.clear();
+        self.node_blocks.clear();
         self.nodes.clear();
-        *self
-            .redundancy
-            .lock()
-            .expect("redundancy snapshot mutex poisoned") = RedundancySnapshot::default();
+        self.redundancy.reset();
     }
 
     fn touch_node_session(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
@@ -440,39 +580,121 @@ impl BlockHashStore {
     }
 
     fn remove_node_owners(&self, node: &str, node_id: Uuid) -> usize {
+        let node: Arc<str> = Arc::from(node);
+        let keys = self
+            .node_blocks
+            .get(&node)
+            .map(|keys| keys.iter().cloned().collect::<Vec<_>>())
+            .unwrap_or_default();
         let mut removed = 0;
-        self.blocks.retain(|_, owners| {
-            if owners
-                .get(node)
-                .is_some_and(|owner| owner.node_id == node_id)
+        for key in keys {
+            if let Some((before_visible, after_visible, _empty)) =
+                self.remove_owner_for_key(&key, &node, node_id)
             {
-                owners.remove(node);
                 removed += 1;
+                self.redundancy.adjust(before_visible, after_visible);
+                self.remove_reverse_index_key(&node, &key);
             }
-            !owners.is_empty()
-        });
+        }
         removed
     }
 
-    /// Evaluate one owner against the current node session and clocks with a
-    /// single `nodes` lookup. A missing node means the owner is neither kept nor
-    /// visible.
-    fn eval_owner(&self, node: &Arc<str>, owner: &OwnerRecord, now: Instant) -> OwnerEval {
-        let Some(record) = self.nodes.get(node.as_ref()) else {
-            return OwnerEval {
-                keep: false,
-                visible: false,
-            };
-        };
-        let node_age = now.duration_since(record.last_seen);
-        OwnerEval {
-            keep: node_age <= self.config.node_stale_after,
-            visible: record.node_id == owner.node_id && node_age <= self.config.node_stale_after,
+    /// Counter visibility intentionally ignores node age. A stale node remains
+    /// represented until the lifecycle sweep removes it, so ordinary mutations
+    /// do not make aggregate counters disagree with the records they describe.
+    fn accounted_owner_count(&self, owners: &HashMap<Arc<str>, OwnerRecord>) -> u64 {
+        owners
+            .iter()
+            .filter(|(node, owner)| {
+                self.nodes
+                    .get(node.as_ref())
+                    .is_some_and(|record| record.node_id == owner.node_id)
+            })
+            .count() as u64
+    }
+
+    fn visible_owner_count_before_heartbeat(
+        &self,
+        owners: &HashMap<Arc<str>, OwnerRecord>,
+        node: &str,
+        node_id: Uuid,
+        now: Instant,
+    ) -> u64 {
+        owners
+            .iter()
+            .filter(|(owner_node, owner)| {
+                if owner_node.as_ref() == node {
+                    owner.node_id == node_id
+                } else {
+                    self.is_owner_visible(owner_node, owner, now)
+                }
+            })
+            .count() as u64
+    }
+
+    fn remove_owner_for_key(
+        &self,
+        key: &BlockKey,
+        node: &Arc<str>,
+        node_id: Uuid,
+    ) -> Option<(u64, u64, bool)> {
+        let mut owners = self.blocks.get_mut(key)?;
+        if !owners
+            .get(node)
+            .is_some_and(|owner| owner.node_id == node_id)
+        {
+            return None;
         }
+        let before_visible = self.accounted_owner_count(&owners);
+        owners.remove(node);
+        let after_visible = self.accounted_owner_count(&owners);
+        let empty = owners.is_empty();
+        drop(owners);
+        if empty {
+            self.blocks.remove_if(key, |_, owners| owners.is_empty());
+        }
+        Some((before_visible, after_visible, empty))
+    }
+
+    fn remove_any_owner_for_key(
+        &self,
+        key: &BlockKey,
+        node: &Arc<str>,
+    ) -> Option<(u64, u64, bool)> {
+        let mut owners = self.blocks.get_mut(key)?;
+        if !owners.contains_key(node) {
+            return None;
+        }
+        let before_visible = self.accounted_owner_count(&owners);
+        owners.remove(node);
+        let after_visible = self.accounted_owner_count(&owners);
+        let empty = owners.is_empty();
+        drop(owners);
+        if empty {
+            self.blocks.remove_if(key, |_, owners| owners.is_empty());
+        }
+        Some((before_visible, after_visible, empty))
+    }
+
+    fn owner_for_node(&self, key: &BlockKey, node: &Arc<str>) -> Option<Uuid> {
+        self.blocks
+            .get(key)
+            .and_then(|owners| owners.get(node).map(|owner| owner.node_id))
+    }
+
+    fn remove_reverse_index_key(&self, node: &Arc<str>, key: &BlockKey) {
+        if let Some(mut keys) = self.node_blocks.get_mut(node) {
+            keys.remove(key);
+        }
+        self.node_blocks.remove_if(node, |_, keys| keys.is_empty());
     }
 
     fn is_owner_visible(&self, node: &Arc<str>, owner: &OwnerRecord, now: Instant) -> bool {
-        self.eval_owner(node, owner, now).visible
+        let Some(record) = self.nodes.get(node.as_ref()) else {
+            return false;
+        };
+        let node_age = now.duration_since(record.last_seen);
+        record.node_id == owner.node_id && node_age <= self.config.node_stale_after
     }
 }
 
@@ -1106,6 +1328,43 @@ mod tests {
         store.sweep_expired();
 
         assert_eq!(store.owner_count(), 1, "raw record still present");
+        assert_eq!(store.redundancy_snapshot(), RedundancySnapshot::default());
+    }
+
+    #[test]
+    fn test_redundancy_counters_follow_owner_mutations() {
+        let store = BlockHashStore::new();
+        let node_a = heartbeat_node(&store, "node-a");
+        let node_b = heartbeat_node(&store, "node-b");
+        let hash = vec![1];
+
+        store
+            .insert_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a)
+            .unwrap();
+        assert_eq!(store.redundancy_snapshot().keys_1, 1);
+
+        store
+            .insert_hashes("ns", std::slice::from_ref(&hash), "node-b", node_b)
+            .unwrap();
+        assert_eq!(store.redundancy_snapshot().keys_2, 1);
+        assert_eq!(store.redundancy_snapshot().copies, 2);
+
+        store
+            .remove_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a)
+            .unwrap();
+        assert_eq!(store.redundancy_snapshot().keys_1, 1);
+        assert_eq!(store.redundancy_snapshot().keys_2, 0);
+        assert_eq!(store.redundancy_snapshot().copies, 1);
+
+        store
+            .blocks
+            .get_mut(&BlockKey::new("ns".to_string(), hash))
+            .unwrap()
+            .get_mut("node-b")
+            .unwrap()
+            .key_register_time = Instant::now() - Duration::from_secs(3601);
+        let cleanup = store.remove_owners_older_than(Duration::from_secs(3600));
+        assert_eq!(cleanup.removed_owners, 1);
         assert_eq!(store.redundancy_snapshot(), RedundancySnapshot::default());
     }
 }

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -267,6 +267,7 @@ impl BlockHashStore {
             drop(record);
             let is_new_owner = previous.is_none_or(|owner| owner.node_id != node_id);
             if is_new_owner
+                && owners.len() >= MIN_RECLAIMABLE_OWNER_COUNT
                 && owners
                     .iter()
                     .filter(|(node, owner)| self.is_owner_visible(node, owner, now))
@@ -291,7 +292,8 @@ impl BlockHashStore {
         let mut removed = 0;
         for hash in hashes {
             let key = BlockKey::new(namespace.to_string(), hash.clone());
-            let should_remove_key = if let Some(mut owners) = self.blocks.get_mut(&key) {
+            if let Entry::Occupied(mut entry) = self.blocks.entry(key) {
+                let owners = entry.get_mut();
                 let before = owners.len();
                 if owners
                     .get(node)
@@ -301,12 +303,9 @@ impl BlockHashStore {
                     removed += 1;
                 }
                 self.redundancy.adjust(before as u64, owners.len() as u64);
-                owners.is_empty()
-            } else {
-                false
-            };
-            if should_remove_key {
-                self.blocks.remove_if(&key, |_, owners| owners.is_empty());
+                if owners.is_empty() {
+                    entry.remove();
+                }
             }
         }
         Ok(removed)
@@ -393,7 +392,8 @@ impl BlockHashStore {
     }
 
     pub fn entry_count(&self) -> u64 {
-        self.blocks.len() as u64
+        let snap = self.redundancy.snapshot();
+        snap.keys_1 + snap.keys_2 + snap.keys_3 + snap.keys_4plus
     }
 
     pub fn owner_count(&self) -> u64 {
@@ -509,6 +509,7 @@ pub(crate) mod tests {
             expected.copies += owners.len() as u64;
         }
         assert_eq!(store.owner_count(), expected.copies);
+        assert_eq!(store.entry_count(), store.blocks.len() as u64);
         assert_eq!(store.redundancy_snapshot(), expected);
     }
 
@@ -607,7 +608,7 @@ pub(crate) mod tests {
         store.nodes.get_mut("node-a").unwrap().last_seen = Instant::now() - Duration::from_secs(31);
         assert!(store.query_prefix("ns", &[vec![1]]).is_empty());
 
-        // A held block shard must not prevent the healthy-node-table fast path.
+        // Healthy sweeps and entry metrics must not wait for block shard locks.
         let guard = store
             .blocks
             .get_mut(&BlockKey::new("ns".into(), vec![1]))
@@ -615,10 +616,13 @@ pub(crate) mod tests {
         std::thread::scope(|scope| {
             let (tx, rx) = std::sync::mpsc::channel();
             let store_ref = &store;
-            scope.spawn(move || tx.send(store_ref.sweep_expired()).unwrap());
+            scope.spawn(move || {
+                tx.send((store_ref.sweep_expired(), store_ref.entry_count()))
+                    .unwrap();
+            });
             let result = rx.recv_timeout(Duration::from_secs(2));
             drop(guard);
-            assert_eq!(result.unwrap(), SweepStats::default());
+            assert_eq!(result.unwrap(), (SweepStats::default(), 1));
         });
         assert_eq!(store.node_counts(), (0, 1));
         assert_stored_counts(&store);
@@ -1218,69 +1222,39 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_redundancy_snapshot_buckets_stored_owners() {
+    fn test_redundancy_counters_follow_owner_mutations() {
         let store = BlockHashStore::new();
-        let a = heartbeat_node(&store, "n-a");
-        let b = heartbeat_node(&store, "n-b");
-        let c = heartbeat_node(&store, "n-c");
-        let d = heartbeat_node(&store, "n-d");
-
-        // 1 owner, 2 owners, and 4 owners across three distinct keys.
-        store.insert_hashes("ns", &[vec![1]], "n-a", a).unwrap();
-        store.insert_hashes("ns", &[vec![2]], "n-a", a).unwrap();
-        store.insert_hashes("ns", &[vec![2]], "n-b", b).unwrap();
-        for (node, id) in [("n-a", a), ("n-b", b), ("n-c", c), ("n-d", d)] {
-            store.insert_hashes("ns", &[vec![3]], node, id).unwrap();
+        let nodes = ["a", "b", "c", "d", "e"];
+        let ids = nodes.map(|node| heartbeat_node(&store, node));
+        let hashes = [vec![1], vec![2], vec![3], vec![4], vec![5]];
+        assert_stored_counts(&store);
+        for (i, node) in nodes.iter().enumerate() {
+            for _ in 0..2 {
+                store
+                    .insert_hashes("ns", &hashes[i..], node, ids[i])
+                    .unwrap();
+                assert_stored_counts(&store);
+            }
         }
-
-        store.sweep_expired();
-
         assert_eq!(
             store.redundancy_snapshot(),
             RedundancySnapshot {
                 keys_1: 1,
                 keys_2: 1,
-                keys_3: 0,
-                keys_4plus: 1,
-                copies: 1 + 2 + 4,
+                keys_3: 1,
+                keys_4plus: 2,
+                copies: 15,
             }
         );
-    }
-
-    #[test]
-    fn test_redundancy_counters_follow_owner_mutations() {
-        let store = BlockHashStore::new();
-        let node_a = heartbeat_node(&store, "node-a");
-        let node_b = heartbeat_node(&store, "node-b");
-        let hash = vec![1];
-
-        store
-            .insert_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a)
-            .unwrap();
-        assert_eq!(store.redundancy_snapshot().keys_1, 1);
-
-        store
-            .insert_hashes("ns", std::slice::from_ref(&hash), "node-b", node_b)
-            .unwrap();
-        assert_eq!(store.redundancy_snapshot().keys_2, 1);
-        assert_eq!(store.redundancy_snapshot().copies, 2);
-
-        store
-            .remove_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a)
-            .unwrap();
-        assert_eq!(store.redundancy_snapshot().keys_1, 1);
-        assert_eq!(store.redundancy_snapshot().keys_2, 0);
-        assert_eq!(store.redundancy_snapshot().copies, 1);
-
-        store
-            .blocks
-            .get_mut(&BlockKey::new("ns".to_string(), hash))
-            .unwrap()
-            .get_mut("node-b")
-            .unwrap()
-            .key_register_time = Instant::now() - Duration::from_secs(3601);
-        let cleanup = store.remove_owners_older_than(Duration::from_secs(3600));
-        assert_eq!(cleanup.removed_owners, 1);
+        for (i, node) in nodes.iter().enumerate() {
+            assert_eq!(
+                store
+                    .remove_hashes("ns", &hashes[i..], node, ids[i])
+                    .unwrap(),
+                hashes.len() - i
+            );
+            assert_stored_counts(&store);
+        }
         assert_eq!(store.redundancy_snapshot(), RedundancySnapshot::default());
     }
 }

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 const MIN_RECLAIMABLE_OWNER_COUNT: usize = 3;
+const MUTATION_BATCH_SIZE: usize = 256;
 
 pub const DEFAULT_NODE_STALE_SECS: u64 = 30;
 pub const DEFAULT_TTL_MINUTES: u64 = 120;
@@ -158,6 +159,7 @@ pub struct BlockHashStore {
     /// Serializes metadata mutations so per-key visibility transitions and
     /// aggregate redundancy counters stay consistent with one another.
     mutation_lock: Mutex<()>,
+    owners_total: AtomicU64,
     /// Incremental live-owner redundancy counters read by metric callbacks.
     redundancy: RedundancyCounters,
 }
@@ -174,6 +176,7 @@ impl BlockHashStore {
             nodes: DashMap::new(),
             config,
             mutation_lock: Mutex::new(()),
+            owners_total: AtomicU64::new(0),
             redundancy: RedundancyCounters::default(),
         }
     }
@@ -205,14 +208,15 @@ impl BlockHashStore {
         };
 
         let same_session = current.node_id == node_id;
+        if same_session {
+            return self.touch_node_session(node, node_id);
+        }
         let stale_session = now.duration_since(current.last_seen) > self.config.node_stale_after;
-        if same_session || stale_session {
-            if stale_session && !same_session {
-                info!(
-                    "MetaServer node session takeover: node={} old_node_id={} new_node_id={}",
-                    node, current.node_id, node_id
-                );
-            }
+        if stale_session {
+            info!(
+                "MetaServer node session takeover: node={} old_node_id={} new_node_id={}",
+                node, current.node_id, node_id
+            );
             let keys = self
                 .node_blocks
                 .get(node)
@@ -221,17 +225,9 @@ impl BlockHashStore {
             let before: Vec<(BlockKey, u64)> = keys
                 .iter()
                 .filter_map(|key| {
-                    self.blocks.get(key).map(|owners| {
-                        (
-                            key.clone(),
-                            self.visible_owner_count_before_heartbeat(
-                                &owners,
-                                node,
-                                current.node_id,
-                                now,
-                            ),
-                        )
-                    })
+                    self.blocks
+                        .get(key)
+                        .map(|owners| (key.clone(), self.accounted_owner_count(&owners)))
                 })
                 .collect();
 
@@ -292,41 +288,48 @@ impl BlockHashStore {
         node: &str,
         node_id: Uuid,
     ) -> Result<Vec<Vec<u8>>, StoreError> {
-        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
-        self.touch_node_session(node, node_id)?;
         let node: Arc<str> = Arc::from(node);
-        let now = Instant::now();
         let mut reclaimable_hashes = Vec::new();
-        for hash in hashes {
-            let key = BlockKey::new(namespace.to_string(), hash.clone());
-            let mut owners = self.blocks.entry(key).or_default();
-            let before_visible = self.accounted_owner_count(&owners);
-            let previous = owners.insert(
-                Arc::clone(&node),
-                OwnerRecord {
-                    node_id,
-                    key_register_time: now,
-                },
-            );
-            let is_new_owner = previous.is_none_or(|owner| owner.node_id != node_id);
-            if is_new_owner
-                && owners
-                    .iter()
-                    .filter(|(node, owner)| self.is_owner_visible(node, owner, now))
-                    .take(MIN_RECLAIMABLE_OWNER_COUNT)
-                    .count()
-                    == MIN_RECLAIMABLE_OWNER_COUNT
-            {
-                reclaimable_hashes.push(hash.clone());
+        for batch in hashes.chunks(MUTATION_BATCH_SIZE) {
+            let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
+            self.touch_node_session(&node, node_id)?;
+            let now = Instant::now();
+            for hash in batch {
+                let key = BlockKey::new(namespace.to_string(), hash.clone());
+                let mut owners = self.blocks.entry(key).or_default();
+                let before_visible = self.accounted_owner_count(&owners);
+                let previous = owners.insert(
+                    Arc::clone(&node),
+                    OwnerRecord {
+                        node_id,
+                        key_register_time: now,
+                    },
+                );
+                if previous.is_none() {
+                    self.owners_total.fetch_add(1, Ordering::Relaxed);
+                }
+                let is_new_owner = previous
+                    .as_ref()
+                    .is_none_or(|owner| owner.node_id != node_id);
+                if is_new_owner
+                    && owners
+                        .iter()
+                        .filter(|(node, owner)| self.is_owner_visible(node, owner, now))
+                        .take(MIN_RECLAIMABLE_OWNER_COUNT)
+                        .count()
+                        == MIN_RECLAIMABLE_OWNER_COUNT
+                {
+                    reclaimable_hashes.push(hash.clone());
+                }
+                let after_visible = self.accounted_owner_count(&owners);
+                self.redundancy.adjust(before_visible, after_visible);
+                let key = BlockKey::new(namespace.to_string(), hash.clone());
+                drop(owners);
+                self.node_blocks
+                    .entry(Arc::clone(&node))
+                    .or_default()
+                    .insert(key);
             }
-            let after_visible = self.accounted_owner_count(&owners);
-            self.redundancy.adjust(before_visible, after_visible);
-            let key = BlockKey::new(namespace.to_string(), hash.clone());
-            drop(owners);
-            self.node_blocks
-                .entry(Arc::clone(&node))
-                .or_default()
-                .insert(key);
         }
         Ok(reclaimable_hashes)
     }
@@ -338,38 +341,41 @@ impl BlockHashStore {
         node: &str,
         node_id: Uuid,
     ) -> Result<usize, StoreError> {
-        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
-        self.touch_node_session(node, node_id)?;
         let node_key: Arc<str> = Arc::from(node);
         let mut removed = 0;
-        for hash in hashes {
-            let key = BlockKey::new(namespace.to_string(), hash.clone());
-            let change = if let Some(mut owners) = self.blocks.get_mut(&key) {
-                let before_visible = self.accounted_owner_count(&owners);
-                if owners
-                    .get(node)
-                    .is_some_and(|owner| owner.node_id == node_id)
-                {
-                    owners.remove(node);
-                    removed += 1;
-                    let after_visible = self.accounted_owner_count(&owners);
-                    Some((before_visible, after_visible))
+        for batch in hashes.chunks(MUTATION_BATCH_SIZE) {
+            let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
+            self.touch_node_session(node, node_id)?;
+            for hash in batch {
+                let key = BlockKey::new(namespace.to_string(), hash.clone());
+                let change = if let Some(mut owners) = self.blocks.get_mut(&key) {
+                    let before_visible = self.accounted_owner_count(&owners);
+                    if owners
+                        .get(node)
+                        .is_some_and(|owner| owner.node_id == node_id)
+                    {
+                        owners.remove(node);
+                        self.owners_total.fetch_sub(1, Ordering::Relaxed);
+                        removed += 1;
+                        let after_visible = self.accounted_owner_count(&owners);
+                        Some((before_visible, after_visible))
+                    } else {
+                        None
+                    }
                 } else {
                     None
+                };
+                if let Some((before_visible, after_visible)) = change {
+                    self.remove_reverse_index_key(&node_key, &key);
+                    self.redundancy.adjust(before_visible, after_visible);
                 }
-            } else {
-                None
-            };
-            if let Some((before_visible, after_visible)) = change {
-                self.remove_reverse_index_key(&node_key, &key);
-                self.redundancy.adjust(before_visible, after_visible);
-            }
-            if self
-                .blocks
-                .get(&key)
-                .is_some_and(|owners| owners.is_empty())
-            {
-                self.blocks.remove_if(&key, |_, owners| owners.is_empty());
+                if self
+                    .blocks
+                    .get(&key)
+                    .is_some_and(|owners| owners.is_empty())
+                {
+                    self.blocks.remove_if(&key, |_, owners| owners.is_empty());
+                }
             }
         }
         Ok(removed)
@@ -411,7 +417,6 @@ impl BlockHashStore {
     /// Sweep owners belonging to nodes that are missing or no longer active.
     /// The reverse index limits work to keys owned by those nodes.
     pub fn sweep_expired(&self) -> SweepStats {
-        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
         let now = Instant::now();
         let mut stats = SweepStats::default();
         let stale_nodes: Vec<(Arc<str>, Uuid, u64)> = self
@@ -430,24 +435,35 @@ impl BlockHashStore {
                 .get(&node)
                 .map(|keys| keys.iter().cloned().collect::<Vec<_>>())
                 .unwrap_or_default();
-            for key in keys {
-                if let Some((before_visible, after_visible, empty)) =
-                    self.remove_any_owner_for_key(&key, &node)
-                {
-                    stats.removed_owners += 1;
-                    stats.removed_keys += usize::from(empty);
-                    self.redundancy.adjust(before_visible, after_visible);
-                    self.remove_reverse_index_key(&node, &key);
-                } else if self.owner_for_node(&key, &node).is_none() {
-                    // Clean an index entry left behind by an earlier remove.
-                    // Keep it when a newer session has re-registered the owner.
-                    self.remove_reverse_index_key(&node, &key);
+            for batch in keys.chunks(MUTATION_BATCH_SIZE) {
+                let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
+                if !self.nodes.get(&node).is_some_and(|record| {
+                    record.node_id == node_id
+                        && record.last_seen.elapsed() > self.config.node_stale_after
+                }) {
+                    break;
+                }
+                for key in batch {
+                    if let Some((before_visible, after_visible, empty)) =
+                        self.remove_any_owner_for_key(key, &node)
+                    {
+                        stats.removed_owners += 1;
+                        stats.removed_keys += usize::from(empty);
+                        self.redundancy.adjust(before_visible, after_visible);
+                        self.remove_reverse_index_key(&node, key);
+                    } else if self.owner_for_node(key, &node).is_none() {
+                        self.remove_reverse_index_key(&node, key);
+                    }
                 }
             }
 
+            let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
             if self
                 .nodes
-                .remove_if(&node, |_, record| record.node_id == node_id)
+                .remove_if(&node, |_, record| {
+                    record.node_id == node_id
+                        && record.last_seen.elapsed() > self.config.node_stale_after
+                })
                 .is_some()
             {
                 stats.removed_nodes += 1;
@@ -458,6 +474,7 @@ impl BlockHashStore {
             }
         }
 
+        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
         let empty_nodes: Vec<Arc<str>> = self
             .node_blocks
             .iter()
@@ -475,7 +492,6 @@ impl BlockHashStore {
     /// liveness. This is reserved for explicit operator maintenance; the
     /// periodic lifecycle sweep intentionally does not use owner age.
     pub fn remove_owners_older_than(&self, max_age: Duration) -> SweepStats {
-        let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
         let now = Instant::now();
         let mut stats = SweepStats::default();
 
@@ -484,33 +500,36 @@ impl BlockHashStore {
             .iter()
             .map(|entry| entry.key().clone())
             .collect();
-        for key in keys {
-            let mut removed_nodes = Vec::new();
-            if let Some(mut owners) = self.blocks.get_mut(&key) {
-                let before_visible = self.accounted_owner_count(&owners);
-                owners.retain(|node, owner| {
-                    if now.duration_since(owner.key_register_time) > max_age {
-                        removed_nodes.push(Arc::clone(node));
-                        false
-                    } else {
-                        true
-                    }
-                });
-                let after_visible = self.accounted_owner_count(&owners);
-                stats.removed_owners += removed_nodes.len();
-                self.redundancy.adjust(before_visible, after_visible);
-                drop(owners);
-            }
-            for node in removed_nodes {
-                self.remove_reverse_index_key(&node, &key);
-            }
-            if self
-                .blocks
-                .get(&key)
-                .is_some_and(|owners| owners.is_empty())
-            {
-                self.blocks.remove_if(&key, |_, owners| owners.is_empty());
-                stats.removed_keys += 1;
+        // Snapshot keys without holding the mutation lock, then recheck owner
+        // timestamps in bounded batches so concurrent refreshes are preserved.
+        for batch in keys.chunks(MUTATION_BATCH_SIZE) {
+            let _mutation_guard = self.mutation_lock.lock().expect("mutation lock poisoned");
+            for key in batch {
+                let mut removed_nodes = Vec::new();
+                if let Some(mut owners) = self.blocks.get_mut(key) {
+                    let before_visible = self.accounted_owner_count(&owners);
+                    owners.retain(|node, owner| {
+                        if now.saturating_duration_since(owner.key_register_time) > max_age {
+                            removed_nodes.push(Arc::clone(node));
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                    let after_visible = self.accounted_owner_count(&owners);
+                    stats.removed_owners += removed_nodes.len();
+                    self.owners_total
+                        .fetch_sub(removed_nodes.len() as u64, Ordering::Relaxed);
+                    self.redundancy.adjust(before_visible, after_visible);
+                    drop(owners);
+                }
+                for node in removed_nodes {
+                    self.remove_reverse_index_key(&node, key);
+                }
+                if self.blocks.get(key).is_some_and(|owners| owners.is_empty()) {
+                    self.blocks.remove_if(key, |_, owners| owners.is_empty());
+                    stats.removed_keys += 1;
+                }
             }
         }
 
@@ -527,10 +546,7 @@ impl BlockHashStore {
     }
 
     pub fn owner_count(&self) -> u64 {
-        self.blocks
-            .iter()
-            .map(|entry| entry.value().len() as u64)
-            .sum()
+        self.owners_total.load(Ordering::Relaxed)
     }
 
     pub fn node_counts(&self) -> (u64, u64) {
@@ -558,6 +574,7 @@ impl BlockHashStore {
         self.node_blocks.clear();
         self.nodes.clear();
         self.redundancy.reset();
+        self.owners_total.store(0, Ordering::Relaxed);
     }
 
     fn touch_node_session(&self, node: &str, node_id: Uuid) -> Result<(), StoreError> {
@@ -613,25 +630,6 @@ impl BlockHashStore {
             .count() as u64
     }
 
-    fn visible_owner_count_before_heartbeat(
-        &self,
-        owners: &HashMap<Arc<str>, OwnerRecord>,
-        node: &str,
-        node_id: Uuid,
-        now: Instant,
-    ) -> u64 {
-        owners
-            .iter()
-            .filter(|(owner_node, owner)| {
-                if owner_node.as_ref() == node {
-                    owner.node_id == node_id
-                } else {
-                    self.is_owner_visible(owner_node, owner, now)
-                }
-            })
-            .count() as u64
-    }
-
     fn remove_owner_for_key(
         &self,
         key: &BlockKey,
@@ -647,6 +645,7 @@ impl BlockHashStore {
         }
         let before_visible = self.accounted_owner_count(&owners);
         owners.remove(node);
+        self.owners_total.fetch_sub(1, Ordering::Relaxed);
         let after_visible = self.accounted_owner_count(&owners);
         let empty = owners.is_empty();
         drop(owners);
@@ -667,6 +666,7 @@ impl BlockHashStore {
         }
         let before_visible = self.accounted_owner_count(&owners);
         owners.remove(node);
+        self.owners_total.fetch_sub(1, Ordering::Relaxed);
         let after_visible = self.accounted_owner_count(&owners);
         let empty = owners.is_empty();
         drop(owners);
@@ -1366,5 +1366,28 @@ mod tests {
         let cleanup = store.remove_owners_older_than(Duration::from_secs(3600));
         assert_eq!(cleanup.removed_owners, 1);
         assert_eq!(store.redundancy_snapshot(), RedundancySnapshot::default());
+    }
+
+    #[test]
+    fn heartbeat_does_not_recount_unswept_stale_owners() {
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::from_secs(30),
+            ..StoreConfig::default()
+        });
+        let node_a = heartbeat_node(&store, "node-a");
+        let node_b = heartbeat_node(&store, "node-b");
+        let hash = vec![7];
+        store
+            .insert_hashes("ns", std::slice::from_ref(&hash), "node-a", node_a)
+            .unwrap();
+        store
+            .insert_hashes("ns", std::slice::from_ref(&hash), "node-b", node_b)
+            .unwrap();
+        let before = store.redundancy_snapshot();
+
+        store.nodes.get_mut("node-b").unwrap().last_seen = Instant::now() - Duration::from_secs(31);
+        store.heartbeat_node("node-a", node_a).unwrap();
+
+        assert_eq!(store.redundancy_snapshot(), before);
     }
 }

--- a/pegaflow-metaserver/src/store.rs
+++ b/pegaflow-metaserver/src/store.rs
@@ -10,6 +10,7 @@ const MIN_RECLAIMABLE_OWNER_COUNT: usize = 3;
 
 pub const DEFAULT_NODE_STALE_SECS: u64 = 30;
 pub const DEFAULT_TTL_MINUTES: u64 = 120;
+pub const MANUAL_CLEANUP_AGE_SECS: u64 = 60 * 60;
 
 /// A prefix query result: one block hash and all live nodes that own it.
 #[derive(Debug, Clone)]
@@ -97,9 +98,9 @@ struct NodeRecord {
 }
 
 /// Both lifecycle decisions for one owner record, produced from a single `nodes`
-/// lookup: `keep` (survives the TTL purge) and `visible` (query-visible: current
-/// session and node still fresh). Lets the sweep tally live redundancy without
-/// probing the node map twice per owner.
+/// lookup: `keep` (survives the node-liveness sweep) and `visible` (query-visible:
+/// current session and node still fresh). Lets the sweep tally live redundancy
+/// without probing the node map twice per owner.
 struct OwnerEval {
     keep: bool,
     visible: bool,
@@ -300,8 +301,8 @@ impl BlockHashStore {
         result
     }
 
-    /// Sweep owners whose node is missing or whose ownership TTL has expired, and
-    /// refresh the cached live-owner redundancy snapshot in the same walk.
+    /// Sweep owners whose node is missing or no longer active, and refresh the
+    /// cached live-owner redundancy snapshot in the same walk.
     pub fn sweep_expired(&self) -> SweepStats {
         let now = Instant::now();
         let mut stats = SweepStats::default();
@@ -327,9 +328,9 @@ impl BlockHashStore {
         });
 
         let node_before = self.nodes.len();
-        let ttl = self.config.ttl;
+        let node_stale_after = self.config.node_stale_after;
         self.nodes.retain(|node, record| {
-            let keep = now.duration_since(record.last_seen) <= ttl;
+            let keep = now.duration_since(record.last_seen) <= node_stale_after;
             if !keep {
                 info!(
                     "MetaServer node swept: node={} node_id={} last_seen_age_secs={}",
@@ -346,6 +347,28 @@ impl BlockHashStore {
             .redundancy
             .lock()
             .expect("redundancy snapshot mutex poisoned") = snapshot;
+
+        stats
+    }
+
+    /// Remove ownership records older than `max_age`, regardless of node
+    /// liveness. This is reserved for explicit operator maintenance; the
+    /// periodic lifecycle sweep intentionally does not use owner age.
+    pub fn remove_owners_older_than(&self, max_age: Duration) -> SweepStats {
+        let now = Instant::now();
+        let mut stats = SweepStats::default();
+
+        self.blocks.retain(|_, owners| {
+            let before = owners.len();
+            owners.retain(|_, owner| now.duration_since(owner.key_register_time) <= max_age);
+            stats.removed_owners += before.saturating_sub(owners.len());
+            if owners.is_empty() {
+                stats.removed_keys += 1;
+                false
+            } else {
+                true
+            }
+        });
 
         stats
     }
@@ -377,7 +400,7 @@ impl BlockHashStore {
             let age = now.duration_since(node.last_seen);
             if age <= self.config.node_stale_after {
                 active += 1;
-            } else if age <= self.config.ttl {
+            } else {
                 stale += 1;
             }
         }
@@ -443,8 +466,7 @@ impl BlockHashStore {
         };
         let node_age = now.duration_since(record.last_seen);
         OwnerEval {
-            keep: now.duration_since(owner.key_register_time) <= self.config.ttl
-                && node_age <= self.config.ttl,
+            keep: node_age <= self.config.node_stale_after,
             visible: record.node_id == owner.node_id && node_age <= self.config.node_stale_after,
         }
     }
@@ -915,6 +937,58 @@ mod tests {
         let removed = store.sweep_expired();
         assert_eq!(removed, SweepStats::default());
         assert_eq!(store.entry_count(), 2);
+    }
+
+    #[test]
+    fn test_sweep_keeps_old_owner_on_active_node() {
+        let store = BlockHashStore::with_config(StoreConfig {
+            node_stale_after: Duration::from_secs(60),
+            ttl: Duration::from_secs(1),
+        });
+        let node_id = heartbeat_node(&store, "node-a");
+        store
+            .insert_hashes("ns", &[vec![1]], "node-a", node_id)
+            .unwrap();
+        store
+            .blocks
+            .get_mut(&BlockKey::new("ns".to_string(), vec![1]))
+            .unwrap()
+            .get_mut("node-a")
+            .unwrap()
+            .key_register_time = Instant::now() - Duration::from_secs(2);
+
+        let removed = store.sweep_expired();
+        assert_eq!(removed, SweepStats::default());
+        assert_eq!(store.owner_count(), 1);
+        assert_eq!(store.query_prefix("ns", &[vec![1]]).len(), 1);
+    }
+
+    #[test]
+    fn test_remove_owners_older_than_removes_only_expired_owners() {
+        let store = BlockHashStore::new();
+        let node_id = heartbeat_node(&store, "node-a");
+        store
+            .insert_hashes("ns", &[vec![1], vec![2]], "node-a", node_id)
+            .unwrap();
+        store
+            .blocks
+            .get_mut(&BlockKey::new("ns".to_string(), vec![1]))
+            .unwrap()
+            .get_mut("node-a")
+            .unwrap()
+            .key_register_time = Instant::now() - Duration::from_secs(3601);
+
+        let removed = store.remove_owners_older_than(Duration::from_secs(3600));
+        assert_eq!(
+            removed,
+            SweepStats {
+                removed_owners: 1,
+                removed_keys: 1,
+                removed_nodes: 0,
+            }
+        );
+        assert_eq!(store.owner_count(), 1);
+        assert_eq!(store.entry_count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The 600-second MetaServer sweep walked every block and rebuilt redundancy state even when all nodes were healthy. During a real vLLM run this can hold block shard locks long enough for query-prefetch retries to grow.

## Change

- A healthy sweep checks node liveness only. A block walk runs after an actual node removal or pending session takeover.
- Redundancy counters are maintained incrementally under existing shard guards; metrics read the counters without scanning block shards.
- Registration age is removed from background sweep decisions.
- Add `POST /admin/cleanup-expired-blocks` to the existing `--http-addr` listener (default `0.0.0.0:9092`). It removes owners registered strictly more than one hour before the call, preserves nodes and physical KV data, and returns `removed_owners`/`removed_keys`.

## RTX 4090 vLLM A/B

Master `0c49ca3` and feature `6365f1a` ran sequentially on the same host with two TP2 DeepSeek-V2-Lite-Chat instances, block size 16, two PegaFlow servers, 400 GB pools, 1M+ retained logical keys, 660 seconds of steady traffic, and an added identical 20-request/s real short-cold stream. The measurement proxy adds one identical local gRPC hop to both variants.

| Metric | Master | Feature |
| --- | ---: | ---: |
| Keys after seed drain | 1,009,664 | 1,001,472 |
| Steady QueryPrefixBlocks mean / P99 / max | 0.751 / 1.750 / 382.747 ms | 0.570 / 1.432 / 24.074 ms |
| Steady InsertBlockHashes mean / P99 / max | 0.554 / 1.574 / 66.977 ms | 0.519 / 1.522 / 33.749 ms |
| Steady HeartbeatNode mean / P99 / max | 0.609 / 1.474 / 4.857 ms | 0.543 / 1.183 / 1.930 ms |
| Query max near the 600-second sweep (3-second window) | 382.747 ms | 1.140 ms |
| Insert max in the same window | 1.568 ms | 7.448 ms |
| query-prefetch rate in sweep bin / nearby median | 147.5 / 51.7 s⁻¹ | 49.2 / 49.5 s⁻¹ |
| Steady MetaServer RPC errors | 0 | 0 |

The master query stall and 2.85x query-prefetch increase occur in the same sweep bin. Feature has no corresponding query stall or rate spike, but its isolated Insert maximum is higher in that window; causality is unresolved. Each steady run includes approximately 25k Inserts and 88 Heartbeats, limiting heartbeat tail conclusions. All steady RPCs and inference requests succeeded; one feature pressure request returned 500 during teardown after `finished`.

The proxy captured QueryPrefixBlocks, InsertBlockHashes and HeartbeatNode. No RemoveBlockHashes or UnregisterNode calls were recorded, so their latency is unmeasured. HTTP cleanup measures an internal MetaServer scan; it does not cover the server-to-MetaServer RemoveBlockHashes RPC. RPC timing starts at proxy forwarding and excludes time queued in the PegaFlow server.

## Cleanup endpoint measurement

All feature requests were made while the real vLLM load continued.

| Call | HTTP | Removed owners / keys | Duration | Overlapping Query / Insert max |
| --- | ---: | ---: | ---: | ---: |
| Fresh scan 1/2/3 | 200 | 0 / 0 each | 291.1 / 161.2 / 200.9 ms | ≤1.148 / ≤0.947 ms |
| Aged (>1h) | 200 | 182,272 / 182,272 | 394.4 ms | 1.087 / 0.825 ms |
| Aged repeat (+30s) | 200 | 77,952 / 77,952 | 265.8 ms | 5.476 / 1.881 ms |

The repeat call overlapped only 4 Queries / 9 Inserts. Query mean before/during/after was 0.588/4.709/0.600 ms; Insert was 0.572/1.084/0.507 ms (30-second before/after windows). This shows a transient increase, with too few samples for stable tail estimates. The extra 77,952 deletions match seed registrations crossing the one-hour cutoff during the 30-second gap.

The cleanup POST is served on the existing HTTP listener and remains POST-only (GET returns 405). Two nodes remained active throughout; final retained keys were 1,066,748. The aged calls delete metadata owners only, so existing physical KV allocations are not reclaimed by this endpoint.

This is one sequential A/B on a single host using real vLLM-generated metadata registrations; the vLLM correctness gate was not run. Full raw artifacts and analysis are in `.local/reports/pr451-vllm/`; the remote run directories are under `/root/kexi/vllm_meta_ab/`.

