### PR TITLE
fix(connector): drop the block hash past a popped last token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pegaflow-common"
-version = "0.24.3"
+version = "0.24.4"
 dependencies = [
  "colored",
  "libc",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-core"
-version = "0.24.3"
+version = "0.24.4"
 dependencies = [
  "ahash",
  "bytesize",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-metaserver"
-version = "0.24.3"
+version = "0.24.4"
 dependencies = [
  "axum",
  "clap",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-pd-wire"
-version = "0.24.3"
+version = "0.24.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-proto"
-version = "0.24.3"
+version = "0.24.4"
 dependencies = [
  "prost",
  "tonic",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-py"
-version = "0.24.3"
+version = "0.24.4"
 dependencies = [
  "log",
  "mea",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-server"
-version = "0.24.3"
+version = "0.24.4"
 dependencies = [
  "axum",
  "clap",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "pegaflow-transfer"
-version = "0.24.3"
+version = "0.24.4"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.24.3"
+version = "0.24.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -242,21 +242,33 @@ class SchedulerConnector:
     def _request_block_hashes(self, request: "Request") -> tuple[bytes, ...]:
         """Per-block keys from `Request.block_hashes` (see `ConnectorContext.hash_scale`).
 
-        vLLM hashes full spans only, so there can never be more keys than the
-        request has full blocks. More means the hashes are finer than the
-        scale says, and keying blocks by them would file block ``i`` under the
-        hash of a shorter prefix — any request sharing that prefix would then
-        load this request's blocks. Fail loudly instead.
+        vLLM hashes full spans only, so the hashes never reach past the
+        request's tokens — except when a connector pops the last token after
+        vLLM hashed it (NIXL / Mooncake truncate hybrid-model prompts by one
+        token on the prefiller so it computes ``h(N-1)``) without trimming
+        ``block_hashes``. A hash spanning a token the request no longer has
+        fingerprints a prefix vLLM will not compute; drop it. Anything beyond
+        that single tail hash means the hashes are finer than the scale says,
+        and keying blocks by them would file block ``i`` under the hash of a
+        shorter prefix — any request sharing that prefix would then load this
+        request's blocks. Fail loudly instead.
         """
-        per_block = block_hashes_per_block(request.block_hashes, self._ctx.hash_scale)
-        full_blocks = getattr(request, "num_tokens", 0) // self._ctx.virtual_block_size
-        if full_blocks and len(per_block) > full_blocks:
-            raise RuntimeError(
-                f"req {request.request_id}: {len(request.block_hashes)} block hashes give "
-                f"{len(per_block)} keys at scale {self._ctx.hash_scale} for {full_blocks} "
-                f"full blocks; vLLM's hash granularity is finer than the connector's"
-            )
-        return per_block
+        block_hashes = request.block_hashes
+        num_tokens = getattr(request, "num_tokens", 0)
+        if num_tokens:
+            hash_block_size = self._ctx.hash_block_size or self._ctx.virtual_block_size
+            hashed = num_tokens // hash_block_size
+            stale = len(block_hashes) - hashed
+            if stale > 1:
+                raise RuntimeError(
+                    f"req {request.request_id}: {len(block_hashes)} block hashes span "
+                    f"{len(block_hashes) * hash_block_size} tokens but the request has "
+                    f"{num_tokens}; vLLM's hash granularity is finer than the connector's "
+                    f"{hash_block_size}"
+                )
+            if stale == 1:
+                block_hashes = block_hashes[:hashed]
+        return block_hashes_per_block(block_hashes, self._ctx.hash_scale)
 
     def get_num_new_matched_tokens(
         self,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pegaflow-llm"
-version = "0.24.3"
+version = "0.24.4"
 description = "High-performance key-value storage engine with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -114,6 +114,6 @@ profile = "black"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.24.3"
+version = "0.24.4"
 version_files = ["pyproject.toml:^version", "../Cargo.toml:^version"]
 tag_format = "v$version"

--- a/python/tests/test_hash_block_size_scale.py
+++ b/python/tests/test_hash_block_size_scale.py
@@ -133,6 +133,23 @@ def test_more_keys_than_full_blocks_is_rejected():
         _scheduler(hash_block_size=None)._build_query(_request("r1", 4 * VBS), 0)
 
 
+def test_hash_past_a_popped_last_token_is_dropped():
+    # NIXL/Mooncake pop the prefiller's last prompt token for hybrid models
+    # after vLLM hashed the full prompt: a 30-block prompt keeps 360 hashes
+    # over 29 full blocks. The hash closing the 30th block spans a token the
+    # request no longer has and must not become a key (K3 production: group
+    # restarts on every 1536-aligned prompt).
+    req = _request("r1", 30 * VBS)
+    req.num_tokens = req.num_prompt_tokens = 30 * VBS - 1
+    keys, _ = _scheduler()._build_query(req, 0)
+    assert keys == tuple(_key(i) for i in range(29))
+
+    # An unaligned prompt leaves no stale hash and is unaffected.
+    req = _request("r1", 30 * VBS + 5)
+    req.num_tokens = req.num_prompt_tokens = 30 * VBS + 4
+    assert _scheduler()._build_query(req, 0)[0] == tuple(_key(i) for i in range(30))
+
+
 def test_hash_block_size_isolates_namespace():
     cfg = SimpleNamespace(
         model_config=SimpleNamespace(


### PR DESCRIPTION
## Problem

Since 0.24.3 (#450) the K3 prefill groups restart on a fatal EngineCore error raised from `get_num_new_matched_tokens`:

```
RuntimeError: req chatcmpl-...: 360 block hashes give 30 keys at scale 12 for 29 full blocks;
vLLM's hash granularity is finer than the connector's
```

The prefill node runs `MultiConnector = NixlConnector (producer) + PegaKVConnector`. For hybrid (mamba) models NIXL's `get_num_new_matched_tokens` pops the last prompt token on the P side (`_truncate_mamba_request_for_prefill`, so P computes `h(N-1)` and D recomputes the last token) *after* vLLM has already hashed the full prompt, and it never trims `Request.block_hashes` (same invariant break as vllm-project/vllm#49377; Mooncake has the identical pop). MultiConnector calls NIXL first, so PegaFlow sees `num_tokens = N-1` with hashes for `N` tokens.

With `--prefix-match-unit 128` over 1536-token blocks the extra hash only becomes a key when the prompt is exactly 1536-aligned: `N = 46080 = 30 × 1536` gives 360 hashes → 30 keys against `46079 // 1536 = 29` full blocks, which trips the fail-loud guard added in #450. Every such request kills the group; the group comes back and dies on the next aligned prompt.

## Fix

`_request_block_hashes` drops hashes that reach past `request.num_tokens` before scaling them to per-block keys. Exactly one tail hash is the signature of a popped last token; anything more still means vLLM's hash granularity is finer than the connector's and keeps failing loudly, so the contamination guard from #450 stays in place.

The dropped hash fingerprints a prefix the prefiller will never compute (the last block is partial after the pop), so no key is lost.

Second commit bumps the version to 0.24.4 (`Cargo.toml`, `Cargo.lock`, `python/pyproject.toml`) so the squash merge can be tagged and released directly.

## Tests

- `test_hash_past_a_popped_last_token_is_dropped`: 30-block prompt with 360 hashes and `num_tokens = 30 × 1536 − 1` yields 29 keys; an unaligned prompt is unaffected.
- `python/tests`: 304 passed, ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157jRXpY76iVctr9ERAtiLw
